### PR TITLE
yubico: fix tokentype yubico validation against privacyidea

### DIFF
--- a/privacyidea/lib/tokens/yubicotoken.py
+++ b/privacyidea/lib/tokens/yubicotoken.py
@@ -174,10 +174,9 @@ class YubicoTokenClass(TokenClass):
                     return_hash = m.group(1)
 
                     # check signature:
-                    elements = response.split('\r')
+                    elements = response.split('\n')
                     hash_elements = []
                     for elem in elements:
-                        elem = elem.strip('\n')
                         if elem and elem[:2] != "h=":
                             hash_elements.append(elem)
 


### PR DESCRIPTION
I've run yubicotoken against the privacyidea /ttype/yubikey
and that failed with an invalid signature. This patch fixes
the error - the answer from the validationserver is
line-delimited with \n, not \r.

Testsuite passes after the change, as well as validation
against privacyidea. I've no registered Id with Yubico,
so I didn't test that.