### PR TITLE
Remove qrcode.js references

### DIFF
--- a/privacyidea/templates/selfservice/base.mako
+++ b/privacyidea/templates/selfservice/base.mako
@@ -24,8 +24,6 @@
 <script type="text/javascript" src="/js/jquery.tools.min.js"></script>
 <script type="text/javascript" src="/js/jquery.validate.js"></script>
 
-<script type="text/javascript" src="/js/qrcode.js"></script>
-<script type="text/javascript" src="/js/qrcode-helper.js"></script>
 <script type="text/javascript" src="/js/privacyidea_utils.js"></script>
 <script type="text/javascript" src="/js/flexigrid.js"></script>
 <script type="text/javascript" src="/js/selfservice.js"></script>


### PR DESCRIPTION
Perhaps I'm missing something - if I am please close this - but `selfservice/base.mako` still requires qrcode.js. However, restoring them still results in what appears to be a broken selfservice page. I am unable to meaningfully view any tokens.

![Imgur](http://i.imgur.com/hRw4aog.png)
