### PR TITLE
Fixed issue searching for attribute values containing spaces.

### DIFF
--- a/tests/ldap3mock.py
+++ b/tests/ldap3mock.py
@@ -423,7 +423,12 @@ class Connection(object):
         rpar  = pyparsing.Literal(')').suppress()
 
         k = pyparsing.Word(pyparsing.alphanums)
-        v = pyparsing.Word(pyparsing.alphanums + "*@.\\")
+        # NOTE: We may need to expand on this list, but as this is not a real
+        # LDAP server we should be OK.
+        # Value to contain:
+        #   numbers, upper/lower case letters, astrisk, at symbol, full stop
+        #   backslash or a space
+        v = pyparsing.Word(pyparsing.alphanums + "*@.\\ ")
         rel = pyparsing.oneOf("= ~= >= <=")
 
         expr = pyparsing.Forward()

--- a/tests/test_mock_ldap3.py
+++ b/tests/test_mock_ldap3.py
@@ -35,6 +35,7 @@ LDAPDirectory = [{"dn": "cn=alice,ou=example,o=test",
                  "attributes": {'cn': 'bob',
                                 "sn": "Marley",
                                 "givenName": "Robert",
+                                "description": "Bobs Account",
                                 "email": "bob@example.com",
                                 "mobile": "123456",
                                 "homeDirectory": "/home/bob",
@@ -908,4 +909,14 @@ class LDAPMockTestCase(unittest.TestCase):
         self.assertTrue(len(self.c.response) == 1)
         self.assertTrue(self.c.response[0].get("dn") == dn)
 
+
+    def test_24_filter_containing_spaces(self):
+        dn = "cn=bob,ou=example,o=test"
+        s = "(&(description=Bobs Account))"
+
+        self.c.search(search_base=self.base, search_filter=s, search_scope=ldap3.SUBTREE,
+                attributes = ldap3.ALL_ATTRIBUTES, paged_size = 5)
+
+        self.assertTrue(len(self.c.response) == 1)
+        self.assertTrue(self.c.response[0].get("dn") == dn)
 


### PR DESCRIPTION
Hi Cornelius,

Hope you are well?

This patch fixes a issue in the ldapmock. If you create a ldap search like (&(cn=John Smith)) the mock returns no results even if an entry with that "cn" exists.

I've added an additional test for this situation and the ldapmock tests and the lib_resolver tests all still pass.

Best Regards

Martin
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/564%23issuecomment-264705667%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/564%23issuecomment-264718423%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/564%23issuecomment-264705667%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/564%3Fsrc%3Dpr%29%20is%2095.85%25%20%28diff%3A%20100%25%29%5Cn%5Cn%5Cn%3E%20No%20coverage%20report%20found%20for%20%2A%2Amaster%2A%2A%20at%204b98c83.%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20update%20%5B4b98c83...570da29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/4b98c83250f7c2e94e4699d0b95f85a2fa78b3ff...570da2974524f1c704e8cee291a3a373e393def0%3Fsrc%3Dpr%29%22%2C%20%22created_at%22%3A%20%222016-12-04T14%3A01%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40wheldom01%20%5Cr%5Cnthanks%20for%20the%20pull%20request.%20Did%20you%20expirence%20problems%20in%20productive%20use%20or%20is%20this%20only%20to%20test%20for%20more%20scenarios%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-12-04T17%3A45%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/564#issuecomment-264705667'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage](https://codecov.io/gh/privacyidea/privacyidea/pull/564?src=pr) is 95.85% (diff: 100%)
> No coverage report found for **master** at 4b98c83.
> Powered by [Codecov](https://codecov.io?src=pr). Last update [4b98c83...570da29](https://codecov.io/gh/privacyidea/privacyidea/compare/4b98c83250f7c2e94e4699d0b95f85a2fa78b3ff...570da2974524f1c704e8cee291a3a373e393def0?src=pr)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Hi @wheldom01
thanks for the pull request. Did you expirence problems in productive use or is this only to test for more scenarios?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/564?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/564?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/564'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>