### PR TITLE
Added add_user/delete_user to LDAPresolver and ldap3mock

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -676,7 +676,7 @@ class IdResolver (UserIdResolver):
             self._bind()
 
             params = self._attributes_to_ldap_attributes(attributes)
-            if dn == None:
+            if dn is None:
                 self.l.add(self._getDN(uid), object_class, params)
             else:
                 self.l.add(dn, object_class, params)

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -654,7 +654,7 @@ class IdResolver (UserIdResolver):
         
         return success, desc
 
-    def add_user(self, uid, object_class=None, attributes=None):
+    def add_user(self, uid, object_class=None, attributes=None, dn=None):
         """
         Add a new user to the LDAP directory.
 
@@ -676,7 +676,11 @@ class IdResolver (UserIdResolver):
             self._bind()
 
             params = self._attributes_to_ldap_attributes(attributes)
-            self.l.add(uid, object_class, params)
+            if dn == None:
+                self.l.add(self._getDN(uid), object_class, params)
+            else:
+                self.l.add(dn, object_class, params)
+
         except Exception as e:
             log.error("Error accessing LDAP server: {0}".format(e))
             log.debug("{0}".format(traceback.format_exc()))
@@ -702,7 +706,7 @@ class IdResolver (UserIdResolver):
         try:
             self._bind()
 
-            self.l.delete(uid)
+            self.l.delete(self._getDN(uid))
         except Exception as exx:
             log.error("Error deleting user: {0}".format(exx))
             res = False

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -654,6 +654,60 @@ class IdResolver (UserIdResolver):
         
         return success, desc
 
+    def add_user(self, uid, object_class=None, attributes=None):
+        """
+        Add a new user to the LDAP directory.
+
+        attributes are these
+        "username", "surname", "givenname", "email",
+        "mobile", "phone", "password"
+
+        :param uid: The uid of the user object in the resolver
+        :type uid: string
+        :param object_class: Attributes according to the attribute mapping
+        :type object_class: list
+        :param attributes: Attributes according to the attribute mapping
+        :type attributes: dict
+        :return: The new UID of the user. The UserIdResolver needs to
+        determine the way how to create the UID.
+        """
+        attributes = attributes or {}
+        try:
+            self._bind()
+
+            params = self._attributes_to_ldap_attributes(attributes)
+            self.l.add(uid, object_class, params)
+        except Exception as e:
+            log.error("Error accessing LDAP server: {0}".format(e))
+            log.debug("{0}".format(traceback.format_exc()))
+            return False
+
+        if self.l.result.get('result') != 0:
+            log.error("Error during adding of user: {0} details".format(uid))
+            return False
+
+        return uid
+
+    def delete_user(self, uid):
+        """
+        Delete a user from the LDAP Directory.
+
+        The user is referenced by the user id.
+        :param uid: The uid of the user object, that should be deleted.
+        :type uid: basestring
+        :return: Returns True in case of success
+        :rtype: bool
+        """
+        res = True
+        try:
+            self._bind()
+
+            self.l.delete(uid)
+        except Exception as exx:
+            log.error("Error deleting user: {0}".format(exx))
+            res = False
+        return res
+
     def _attributes_to_ldap_attributes(self, attributes):
         """
         takes the attributes and maps them to the LDAP attributes
@@ -665,17 +719,44 @@ class IdResolver (UserIdResolver):
         for fieldname, value in attributes.iteritems():
             if self.map.get(fieldname):
                 if fieldname == "password":
-                    password = value 
-                    # Create a {SSHA} password
-                    salt = geturandom(4)
-                    hr = hashlib.sha1(password)
-                    hr.update(salt)
-                    ldap_attributes[self.map.get(fieldname)] = \
-                        "{SSHA}" + hr.digest() + salt
+                    # Variable value may be either a string or a list
+                    # so catch the TypeError exception if we get the wrong
+                    # variable type
+                    try:
+                        pw_hash = self._create_ssha(value[1][0])
+                        value[1][0] = pw_hash
+                        ldap_attributes[self.map.get(fieldname)] = value
+                    except TypeError as e:
+                        pw_hash = self._create_ssha(value)
+                        ldap_attributes[self.map.get(fieldname)] = pw_hash
                 else:
                     ldap_attributes[self.map.get(fieldname)] = value 
 
         return ldap_attributes
+
+    @staticmethod
+    def _create_ssha(password):
+        """
+        Encodes the given password as a base64 SSHA hash
+        :param password: string to hash 
+        :type password: basestring
+        :return: string encoded as a base64 SSHA hash 
+        """
+
+        salt = geturandom(4)
+
+        # Hash password string and append the salt
+        sha_hash = hashlib.sha1(password)
+        sha_hash.update(salt)
+
+        # Create a base64 encoded string
+        digest_b64 = '{0}{1}'.format(sha_hash.digest(),
+                salt).encode('base64').strip()
+
+        # Tag it with SSHA
+        tagged_digest = '{{SSHA}}{}'.format(digest_b64)
+
+        return tagged_digest 
 
     def _create_ldap_modify_changes(self, attributes, uid):
         """


### PR DESCRIPTION
Please have a look at this new pull request. I've removed the callback functionality and squashed the change into a single commit.

Best Regards

Martin
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/371%23issuecomment-208834741%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23issuecomment-208835386%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23issuecomment-209288247%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59353039%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59353083%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59353160%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59354156%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59354195%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59354289%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59354813%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59357295%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59381833%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59505546%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59505960%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23issuecomment-208834741%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20a%20lot%2C%20this%20is%20much%20clearer%20to%20read.%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A19%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A22%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-04-13T07%3A50%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20669933b07d9e363ed20dc9814343ec1523560d42%20privacyidea/lib/resolvers/LDAPIdResolver.py%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59353083%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20here.%20Transform%20the%20uid%20to%20the%20DN%20with%5Cr%5Cn%5Cr%5Cn%20%20%20%20self._getDN%28uid%29%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A20%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20update%20this%20one%20too.%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A31%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15330084%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wheldom01%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL654-714%22%7D%2C%20%22Pull%20c3603f8f0e8a8d7a132811c35dc2e53fb3558dd6%20privacyidea/lib/resolvers/LDAPIdResolver.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59505546%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%2C%20I%20see%20the%20problem%20now%2C%20since%20the%20uid%20%28being%20the%20objectGUID%20or%20whatever%20is%20not%20available%29.%5Cr%5Cn%5Cr%5CnBut%20this%20does%20not%20work%20with%20the%20normal%20REST%20API%20and%20the%20Web%20UI.%20I%20would%20like%20to%20keep%20this%20transparent%20for%20the%20toplevel%20and%20thus%20I%20would%20like%20to%20avoid%20to%20change%20the%20signature%20of%20this%20method.%5Cr%5Cn%5Cr%5CnWhat%20do%20you%20think%20of%20this.%5Cr%5CnTo%20be%20able%20to%20keep%20this%20transparent%20to%20the%20levels%20above%20we%20need%20to%20create%20the%20DN%20out%20of%20the%20given%20attributes.%5Cr%5Cn%5Cr%5CnUsually%20you%20would%20give%20the%20loginname%20during%20creation%20of%20the%20user%2C%20the%20givenName%20and%20or%20the%20surname.%5Cr%5Cn%5Cr%5CnThen%20the%20DN%20could%20either%20be%20created%20like%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20CN%3D%3Cgivenname%3E%20%3Csurname%3E%2C%20%3CbaseDN%3E%5Cr%5Cn%5Cr%5Cnor%20%5Cr%5Cn%5Cr%5Cn%20%20%20CN%3D%3Cloginname%3E%2C%20%3CbaseDN%3E%5Cr%5Cn%5Cr%5CnTo%20keep%20it%20simple%2C%20I%20would%20prefer%20to%20take%20the%20baseDN%2C%20which%20already%20exist.%20And%20then%20only%20define%2C%20what%20would%20be%20the%20creating%20attribute%20of%20the%20CN.%20%28This%20would%20be%20an%20additional%20resolver%20parameter.%29%5Cr%5Cn%5Cr%5CnJust%20tell%20me%2C%20what%20you%20think%20of%20this%20-%20I%20can%20do%20this%20later.%5Cr%5Cn%5Cr%5CnTill%20then%2C%20can%20you%20please%20remove%20the%20%5C%22dn%5C%22%20from%20the%20parameter%20list%20and...%20well%20...at%20the%20moment%20just%20remove%20the%20add_user%20method%3F%20So%20we%20can%20merge%20the%20delete_user%20function%2C%20now.%5Cr%5Cn%5Cr%5CnThanks%20a%20lot%20%5Cr%5CnCornelius%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-04-13T07%3A45%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ach.%20I%20will%20just%20merge%20it%20and%20modify%20it%20myself%20%3B-%29%5Cr%5CnNo%20need%20to%20bother%20you%21%5Cr%5CnTHanks%20a%20lot%21%22%2C%20%22created_at%22%3A%20%222016-04-13T07%3A49%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL654-661%22%7D%2C%20%22Pull%20669933b07d9e363ed20dc9814343ec1523560d42%20privacyidea/lib/resolvers/LDAPIdResolver.py%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59353039%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20need%20to%20call%5Cr%5Cn%5Cr%5Cn%20%20%20%20self.l.add%28self._getDN%28uid%29%2C%20object_class%2C%20params%29%5Cr%5Cn%5Cr%5CnOtherwise%20it%20will%20only%20work%2C%20if%20the%20uidtype%20is%20DN.%20If%20you%20are%20using%20uidtype%3DobjectGUID%2C%20the%20uid%20will%20be%20the%20objectGUID%20and%20it%20will%20fail.%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A20%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Don%27t%20know%20how%20I%20missed%20that%2C%20sorry.%5Cr%5CnI%27ll%20update%20the%20code.%5Cr%5Cn%5Cr%5CnMartin%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A31%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15330084%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wheldom01%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20has%20implication%20for%20the%20ldap3mock%20too%2C%20the%20modify%20method%20currently%20only%20supports%20dn.%5Cr%5CnHow%20do%20you%20want%20to%20handle%20the%20changes%3F%5Cr%5CnLooks%20like%20the%20following%20changes%20would%20be%20required%3A%5Cr%5Cn1.%20Add%20additional%20test%28s%29%20to%20handle%20add/delete/modify%20of%20users%20with%20alternative%20uidtypes%5Cr%5Cn2.%20Fix%20the%20ldap3mock%5Cr%5Cn%5Cr%5CnDoes%20this%20sound%20like%20it%20could%20be%20added%20to%20this%20pull%20request%20or%20would%20you%20prefer%20it%20separating%20out%3F%5Cr%5Cn%5Cr%5CnBest%20Regards%5Cr%5Cn%5Cr%5CnMartin%22%2C%20%22created_at%22%3A%20%222016-04-12T11%3A02%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15330084%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wheldom01%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20fixed%20this%20now%2C%20I%20was%20mistaken%20regarding%20the%20ldap3mock%20no%20%20changes%20required.%22%2C%20%22created_at%22%3A%20%222016-04-12T14%3A07%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15330084%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wheldom01%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL654-714%22%7D%2C%20%22Pull%20669933b07d9e363ed20dc9814343ec1523560d42%20privacyidea/lib/resolvers/LDAPIdResolver.py%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/371%23discussion_r59353160%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20we%20can%20move%20this%20to%20privacyidea.lib.utils%20later...%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A21%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Again%20no%20problem%2C%20there%20may%20be%20a%20case%20for%20supporting%20other%20hashing%20mechanisms%20too.%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A32%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15330084%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wheldom01%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20can%20take%20a%20look%20at%20this%20later.%20There%20are%20also%20several%20password%20hash%20thingys%20in%20the%20sql%20resolver.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-04-12T10%3A37%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL719-764%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cornelinux%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cornelinux'><img src='https://avatars.githubusercontent.com/u/1908620?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 669933b07d9e363ed20dc9814343ec1523560d42 privacyidea/lib/resolvers/LDAPIdResolver.py 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/371#discussion_r59353039'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L654-714</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> You need to call
self.l.add(self._getDN(uid), object_class, params)
Otherwise it will only work, if the uidtype is DN. If you are using uidtype=objectGUID, the uid will be the objectGUID and it will fail.
- <a href='https://github.com/wheldom01'><img border=0 src='https://avatars.githubusercontent.com/u/15330084?v=3' height=16 width=16'></a> Don't know how I missed that, sorry.
I'll update the code.
Martin
- <a href='https://github.com/wheldom01'><img border=0 src='https://avatars.githubusercontent.com/u/15330084?v=3' height=16 width=16'></a> This has implication for the ldap3mock too, the modify method currently only supports dn.
How do you want to handle the changes?
Looks like the following changes would be required:
1. Add additional test(s) to handle add/delete/modify of users with alternative uidtypes
2. Fix the ldap3mock
Does this sound like it could be added to this pull request or would you prefer it separating out?
Best Regards
Martin
- <a href='https://github.com/wheldom01'><img border=0 src='https://avatars.githubusercontent.com/u/15330084?v=3' height=16 width=16'></a> I've fixed this now, I was mistaken regarding the ldap3mock no  changes required.
- [ ] <a href='#crh-comment-Pull 669933b07d9e363ed20dc9814343ec1523560d42 privacyidea/lib/resolvers/LDAPIdResolver.py 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/371#discussion_r59353083'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L654-714</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Same here. Transform the uid to the DN with
self._getDN(uid)
- <a href='https://github.com/wheldom01'><img border=0 src='https://avatars.githubusercontent.com/u/15330084?v=3' height=16 width=16'></a> I'll update this one too.
- [ ] <a href='#crh-comment-Pull 669933b07d9e363ed20dc9814343ec1523560d42 privacyidea/lib/resolvers/LDAPIdResolver.py 88'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/371#discussion_r59353160'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L719-764</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> maybe we can move this to privacyidea.lib.utils later...
- <a href='https://github.com/wheldom01'><img border=0 src='https://avatars.githubusercontent.com/u/15330084?v=3' height=16 width=16'></a> Again no problem, there may be a case for supporting other hashing mechanisms too.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> I can take a look at this later. There are also several password hash thingys in the sql resolver.
- [ ] <a href='#crh-comment-Pull c3603f8f0e8a8d7a132811c35dc2e53fb3558dd6 privacyidea/lib/resolvers/LDAPIdResolver.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/371#discussion_r59505546'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L654-661</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> OK, I see the problem now, since the uid (being the objectGUID or whatever is not available).
But this does not work with the normal REST API and the Web UI. I would like to keep this transparent for the toplevel and thus I would like to avoid to change the signature of this method.
What do you think of this.
To be able to keep this transparent to the levels above we need to create the DN out of the given attributes.
Usually you would give the loginname during creation of the user, the givenName and or the surname.
Then the DN could either be created like:
CN=<givenname> <surname>, <baseDN>
or
CN=<loginname>, <baseDN>
To keep it simple, I would prefer to take the baseDN, which already exist. And then only define, what would be the creating attribute of the CN. (This would be an additional resolver parameter.)
Just tell me, what you think of this - I can do this later.
Till then, can you please remove the "dn" from the parameter list and... well ...at the moment just remove the add_user method? So we can merge the delete_user function, now.
Thanks a lot
Cornelius
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Ach. I will just merge it and modify it myself ;-)
No need to bother you!
THanks a lot!
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/371#issuecomment-208834741'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Thanks a lot, this is much clearer to read.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/371?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/371?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/371?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/371'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>