### PR TITLE
BUGFIX: empty realm; changed default realm

### DIFF
--- a/authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php
+++ b/authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php
@@ -94,7 +94,7 @@ class PrivacyideaService extends \TYPO3\CMS\Sv\AbstractAuthenticationService {
             }
             $this->privacyIDEAAuth = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('NetKnightsGmbH\privacyidea\PrivacyideaAuth',
             													$this->extConf["privacyIDEAURL"],
-            													$this->extConf["realm"],
+            													$this->extConf["privacyIDEARealm"],
             													$this->extConf["privacyIDEAsslcheck"]);            
             return $available;
         }

--- a/authmodules/TYPO3/privacyidea/ext_conf_template.txt
+++ b/authmodules/TYPO3/privacyidea/ext_conf_template.txt
@@ -11,7 +11,7 @@ privacyIDEAURL = https://localhost
 privacyIDEACertCheck = 0
 
 # cat=Server/Optional; type=string; label=privacyIDEA realm
-privacyIDEARealm = defrealm
+privacyIDEARealm = 
 
 # cat=Debug; type=boolean; label=Devlog: Write Debug Information to devlog
 devlog = 0

--- a/authmodules/TYPO3/privacyidea/ext_conf_template.txt
+++ b/authmodules/TYPO3/privacyidea/ext_conf_template.txt
@@ -11,7 +11,7 @@ privacyIDEAURL = https://localhost
 privacyIDEACertCheck = 0
 
 # cat=Server/Optional; type=string; label=privacyIDEA realm
-privacyIDEARealm = ""
+privacyIDEARealm = defrealm
 
 # cat=Debug; type=boolean; label=Devlog: Write Debug Information to devlog
 devlog = 0


### PR DESCRIPTION
Thanks for this great extension! I have a small improvement :)
- extension template set default realm to literal "" instead of being empty. suggestion: set it to defrealm
- bugfix: realm empty, because wrong variable was read from extension template
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/418%23issuecomment-223642727%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23issuecomment-223703677%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23discussion_r65761826%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23discussion_r65762235%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23discussion_r65779250%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23discussion_r65781263%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23discussion_r65781264%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23issuecomment-223642727%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A96.47%25%2A%2A%5Cn%3E%20Merging%20%5B%23418%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20decrease%20coverage%20by%20%2A%2A%3C.01%25%2A%2A%5Cn%5Cn1.%20File%20%60...ea/lib/tokens/u2f.py%60%20%28not%20in%20diff%29%20was%20modified.%20%5Bmore%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/c0d019a062cd598efaeafea693f6d544dacc3223/changes%3Fsrc%3Dpr%2370726976616379696465612F6C69622F746F6B656E732F7532662E7079%29%20%5Cn%20%20-%20Misses%20%60%2B3%60%20%5Cn%20%20-%20Partials%20%600%60%20%5Cn%20%20-%20Hits%20%60-3%60%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23418%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20109%20%20%20%20%20%20%20%20109%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2012589%20%20%20%20%20%2012589%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%20%20%2012147%20%20%20%20%20%2012144%20%20%20%20%20-3%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20442%20%20%20%20%20%20%20%20445%20%20%20%20%20%2B3%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5Bc8a59f7...c0d019a%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/compare/c8a59f7af4d9a3814b4d4b8ccc053c0c8fcb4986...c0d019a062cd598efaeafea693f6d544dacc3223%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/pull/418%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-06-03T17%3A33%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-06-03T21%3A52%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c0d019a062cd598efaeafea693f6d544dacc3223%20authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23discussion_r65762235%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Your%20change%20is%20correct.%5Cr%5CnTHank%20you%21%22%2C%20%22created_at%22%3A%20%222016-06-03T19%3A22%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-06-03T21%3A52%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php%3AL94-101%22%7D%2C%20%22Pull%20c0d019a062cd598efaeafea693f6d544dacc3223%20authmodules/TYPO3/privacyidea/ext_conf_template.txt%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/418%23discussion_r65761826%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20is%20not%20sure%2C%20if%20you%20have%20a%20realm%20called%20%5C%22defrealm%5C%22.%20%5Cr%5CnPlease%20remove%20this%20again.%5Cr%5CnIf%20the%20realm%20is%20empty%20%28like%20it%20is%20configured%20originall%29%2C%20the%20default%20realm%20is%20used.%5Cr%5CnAn%20empty%20realm%20always%20means%20default%20realm.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-06-03T19%3A19%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%20I%20have%20tested%20it%20and%20if%20I%20leave%20it%20empty%20then%20the%20default%20realm%20is%20used.%20As%20a%20result%20this%20line%20should%20be%3A%5Cr%5Cn%60privacyIDEARealm%20%3D%20%60%22%2C%20%22created_at%22%3A%20%222016-06-03T21%3A34%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8084342%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jalr%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-06-03T21%3A52%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20authmodules/TYPO3/privacyidea/ext_conf_template.txt%3AL11-18%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/418#issuecomment-223642727'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **96.47%**
> Merging [#418][cc-pull] into [master][cc-base-branch] will decrease coverage by **<.01%**
1. File `...ea/lib/tokens/u2f.py` (not in diff) was modified. [more](https://codecov.io/gh/privacyidea/privacyidea/commit/c0d019a062cd598efaeafea693f6d544dacc3223/changes?src=pr#70726976616379696465612F6C69622F746F6B656E732F7532662E7079)
- Misses `+3`
- Partials `0`
- Hits `-3`
```diff
@@             master       #418   diff @@
==========================================
Files           109        109
Lines         12589      12589
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
- Hits          12147      12144     -3
- Misses          442        445     +3
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [c8a59f7...c0d019a][cc-compare]
[cc-base-branch]: https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/privacyidea/privacyidea/compare/c8a59f7af4d9a3814b4d4b8ccc053c0c8fcb4986...c0d019a062cd598efaeafea693f6d544dacc3223
[cc-pull]: https://codecov.io/gh/privacyidea/privacyidea/pull/418?src=pr
- [x] <a href='#crh-comment-Pull c0d019a062cd598efaeafea693f6d544dacc3223 authmodules/TYPO3/privacyidea/ext_conf_template.txt 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/418#discussion_r65761826'>File: authmodules/TYPO3/privacyidea/ext_conf_template.txt:L11-18</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> It is not sure, if you have a realm called "defrealm".
Please remove this again.
If the realm is empty (like it is configured originall), the default realm is used.
An empty realm always means default realm.
- <a href='https://github.com/jalr'><img border=0 src='https://avatars.githubusercontent.com/u/8084342?v=3' height=16 width=16'></a> OK I have tested it and if I leave it empty then the default realm is used. As a result this line should be:
`privacyIDEARealm = `
- [x] <a href='#crh-comment-Pull c0d019a062cd598efaeafea693f6d544dacc3223 authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/418#discussion_r65762235'>File: authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php:L94-101</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Your change is correct.
THank you!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/418?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/418?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/418'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>