### PR TITLE
Document option reneg-sec for openvpn

### DIFF
--- a/doc/application_plugins/openvpn.rst
+++ b/doc/application_plugins/openvpn.rst
@@ -26,6 +26,25 @@ The entered password is sent to privacyIDEA. Thus you can require the user to
 enter a password consisting of a static part he knows and the OTP part which
 the user needs to generate with the OTP token he possesses.
 
+Another addition you most probably want to make is adding the following option
+to both the client and the server configuration:
+
+   reneg-sec 0
+
+By default, the channel key gets renegotiated after 3600 seconds, either
+partner can request a renegotiation. If only one partner disables this
+option, the other one will request it. This works fine for static password
+or dual-factor authentication where both factors are static (e.g. password
+and certificate/smartcard).
+
+When using OTP authentication, note that this default value may cause the
+end user to be challenged to reauthorize once per hour. The OpenVPN client
+with the option --auth-user-pass prompts for username and password for
+every renegotiation.
+
+Network-Manager does not rechallenge the user and the VPN connection hangs,
+so you'll need to disabled the renegotiation.
+
 If you are also requiring client certificates, the user needs
 
    1. a machine certificate


### PR DESCRIPTION
Not using the option "reneg-sec 0" will either rechallenge the user
or just hang the session after an hour.

You can't push that option from the server, so you'll need to
add the option to both the client and the server.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/458%23issuecomment-231610499%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/458%23discussion_r70188252%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/458%23issuecomment-231827279%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/458%23issuecomment-231828379%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/458%23issuecomment-235388701%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/458%23issuecomment-235514026%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/458%23issuecomment-231610499%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A96.38%25%2A%2A%5Cn%3E%20Merging%20%5B%23458%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20decrease%20coverage%20by%20%2A%2A0.02%25%2A%2A%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23458%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20110%20%20%20%20%20%20%20%20110%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2012930%20%20%20%20%20%2012930%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%20%20%2012465%20%20%20%20%20%2012462%20%20%20%20%20-3%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20465%20%20%20%20%20%20%20%20468%20%20%20%20%20%2B3%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5B8d4ca10...1d1456f%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/compare/8d4ca10d35bcfd7978150bdbc77eef6f33cf6291...1d1456fb0017b16ffc26a2c1776fef173bcbb06e%3Fsrc%3Dpr%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/privacyidea/privacyidea/pull/458%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-07-10T20%3A58%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20from%20the%20OpenVPN%20documentation%2C%20but%20I%27ll%20probably%20change%20that.%5Cr%5CnCertificates%20don%27t%20change%2C%20so%20it%20would%20stay%20valid%20and%20renegotiation%20would%20work.%5Cr%5Cn%5BI%27ll%20probably%20try%20that%20next%20week%5D.%5Cr%5Cn%5Cr%5CnRight%20now%20I%20see%20the%20following%20options%20as%20needed%20for%20OTP%20secured%20OpenVPN%20sessions%3A%5Cr%5Cn%5Cr%5Cn-%20For%20the%20OpenVPN%20server%3A%20add%20%5C%22reneg-sec%200%5C%22%5Cr%5Cn-%20Iff%20OpenVPN%20commandline%20is%20used%20as%20VPN%20client%2C%20also%20add%20%5C%22reneg-sec%200%5C%22%5Cr%5Cn-%20When%20using%20Network%20Manager%2C%20%5C%22reneg-sec%200%5C%22%20is%20the%20default%2C%20so%20no%20client%20change%20is%20needed.%5Cr%5Cn%5Cr%5CnThere%20might%20also%20be%20a%20connection%20to%20%5C%22auth-nocache%5C%22%20-%20Network%20Manager%20GUI%20didn%27t%20ask%5Cr%5Cnme%20to%20re-authenticate.%20Maybe%20I%27ll%20have%20time%20to%20check%20with%20a%20OpenVPN%20command%20line%5Cr%5Cnand%20see%20if%20I%27ll%20get%20prompted%20for%20re-authentication.%20%5Cr%5Cn%5Cr%5CnSo%20for%20now%2C%20thanks%20for%20the%20feedback%2C%20I%27ll%20try%20some%20more%20things%20first%20and%20will%20prepare%5Cr%5Cna%20new%20patch%20later.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-11T18%3A45%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20just%20a%20bit%20picky%20about%20the%20dual-factor%20or%20two-factor.%20Nowadays%20two-factor%20auth%20is%20often%20equated%20with%20OTP.%20But%20as%20we%20saw%20it%20is%20not.%20Any%20maybe%20it%20is%20my%20personal%20mission%20to%20keep%20this%20information%20up.%20This%20is%20why%20i%20would%20like%20to%20be%20very%20precise%20in%20the%20privacyIDEA%20documentation%20%3A-%29%5Cr%5Cn%5Cr%5CnThanks%20a%20lot%20for%20your%20work%21%22%2C%20%22created_at%22%3A%20%222016-07-11T18%3A49%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20updated%20the%20patch%20-%20please%20have%20a%20look.%22%2C%20%22created_at%22%3A%20%222016-07-26T20%3A07%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%2C%20%7B%22body%22%3A%20%22Great%21%20THanks%20a%20lot.%20%5Cr%5CnIn%20certain%20cases%20it%20may%20even%20be%20a%20feature%2C%20to%20reeter%20a%20new%20OTP%20every%20x%20hours...%22%2C%20%22created_at%22%3A%20%222016-07-27T07%3A58%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201d1456fb0017b16ffc26a2c1776fef173bcbb06e%20doc/application_plugins/openvpn.rst%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/458%23discussion_r70188252%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20change%20this%20to%20%5C%22one%20time%20password%20authentication%5C%22%20or%20something%20similar.%20two%20factor%20authentication%20is%20nowadays%20often%20confused%20with%20OTP.%20But%20OTP%20is%20only%20one%20possiblity%20of%202FA.%20%5Cr%5CnYou%20could%20very%20well%20do%20two%20factor%20authentication%20with%20smartcards%20without%20any%20problem%21%22%2C%20%22created_at%22%3A%20%222016-07-10T21%3A01%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/application_plugins/openvpn.rst%3AL26-45%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/458#issuecomment-231610499'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **96.38%**
> Merging [#458][cc-pull] into [master][cc-base-branch] will decrease coverage by **0.02%**
```diff
@@             master       #458   diff @@
==========================================
Files           110        110
Lines         12930      12930
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
- Hits          12465      12462     -3
- Misses          465        468     +3
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [8d4ca10...1d1456f][cc-compare]
[cc-base-branch]: https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/privacyidea/privacyidea/compare/8d4ca10d35bcfd7978150bdbc77eef6f33cf6291...1d1456fb0017b16ffc26a2c1776fef173bcbb06e?src=pr
[cc-pull]: https://codecov.io/gh/privacyidea/privacyidea/pull/458?src=pr
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars.githubusercontent.com/u/4837658?v=3' height=16 width=16'></a> This is from the OpenVPN documentation, but I'll probably change that.
Certificates don't change, so it would stay valid and renegotiation would work.
[I'll probably try that next week].
Right now I see the following options as needed for OTP secured OpenVPN sessions:
- For the OpenVPN server: add "reneg-sec 0"
- Iff OpenVPN commandline is used as VPN client, also add "reneg-sec 0"
- When using Network Manager, "reneg-sec 0" is the default, so no client change is needed.
There might also be a connection to "auth-nocache" - Network Manager GUI didn't ask
me to re-authenticate. Maybe I'll have time to check with a OpenVPN command line
and see if I'll get prompted for re-authentication.
So for now, thanks for the feedback, I'll try some more things first and will prepare
a new patch later.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> I am just a bit picky about the dual-factor or two-factor. Nowadays two-factor auth is often equated with OTP. But as we saw it is not. Any maybe it is my personal mission to keep this information up. This is why i would like to be very precise in the privacyIDEA documentation :-)
Thanks a lot for your work!
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars.githubusercontent.com/u/4837658?v=3' height=16 width=16'></a> I've updated the patch - please have a look.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Great! THanks a lot.
In certain cases it may even be a feature, to reeter a new OTP every x hours...
- [ ] <a href='#crh-comment-Pull 1d1456fb0017b16ffc26a2c1776fef173bcbb06e doc/application_plugins/openvpn.rst 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/458#discussion_r70188252'>File: doc/application_plugins/openvpn.rst:L26-45</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Please change this to "one time password authentication" or something similar. two factor authentication is nowadays often confused with OTP. But OTP is only one possiblity of 2FA.
You could very well do two factor authentication with smartcards without any problem!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/458?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/458?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/458'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>