### PR TITLE
FIX: deb packages break Apache and FreeRADIUS sites.

### DIFF
--- a/deploy/debian-jessie/privacyidea-radius.postinst
+++ b/deploy/debian-jessie/privacyidea-radius.postinst
@@ -35,7 +35,6 @@ HERE
 }
 
 activate_site() {
-	rm /etc/freeradius/sites-enabled/*
 	ln -s /etc/freeradius/sites-available/privacyidea /etc/freeradius/sites-enabled/	
 }
 

--- a/deploy/debian-ubuntu/privacyidea-apache2.postinst
+++ b/deploy/debian-ubuntu/privacyidea-apache2.postinst
@@ -95,7 +95,6 @@ create_database() {
 }
 
 enable_apache() {
-        rm -f /etc/apache2/sites-enabled/*
         a2enmod wsgi
         a2enmod headers
         a2enmod ssl

--- a/deploy/debian-ubuntu/privacyidea-radius.postinst
+++ b/deploy/debian-ubuntu/privacyidea-radius.postinst
@@ -35,7 +35,6 @@ HERE
 }
 
 activate_site() {
-	rm /etc/freeradius/sites-enabled/*
 	ln -s /etc/freeradius/sites-available/privacyidea /etc/freeradius/sites-enabled/	
 }
 


### PR DESCRIPTION
FIX: deb packages break Apache and FreeRADIUS sites.
Deb packages "privacyidea-apache2" and "privacyidea-radius" have
"rm -f /etc/apache2/sites-enabled/*" and "rm /etc/freeradius/sites-enabled/*"
in "postinst" files.
This disable all Apache VirtualHost and FreeRADIUS VirtualServers.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/373?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/373'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>