### PR TITLE
Add option for BE auth: exclusive for admins

### DIFF
--- a/authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php
+++ b/authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php
@@ -82,7 +82,7 @@ class PrivacyideaService extends \TYPO3\CMS\Sv\AbstractAuthenticationService {
 		$this->logger->info("Initialize privacyIDEA");
 		$available = FALSE;
 		$this->extConf = unserialize ($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['privacyidea']);
-		if (isset($this->extConf['privacyIDEABackend']) && $this->extConf['privacyIDEABackend'] == 'always' && TYPO3_MODE == 'BE') {
+		if (isset($this->extConf['privacyIDEABackend']) && $this->extConf['privacyIDEABackend'] == 'allUsers' && TYPO3_MODE == 'BE') {
 			$this->logger->info("Authenticating with privacyIDEA at the Backend");
 			$available = TRUE;
 		} elseif (isset($this->extConf['privacyIDEABackend']) && $this->extConf['privacyIDEABackend'] == 'adminOnly' && TYPO3_MODE == 'BE') {

--- a/authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php
+++ b/authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php
@@ -82,8 +82,11 @@ class PrivacyideaService extends \TYPO3\CMS\Sv\AbstractAuthenticationService {
 		$this->logger->info("Initialize privacyIDEA");
 		$available = FALSE;
 		$this->extConf = unserialize ($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['privacyidea']);
-		if (isset($this->extConf['privacyIDEABackend']) && (bool)$this->extConf['privacyIDEABackend'] && TYPO3_MODE == 'BE') {
+		if (isset($this->extConf['privacyIDEABackend']) && $this->extConf['privacyIDEABackend'] == 'always' && TYPO3_MODE == 'BE') {
 			$this->logger->info("Authenticating with privacyIDEA at the Backend");
+			$available = TRUE;
+		} elseif (isset($this->extConf['privacyIDEABackend']) && $this->extConf['privacyIDEABackend'] == 'adminOnly' && TYPO3_MODE == 'BE') {
+			$this->logger->info("Authenticating with privacyIDEA at the Backend (Admin Users)");
 			$available = TRUE;
 		} elseif (isset($this->extConf['privacyIDEAFrontend']) && (bool)$this->extConf['privacyIDEAFrontend'] && TYPO3_MODE == 'FE') {
 			$this->logger->info("Authenticating with privacyIDEA at the Frontend");
@@ -110,23 +113,30 @@ class PrivacyideaService extends \TYPO3\CMS\Sv\AbstractAuthenticationService {
 	 * @return int authentication statuscode, one of 0, 100 and 200
 	 */
 	public function authUser(array $user) {
-		// 0 means authentication failure
-		$ret = 0;
-		$username = $this->login['uname'];
-		$password = $this->login['uident_text'];
-		$this->logger->info("try to authenticate user [$username]");
+		if ($this->extConf['privacyIDEABackend'] != 'adminOnly'
+			|| (bool)$user['admin']
+			|| $this->authInfo['loginType'] == 'FE'
+		) {
+			// 0 means authentication failure
+			$ret = 0;
+			$username = $this->login['uname'];
+			$password = $this->login['uident_text'];
+			$this->logger->info("try to authenticate user [$username]");
 
-		$authResult = $this->privacyIDEAAuth->checkOtp($username, $password);
+			$authResult = $this->privacyIDEAAuth->checkOtp($username, $password);
 
-		if ($authResult === TRUE) {
-			$ret = 200;
-		} else {
-			if ($this->extConf['privacyIDEApassthru']) {
-				$ret = 100;
-				$this->logger->info("privacyIDEA authentication failed, but passing to other authentication modules.");
+			if ($authResult === TRUE) {
+				$ret = 200;
 			} else {
-				$this->logger->error("Failed to authenticate $username");
+				if ($this->extConf['privacyIDEApassthru']) {
+					$ret = 100;
+					$this->logger->info("privacyIDEA authentication failed, but passing to other authentication modules.");
+				} else {
+					$this->logger->error("Failed to authenticate $username");
+				}
 			}
+		} else {
+			$ret = 100;
 		}
 		return $ret;
 	}

--- a/authmodules/TYPO3/privacyidea/Classes/Utility/ExtensionManagerConfigurationUtility.php
+++ b/authmodules/TYPO3/privacyidea/Classes/Utility/ExtensionManagerConfigurationUtility.php
@@ -40,7 +40,7 @@ class ExtensionManagerConfigurationUtility {
      * @return void
      */
 	private function init() {
-		$this->beModes = array('disabled', 'adminOnly', 'always');
+		$this->beModes = array('disabled', 'adminOnly', 'allUsers');
         $this->getLanguageService()->includeLLFile('EXT:privacyidea/Resources/Private/Language/locallang.xlf');
     }
 

--- a/authmodules/TYPO3/privacyidea/Classes/Utility/ExtensionManagerConfigurationUtility.php
+++ b/authmodules/TYPO3/privacyidea/Classes/Utility/ExtensionManagerConfigurationUtility.php
@@ -1,0 +1,76 @@
+<?php
+namespace NetKnightsGmbH\privacyidea\Utility;
+
+/***************************************************************
+ *
+ *  Copyright notice
+ *
+ *  (c) 2015 Cornelius Kölbel <cornelius.koelbel@netknights.it>, NetKnights GmbH
+ *           Jakob Lechner <mail@jalr.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+class ExtensionManagerConfigurationUtility {
+
+	/**
+     * @var array
+     */
+	protected $beModes = array();
+
+    /**
+     * Initializes this object.
+     *
+     * @return void
+     */
+	private function init() {
+		$this->beModes = array('disabled', 'adminOnly', 'always');
+        $this->getLanguageService()->includeLLFile('EXT:privacyidea/Resources/Private/Language/locallang.xlf');
+    }
+
+	/**
+	 * Renders a selector element that allows to select how privacyidea is used in backend
+     *
+     * @param array $params Field information to be rendered
+     * @param \TYPO3\CMS\Core\TypoScript\ConfigurationForm $pObj The calling parent object.
+     * @return string The HTML selector
+     */
+	public function buildBeModeSelector(array $params, $pObj) {
+		$this->init();
+
+        $propertyName = $params['propertyName'];
+        $pField = '';
+        $registeredMethods = \TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::getRegisteredSaltedHashingMethods();
+        foreach ($this->beModes as $beMode) {
+			$sel = ($params['fieldValue'] == $beMode ? ' selected="selected" ' : '');
+			$pField .= '<option value="' . htmlspecialchars($beMode) . '"' . $sel . '>' . $this->getLanguageService()->getLL('ext.privacyidea.beMode.' . $beMode) . '</option>';
+        }
+		$pField = '<select id="' . $propertyName . '" name="' . $params['fieldName'] . '" >' . $pField . '</select>';
+		return $pField;
+	}
+
+    /**
+     * @return \TYPO3\CMS\Lang\LanguageService
+     */
+    protected function getLanguageService() {
+        return $GLOBALS['LANG'];
+    }
+
+}
+

--- a/authmodules/TYPO3/privacyidea/Resources/Private/Language/locallang.xlf
+++ b/authmodules/TYPO3/privacyidea/Resources/Private/Language/locallang.xlf
@@ -12,7 +12,7 @@
 			<trans-unit id="ext.privacyidea.beMode.adminOnly">
 				<source>Only for administrators</source>
 			</trans-unit>
-			<trans-unit id="ext.privacyidea.beMode.always">
+			<trans-unit id="ext.privacyidea.beMode.allUsers">
 				<source>All backend users</source>
 			</trans-unit>
 		</body>

--- a/authmodules/TYPO3/privacyidea/Resources/Private/Language/locallang.xlf
+++ b/authmodules/TYPO3/privacyidea/Resources/Private/Language/locallang.xlf
@@ -6,6 +6,15 @@
 			<trans-unit id="tx_privacyidea_domain_model_privacyideaauth">
 				<source>Privacy I D E A Auth</source>
 			</trans-unit>
+			<trans-unit id="ext.privacyidea.beMode.disabled">
+				<source>Disabled</source>
+			</trans-unit>
+			<trans-unit id="ext.privacyidea.beMode.adminOnly">
+				<source>Only for administrators</source>
+			</trans-unit>
+			<trans-unit id="ext.privacyidea.beMode.always">
+				<source>All backend users</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/authmodules/TYPO3/privacyidea/Resources/Private/Language/locallang_em.xlf
+++ b/authmodules/TYPO3/privacyidea/Resources/Private/Language/locallang_em.xlf
@@ -6,6 +6,24 @@
 			<trans-unit id="privacyidea.config.privacyIDEABackend">
 				<source>Enable privacyIDEA authentication for TYPO3 backend users</source>
 			</trans-unit>
+			<trans-unit id="privacyidea.config.privacyIDEAFrontend">
+				<source>Enable privacyIDEA authentication for TYPO3 frontend users</source>
+			</trans-unit>
+			<trans-unit id="privacyidea.config.privacyIDEAURL">
+				<source>privacyIDEA Server URL: This is the base URL part of the privacyIDEA server. You do not need to add the trailing "validate/check" part.</source>
+			</trans-unit>
+			<trans-unit id="privacyidea.config.privacyIDEACertCheck">
+				<source>Check certificate: We recommend that you always check the certificate in productive environments. Otherwise the authentication could suffer from a MitM attack.</source>
+			</trans-unit>
+			<trans-unit id="privacyidea.config.privacyIDEARealm">
+				<source>privacyIDEA realm</source>
+			</trans-unit>
+			<trans-unit id="privacyidea.config.devlog">
+				<source>Devlog: Write Debug Information to devlog</source>
+			</trans-unit>
+			<trans-unit id="privacyidea.config.privacyIDEApassthru">
+				<source>Pass to other authentication module:In case that privacyIDEA fails to authenticate the user the authentication request is passed to the next authentication module.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/authmodules/TYPO3/privacyidea/Resources/Private/Language/locallang_em.xlf
+++ b/authmodules/TYPO3/privacyidea/Resources/Private/Language/locallang_em.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
+	<file t3:id="2371932330" source-language="en" datatype="plaintext" original="messages" date="2016-06-07T02:38:00Z" product-name="privacyidea">
+		<header/>
+		<body>
+			<trans-unit id="privacyidea.config.privacyIDEABackend">
+				<source>Enable privacyIDEA authentication for TYPO3 backend users</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/authmodules/TYPO3/privacyidea/ext_conf_template.txt
+++ b/authmodules/TYPO3/privacyidea/ext_conf_template.txt
@@ -1,5 +1,5 @@
-# cat=Server/Enable; type=boolean; label=Enable privacyIDEA authentication for TYPO3 backend users
-privacyIDEABackend = 1
+# cat=Server/enable; type=user[EXT:privacyidea/Classes/Utility/ExtensionManagerConfigurationUtility.php:NetKnightsGmbH\privacyidea\Utility\ExtensionManagerConfigurationUtility->buildBeModeSelector]; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.privacyIDEABackend
+privacyIDEABackend = always
 
 # cat=Server/Enable; type=boolean; label=Enable privacyIDEA authentication for TYPO3 frontend users
 privacyIDEAFrontend = 0
@@ -16,5 +16,5 @@ privacyIDEARealm =
 # cat=Debug; type=boolean; label=Devlog: Write Debug Information to devlog
 devlog = 0
 
-# cat=Authentication; type=boolean; label=Pass to other authentication module:In case that privacyIDEA fails to authenticate the user the authentication request is passed to the next authentication module. 
+# cat=Authentication; type=boolean; label=Pass to other authentication module:In case that privacyIDEA fails to authenticate the user the authentication request is passed to the next authentication module.
 privacyIDEApassthru = 0

--- a/authmodules/TYPO3/privacyidea/ext_conf_template.txt
+++ b/authmodules/TYPO3/privacyidea/ext_conf_template.txt
@@ -1,5 +1,5 @@
 # cat=Server/enable; type=user[EXT:privacyidea/Classes/Utility/ExtensionManagerConfigurationUtility.php:NetKnightsGmbH\privacyidea\Utility\ExtensionManagerConfigurationUtility->buildBeModeSelector]; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.privacyIDEABackend
-privacyIDEABackend = always
+privacyIDEABackend = disabled
 
 # cat=Server/Enable; type=boolean; label=Enable privacyIDEA authentication for TYPO3 frontend users
 privacyIDEAFrontend = 0

--- a/authmodules/TYPO3/privacyidea/ext_conf_template.txt
+++ b/authmodules/TYPO3/privacyidea/ext_conf_template.txt
@@ -1,20 +1,20 @@
 # cat=Server/enable; type=user[EXT:privacyidea/Classes/Utility/ExtensionManagerConfigurationUtility.php:NetKnightsGmbH\privacyidea\Utility\ExtensionManagerConfigurationUtility->buildBeModeSelector]; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.privacyIDEABackend
 privacyIDEABackend = disabled
 
-# cat=Server/Enable; type=boolean; label=Enable privacyIDEA authentication for TYPO3 frontend users
+# cat=Server/Enable; type=boolean; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.privacyIDEAFrontend
 privacyIDEAFrontend = 0
 
-# cat=Server; type=string; label=privacyIDEA Server URL: This is the base URL part of the privacyIDEA server. You do not need to add the trailing "validate/check" part.
+# cat=Server; type=string; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.privacyIDEAURL
 privacyIDEAURL = https://localhost
 
-# cat=Server; type=boolean; label=Check certificate: We recommend that you always check the certificate in productive environments. Otherwise the authentication could suffer from a MitM attack.
+# cat=Server; type=boolean; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.privacyIDEACertCheck
 privacyIDEACertCheck = 0
 
-# cat=Server/Optional; type=string; label=privacyIDEA realm
+# cat=Server/Optional; type=string; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.privacyIDEARealm
 privacyIDEARealm = 
 
-# cat=Debug; type=boolean; label=Devlog: Write Debug Information to devlog
+# cat=Debug; type=boolean; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.devlog
 devlog = 0
 
-# cat=Authentication; type=boolean; label=Pass to other authentication module:In case that privacyIDEA fails to authenticate the user the authentication request is passed to the next authentication module.
+# cat=Authentication; type=boolean; label=LLL:EXT:privacyidea/Resources/Private/Language/locallang_em.xlf:privacyidea.config.privacyIDEApassthru
 privacyIDEApassthru = 0


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/422%23issuecomment-224306991%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66156085%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66165867%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66197867%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66199652%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66202734%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66209704%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66398748%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23issuecomment-224306991%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A96.46%25%2A%2A%5Cn%3E%20Merging%20%5B%23422%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20decrease%20coverage%20by%20%2A%2A0.02%25%2A%2A%5Cn%5Cn1.%20File%20%60...ea/lib/tokens/u2f.py%60%20%28not%20in%20diff%29%20was%20modified.%20%5Bmore%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/6d711e7f5fb04df3abe8e3449bfd18db1540b6a8/changes%3Fsrc%3Dpr%2370726976616379696465612F6C69622F746F6B656E732F7532662E7079%29%20%5Cn%20%20-%20Misses%20%60%2B3%60%20%5Cn%20%20-%20Partials%20%600%60%20%5Cn%20%20-%20Hits%20%60-3%60%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23422%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20109%20%20%20%20%20%20%20%20109%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2012588%20%20%20%20%20%2012588%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%20%20%2012146%20%20%20%20%20%2012143%20%20%20%20%20-3%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20442%20%20%20%20%20%20%20%20445%20%20%20%20%20%2B3%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5B8aa27f5...6d711e7%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/compare/8aa27f57894a8c1e657419e62aa7a671649404c7...6d711e7f5fb04df3abe8e3449bfd18db1540b6a8%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/pull/422%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-06-07T14%3A55%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206d711e7f5fb04df3abe8e3449bfd18db1540b6a8%20authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66156085%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Honestly%20I%20do%20not%20get%20this%20logic.%5Cr%5CnWhat%20do%20you%20want%20to%20achieve%3F%22%2C%20%22created_at%22%3A%20%222016-06-07T21%3A26%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22yeah%20this%20is%20really%20untransparent%20%3A%28%5Cr%5CnI%20want%20to%20do%20this%20check%3A%5Cr%5Cn%60%60%60%5Cr%5Cnif%20%28%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%28%24this-%3EauthInfo%5B%27loginType%27%5D%20%3D%3D%20%27BE%27%20%26%26%20%24this-%3EextConf%5B%27privacyIDEABackend%27%5D%20%3D%3D%20%27adminOnly%27%20%26%26%20%28bool%29%24user%5B%27admin%27%5D%29%20%7C%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%28%24this-%3EauthInfo%5B%27loginType%27%5D%20%3D%3D%20%27BE%27%20%26%26%20%24this-%3EextConf%5B%27privacyIDEABackend%27%5D%20%3D%3D%20%27always%27%29%20%7C%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%28%24this-%3EauthInfo%5B%27loginType%27%5D%20%3D%3D%20%27FE%27%29%5Cr%5Cn%29%5Cr%5Cn%60%60%60%5Cr%5CnBut%20in%20the%20init%28%29%20function%2C%20there%20is%20already%20checked%20whether%20to%20do%20the%20auth%20or%20not%20so%20we%20can%20omit%20a%20few%20checks.%20For%20reasons%20of%20readability%2C%20would%20the%20upper%20logic%20be%20a%20better%20solution%3F%22%2C%20%22created_at%22%3A%20%222016-06-07T22%3A42%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8084342%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jalr%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20you%20want%20%5Cr%5Cn%5Cr%5Cn%20%201.%20the%20frontend%20user%20to%20authenticate%20with%202%20factors.%5Cr%5Cn%20%202.%20All%20backend%20users%20with%202%20factors%2C%20if%20%5C%22always%5C%22%20is%20set.%5Cr%5Cn%20%203.%20Only%20backend%20admins%20with%202factor%2C%20it%20%5C%22adminonly%5C%22%20is%20set.%5Cr%5Cn%5Cr%5CnWhat%20is%20the%20sense%20in%20have%20non-admin%20users%20NOT%20authenticate%20with%202%20factors%20but%20with%20their%20normal%20password%3F%5Cr%5CnI%20would%20not%20distinguish%20this%2C%20because%2C%20if%20you%20want%20to%2C%20you%20can%20distinguish%20this%20in%20privacyIDEA.%5Cr%5CnIf%20you%20do%20not%20enroll%20tokens%20for%20the%20non-admin-BE-users%2C%20than%20these%20users%20could%20authenticate%20with%20their%20password.%5Cr%5Cn%5Cr%5CnIn%20my%20opinion%20it%20is%20more%20straight%20forward%20to%20say%3A%5Cr%5Cn%5Cr%5Cn%20%201.%20should%20BE%20users%20use%20privacyIDEA%5Cr%5Cn%20%202.%20should%20FE%20users%20use%20privacyIDEA%5Cr%5Cn%5Cr%5Cnand%20leave%20the%20more%20complicated%20logic%20to%20privacyidea.%22%2C%20%22created_at%22%3A%20%222016-06-08T06%3A18%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20want%20to%20use%20the%20extension%20in%20our%20agency%20because%20we%20have%20a%20few%20admin%20users%20which%20have%20access%20to%20all%20our%20installations.%20Using%20a%20central%20privacyIDEA%20server%20I%20can%20easily%20manage%20these%20users.%5Cr%5CnIf%20normal%20backend%20users%20are%20also%20checked%20via%20privacyIDEA%20I%20have%20to%20enable%20passthru%20and%20get%20an%20entry%20for%20every%20normal%20user%20who%20logs%20in.%22%2C%20%22created_at%22%3A%20%222016-06-08T06%3A40%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8084342%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jalr%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20right.%20Why%20do%20you%20want%20to%20avoid%20the%20log%20entries%3F%5Cr%5Cn%5Cr%5CnWould%20you%20mind%20to%20rename%20the%20%5C%22always%5C%22%20to%20%5C%22allUsers%5C%22.%20This%20way%20it%20is%20imho%20more%20clear%20having%20%5C%22adminsOnly%5C%22%20and%20%5C%22allUsers%5C%22.%20We%20should%20redesign%20the%20if-statement%20to%20have%20better%20readable%20code.%22%2C%20%22created_at%22%3A%20%222016-06-08T07%3A10%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20would%20like%20to%20have%20the%20adminOnly%20functionality%20because%3A%5Cr%5Cn-%20if%20the%20auth%20service%20is%20broken%2C%20normal%20users%20can%20still%20login%5Cr%5Cn-%20the%20audit%20would%20otherwise%20contain%20personal%20data%20%28IP%20addresses%29%20of%20our%20customers%5Cr%5Cn-%20I%20can%20distinguish%20between%20password%20logins%20and%20failed%202factor%20auths%20at%20first%20sight%5Cr%5Cn%5Cr%5Cn%5C%22allUsers%5C%22%20is%20a%20better%20term%2C%20changed%20it.%22%2C%20%22created_at%22%3A%20%222016-06-08T08%3A11%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8084342%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jalr%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php%3AL113-143%22%7D%2C%20%22Pull%20d20bdd7bd6a110bedcd34332f306bb0fae43175e%20authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/422%23discussion_r66398748%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20still%20do%20not%20get%2C%20why%20we%20need%20this%20if%3F%20And%20which%20condition%20it%20should%20check%21%5Cr%5Cn%5Cr%5CnIsn%27t%20the%20authUser%20Method%20called%2C%20when%20the%20init%20returned%20True.%20And%20if%20not%2C%20this%20method%20is%20not%20called%20at%20all.%5Cr%5CnSo%20we%20do%20not%20need%20this%20if%20at%20all.%20%28Was%20not%20there%20in%20the%20first%20place%20%3B-%29%22%2C%20%22created_at%22%3A%20%222016-06-09T08%3A13%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php%3AL113-143%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/422#issuecomment-224306991'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **96.46%**
> Merging [#422][cc-pull] into [master][cc-base-branch] will decrease coverage by **0.02%**
1. File `...ea/lib/tokens/u2f.py` (not in diff) was modified. [more](https://codecov.io/gh/privacyidea/privacyidea/commit/6d711e7f5fb04df3abe8e3449bfd18db1540b6a8/changes?src=pr#70726976616379696465612F6C69622F746F6B656E732F7532662E7079)
- Misses `+3`
- Partials `0`
- Hits `-3`
```diff
@@             master       #422   diff @@
==========================================
Files           109        109
Lines         12588      12588
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
- Hits          12146      12143     -3
- Misses          442        445     +3
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [8aa27f5...6d711e7][cc-compare]
[cc-base-branch]: https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/privacyidea/privacyidea/compare/8aa27f57894a8c1e657419e62aa7a671649404c7...6d711e7f5fb04df3abe8e3449bfd18db1540b6a8
[cc-pull]: https://codecov.io/gh/privacyidea/privacyidea/pull/422?src=pr
- [ ] <a href='#crh-comment-Pull 6d711e7f5fb04df3abe8e3449bfd18db1540b6a8 authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/422#discussion_r66156085'>File: authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php:L113-143</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Honestly I do not get this logic.
What do you want to achieve?
- <a href='https://github.com/jalr'><img border=0 src='https://avatars.githubusercontent.com/u/8084342?v=3' height=16 width=16'></a> yeah this is really untransparent :(
I want to do this check:
```
if (
($this->authInfo['loginType'] == 'BE' && $this->extConf['privacyIDEABackend'] == 'adminOnly' && (bool)$user['admin']) ||
($this->authInfo['loginType'] == 'BE' && $this->extConf['privacyIDEABackend'] == 'always') ||
($this->authInfo['loginType'] == 'FE')
)
```
But in the init() function, there is already checked whether to do the auth or not so we can omit a few checks. For reasons of readability, would the upper logic be a better solution?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> OK, you want
1. the frontend user to authenticate with 2 factors.
2. All backend users with 2 factors, if "always" is set.
3. Only backend admins with 2factor, it "adminonly" is set.
What is the sense in have non-admin users NOT authenticate with 2 factors but with their normal password?
I would not distinguish this, because, if you want to, you can distinguish this in privacyIDEA.
If you do not enroll tokens for the non-admin-BE-users, than these users could authenticate with their password.
In my opinion it is more straight forward to say:
1. should BE users use privacyIDEA
2. should FE users use privacyIDEA
and leave the more complicated logic to privacyidea.
- <a href='https://github.com/jalr'><img border=0 src='https://avatars.githubusercontent.com/u/8084342?v=3' height=16 width=16'></a> I want to use the extension in our agency because we have a few admin users which have access to all our installations. Using a central privacyIDEA server I can easily manage these users.
If normal backend users are also checked via privacyIDEA I have to enable passthru and get an entry for every normal user who logs in.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> This is right. Why do you want to avoid the log entries?
Would you mind to rename the "always" to "allUsers". This way it is imho more clear having "adminsOnly" and "allUsers". We should redesign the if-statement to have better readable code.
- <a href='https://github.com/jalr'><img border=0 src='https://avatars.githubusercontent.com/u/8084342?v=3' height=16 width=16'></a> I would like to have the adminOnly functionality because:
- if the auth service is broken, normal users can still login
- the audit would otherwise contain personal data (IP addresses) of our customers
- I can distinguish between password logins and failed 2factor auths at first sight
"allUsers" is a better term, changed it.
- [ ] <a href='#crh-comment-Pull d20bdd7bd6a110bedcd34332f306bb0fae43175e authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/422#discussion_r66398748'>File: authmodules/TYPO3/privacyidea/Classes/PrivacyideaService.php:L113-143</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> I still do not get, why we need this if? And which condition it should check!
Isn't the authUser Method called, when the init returned True. And if not, this method is not called at all.
So we do not need this if at all. (Was not there in the first place ;-)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/422?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/422?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/422'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>