### PR TITLE
Added example to authenitcation.rst

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -209,6 +209,11 @@ matter what OTP PIN he enters, a policy might look like this::
 
    action: mangle=pass/.*(.{6})/\\1/
 
+**Example**: If you want to strip a string from the front of a username, for
+example to have "admin_username" resolve to just "username", it would look like
+this::
+
+   action: mangle=user/admin_(.*)/\\1/
 
 .. _policy_challenge_response:
 


### PR DESCRIPTION
As requested (https://github.com/privacyidea/privacyidea/issues/387#issuecomment-214764360), added example to mangle section
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/389?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/389'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>