### PR TITLE
Fix layout in token details info section

### DIFF
--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -126,9 +126,11 @@
         <tr>
             <td translate>Info</td>
             <td>
-                <li ng-repeat="(k,v) in token.info">
-                    {{ k }}: {{ v | truncate:30 }}
-                </li>
+                <ul>
+                    <li ng-repeat="(k,v) in token.info">
+                        {{ k }}: {{ v | truncate:30 }}
+                    </li>
+                <ul>
                 <div ng-show="editTokenInfo">
                     <div class="form-group">
                         <label for="max_auth_count"


### PR DESCRIPTION
Hi,

Just a tiny patch to fix the layout of the list in the info section of token details.

Best Regards

Martin