### PR TITLE
Rewrite of ldap3mock search method

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -399,7 +399,7 @@ class IdResolver (UserIdResolver):
                 comperator = ">="
                 if searchDict[search_key] in ["1", 1]:
                     comperator = "<="
-                filter += "(|({0!s}{1!s}{2!s})({3!s}!=0))".format(self.userinfo[search_key],
+                filter += "(&({0!s}{1!s}{2!s})(!({3!s}=0)))".format(self.userinfo[search_key],
                                                   comperator,
                                                   get_ad_timestamp_now(),
                                                   self.userinfo[search_key])

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
                 "sphinxcontrib-httpdomain>=1.3.0"],
         'test': ["coverage>=3.7.1",
                  "mock>=1.0.1",
+                 "pyparsing>=2.0.3",
                  "nose>=1.3.4",
                  "responses>=0.4.0",
                  "six>=1.8.0"],

--- a/tests/ldap3mock.py
+++ b/tests/ldap3mock.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 """
+2016-05-26 Martin Wheldon <martin.wheldon@greenhills-it.co.uk>
+           Rewrite of search functionality to add recursive parsing
+           of ldap search filters
+           Fixed issue searching for attributes with multiple values
+           Added ability to use ~= in searches
+           Created unittests for mock
 2016-02-19 Cornelius Kölbel <cornelius.koelbel@netknights.it>
            Add the possibility to check objectGUID
 2015-01-31 Change responses.py to be able to run with SMTP
@@ -31,6 +37,8 @@ from ast import literal_eval
 import hashlib
 import ldap3
 from ldap3.utils.conv import check_escape
+import re
+import pyparsing
 
 try:
     from six import cStringIO as BufferIO
@@ -124,6 +132,12 @@ class Connection(object):
         self.directory = copy.deepcopy(directory)
         self.bound = False
         self.extend = self.Extend(self)
+
+        self.operation = {
+                    "!" : self._search_not,
+                    "&" : self._search_and,
+                    "|" : self._search_or,
+            }
 
     def set_directory(self, directory):
         self.directory = directory
@@ -243,77 +257,382 @@ class Connection(object):
 
         return True
 
+    @staticmethod
+    def _match_greater_than_or_equal(search_base, attribute, value, candidates):
+        matches = list()
+        for entry in candidates:
+            dn = entry.get("dn")
+            if not dn.endswith(search_base):
+                continue
+
+            value_from_directory = entry.get("attributes").get(attribute)
+            if str(value_from_directory) >= str(value):
+                entry["type"] = "searchResEntry"
+                matches.append(entry)
+
+        return matches
+
+    @staticmethod
+    def _match_greater_than(search_base, attribute, value, candidates):
+        matches = list()
+        for entry in candidates:
+            dn = entry.get("dn")
+            if not dn.endswith(search_base):
+                continue
+
+            value_from_directory = entry.get("attributes").get(attribute)
+            if str(value_from_directory) > str(value):
+                entry["type"] = "searchResEntry"
+                matches.append(entry)
+
+        return matches
+
+    @staticmethod
+    def _match_less_than_or_equal(search_base, attribute, value, candidates):
+        matches = list()
+        for entry in candidates:
+            dn = entry.get("dn")
+            if not dn.endswith(search_base):
+                continue
+
+            value_from_directory = entry.get("attributes").get(attribute)
+            if str(value_from_directory) <= str(value):
+                entry["type"] = "searchResEntry"
+                matches.append(entry)
+
+        return matches
+
+    @staticmethod
+    def _match_less_than(search_base, attribute, value, candidates):
+        matches = list()
+        for entry in candidates:
+            dn = entry.get("dn")
+            if not dn.endswith(search_base):
+                continue
+
+            value_from_directory = entry.get("attributes").get(attribute)
+            if str(value_from_directory) < str(value):
+                entry["type"] = "searchResEntry"
+                matches.append(entry)
+
+        return matches
+
+    @staticmethod
+    def _match_equal_to(search_base, attribute, value, candidates):
+        matches = list()
+        regex = value.replace('*', '.*')
+        if value == regex:
+            regex = check_escape(value)
+
+        for entry in candidates:
+            dn = entry.get("dn")
+
+            if not attribute in entry.get("attributes") \
+                or not dn.endswith(search_base):
+
+                continue
+
+            values_from_directory = entry.get("attributes").get(attribute)
+            if isinstance(values_from_directory, list):
+                for item in values_from_directory:
+                    m = re.match(regex, str(item), re.I)
+                    if m:
+                        entry["type"] = "searchResEntry"
+                        matches.append(entry)
+            else:
+                m = re.match(regex, str(values_from_directory), re.I)
+                if m:
+                    entry["type"] = "searchResEntry"
+                    matches.append(entry)
+
+        return matches
+
+    @staticmethod
+    def _match_notequal_to(search_base, attribute, value, candidates):
+        matches = list()
+        regex = value.replace('*', '.*')
+        if value == regex:
+            regex = check_escape(value)
+
+        for entry in candidates:
+            dn = entry.get("dn")
+
+            if not dn.endswith(search_base):
+                continue
+
+            values_from_directory = entry.get("attributes").get(attribute)
+            if isinstance(values_from_directory, list):
+                for item in values_from_directory:
+                    m = re.match(regex, str(item), re.I)
+                    if not m:
+                        entry["type"] = "searchResEntry"
+                        matches.append(entry)
+            else:
+                m = re.match(regex, str(values_from_directory), re.I)
+                if not m:
+                    entry["type"] = "searchResEntry"
+                    matches.append(entry)
+
+        return matches
+
+    @staticmethod
+    def _parse_filter():
+        op = pyparsing.oneOf('! & |')
+        lpar  = pyparsing.Literal('(').suppress()
+        rpar  = pyparsing.Literal(')').suppress()
+
+        k = pyparsing.Word(pyparsing.alphanums)
+        v = pyparsing.Word(pyparsing.alphanums + "*@.\\")
+        rel = pyparsing.oneOf("= ~= >= <=")
+
+        expr = pyparsing.Forward()
+        atom = pyparsing.Group(lpar + op + expr + rpar) \
+                            | pyparsing.Combine(lpar + k + rel + v + rpar)
+        expr << atom + pyparsing.ZeroOrMore( expr )
+
+        return expr
+
+    @staticmethod
+    def _deDuplicate(results):
+        found = dict()
+        deDuped = list()
+        for entry in results:
+            dn = entry.get("dn")
+            if not dn in found.keys():
+                found[dn] = 1
+                deDuped.append(entry)
+
+        return deDuped
+
+    def _invert_results(self, candidates):
+        inverted_candidates = list(self.directory)
+
+        for candidate in candidates:
+            try:
+                inverted_candidates.remove(candidate)
+            except ValueError:
+                pass
+
+        return inverted_candidates
+
+    def _search_not(self, base, search_filter, candidates=None):
+        # Create empty candidates list as we need to use self.directory for
+        # each search
+        candidates = list()
+        this_filter = list()
+
+        index = 0
+        search_filter.remove("!")
+        for condition in search_filter:
+            if not isinstance(condition, list):
+                this_filter.append(condition)
+            index +=1
+
+        # Remove this_filter items from search_filter list
+        for condition in this_filter:
+            search_filter.remove(condition)
+
+        try:
+            search_filter = list(search_filter[0])
+            for sub_filter in search_filter:
+                if not isinstance(sub_filter, list):
+                    if sub_filter == "&":
+                        candidates = self.operation.get(sub_filter) \
+                                                            (base,
+                                                             search_filter,
+                                                             candidates)
+                    else:
+                        candidates = self.operation.get(sub_filter) \
+                                                            (base,
+                                                             search_filter)
+                else:
+                    if sub_filter == "&":
+                        candidates = self.operation.get(sub_filter[0]) \
+                                                            (base,
+                                                             sub_filter,
+                                                             candidates)
+                    else:
+                        candidates = self.operation.get(sub_filter[0]) \
+                                                            (base,
+                                                             sub_filter)
+        except IndexError:
+            pass
+
+        candidates = self._invert_results(candidates)
+
+        for item in this_filter:
+            if "!" in item or "&" in item or "|" in item:
+                continue
+
+            if ">=" in item:
+                k, v = item.split(">=")
+                candidates = Connection._match_less_than(base, k, v,
+                                                            self.directory)
+            elif "<=" in item:
+                k, v = item.split("<=")
+                candidates = Connection._match_greater_than(base, k, v,
+                                                         self.directory)
+            # Emulate AD functionality, same as "="
+            elif "~=" in item:
+                k, v = item.split("~=")
+                candidates = Connection._match_notequal_to(base, k, v,
+                                                         self.directory)
+            elif "=" in item:
+                k, v = item.split("=")
+                candidates = Connection._match_notequal_to(base, k, v,
+                                                         self.directory)
+        return candidates
+
+    def _search_and(self, base, search_filter, candidates=None):
+        # Load the data from the directory, if we arn't passed any
+        if candidates == [] or candidates == None:
+            candidates = self.directory
+        this_filter = list()
+
+        index = 0
+        search_filter.remove("&")
+        for condition in search_filter:
+            if not isinstance(condition, list):
+                this_filter.append(condition)
+            index +=1
+
+        # Remove this_filter items from search_filter list
+        for condition in this_filter:
+            search_filter.remove(condition)
+
+        try:
+            search_filter = list(search_filter[0])
+            for sub_filter in search_filter:
+                if not isinstance(sub_filter, list):
+                    if sub_filter == "&":
+                        candidates = self.operation.get(sub_filter) \
+                                                            (base,
+                                                             search_filter,
+                                                             candidates)
+                    else:
+                        candidates = self.operation.get(sub_filter) \
+                                                            (base,
+                                                             search_filter)
+                else:
+                    if sub_filter == "&":
+                        candidates = self.operation.get(sub_filter[0]) \
+                                                            (base,
+                                                             sub_filter,
+                                                             candidates)
+                    else:
+                        candidates = self.operation.get(sub_filter[0]) \
+                                                            (base, sub_filter)
+        except IndexError:
+            pass
+
+        for item in this_filter:
+            if "!" in item or "&" in item or "|" in item:
+                continue
+
+            if ">=" in item:
+                k, v = item.split(">=")
+                candidates = Connection._match_greater_than_or_equal(base, k, v,
+                                                                     candidates)
+            elif "<=" in item:
+                k, v = item.split("<=")
+                candidates = Connection._match_less_than_or_equal(base, k, v,
+                                                                  candidates)
+            # Emulate AD functionality, same as "="
+            elif "~=" in item:
+                k, v = item.split("~=")
+                candidates = Connection._match_equal_to(base, k, v,
+                                                         candidates)
+            elif "=" in item:
+                k, v = item.split("=")
+                candidates = Connection._match_equal_to(base, k, v,
+                                                         candidates)
+        return candidates
+
+    def _search_or(self, base, search_filter, candidates=None):
+        # Create empty candidates list as we need to use self.directory for
+        # each search
+        candidates = list()
+        this_filter = list()
+
+        index = 0
+        search_filter.remove("|")
+        for condition in search_filter:
+            if not isinstance(condition, list):
+                this_filter.append(condition)
+            index +=1
+
+        # Remove this_filter items from search_filter list
+        for condition in this_filter:
+            search_filter.remove(condition)
+
+        try:
+            search_filter = list(search_filter[0])
+            for sub_filter in search_filter:
+                if not isinstance(sub_filter, list):
+                    if sub_filter == "&":
+                        candidates += self.operation.get(sub_filter) \
+                                                             (base,
+                                                              search_filter,
+                                                              candidates)
+                    else:
+                        candidates += self.operation.get(sub_filter) \
+                                                             (base,
+                                                              search_filter)
+                else:
+                    if sub_filter == "&":
+                        candidates += self.operation.get(sub_filter[0]) \
+                                                             (base,
+                                                              sub_filter,
+                                                              candidates)
+                    else:
+                        candidates += self.operation.get(sub_filter[0]) \
+                                                             (base,
+                                                              sub_filter)
+        except IndexError:
+            pass
+
+        for item in this_filter:
+            if "!" in item or "&" in item or "|" in item:
+                continue
+
+            if ">=" in item:
+                k, v = item.split(">=")
+                candidates += Connection._match_greater_than_or_equal(base, k, v,
+                                                             self.directory)
+            elif "<=" in item:
+                k, v = item.split("<=")
+                candidates += Connection._match_less_than_or_equal(base, k, v,
+                                                          self.directory)
+            # Emulate AD functionality, same as "="
+            elif "~=" in item:
+                k, v = item.split("~=")
+                candidates += Connection._match_equal_to(base, k, v,
+                                                         self.directory)
+            elif "=" in item:
+                k, v = item.split("=")
+                candidates += Connection._match_equal_to(base, k, v,
+                                                         self.directory)
+        return candidates
+
     def search(self, search_base=None, search_scope=None,
                search_filter=None, attributes=None, paged_size=5,
                size_limit=0, paged_cookie=None):
-        self.response = []
-        self.result = {}
-        condition = {}
-        # (&(cn=*)(cn=bob)) -> (cn=*)(cn=bob)
-        search_filter = search_filter[2:-1]
-        while search_filter:
-            pos = search_filter.find(')')+1
-            cur = search_filter[0:pos]
-            cur = cur[1:-1]
-            cur = cur.strip("|").strip("(").strip(")")
-            if cur:
-                (k, v) = cur.split("=")
-                if v != "*":
-                    condition[k] = check_escape(v)
-            search_filter = search_filter[pos:]
-        for entry in self.directory:
-            dn = entry.get("dn")
-            if dn.endswith(search_base):
-                # The entry is in the correct search base
-                # NOTE: Checking condition works only for one condition
-                found = True
-                for k, v in condition.iteritems():
-                    try:
-                        lesser = False
-                        unequal = False
-                        if k.endswith("<"):
-                            lesser = True
-                            k = k.strip("<")
-                        if k.endswith("!"):
-                            unequal = True
-                            k = k.strip("!")
-                        if k in entry.get("attributes").keys():
-                            if unequal:
-                                ldap_value = entry.get("attributes").get(k)
-                                requested_value = int(v)
-                                found = found and (ldap_value !=
-                                                   requested_value)
-                            elif lesser:
-                                # first we try <=
-                                ldap_value = entry.get("attributes").get(k)
-                                requested_value = int(v)
-                                # If the LDAP value is greater, then we do not
-                                # return this entry
-                                found = found and (ldap_value < requested_value)
-                            elif entry.get("attributes").get(k) == v:
-                                # exact matching
-                                found = found and True
-                            elif "*" in v:
-                                # rough substring matching
-                                # We assume, that there are only leading and
-                                # trailing asterisks
-                                v = v.replace("*", "")
-                                if v not in entry.get("attributes").get(k, ""):
-                                    found = False
-                            else:
-                                found = found and False
-                        else:
-                            # The entry does not have such an attribute at all!
-                            found = False
-                    except UnicodeDecodeError:
-                        # This happens when we check for a "*" in the binary
-                        # string as it occurs in objectGUID
-                        print("OK, some potential objectGUID exception. But "
-                              "this is OK")
-                        found = False
-                if found:
-                    entry["type"] = "searchResEntry"
-                    self.response.append(entry)
+        s_filter = list()
+        candidates = list()
+        self.response = list()
+        self.result = dict()
+
+        try:
+            expr = Connection._parse_filter()
+            s_filter = expr.parseString(search_filter).asList()[0]
+        except pyparsing.ParseBaseException:
+            pass
+
+        for item in s_filter:
+            if item[0] in self.operation:
+                candidates = self.operation.get(item[0])(search_base,
+                                                         s_filter)
+        self.response = Connection._deDuplicate(candidates)
 
         return True
 

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -36,7 +36,7 @@ LDAPDirectory = [{"dn": "cn=alice,ou=example,o=test",
                                 "email": "alice@test.com",
                                 "accountExpires": 131024988000000000,
                                 "objectGUID": '\xef6\x9b\x03\xc0\xe7\xf3B'
-                                              '\x9b\xf9\xcajl\rMw1',
+                                              '\x9b\xf9\xcajl\rM1',
                                 'mobile': ["1234", "45678"]}},
                 {"dn": 'cn=bob,ou=example,o=test',
                  "attributes": {'cn': 'bob',

--- a/tests/test_mock_ldap3.py
+++ b/tests/test_mock_ldap3.py
@@ -1,0 +1,951 @@
+#-*- coding: utf-8 -*-
+"""
+This test file tests the test.ldap3mock
+"""
+
+import unittest
+import ldap3
+import ldap3mock
+
+LDAPDirectory = [{"dn": "cn=alice,ou=example,o=test",
+                 "attributes": {'cn': 'alice',
+                                "sn": "Cooper",
+                                "givenName": "Alice",
+                                'userPassword': 'alicepw',
+                                'oid': "2",
+                                "homeDirectory": "/home/alice",
+                                "email": "alice@test.com",
+                                "accountExpires": 9223372036854775805,
+                                "objectGUID": '\xfd\x9a\xd9\x9dxvL\x81\x9b3;'
+                                              '\x1c\xd6\x8aq\x01',
+                                'mobile': ["1234", "45678"]}},
+                {"dn": 'cn=mini,ou=example,o=test',
+                 "attributes": {'cn': 'mini',
+                                "sn": "Cooper",
+                                "givenName": "Mini",
+                                'userPassword': 'minipw',
+                                'oid': "2",
+                                "homeDirectory": "/home/mini",
+                                "email": "mini@test.com",
+                                "accountExpires": 0,
+                                "objectGUID": '\x1a\xe3\xfd\x9e\xbd\xaeCq'
+                                              '\x97\xed!\x87\xeb\xa5i$',
+                                'mobile': ["1234", "45678"]}},
+                {"dn": 'cn=bob,ou=example,o=test',
+                 "attributes": {'cn': 'bob',
+                                "sn": "Marley",
+                                "givenName": "Robert",
+                                "email": "bob@example.com",
+                                "mobile": "123456",
+                                "homeDirectory": "/home/bob",
+                                'userPassword': 'bobpwééé',
+                                "accountExpires": 9223372036854775807,
+                                "objectGUID": '\xef6\x9b\x03\xc0\xe7\xf3B'
+                                              '\x9b\xf9\xcajl\rMw',
+                                'oid': "3"}},
+                {"dn": 'cn=manager,ou=example,o=test',
+                 "attributes": {'cn': 'manager',
+                                "givenName": "Corny",
+                                "sn": "keule",
+                                "email": "ck@o",
+                                "mobile": "123354",
+                                "accountExpires": 9223372036854775808,
+                                'userPassword': 'ldaptest',
+                                "objectGUID": '\xef6\x9b\x03\xc0\xe7\xf3B'
+                                              '\x9b\xf9\xcajl\rMT',
+                                'oid': "1"}}]
+
+class LDAPMockTestCase(unittest.TestCase):
+    """
+    Test the ldap3mock
+    """
+
+    @ldap3mock.activate
+    def setUp(self):
+        ldap3mock.setLDAPDirectory(LDAPDirectory)
+
+        host = "localhost"
+        u = "manager"
+        p = "ldaptest"
+        self.base = "o=test"
+
+        srv = ldap3.Server(host, port=389, use_ssl=False, connect_timeout=5)
+        self.c = ldap3.Connection(srv, user=u, password=p,
+                                  auto_referrals=False,
+                                  client_strategy=ldap3.SYNC, check_names=True,
+                                  authentication=ldap3.SIMPLE, auto_bind=False)
+        self.c.open()
+        self.c.bind()
+
+    def tearDown(self):
+        self.c.unbind()
+
+    def test_00_wrong_basedn(self):
+
+        s = "(&(cn=*))"
+        base = "o=invalid"
+        self.c.search(search_base=base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+        s = "(!(cn=*))"
+        base = "o=invalid"
+        self.c.search(search_base=base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+        s = "(|(cn=*)(sn=*))"
+        base = "o=invalid"
+        self.c.search(search_base=base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+    def test_01_invalid_attribute(self):
+
+        s = "(&(invalid=*))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+    def test_02_invalid_search_string(self):
+
+        s = "(&cn=*))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+        s = "(&(cn=*)sn=*)"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+    def test_03_simple_AND_simple_EQUAL_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=bob))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=bob))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        s = "(&(sn=Cooper))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        s = "(&(sn~=Cooper))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(objectGUID=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(objectGUID~=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(email=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(email~=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(&(accountExpires=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(&(accountExpires~=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_04_simple_AND_wildcard_EQUAL_condition(self):
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=bo*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=bo*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=*ob))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=*ob))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=b*b))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=b*b))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+
+    def test_05_simple_AND_simple_GREATER_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(oid>=3))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(&(accountExpires>=9223372036854775808))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_06_simple_AND_simple_LESS_condition(self):
+        dn = "cn=manager,ou=example,o=test"
+        s = "(&(oid<=1))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        s = "(&(accountExpires<=9223372036854775805))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+    def test_07_multi_AND(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(oid>=2)(sn=Marley))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=bob)(sn=*e*)(accountExpires>=100))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_08_simple_NOT_simple_EQUAL_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn=Cooper))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn~=Cooper))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(objectGUID=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(objectGUID~=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(email=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(email~=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=bob,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(accountExpires=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=bob,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(accountExpires~=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+    def test_09_simple_NOT_wildcard_EQUAL_condition(self):
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn=Coope*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn~=Coope*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn=*ooper))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn~=*ooper))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn=Co*er))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn~=Co*er))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+    def test_10_simple_NOT_simple_GREATER_condition(self):
+        dn = "cn=manager,ou=example,o=test"
+        s = "(!(oid>=2))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(!(accountExpires>=1))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_11_simple_NOT_simple_LESS_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(!(oid<=2))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(!(accountExpires<=9223372036854775807))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_12_multi_NOT(self):
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=bob,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(&(sn~=Cooper)(cn=mini)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(!(|(cn~=bob)(sn=*le*)(accountExpires>=100)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_13_simple_OR_simple_EQUAL_condition(self):
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(cn=mini))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(cn~=mini))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(objectGUID=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(objectGUID~=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(email=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(email~=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(accountExpires=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(accountExpires~=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_14_simple_OR_wildcard_EQUAL_condition(self):
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn=manage*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn~=manage*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn=*anager))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn~=*anager))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn=ma*er))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn~=ma*er))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_15_simple_OR_simple_GREATER_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(oid>=3))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(accountExpires>=9223372036854775808))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_16_simple_OR_simple_LESS_condition(self):
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(oid<=1))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(accountExpires<=100))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_17_multi_OR(self):
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        s = "(|(oid>=3)(accountExpires=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        dn2 = "cn=mini,ou=example,o=test"
+        s = "(|(cn~=bob)(sn=ke*le)(accountExpires<=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+    def test_18_simple_AND_multi_value_attribute(self):
+
+        dn1 = "cn=alice,ou=example,o=test"
+        dn2 = "cn=mini,ou=example,o=test"
+        s = "(&(mobile=45678))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn1)
+        self.assertTrue(self.c.response[1].get("dn") == dn2)
+
+    def test_19_simple_OR_multi_value_attribute(self):
+
+        dn1 = "cn=alice,ou=example,o=test"
+        dn2 = "cn=mini,ou=example,o=test"
+        s = "(|(mobile=45678))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn1)
+        self.assertTrue(self.c.response[1].get("dn") == dn2)
+
+    @unittest.skip("SKIP: broken functionality")
+    def test_20_simple_NOT_multi_value_attribute(self):
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(mobile=45678))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn2)
+
+    @unittest.skip("SKIP: broken functionality")
+    def test_21_NOT_multi_OR_multi_value_attribute(self):
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(|(mobile=1234)(mobile=45678)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn2)
+
+    def test_22_two_levels_of_filter(self):
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=bob,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(|(accountExpires>=9223372036854775807)(!(accountExpires=0)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        s = "(&(accountExpires<=9223372036854775806)(!(accountExpires=0)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_23_three_levels_of_filter(self):
+        dn = "cn=alice,ou=example,o=test"
+        s = "(&(cn=*)(&(accountExpires<=9223372036854775806)(!(accountExpires=0))))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    @unittest.skip("SKIP: issue with wildcards in escaped strings")
+    def test_24_simple_AND_wild_problematic(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(objectGUID=\\ef\\36\\9b\\03*\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(objectGUID~=\\ef\\36\\9b\\03*\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(objectGUID=\\ef\\36\\9b\\03*\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(objectGUID~=\\ef\\36\\9b\\03*\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(!(objectGUID=\\ef\\36\\9b\\03*\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(!(objectGUID~=\\ef\\36\\9b\\03*\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(email=bob@e*)"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(email~=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(email=bob@e*)"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(email~=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(!(email=bob@e*)"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(!(email~=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)


### PR DESCRIPTION
Hi,

I've completely rewritten the ldap3mock search method so it now supports complex search filters. It can also handle ~= matches and mostly supports wildcards anywhere in the search string, some attribute types are currently broken for this. I've also added unittest for the mock which include some that are skipped due to the issues above.

Best Regards

Martin
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/413?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/413'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>