### PR TITLE
Fixed rendering issues in Create new policy page

### DIFF
--- a/privacyidea/static/components/config/views/config.policies.details.html
+++ b/privacyidea/static/components/config/views/config.policies.details.html
@@ -78,14 +78,16 @@
 
     <div class="text-center"
          ng-show="checkRight('policywrite')">
-        <button ng-click="createPolicy()"
-                id="createPolicyButton"
-                ng-disabled="formPolicyAdd.$invalid"
-                class="btn btn-primary">
-            <div class="glyphicon glyphicon-plus" translate>
-                Create Policy
-            </div>
-        </button>
+        <p>
+            <button ng-click="createPolicy()"
+                    id="createPolicyButton"
+                    ng-disabled="formPolicyAdd.$invalid"
+                    class="btn btn-primary">
+                <div class="glyphicon glyphicon-plus" translate>
+                    Create Policy
+                </div>
+            </button>
+        </p>
     </div>
 
     <div class="form-group">
@@ -139,75 +141,91 @@
             </div>
             <div ng-show="isActionValues">
                 <table class="table table-hover">
-                    <tr ng-repeat="action in actions">
-                        <td>
-                            <label for="cb_{{ action.name }}">
-                            <input type="checkbox" name="{{ action.name }}"
-                                   ng-model="actionCheckBox[action.name]"
-                                    id="cb_{{ action.name }}">
-                                {{ action.name }}
-                            </label>
-                        </td>
-
-                        <td class="policyaction">
-                            <select class="form-control"
-                                    ng-show="action.allowedValues && action.type=='str'"
-                                    ng-model="actionValuesStr[action.name]"
-                                    ng-disabled="!actionCheckBox[action.name]"
-                                    name="action.name"
-                                    ng-options="select for select in action
-                                    .allowedValues"
-                                    >
-                            </select>
-                            <select class="form-control"
-                                    ng-show="action.allowedValues && action.type=='int'"
-                                    ng-model="actionValuesNum[action.name]"
-                                    ng-disabled="!actionCheckBox[action.name]"
-                                    name="action.name"
-                                    ng-options="select for select in action
-                                    .allowedValues"
-                                    >
-                            </select>
-                            <select class="form-control"
-                                    ng-show="action.allowedValues && action.type=='text'"
-                                    ng-model="actionValuesText[action.name]"
-                                    ng-disabled="!actionCheckBox[action.name]"
-                                    name="action.name"
-                                    ng-options="select for select in action
-                                    .allowedValues"
-                                    >
-                            </select>
-                            <input type="text"
-                                   placeholder="text..."
-                                   ng-model="actionValuesStr[action.name]"
-                                   ng-show="action.type=='str' && !action.allowedValues"
-                                   ng-disabled="!actionCheckBox[action.name]"
-                                   ng-required="actionCheckBox[action.name] &&
-                                   action.type=='str'"
-                                   class="form-control"/>
-                            <input type="number"
-                                   ng-model="actionValuesNum[action.name]"
-                                   ng-show="action.type=='int' && !action.allowedValues"
-                                   ng-disabled="!actionCheckBox[action.name]"
-                                   ng-required="actionCheckBox[action.name] &&action
-                                   .type=='num'"
-                                   class="form-control"/>
-                            <textarea
-                                   ng-model="actionValuesText[action.name]"
-                                   ng-show="action.type=='text' && !action.allowedValues"
-                                   ng-disabled="!actionCheckBox[action.name]"
-                                   ng-required="actionCheckBox[action.name] &&action
-                                   .type=='text'"
-                                   class="form-control"></textarea>
-                        </td>
-                        <td>
-                            <!-- This is the description of the policy action
-                             -->
-                            <p class="help help-block">
-                                {{ action.desc }}
-                            </p>
-                        </td>
-                    </tr>
+                    <thead>
+                        <tr>
+                            <th translate=""></th>
+                            <th translate="">
+                               <span class="ng-scope">Permission</span>
+                            </th>
+                            <th translate=""></th>
+                            <th translate="">
+                               <span class="ng-scope">Description</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr ng-repeat="action in actions">
+                            <td>
+                                <input type="checkbox" name="selectAll"
+                                       ng-click="toggleAll"
+                                       ng-model="actionCheckBox[action.name]">
+                            </td>
+                            <td>
+                                <label for="cb_{{ action.name }}">
+                                    {{ action.name }}
+                                </label>
+                            </td>
+    
+                            <td class="policyaction">
+                                <select class="form-control"
+                                        ng-show="action.allowedValues && action.type=='str'"
+                                        ng-model="actionValuesStr[action.name]"
+                                        ng-disabled="!actionCheckBox[action.name]"
+                                        name="action.name"
+                                        ng-options="select for select in action
+                                        .allowedValues"
+                                        >
+                                </select>
+                                <select class="form-control"
+                                        ng-show="action.allowedValues && action.type=='int'"
+                                        ng-model="actionValuesNum[action.name]"
+                                        ng-disabled="!actionCheckBox[action.name]"
+                                        name="action.name"
+                                        ng-options="select for select in action
+                                        .allowedValues"
+                                        >
+                                </select>
+                                <select class="form-control"
+                                        ng-show="action.allowedValues && action.type=='text'"
+                                        ng-model="actionValuesText[action.name]"
+                                        ng-disabled="!actionCheckBox[action.name]"
+                                        name="action.name"
+                                        ng-options="select for select in action
+                                        .allowedValues"
+                                        >
+                                </select>
+                                <input type="text"
+                                       placeholder="text..."
+                                       ng-model="actionValuesStr[action.name]"
+                                       ng-show="action.type=='str' && !action.allowedValues"
+                                       ng-disabled="!actionCheckBox[action.name]"
+                                       ng-required="actionCheckBox[action.name] &&
+                                       action.type=='str'"
+                                       class="form-control"/>
+                                <input type="number"
+                                       ng-model="actionValuesNum[action.name]"
+                                       ng-show="action.type=='int' && !action.allowedValues"
+                                       ng-disabled="!actionCheckBox[action.name]"
+                                       ng-required="actionCheckBox[action.name] &&action
+                                       .type=='num'"
+                                       class="form-control"/>
+                                <textarea
+                                       ng-model="actionValuesText[action.name]"
+                                       ng-show="action.type=='text' && !action.allowedValues"
+                                       ng-disabled="!actionCheckBox[action.name]"
+                                       ng-required="actionCheckBox[action.name] &&action
+                                       .type=='text'"
+                                       class="form-control"></textarea>
+                            </td>
+                            <td>
+                                <!-- This is the description of the policy action
+                                 -->
+                                <p class="help help-block">
+                                    {{ action.desc }}
+                                </p>
+                            </td>
+                        </tr>
+                    <tbody>
                 </table>
             </div>
         </div>
@@ -285,14 +303,16 @@
 
     <div class="text-center"
          ng-show="checkRight('policywrite')">
-        <button ng-click="createPolicy()"
-                id="createPolicyButton"
-                ng-disabled="formPolicyAdd.$invalid"
-                class="btn btn-primary">
-            <div class="glyphicon glyphicon-plus" translate>
-                Create Policy
-            </div>
-        </button>
+        <p>
+            <button ng-click="createPolicy()"
+                    id="createPolicyButton"
+                    ng-disabled="formPolicyAdd.$invalid"
+                    class="btn btn-primary">
+                <div class="glyphicon glyphicon-plus" translate>
+                    Create Policy
+                </div>
+            </button>
+        </p>
     </div>
 
 </form>


### PR DESCRIPTION
This patch fixes the table rendering by separating the checkbox into a additional table column.
It also adds white space around the create policy buttons.

Best Regards

Martin
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/374%23issuecomment-209837044%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/374%23issuecomment-209843612%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/374%23issuecomment-209867198%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/374%23issuecomment-209837044%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22HI%20Martin%2C%5Cr%5Cn%5Cr%5Cnthanks%20for%20digging%20down%20into%20all%20the%20code%20and%20your%20time.%5Cr%5CnBut%20can%20you%20tell%20me%2C%20which%20issue%20this%20PR%20is%20supposed%20to%20fix%3F%5Cr%5Cn%5Cr%5CnOn%20the%20other%20hand%20I%20realize%20another%20issue%20with%20this%20PR.%20The%20text%20next%20to%20the%20checkboxes%20is%20the%20label%20of%20the%20checkboxes.%20Thus%20you%20can%20also%20click%20the%20text%20to%20enable%20the%20checkbox.%20This%20is%20not%20possible%20with%20your%20commit%20anymore%20-%20and%20I%20would%20like%20to%20keep%20it%20that%20way%2C%20since%20it%20is%20easier%20to%20use.%5Cr%5Cn%5Cr%5CnKind%20regards%5Cr%5CnCornelius%22%2C%20%22created_at%22%3A%20%222016-04-14T09%3A01%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20Cornelius%2C%5Cr%5Cn%5Cr%5CnSorry%20I%20hadn%27t%20picked%20up%20on%20that%20functionality%2C%20I%27ll%20take%20another%20look%20this%20evening%20and%20see%20if%20I%20can%20restore%20that%20functionality%20with%20the%20additional%20table%20column.%5Cr%5CnIt%20was%20designed%20to%20stop%20the%20shifting%20of%20the%20checkboxes%20when%20the%20policy%20attribute%20is%20longer%20that%20the%20table%20cell.%20%5Cr%5Cn%5Cr%5CnOn%20a%20more%20general%20note%20regarding%20the%20web%20UI%20there%20seems%20to%20be%20quite%20a%20few%20inconsistencies%20with%20table%20formatting.%20I%20would%20like%20to%20see%20some%20more%20consistency%2C%20but%20would%20like%20a%20steer%20on%20how%20you%20would%20like%20to%20see%20them%20formatted.%20At%20the%20moment%20some%20have%20borders%20and%20others%20don%27t.%5Cr%5CnIf%20you%20let%20me%20know%20which%20table%28s%29%20are%20how%20you%20would%20like%20to%20see%20them.%5Cr%5CnI%20would%20also%20like%20to%20remove%20some%20information%20from%20some%20of%20the%20tables%2C%20for%20example%20removing%20the%20id%20from%20the%20user%20table%20and%20tidy%20up%20the%20raw%20python%20lists%20for%20mobile%20number%20etc..%5Cr%5Cn%5Cr%5CnAgain%20I%27m%20more%20than%20happy%20to%20provide%20patches.%20Should%20I%20raise%20a%20Web%20UI%20issue%20to%20capture%20this%20type%20of%20detail%3F%5Cr%5Cn%5Cr%5CnBest%20Regards%5Cr%5Cn%5Cr%5CnMartin%22%2C%20%22created_at%22%3A%20%222016-04-14T09%3A18%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15330084%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wheldom01%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sounds%20sensible%20to%20me.%20So%20we%20can%20discuss%20what%20needs%20to%20be%20improved%20and%20how.%22%2C%20%22created_at%22%3A%20%222016-04-14T10%3A21%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/374#issuecomment-209837044'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> HI Martin,
thanks for digging down into all the code and your time.
But can you tell me, which issue this PR is supposed to fix?
On the other hand I realize another issue with this PR. The text next to the checkboxes is the label of the checkboxes. Thus you can also click the text to enable the checkbox. This is not possible with your commit anymore - and I would like to keep it that way, since it is easier to use.
Kind regards
Cornelius
- <a href='https://github.com/wheldom01'><img border=0 src='https://avatars.githubusercontent.com/u/15330084?v=3' height=16 width=16'></a> Hi Cornelius,
Sorry I hadn't picked up on that functionality, I'll take another look this evening and see if I can restore that functionality with the additional table column.
It was designed to stop the shifting of the checkboxes when the policy attribute is longer that the table cell.
On a more general note regarding the web UI there seems to be quite a few inconsistencies with table formatting. I would like to see some more consistency, but would like a steer on how you would like to see them formatted. At the moment some have borders and others don't.
If you let me know which table(s) are how you would like to see them.
I would also like to remove some information from some of the tables, for example removing the id from the user table and tidy up the raw python lists for mobile number etc..
Again I'm more than happy to provide patches. Should I raise a Web UI issue to capture this type of detail?
Best Regards
Martin
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Sounds sensible to me. So we can discuss what needs to be improved and how.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/374?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/374?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/374'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>