### PR TITLE
yubico: make the Yubico cloud URL configurable

### DIFF
--- a/privacyidea/lib/tokens/yubicotoken.py
+++ b/privacyidea/lib/tokens/yubicotoken.py
@@ -51,7 +51,7 @@ import binascii
 
 YUBICO_LEN_ID = 12
 YUBICO_LEN_OTP = 44
-YUBICO_URL = "http://api.yubico.com/wsapi/2.0/verify"
+YUBICO_URL = "https://api.yubico.com/wsapi/2.0/verify"
 DEFAULT_CLIENT_ID = 20771
 DEFAULT_API_KEY = "9iE9DRkPHQDJbAFFC31/dum5I54="
 
@@ -138,6 +138,7 @@ class YubicoTokenClass(TokenClass):
 
         apiId = get_from_config("yubico.id", DEFAULT_CLIENT_ID)
         apiKey = get_from_config("yubico.secret", DEFAULT_API_KEY)
+        yubico_url = get_from_config("yubico.url", YUBICO_URL)
 
         if apiKey == DEFAULT_API_KEY or apiId == DEFAULT_CLIENT_ID:
             log.warning("Usage of default apiKey or apiId not recomended!")
@@ -159,7 +160,7 @@ class YubicoTokenClass(TokenClass):
                  'id': apiId}
 
             try:
-                r = requests.post(YUBICO_URL,
+                r = requests.post(yubico_url,
                                   data=p)
 
                 if r.status_code == requests.codes.ok:

--- a/privacyidea/static/components/config/views/config.token.yubico.html
+++ b/privacyidea/static/components/config/views/config.token.yubico.html
@@ -30,4 +30,13 @@
            ng-model="form['yubico.secret']" name="yubicoKey">
 </div>
 
+<div class="form-group">
+    <label for="yubicoURL" translate>Yubico URL</label>
+    <input type="url"
+           required
+           class="form-control"
+           placeholder="https://api.yubico.com/wsapi/2.0/verify"
+           ng-model="form['yubico.url']" name="yubicoURL">
+</div>
+
 


### PR DESCRIPTION
This patch adds a field to Config -> Tokens -> Yubico which can
contain another validation server than the Yubico servers.

If there is no configuration stored we still use the Yubico
servers as default, but we switch to the https-URL.

The files is marked tranlateable, but I don't have grunt available,
so there is no updated translation.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/353%23discussion_r57751816%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/353%23discussion_r57751876%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/353%23discussion_r57774402%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/353%23discussion_r57777065%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20bf9a711b7ccee5a75758d4a802e5c2890474df48%20privacyidea/lib/tokens/yubicotoken.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/353%23discussion_r57751876%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22call%20this%20lowercase%20%5C%22yubico_url%5C%22.%20But%20you%20need%20to%20change%20this%20in%20the%20function%20below.%22%2C%20%22created_at%22%3A%20%222016-03-29T16%3A14%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Cornelius%20K%5Cu00f6lbel%20%3Cnotifications%40github.com%3E%20writes%3A%5Cn%5Cn%3E%3E%20%40%40%20-138%2C6%20%2B138%2C7%20%40%40%20def%20check_otp%28self%2C%20anOtpVal%2C%20counter%3DNone%2C%20window%3DNone%2C%20options%3DNone%29%3A%5Cn%3E%3E%20%20%5Cn%3E%3E%20%20%20%20%20%20%20%20%20%20apiId%20%3D%20get_from_config%28%5C%22yubico.id%5C%22%2C%20DEFAULT_CLIENT_ID%29%5Cn%3E%3E%20%20%20%20%20%20%20%20%20%20apiKey%20%3D%20get_from_config%28%5C%22yubico.secret%5C%22%2C%20DEFAULT_API_KEY%29%5Cn%3E%3E%20%2B%20%20%20%20%20%20%20%20YUBICO_URL%20%3D%20get_from_config%28%5C%22yubico.url%5C%22%2C%20DEFAULT_YUBICO_URL%29%5Cn%3E%5Cn%3E%20call%20this%20lowercase%20%5C%22yubico_url%5C%22.%20But%20you%20need%20to%20change%20this%20in%20the%20function%20below.%5Cn%5CnSomething%20like%3A%5Cn%5Cndiff%20--git%20a/privacyidea/lib/tokens/yubicotoken.py%20b/privacyidea/lib/tokens/yubicotoken.py%5Cnindex%207b69fe1..19e14d1%20100644%5Cn---%20a/privacyidea/lib/tokens/yubicotoken.py%5Cn%2B%2B%2B%20b/privacyidea/lib/tokens/yubicotoken.py%5Cn%40%40%20-51%2C7%20%2B51%2C7%20%40%40%20import%20binascii%5Cn%20%5Cn%20YUBICO_LEN_ID%20%3D%2012%5Cn%20YUBICO_LEN_OTP%20%3D%2044%5Cn-YUBICO_URL%20%3D%20%5C%22http%3A//api.yubico.com/wsapi/2.0/verify%5C%22%5Cn%2BYUBICO_URL%20%3D%20%5C%22https%3A//api.yubico.com/wsapi/2.0/verify%5C%22%5Cn%20DEFAULT_CLIENT_ID%20%3D%2020771%5Cn%20DEFAULT_API_KEY%20%3D%20%5C%229iE9DRkPHQDJbAFFC31/dum5I54%3D%5C%22%5Cn%20%5Cn%40%40%20-138%2C6%20%2B138%2C7%20%40%40%20class%20YubicoTokenClass%28TokenClass%29%3A%5Cn%20%5Cn%20%20%20%20%20%20%20%20%20apiId%20%3D%20get_from_config%28%5C%22yubico.id%5C%22%2C%20DEFAULT_CLIENT_ID%29%5Cn%20%20%20%20%20%20%20%20%20apiKey%20%3D%20get_from_config%28%5C%22yubico.secret%5C%22%2C%20DEFAULT_API_KEY%29%5Cn%2B%20%20%20%20%20%20%20%20yubico_url%20%3D%20get_from_config%28%5C%22yubico.url%5C%22%2C%20YUBICO_URL%29%5Cn%20%5Cn%20%20%20%20%20%20%20%20%20if%20apiKey%20%3D%3D%20DEFAULT_API_KEY%20or%20apiId%20%3D%3D%20DEFAULT_CLIENT_ID%3A%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20log.warning%28%5C%22Usage%20of%20default%20apiKey%20or%20apiId%20not%20recomended%21%5C%22%29%5Cn%40%40%20-159%2C7%20%2B160%2C7%20%40%40%20class%20YubicoTokenClass%28TokenClass%29%3A%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27id%27%3A%20apiId%7D%5Cn%20%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20try%3A%5Cn-%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20r%20%3D%20requests.post%28YUBICO_URL%2C%5Cn%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20r%20%3D%20requests.post%28yubico_url%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20data%3Dp%29%5Cn%20%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20r.status_code%20%3D%3D%20requests.codes.ok%3A%5Cn%5Cn--%20%5CnThe%20only%20problem%20with%20troubleshooting%20is%20that%20the%20trouble%20shoots%20back.%5Cn%22%2C%20%22created_at%22%3A%20%222016-03-29T18%3A25%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20Further%20below%20in%20the%20exception%20branch%20is%20also%20an%20occurance%20of%20YUBICO_URL%20-%3E%20yubico_url%22%2C%20%22created_at%22%3A%20%222016-03-29T18%3A39%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/yubicotoken.py%3AL138-145%22%7D%2C%20%22Pull%20bf9a711b7ccee5a75758d4a802e5c2890474df48%20privacyidea/lib/tokens/yubicotoken.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/353%23discussion_r57751816%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20constant%20YUBICO_URL%20is%20imported%20in%20a%20test.%20This%20is%20why%20the%20test%20fails.%5Cr%5CnSearch%20the%20code%20for%20YUBICO_URL.%5Cr%5CnI%20would%20leave%20the%20constant%20with%20this%20name%20and%20then%20I%20would...%22%2C%20%22created_at%22%3A%20%222016-03-29T16%3A14%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/yubicotoken.py%3AL51-58%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull bf9a711b7ccee5a75758d4a802e5c2890474df48 privacyidea/lib/tokens/yubicotoken.py 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/353#discussion_r57751816'>File: privacyidea/lib/tokens/yubicotoken.py:L51-58</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> The constant YUBICO_URL is imported in a test. This is why the test fails.
Search the code for YUBICO_URL.
I would leave the constant with this name and then I would...
- [ ] <a href='#crh-comment-Pull bf9a711b7ccee5a75758d4a802e5c2890474df48 privacyidea/lib/tokens/yubicotoken.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/353#discussion_r57751876'>File: privacyidea/lib/tokens/yubicotoken.py:L138-145</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> call this lowercase "yubico_url". But you need to change this in the function below.
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars.githubusercontent.com/u/4837658?v=3' height=16 width=16'></a> Cornelius Kölbel <notifications@github.com> writes:
>> @@ -138,6 +138,7 @@ def check_otp(self, anOtpVal, counter=None, window=None, options=None):
>>
>>          apiId = get_from_config("yubico.id", DEFAULT_CLIENT_ID)
>>          apiKey = get_from_config("yubico.secret", DEFAULT_API_KEY)
>> +        YUBICO_URL = get_from_config("yubico.url", DEFAULT_YUBICO_URL)
>
> call this lowercase "yubico_url". But you need to change this in the function below.
Something like:
diff --git a/privacyidea/lib/tokens/yubicotoken.py b/privacyidea/lib/tokens/yubicotoken.py
index 7b69fe1..19e14d1 100644
--- a/privacyidea/lib/tokens/yubicotoken.py
+++ b/privacyidea/lib/tokens/yubicotoken.py
@@ -51,7 +51,7 @@ import binascii
YUBICO_LEN_ID = 12
YUBICO_LEN_OTP = 44
-YUBICO_URL = "http://api.yubico.com/wsapi/2.0/verify"
+YUBICO_URL = "https://api.yubico.com/wsapi/2.0/verify"
DEFAULT_CLIENT_ID = 20771
DEFAULT_API_KEY = "9iE9DRkPHQDJbAFFC31/dum5I54="
@@ -138,6 +138,7 @@ class YubicoTokenClass(TokenClass):
apiId = get_from_config("yubico.id", DEFAULT_CLIENT_ID)
apiKey = get_from_config("yubico.secret", DEFAULT_API_KEY)
+        yubico_url = get_from_config("yubico.url", YUBICO_URL)
if apiKey == DEFAULT_API_KEY or apiId == DEFAULT_CLIENT_ID:
log.warning("Usage of default apiKey or apiId not recomended!")
@@ -159,7 +160,7 @@ class YubicoTokenClass(TokenClass):
'id': apiId}
try:
-                r = requests.post(YUBICO_URL,
+                r = requests.post(yubico_url,
data=p)
if r.status_code == requests.codes.ok:
--
The only problem with troubleshooting is that the trouble shoots back.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Yes. Further below in the exception branch is also an occurance of YUBICO_URL -> yubico_url


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/353?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/353?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/353'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>