### PR TITLE
Fix X-Forwarded-For HTTP header evaluation

### DIFF
--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -426,15 +426,20 @@ def get_client_ip(request, proxy_settings):
     :param proxy_settings:
     :return:
     """
-    client_ip = request.access_route[0] if request.access_route else \
-        request.remote_addr
 
-    mapped_ip = request.all_data.get("client")
+    client_ip = request.remote_addr
+
+    mapped_ip = request.all_data.get("client") or \
+        request.access_route[0] if request.access_route[0] <> request.remote_addr else None
+
     if mapped_ip:
         if proxy_settings and check_proxy(client_ip, mapped_ip, proxy_settings):
+            log.debug("Proxy {client_ip} overrides client IP to "
+                      "{mapped_ip}.".format(client_ip=client_ip,
+                                            mapped_ip=mapped_ip))
             client_ip = mapped_ip
         else:
-            log.warning("Proxy {client_ip} not allowed to set IP to "
+            log.warning("Proxy {client_ip} not allowed to override client IP to "
                         "{mapped_ip}.".format(client_ip=client_ip,
                                               mapped_ip=mapped_ip))
 


### PR DESCRIPTION
Evaluates X-Forwarded-For HTTP header (together with the client variable) as potential client IP override through a trusted proxy server.

If only the GET or POST `client` variable exists, it's evaluated as possibly mapped IP address.
If only the `X-Forwarded-For` HTTP header variable exists, it's evaluated as possibly mapped IP address.
If both `client` and  `X-Forwarded-For` exist, client is evaluated as possibly mapped IP address (application variable overrides web server variable).

Keep in mind, the reqest.access_route[0] from werkzeug framework is always set. If there is no `X-Forwarded-For` HTTP header variable set, it simply contains the request.remote_addr.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/495%23issuecomment-242125646%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/495%23issuecomment-242125646%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20Bernd%2C%5Cr%5Cnthanks%20for%20the%20head%20up.%5Cr%5CnI%20changed%20the%20code%20accordingly.%5Cr%5CnYou%20may%20check%20the%20latest%20commit%20of%20%23395.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-08-24T16%3A23%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/495#issuecomment-242125646'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Hi Bernd,
thanks for the head up.
I changed the code accordingly.
You may check the latest commit of #395.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/495?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/495?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/495'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>