### PR TITLE
fix thinko: no message if signature is ok

### DIFF
--- a/privacyidea/lib/tokens/yubicotoken.py
+++ b/privacyidea/lib/tokens/yubicotoken.py
@@ -178,9 +178,10 @@ class YubicoTokenClass(TokenClass):
                     # check signature:
                     signature_valid = yubico_check_api_signature(data, apiKey)
 
-                    if signature_valid:
-                        log.error("The hash of the return from the Yubico "
-                                  "Cloud server does not match the data!")
+                    if not signature_valid:
+                        log.error("The hash of the return from the yubico "
+                                  "authentication server ({0!s}) "
+                                  "does not match the data!".format(yubico_url))
 
                     if nonce != return_nonce:
                         log.error("The returned nonce does not match "


### PR DESCRIPTION
The old code read:
  if signature_valid: log error message

Correct is to use "if not signature_valid".

The log message now logs the validation server url,
so the user will know which server failed.  Talk
about "yubico authentication server" not "Yubico
Cloud server" - we might use a locally installed
server.

Closes #453.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/454?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/454'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>