### PR TITLE
fix logfile rotation

### DIFF
--- a/deploy/logging.cfg
+++ b/deploy/logging.cfg
@@ -23,7 +23,7 @@ backupCount=14
 maxBytes=10000000
 formatter=detail
 level=DEBUG
-args=('/var/log/privacyidea/privacyidea.log',)
+args=('/var/log/privacyidea/privacyidea.log')
 
 [loggers]
 keys=root,privacyidea


### PR DESCRIPTION
While looking at creating debug logging I found, that my privacyidea.log had grown larger than 50M,
but the file did not get rotated. The comma after the logfile name looked suspicious, so I
removed it - and the log had been rotated with the next log entry.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/521%23issuecomment-252902952%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/521%23issuecomment-252932778%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/521%23issuecomment-252902952%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/521%3Fsrc%3Dpr%29%20is%2096.26%25%20%28diff%3A%20100%25%29%5Cn%3E%20Merging%20%5B%23521%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/521%3Fsrc%3Dpr%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%29%20will%20not%20change%20coverage%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23521%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20113%20%20%20%20%20%20%20%20113%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2013343%20%20%20%20%20%2013343%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%2012844%20%20%20%20%20%2012844%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20499%20%20%20%20%20%20%20%20499%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20update%20%5Beb331b2...64d261f%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/eb331b2a5c189254bf6f733e200467169976bb32...64d261f40d6ba151eea6ff0e52ce3690fccbdcec%3Fsrc%3Dpr%29%22%2C%20%22created_at%22%3A%20%222016-10-11T12%3A28%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20comma%20in%20fact%20should%20be%20okTM%2C%20since%20the%20args%20is%20a%20python%20tuple.%20The%20comma%20helps%20python%20to%20understand%2C%20that%20his%20is%20a%20tuple.%5Cr%5Cn%5Cr%5CnTHe%20args%20get%20passed%20as%20arguments%20to%20the%20function%3A%5Cr%5Cnhttps%3A//docs.python.org/2/library/logging.handlers.html%23logging.handlers.RotatingFileHandler%5Cr%5Cn%5Cr%5CnSo%20the%20very%20correct%20way%20should%20look%20like%20this%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20args%3D%28%27/var/log/privacyidea/privacyidea.log%27%2C%20%27a%27%2C%2010000000%2C%2014%29%5Cr%5Cn%5Cr%5Cnthis%20would%20be%20the%20parameter%20list%20passed%20to%20%2ARotatingFileHandler%2A.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-10-11T14%3A27%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/521#issuecomment-252902952'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage](https://codecov.io/gh/privacyidea/privacyidea/pull/521?src=pr) is 96.26% (diff: 100%)
> Merging [#521](https://codecov.io/gh/privacyidea/privacyidea/pull/521?src=pr) into [master](https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr) will not change coverage
```diff
@@             master       #521   diff @@
==========================================
Files           113        113
Lines         13343      13343
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
Hits          12844      12844
Misses          499        499
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last update [eb331b2...64d261f](https://codecov.io/gh/privacyidea/privacyidea/compare/eb331b2a5c189254bf6f733e200467169976bb32...64d261f40d6ba151eea6ff0e52ce3690fccbdcec?src=pr)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> The comma in fact should be okTM, since the args is a python tuple. The comma helps python to understand, that his is a tuple.
THe args get passed as arguments to the function:
https://docs.python.org/2/library/logging.handlers.html#logging.handlers.RotatingFileHandler
So the very correct way should look like this:
args=('/var/log/privacyidea/privacyidea.log', 'a', 10000000, 14)
this would be the parameter list passed to *RotatingFileHandler*.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/521?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/521?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/521'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>