### PR TITLE
Fixing #485 LDAP Machine-Resolver

### DIFF
--- a/privacyidea/api/machine.py
+++ b/privacyidea/api/machine.py
@@ -118,7 +118,7 @@ def list_machines_api():
     machines = [mobject.get_dict() for mobject in machines]
     g.audit_object.log({'success': True,
                         'info': "hostname: {0!s}, ip: {1!s}".format(hostname, ip)})
-    
+
     return send_result(machines)
 
 

--- a/privacyidea/lib/machine.py
+++ b/privacyidea/lib/machine.py
@@ -71,8 +71,9 @@ def get_machines(hostname=None, ip=None, id=None, resolver=None, any=None):
         reso_obj = get_resolver_object(reso)
         resolver_machines = reso_obj.get_machines(hostname=hostname,
                                                   ip=ip,
-                                                  machine_id=id, any=any,
-                                                  substring=True)
+                                                  machine_id=id,
+                                                  any=any,
+                                                  substring=False)
         all_machines += resolver_machines
 
     return all_machines

--- a/privacyidea/lib/machine.py
+++ b/privacyidea/lib/machine.py
@@ -73,7 +73,7 @@ def get_machines(hostname=None, ip=None, id=None, resolver=None, any=None):
                                                   ip=ip,
                                                   machine_id=id,
                                                   any=any,
-                                                  substring=False)
+                                                  substring=True)
         all_machines += resolver_machines
 
     return all_machines

--- a/privacyidea/lib/machines/ldap.py
+++ b/privacyidea/lib/machines/ldap.py
@@ -70,7 +70,8 @@ class LdapMachineResolver(BaseMachineResolver):
                 raise Exception("Wrong credentials")
             self.i_am_bound = True
 
-    def _get_entry(self, entry_attribute, entries):
+    @staticmethod
+    def _get_entry(entry_attribute, entries):
         if type(entries.get(entry_attribute)) == list:
             entry = entries.get(entry_attribute)[0]
         else:

--- a/tests/test_lib_machine_resolver_ldap.py
+++ b/tests/test_lib_machine_resolver_ldap.py
@@ -115,7 +115,10 @@ class LdapMachineTestCase(MyTestCase):
 
 
     def test_05_get_single_machine(self):
-        machine = self.mreso.get_machines(machine_id="cn=machine1,ou=example,o=test")[0]
+
+        machines = self.mreso.get_machines(machine_id="cn=machine1,ou=example,o=test")
+        self.assertEqual(len(machines), 1)
+        machine = machines[0]
         self.assertEqual(machine.id, "cn=machine1,ou=example,o=test")
         self.assertTrue(machine.has_hostname("machine1.example.test"))
 


### PR DESCRIPTION
I tried to fix #485 

Please have a look and give feedback
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/486%23discussion_r74285164%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23discussion_r74285245%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23issuecomment-238932704%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23issuecomment-238945708%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23issuecomment-239189306%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23issuecomment-239201045%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23issuecomment-239675298%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23issuecomment-239808581%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23issuecomment-238932704%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Remove%20the%20unused%20reverse_map.%5Cr%5Cn%5Cr%5CnThe%20machine%20LDAP%20tests%20are%20failing%3F%22%2C%20%22created_at%22%3A%20%222016-08-10T17%3A01%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20will%20look%20into%20this%20reverse_map%20and%20your%20comments%20in%20%23485%20tomorrow.%20Actually%20I%20haven%27t%20looked%20into%20the%20reverse_map%20stuff%20so%20I%20might%20have%20missed%20some%20parts%20and%20I%20need%20to%20check%20my%20Pull%20request%20again.%5Cr%5CnI%20will%20also%20remove%20the%20double%20white%20lines%21%20Sorry%20about%20that%2C%20It%27s%20Actually%20my%20very%20first%20commit%20to%20an%20other%20project%20%5Cud83d%5Cude04%20%20I%20also%20saw%20the%20test%20after%20I%20opened%20the%20pull%20request%2C%20so%20I%20missed%20the%20failed%20test...%5Cr%5Cn%5Cr%5CnI%20will%20check%20everything%20later%20or%20tomorrow%21%20thx%20for%20your%20feedback%22%2C%20%22created_at%22%3A%20%222016-08-10T17%3A45%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3875381%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splattner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20pushed%20my%20changes.%20What%20I%20changed%3A%5Cr%5Cn%5Cr%5Cnwhen%20machine_id%20attribute%20is%20the%20dn%2C%20we%20need%20to%20change%20the%20filter%20a%20bit%20and%20also%20the%20ldap%20search%2C%20because%20you%20cannot%20search%20for%20a%20dn%20%28see%20comment%20in%20%23485%29%5Cr%5Cn%5Cr%5CnI%20also%20removed%20the%20reverse_map%20stuff.%20It%27s%20now%20possible%20to%20have%20the%20same%20ldap%20attribute%20multiple%20times%5Cr%5Cn%5Cr%5CnFurthermore%20I%20changed%20%60test_05_get_single_machine%28self%29%60%20to%20make%20sure%20it%20only%20returns%20one%20machine%20object%20%28which%20it%20does%20now%20with%20the%20above%20mentioned%20changes%29%5Cr%5Cn%5Cr%5CnPlease%20have%20a%20look%20and%20give%20feedback%20If%20you%20agree%20with%20this%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-08-11T15%3A04%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3875381%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splattner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20the%20failed%20and%20error%20test%20cases%20are%20not%20related%20to%20my%20change%2C%20do%20you%20agree%3F%22%2C%20%22created_at%22%3A%20%222016-08-11T15%3A42%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3875381%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splattner%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20probably%20right.%20I%20worked%20on%20the%20event%20handler.%5Cr%5CnCan%20you%20please%20rebase%20on%20the%20current%20master%3F%5Cr%5CnI%20will%20then%20check%20the%20pull%20request.%5Cr%5Cnyou%20should%20also%20add%20your%20name%20in%20the%20header%20of%20the%20files.%5Cr%5CnThanks%20a%20lot%5Cr%5CnCornelius%22%2C%20%22created_at%22%3A%20%222016-08-14T14%3A04%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22checked%20the%20tests%20offline.%22%2C%20%22created_at%22%3A%20%222016-08-15T13%3A59%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208f1d6e8008da20331a13c3d4f5c68df80de1bf81%20privacyidea/lib/machines/ldap.py%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23discussion_r74285245%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%20do%20not%20use%20%20double%20white%20lines%22%2C%20%22created_at%22%3A%20%222016-08-10T17%3A00%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/machines/ldap.py%3AL77-99%22%7D%2C%20%22Pull%208f1d6e8008da20331a13c3d4f5c68df80de1bf81%20privacyidea/lib/machines/ldap.py%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/486%23discussion_r74285164%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%20do%20not%20insert%20double%20white%20lines%22%2C%20%22created_at%22%3A%20%222016-08-10T17%3A00%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/machines/ldap.py%3AL156-164%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 8f1d6e8008da20331a13c3d4f5c68df80de1bf81 privacyidea/lib/machines/ldap.py 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/486#discussion_r74285164'>File: privacyidea/lib/machines/ldap.py:L156-164</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> please do not insert double white lines
- [x] <a href='#crh-comment-Pull 8f1d6e8008da20331a13c3d4f5c68df80de1bf81 privacyidea/lib/machines/ldap.py 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/486#discussion_r74285245'>File: privacyidea/lib/machines/ldap.py:L77-99</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> please do not use  double white lines
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/486#issuecomment-238932704'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Remove the unused reverse_map.
The machine LDAP tests are failing?
- <a href='https://github.com/splattner'><img border=0 src='https://avatars.githubusercontent.com/u/3875381?v=3' height=16 width=16'></a> I will look into this reverse_map and your comments in #485 tomorrow. Actually I haven't looked into the reverse_map stuff so I might have missed some parts and I need to check my Pull request again.
I will also remove the double white lines! Sorry about that, It's Actually my very first commit to an other project 😄  I also saw the test after I opened the pull request, so I missed the failed test...
I will check everything later or tomorrow! thx for your feedback
- <a href='https://github.com/splattner'><img border=0 src='https://avatars.githubusercontent.com/u/3875381?v=3' height=16 width=16'></a> I just pushed my changes. What I changed:
when machine_id attribute is the dn, we need to change the filter a bit and also the ldap search, because you cannot search for a dn (see comment in #485)
I also removed the reverse_map stuff. It's now possible to have the same ldap attribute multiple times
Furthermore I changed `test_05_get_single_machine(self)` to make sure it only returns one machine object (which it does now with the above mentioned changes)
Please have a look and give feedback If you agree with this
- <a href='https://github.com/splattner'><img border=0 src='https://avatars.githubusercontent.com/u/3875381?v=3' height=16 width=16'></a> I think the failed and error test cases are not related to my change, do you agree?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> You are probably right. I worked on the event handler.
Can you please rebase on the current master?
I will then check the pull request.
you should also add your name in the header of the files.
Thanks a lot
Cornelius
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> checked the tests offline.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/486?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/486?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/486'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>