### PR TITLE
add rewrite to apache and nginx config to provide /wsapi/2.0/verify

### DIFF
--- a/deploy/apache/sites-available/privacyidea.conf
+++ b/deploy/apache/sites-available/privacyidea.conf
@@ -11,6 +11,14 @@
 		AllowOverride None
 	</Directory>
 
+        # Yubico servers use /wsapi/2.0/verify as the path in the
+        # validation URL. Some tools (e.g. Kolab 2fa) let the 
+        # user/admin change the api host, but not the rest of
+        # the URL. Uncomment the following two lines to reroute 
+        # the api URL internally to privacyideas /ttype/yubikey.
+        #RewriteEngine  on
+        #RewriteRule    "^/wsapi/2.0/verify"  "/ttype/yubikey" [PT]
+
 	# We can run several instances on different paths with different configurations
 	WSGIScriptAlias /      /etc/privacyidea/privacyideaapp.wsgi
 	#WSGIScriptAlias /instance1      /home/cornelius/src/privacyidea/deploy/privacyideaapp1.wsgi
@@ -55,3 +63,17 @@
 
 
 </VirtualHost>
+
+# If you want to forward http request to https enable the
+# following virtual host.
+#<VirtualHost _default_:80>
+#	# This will enable the Rewrite capabilities
+#	RewriteEngine On
+#
+#	# This checks to make sure the connection is not already HTTPS
+#	RewriteCond %{HTTPS} !=on
+#	RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+#</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet
+

--- a/deploy/nginx/sites-available/privacyidea
+++ b/deploy/nginx/sites-available/privacyidea
@@ -1,8 +1,10 @@
-server {
-        listen  80;
-        server_name     $hostname;
-        return 301 https://$hostname$request_uri;
-}
+# If you want to forward http request to https enable the
+# following virtual server.
+#server {
+#        listen  80;
+#        server_name     $hostname;
+#        return 301 https://$hostname$request_uri;
+#}
 
 server {
         listen 443 ssl;
@@ -21,5 +23,13 @@ server {
                 uwsgi_param     SERVER_SOFTWARE nginx/$nginx_version;
                 uwsgi_param SCRIPT_NAME '';
         }
+
+        # Yubico servers use /wsapi/2.0/verify as the path in the
+        # validation URL. Some tools (e.g. Kolab 2fa) let the 
+        # user/admin change the api host, but not the rest of
+        # the URL. Uncomment the following two lines to reroute 
+        # the api URL internally to privacyideas /ttype/yubikey.
+        #rewrite ^/wsapi/2.0/verify(.*)  /ttype/yubikey$1 last;
+
 }
 


### PR DESCRIPTION
Yubico servers use /wsapi/2.0/verify as the path in the
validation URL. Some tools (e.g. Kolab 2fa) let the
user/admin change the api host, but not the rest of
the URL. Let's redirect the api URL to privacyideas
/ttype/yubikey, but we add the configuration only as a comment,
so it's easy to add when needed, but initially inactive.

Until now only the nginx configuration redirected http requests
to https, but not the apache config. Let's add the redirect for
apache too.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/396%23issuecomment-216971550%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/396%23issuecomment-216979559%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/396%23issuecomment-216980080%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/396%23issuecomment-217003646%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/396%23issuecomment-217006624%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/396%23issuecomment-216971550%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20one%20part%20of%20the%20pull%20request%20https%3A//github.com/privacyidea/privacyidea/pull/382%2C%5Cr%5Cnonly%20updates%20to%20the%20web%20server%20configuration.%22%2C%20%22created_at%22%3A%20%222016-05-04T19%3A16%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A96.55%25%2A%2A%5Cn%3E%20Merging%20%5B%23396%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20not%20change%20coverage%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23396%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20105%20%20%20%20%20%20%20%20105%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2012244%20%20%20%20%20%2012244%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%2011822%20%20%20%20%20%2011822%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20422%20%20%20%20%20%20%20%20422%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5B26b4b7b...148b316%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/compare/26b4b7b8562aec9c2e1d657f199fdc543f6a9b32...148b316db5a03656a5eb32adc256b2a1916a2ab2%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/pull/396%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-05-04T19%3A42%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Splitting%20docs%20and%20config%20in%20two%20PRs%20is%20a%20good%20idea.%5Cr%5CnBut%20I%20would%20like%20to%20remove%20the%20port%2080%20virtual%20host%20from%20the%20apache%20config%2C%20as%20this%20might%20lead%20to%20unexpected%20results%20at%20certain%20installations.%5Cr%5CnThanks%20a%20lot%5Cr%5CnCornelius%22%2C%20%22created_at%22%3A%20%222016-05-04T19%3A44%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20we%20remove%20port%2080%20from%20nginx%20too%3F%20We%20have%20this%3A%5Cr%5Cn%5Cr%5Cnserver%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20listen%20%2080%3B%5Cr%5Cn%20%20%20%20%20%20%20%20server_name%20%20%20%20%20%24hostname%3B%5Cr%5Cn%20%20%20%20%20%20%20%20return%20301%20https%3A//%24hostname%24request_uri%3B%5Cr%5Cn%7D%5Cr%5Cn%5Cr%5CnI%20think%20we%20should%20try%20to%20keep%20nginx%20and%20apache%20configuration%5Cr%5Cnsimilar.%20And%20I%20personally%20find%20it%20useful%20that%20I%20get%20redirected%20to%20the%5Cr%5Cnworking%20https-site%20instead%20of%20an%20empty%20index%20page%20when%20calling%5Cr%5Cnhttp%3A//pi.example.org.%5Cr%5Cn%5Cr%5CnI%20see%20three%20possible%20ways%20forward%3A%5Cr%5Cn1.%20both%20nginx%20and%20apache%20forward%20me%20from%20http%20to%20https%5Cr%5Cn2.%20both%20servers%20don%27t%20have%20port%2080%20at%20all%5Cr%5Cn3.%20ngingx%20does%2C%20but%20apache%20doesn%27t%20%28that%27s%20what%20we%20have%20now%29%5Cr%5Cn%5Cr%5CnJust%20confirm%20you%20really%20want%203%20and%20I%27ll%20amend%20the%20commit.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-04T21%3A09%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20might%20not%20be%20the%20best%20situation%20here.%20But%20there%20are%20some%20installations%20relying%20on%20a%20smooth%20update.%20%28Ok%2C%20touch%5Cu00e9%20-%20the%20update%20would%20not%20overwrite%20the%20the%20apache%20config%29.%5Cr%5Cn%5Cr%5CnBut%20I%20got%20complains%20lately%2C%20that%20the%20privacyidea-apache2%20package%20does%20%5C%22too%20much%5C%22.%20And%20listening%20on%20port%2080%2C%20which%20is%20not%20necessary%2C%20is%20%5C%22too%20much%5C%22%2C%20too.%20Someone%20might%20run%20another%20website%20or%20application%20on%20this%20port%20with%20another%20site%20config.%20This%20is%20why%20I%20would%20not%20want%20port%2080%20to%20be%20included...%5Cr%5Cn%5Cr%5Cn...this%20is%20just%20historical%20reasons%2C%20that%20nginx%20does%20it%20but%20apache%20doesn%27t%20do%20it.%5Cr%5CnToday%20I%20would%20probably%20let%20nginx%20NOT%20do%20it.%20I%20would%20probably%20split%20up%20the%20whole%20config%20stuff.%20%28see%20%23376%20-%20other%20story%29.%5Cr%5Cn%5Cr%5CnI%20would%20comment%20the%20forwarding%2080-%3E443%2C%20so%20that%20in%20case%20someone%20needs%20it%2C%20it%20can%20be%20quickly%20activated.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-04T21%3A21%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/396#issuecomment-216971550'>General Comment</a></b>
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars.githubusercontent.com/u/4837658?v=3' height=16 width=16'></a> This is one part of the pull request https://github.com/privacyidea/privacyidea/pull/382,
only updates to the web server configuration.
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **96.55%**
> Merging [#396][cc-pull] into [master][cc-base-branch] will not change coverage
```diff
@@             master       #396   diff @@
==========================================
Files           105        105
Lines         12244      12244
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
Hits          11822      11822
Misses          422        422
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [26b4b7b...148b316][cc-compare]
[cc-base-branch]: https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/privacyidea/privacyidea/compare/26b4b7b8562aec9c2e1d657f199fdc543f6a9b32...148b316db5a03656a5eb32adc256b2a1916a2ab2
[cc-pull]: https://codecov.io/gh/privacyidea/privacyidea/pull/396?src=pr
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Splitting docs and config in two PRs is a good idea.
But I would like to remove the port 80 virtual host from the apache config, as this might lead to unexpected results at certain installations.
Thanks a lot
Cornelius
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars.githubusercontent.com/u/4837658?v=3' height=16 width=16'></a> Should we remove port 80 from nginx too? We have this:
server {
listen  80;
server_name     $hostname;
return 301 https://$hostname$request_uri;
}
I think we should try to keep nginx and apache configuration
similar. And I personally find it useful that I get redirected to the
working https-site instead of an empty index page when calling
http://pi.example.org.
I see three possible ways forward:
1. both nginx and apache forward me from http to https
2. both servers don't have port 80 at all
3. ngingx does, but apache doesn't (that's what we have now)
Just confirm you really want 3 and I'll amend the commit.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> It might not be the best situation here. But there are some installations relying on a smooth update. (Ok, touché - the update would not overwrite the the apache config).
But I got complains lately, that the privacyidea-apache2 package does "too much". And listening on port 80, which is not necessary, is "too much", too. Someone might run another website or application on this port with another site config. This is why I would not want port 80 to be included...
...this is just historical reasons, that nginx does it but apache doesn't do it.
Today I would probably let nginx NOT do it. I would probably split up the whole config stuff. (see #376 - other story).
I would comment the forwarding 80->443, so that in case someone needs it, it can be quickly activated.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/396?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/396?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/396'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>