### PR TITLE
Fix token pagination on custom token page sizes

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -23,6 +23,7 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
                                               instanceUrl,
                                               $rootScope, gettextCatalog,
                                               hotkeys) {
+    $scope.tokensPerPage = $scope.token_page_size;
     $scope.params = {page: 1, sortdir: "asc"};
     $scope.reverse = false;
     $scope.loggedInUser = AuthFactory.getUser();

--- a/privacyidea/static/components/token/views/token.list.html
+++ b/privacyidea/static/components/token/views/token.list.html
@@ -1,10 +1,10 @@
-<pagination ng-show="tokendata.count > 15"
+<pagination ng-show="tokendata.count > tokensPerPage"
             total-items="tokendata.count" ng-model="params.page"
             previous-text="{{ 'Previous'|translate }}"
             next-text="{{ 'Next'|translate }}"
             last-text="{{ 'Last'|translate }}"
             first-text="{{ 'First'|translate }}"
-            items-per-page="15"
+            items-per-page="{{ tokensPerPage }}" 
             max-size="5"
             boundary-links="true" ng-change="pageChanged()"></pagination>
 


### PR DESCRIPTION
While setting up a custom token page size, the web ui token pagination shows a wrong count of pages (with possibly empty pages). This fixes the problem.

The fix was tested manually and works flawlessly.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/405?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/405'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>