### PR TITLE
Fix "Remove duplicate key in dictionary" issue

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -477,7 +477,6 @@ class IdResolver (UserIdResolver):
         descriptor['config'] = {'LDAPURI': 'string',
                                 'LDAPBASE': 'string',
                                 'BINDDN': 'string',
-                                'AUTHTYPE': 'string',
                                 'BINDPW': 'password',
                                 'TIMEOUT': 'int',
                                 'SIZELIMIT': 'int',

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -399,7 +399,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         g.policy_object = PolicyClass()
 
         # request, that matches the policy
-        req.all_data = {"realm": "somerealm",
+        req.all_data = {
                         "user": "cornelius",
                         "realm": "home"}
         init_tokenlabel(req)
@@ -431,7 +431,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         g.policy_object = PolicyClass()
 
         # request, that matches the policy
-        req.all_data = {"realm": "somerealm",
+        req.all_data = {
                         "user": "cornelius",
                         "realm": "home"}
         init_random_pin(req)
@@ -460,7 +460,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         g.policy_object = PolicyClass()
 
         # request, that matches the policy
-        req.all_data = {"realm": "somerealm",
+        req.all_data = {
                         "user": "cornelius",
                         "realm": "home"}
         encrypt_pin(req)
@@ -489,27 +489,27 @@ class PrePolicyDecoratorTestCase(MyTestCase):
                                                  ACTION.OTPPINCONTENTS, "cn"))
         g.policy_object = PolicyClass()
 
-        req.all_data = {"realm": "somerealm",
+        req.all_data = {
                         "user": "cornelius",
                         "realm": "home"}
         # The minimum OTP length is 4
         self.assertRaises(PolicyError, check_otp_pin, req)
 
-        req.all_data = {"realm": "somerealm",
+        req.all_data = {
                         "user": "cornelius",
                         "realm": "home",
                         "pin": "12345566890012"}
         # Fail maximum OTP length
         self.assertRaises(PolicyError, check_otp_pin, req)
 
-        req.all_data = {"realm": "somerealm",
+        req.all_data = {
                         "user": "cornelius",
                         "realm": "home",
                         "pin": "123456"}
         # Good OTP length, but missing character A-Z
         self.assertRaises(PolicyError, check_otp_pin, req)
 
-        req.all_data = {"realm": "somerealm",
+        req.all_data = {
                         "user": "cornelius",
                         "realm": "home",
                         "pin": "abc123"}
@@ -546,7 +546,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         env = builder.get_environ()
         req = Request(env)
         g.policy_object = PolicyClass()
-        req.all_data = {"realm": "somerealm",
+        req.all_data = {
                         "user": "cornelius",
                         "realm": "home"}
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Remove duplicate key in dictionary](https://www.quantifiedcode.com/app/issue_class/7r1WUUmA)
Issue details: [https://www.quantifiedcode.com/app/project/gh:privacyidea:privacyidea?groups=code_patterns/%3A7r1WUUmA](https://www.quantifiedcode.com/app/project/gh:privacyidea:privacyidea?groups=code_patterns/%3A7r1WUUmA)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)