### PR TITLE
yubikey: identify a token by the prefix sent for /ttype/yubikey

### DIFF
--- a/privacyidea/static/components/token/views/token.enroll.yubikey.html
+++ b/privacyidea/static/components/token/views/token.enroll.yubikey.html
@@ -2,6 +2,9 @@
     The Yubikey Token is an USB device that emits an event based One Time
     Password. You can initialize the Yubikey using the tool ykpersonalize.
     Paste the secret hex key here.
+    For tokens compatible with the Yubico cloud service check "emit a public ID".
+    When programming the token the prefix must be 6 bytes, which will give
+    you a UID with 12 characters.
     You also need to choose, if the Yubikey emits the additional UID, which
     is either 12 or 16 characters long. You can check this in the test field.
 </p>


### PR DESCRIPTION
A yubikey is often identified by the serial number in privacyidea, e.g.
when using /validate/check.  This works also for yubikeys in AES mode.
But when we use the yubikey validation protocoll, we don't have the
serial number in the request, so we must use other data.

Yubico cloud service (and pam_yubico) identify the token by the prefix
defined when enrolling which is sent with every request.  We'll do the
same here.

If there is no info in the table tokeninfo stored, we add yubikey.prefix.
When we handle /ttype/yubikey we search alle tokentype=yubikey tokens for
a matching prefix and verify against that token.

This works fine for newly created tokens with --yubikeyrandomprefix 6
[see my patch to privacyideaadm] and after using the token once
[see https://github.com/privacyidea/privacyideaadm/issues/18].
I'm not sure that removing the usage of the serial number completly
is the right solution here. I guess we need some tests with already
enrolled and used tokens.