### PR TITLE
Rewrite of ldap3mock search method

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -399,7 +399,7 @@ class IdResolver (UserIdResolver):
                 comperator = ">="
                 if searchDict[search_key] in ["1", 1]:
                     comperator = "<="
-                filter += "(|({0!s}{1!s}{2!s})({3!s}!=0))".format(self.userinfo[search_key],
+                filter += "(&({0!s}{1!s}{2!s})(!({3!s}=0)))".format(self.userinfo[search_key],
                                                   comperator,
                                                   get_ad_timestamp_now(),
                                                   self.userinfo[search_key])

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
                 "sphinxcontrib-httpdomain>=1.3.0"],
         'test': ["coverage>=3.7.1",
                  "mock>=1.0.1",
+                 "pyparsing>=2.0.3",
                  "nose>=1.3.4",
                  "responses>=0.4.0",
                  "six>=1.8.0"],

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -36,7 +36,7 @@ LDAPDirectory = [{"dn": "cn=alice,ou=example,o=test",
                                 "email": "alice@test.com",
                                 "accountExpires": 131024988000000000,
                                 "objectGUID": '\xef6\x9b\x03\xc0\xe7\xf3B'
-                                              '\x9b\xf9\xcajl\rMw1',
+                                              '\x9b\xf9\xcajl\rM1',
                                 'mobile': ["1234", "45678"]}},
                 {"dn": 'cn=bob,ou=example,o=test',
                  "attributes": {'cn': 'bob',

--- a/tests/test_mock_ldap3.py
+++ b/tests/test_mock_ldap3.py
@@ -1,0 +1,911 @@
+#-*- coding: utf-8 -*-
+"""
+This test file tests the test.ldap3mock
+"""
+
+import unittest
+import ldap3
+import ldap3mock
+
+LDAPDirectory = [{"dn": "cn=alice,ou=example,o=test",
+                 "attributes": {'cn': 'alice',
+                                "sn": "Cooper",
+                                "givenName": "Alice",
+                                'userPassword': 'alicepw',
+                                'oid': "2",
+                                "homeDirectory": "/home/alice",
+                                "email": "alice@test.com",
+                                "accountExpires": 9223372036854775805,
+                                "objectGUID": '\xfd\x9a\xd9\x9dxvL\x81\x9b3;'
+                                              '\x1c\xd6\x8aq\x01',
+                                'mobile': ["1234", "45678"]}},
+                {"dn": 'cn=mini,ou=example,o=test',
+                 "attributes": {'cn': 'mini',
+                                "sn": "Cooper",
+                                "givenName": "Mini",
+                                'userPassword': 'minipw',
+                                'oid': "2",
+                                "homeDirectory": "/home/mini",
+                                "email": "mini@test.com",
+                                "accountExpires": 0,
+                                "objectGUID": '\x1a\xe3\xfd\x9e\xbd\xaeCq'
+                                              '\x97\xed!\x87\xeb\xa5i$',
+                                'mobile': ["1234", "45678"]}},
+                {"dn": 'cn=bob,ou=example,o=test',
+                 "attributes": {'cn': 'bob',
+                                "sn": "Marley",
+                                "givenName": "Robert",
+                                "email": "bob@example.com",
+                                "mobile": "123456",
+                                "homeDirectory": "/home/bob",
+                                'userPassword': 'bobpwééé',
+                                "accountExpires": 9223372036854775807,
+                                "objectGUID": '\xef6\x9b\x03\xc0\xe7\xf3B'
+                                              '\x9b\xf9\xcajl\rMw',
+                                'oid': "3"}},
+                {"dn": 'cn=manager,ou=example,o=test',
+                 "attributes": {'cn': 'manager',
+                                "givenName": "Corny",
+                                "sn": "keule",
+                                "email": "ck@o",
+                                "mobile": "123354",
+                                "accountExpires": 9223372036854775808,
+                                'userPassword': 'ldaptest',
+                                "objectGUID": '\xef6\x9b\x03\xc0\xe7\xf3B'
+                                              '\x9b\xf9\xcajl\rMT',
+                                'oid': "1"}}]
+
+class LDAPMockTestCase(unittest.TestCase):
+    """
+    Test the ldap3mock
+    """
+
+    @ldap3mock.activate
+    def setUp(self):
+        ldap3mock.setLDAPDirectory(LDAPDirectory)
+
+        host = "localhost"
+        u = "manager"
+        p = "ldaptest"
+        self.base = "o=test"
+
+        srv = ldap3.Server(host, port=389, use_ssl=False, connect_timeout=5)
+        self.c = ldap3.Connection(srv, user=u, password=p,
+                                  auto_referrals=False,
+                                  client_strategy=ldap3.SYNC, check_names=True,
+                                  authentication=ldap3.SIMPLE, auto_bind=False)
+        self.c.open()
+        self.c.bind()
+
+    def tearDown(self):
+        self.c.unbind()
+
+    def test_00_wrong_basedn(self):
+
+        s = "(&(cn=*))"
+        base = "o=invalid"
+        self.c.search(search_base=base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+        s = "(!(cn=*))"
+        base = "o=invalid"
+        self.c.search(search_base=base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+        s = "(|(cn=*)(sn=*))"
+        base = "o=invalid"
+        self.c.search(search_base=base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+    def test_01_invalid_attribute(self):
+
+        s = "(&(invalid=*))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+    def test_02_invalid_search_string(self):
+
+        s = "(&cn=*))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+        s = "(&(cn=*)sn=*)"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 0)
+
+    def test_03_simple_and_simple_equal_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=bob))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=bob))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        s = "(&(sn=Cooper))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        s = "(&(sn~=Cooper))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(objectGUID=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(objectGUID~=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(email=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(email~=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(&(accountExpires=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(&(accountExpires~=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_04_simple_and_wildcard_equal_condition(self):
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=bo*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=bo*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=*ob))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=*ob))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=b*b))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=b*b))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(email=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(email~=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_05_simple_and_simple_greater_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(oid>=3))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(&(accountExpires>=9223372036854775808))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_06_simple_and_simple_less_condition(self):
+        dn = "cn=manager,ou=example,o=test"
+        s = "(&(oid<=1))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        s = "(&(accountExpires<=9223372036854775805))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+    def test_07_multi_and(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(oid>=2)(sn=Marley))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn~=bob)(sn=*e*)(accountExpires>=100))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_08_simple_not_simple_equal_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn=Cooper))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn~=Cooper))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(objectGUID=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(objectGUID~=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(email=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(email~=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=bob,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(accountExpires=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=bob,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(accountExpires~=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+    def test_09_simple_not_wildcard_equal_condition(self):
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn=Coope*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn~=Coope*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn=*ooper))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn~=*ooper))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn=Co*er))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(sn~=Co*er))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(email=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(email~=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+    def test_10_simple_not_simple_greater_condition(self):
+        dn = "cn=manager,ou=example,o=test"
+        s = "(!(oid>=2))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(!(accountExpires>=1))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_11_simple_not_simple_less_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(!(oid<=2))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(!(accountExpires<=9223372036854775807))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_12_multi_not(self):
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=bob,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(!(&(sn~=Cooper)(cn=mini)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(!(|(cn~=bob)(sn=*le*)(accountExpires>=100)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_13_simple_or_simple_equal_condition(self):
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(cn=mini))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(cn~=mini))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(objectGUID=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(objectGUID~=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(email=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(email~=bob@example.com))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(accountExpires=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(accountExpires~=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_14_simple_or_wildcard_equal_condition(self):
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn=manage*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn~=manage*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn=*anager))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn~=*anager))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn=ma*er))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(cn~=ma*er))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(email=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(email~=bob@e*))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_15_simple_or_simple_greater_condition(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(|(oid>=3))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(accountExpires>=9223372036854775808))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_16_simple_or_simple_less_condition(self):
+        dn = "cn=manager,ou=example,o=test"
+        s = "(|(oid<=1))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=mini,ou=example,o=test"
+        s = "(|(accountExpires<=100))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_17_multi_or(self):
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=mini,ou=example,o=test"
+        s = "(|(oid>=3)(accountExpires=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        dn2 = "cn=mini,ou=example,o=test"
+        s = "(|(cn~=bob)(sn=ke*le)(accountExpires<=0))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+    def test_18_simple_and_multi_value_attribute(self):
+
+        dn1 = "cn=alice,ou=example,o=test"
+        dn2 = "cn=mini,ou=example,o=test"
+        s = "(&(mobile=45678))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn1)
+        self.assertTrue(self.c.response[1].get("dn") == dn2)
+
+    def test_19_simple_or_multi_value_attribute(self):
+
+        dn1 = "cn=alice,ou=example,o=test"
+        dn2 = "cn=mini,ou=example,o=test"
+        s = "(|(mobile=45678))"
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn1)
+        self.assertTrue(self.c.response[1].get("dn") == dn2)
+
+    def test_20_simple_not_multi_value_attribute(self):
+
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(mobile=45678))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+    def test_21_not_multi_or_multi_value_attribute(self):
+        dn = "cn=bob,ou=example,o=test"
+        dn1 = "cn=manager,ou=example,o=test"
+        s = "(!(|(mobile=1234)(mobile=45678)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 2)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+
+    def test_22_two_levels_of_filter(self):
+        dn = "cn=alice,ou=example,o=test"
+        dn1 = "cn=bob,ou=example,o=test"
+        dn2 = "cn=manager,ou=example,o=test"
+        s = "(|(accountExpires>=9223372036854775807)(!(accountExpires=0)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 3)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+        self.assertTrue(self.c.response[1].get("dn") == dn1)
+        self.assertTrue(self.c.response[2].get("dn") == dn2)
+
+        dn = "cn=alice,ou=example,o=test"
+        s = "(&(accountExpires<=9223372036854775806)(!(accountExpires=0)))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(cn=*)(objectGUID~=\\ef\\36\\9b\\03\\c0\\e7\\f3\\42\\9b\\f9\\ca\\6a\\6c\\0d\\4d\\77))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+    def test_23_three_levels_of_filter(self):
+        dn = "cn=alice,ou=example,o=test"
+        s = "(&(cn=*)(&(accountExpires<=9223372036854775806)(!(accountExpires=0))))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
+
+


### PR DESCRIPTION
Hi,

I've rewritten the search method to support recursive parsing of ldap filters added matching of "~=" conditions, fixed searching on attributes with multiple entries and extended wildcard searching to anywhere in the string rather than just start and end.

I also found a couple of bugs which I fixed, one in the data, a non unique objectGUID and a typo in the a search filter in the LDAP resolver code.

I hope you will find the changes useful?

Best Regards

Martin
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/414%23issuecomment-222504187%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/414%23discussion_r65083941%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/414%23discussion_r65086895%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/414%23issuecomment-222613143%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/414%23issuecomment-222504187%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A96.49%25%2A%2A%5Cn%3E%20Merging%20%5B%23414%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20not%20change%20coverage%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23414%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20109%20%20%20%20%20%20%20%20109%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2012589%20%20%20%20%20%2012589%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%2012147%20%20%20%20%20%2012147%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20442%20%20%20%20%20%20%20%20442%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5B2ac1aa7...c0e49cc%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/compare/2ac1aa73f738dd91f359c92312a770f4dcd392e2...c0e49ccc12ef1f639440ddf7606491b1fac561cb%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/pull/414%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-05-30T14%3A28%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20waiting%20for%20a%20customers%20feedback.%20So%20I%20will%20be%20able%20to%20merge%20this%20by%20the%20end%20of%20this%20week.%22%2C%20%22created_at%22%3A%20%222016-05-31T07%3A32%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c0e49ccc12ef1f639440ddf7606491b1fac561cb%20privacyidea/lib/resolvers/LDAPIdResolver.py%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/414%23discussion_r65083941%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Congratulations%21%20You%20have%20me%20confused%21%5Cr%5Cn%5C%22accountExpires%3D1%5C%22%20is%20used%20by%20this%20script.%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/master/tools/privacyidea-expired-users%5Cr%5Cn%5Cr%5CnIt%20does%20not%20actually%20check%2C%20if%20the%20account%20is%20expired.%20At%20least%20in%20the%20script.%5Cr%5CnThe%20script%20does%20it%20itself...%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/master/tools/privacyidea-expired-users%23L149%5Cr%5Cn%5Cr%5CnAnd%20then%3A%5Cr%5CnWhy%20use%20%28%21%28%7B3%21s%7D%3D0%29%29%20instead%20of%20%28%7B3%21s%7D%21%3D0%29%20%3F%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-30T15%3A11%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20due%20to%20the%20only%20valid%20condition%20matchers%20for%20a%20ldap%20search%20filter%20are%20%5C%22%7E%3D%20%3D%20%3E%3D%20%3C%3D%5C%22%2C%20not%20conditions%20are%20expressed%20as%20%28%21%28%7B3%21s%7D%3D0%29%29.%5Cr%5Cn%5Cr%5CnBest%20Regards%5Cr%5Cn%5Cr%5CnMartin%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-30T15%3A40%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/15330084%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wheldom01%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL399-406%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/414#issuecomment-222504187'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **96.49%**
> Merging [#414][cc-pull] into [master][cc-base-branch] will not change coverage
```diff
@@             master       #414   diff @@
==========================================
Files           109        109
Lines         12589      12589
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
Hits          12147      12147
Misses          442        442
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [2ac1aa7...c0e49cc][cc-compare]
[cc-base-branch]: https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/privacyidea/privacyidea/compare/2ac1aa73f738dd91f359c92312a770f4dcd392e2...c0e49ccc12ef1f639440ddf7606491b1fac561cb
[cc-pull]: https://codecov.io/gh/privacyidea/privacyidea/pull/414?src=pr
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> I am waiting for a customers feedback. So I will be able to merge this by the end of this week.
- [x] <a href='#crh-comment-Pull c0e49ccc12ef1f639440ddf7606491b1fac561cb privacyidea/lib/resolvers/LDAPIdResolver.py 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/414#discussion_r65083941'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L399-406</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Congratulations! You have me confused!
"accountExpires=1" is used by this script.
https://github.com/privacyidea/privacyidea/blob/master/tools/privacyidea-expired-users
It does not actually check, if the account is expired. At least in the script.
The script does it itself...
https://github.com/privacyidea/privacyidea/blob/master/tools/privacyidea-expired-users#L149
And then:
Why use (!({3!s}=0)) instead of ({3!s}!=0) ?
- <a href='https://github.com/wheldom01'><img border=0 src='https://avatars.githubusercontent.com/u/15330084?v=3' height=16 width=16'></a> This is due to the only valid condition matchers for a ldap search filter are "~= = >= <=", not conditions are expressed as (!({3!s}=0)).
Best Regards
Martin


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/414?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/414?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/414'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>