### PR TITLE
fix display of nt-style realm\user

### DIFF
--- a/doc/application_plugins/radius.rst
+++ b/doc/application_plugins/radius.rst
@@ -52,7 +52,7 @@ necessarily the same as the privacyIDEA realms, but they can be mapped.
 
 A user can authenticate to the FreeRADIUS either with a simple username
 "fred", or a username combined with a RADIUS realm in the format like
-"fred@realm1" or "realm1\fred".
+"fred@realm1" or "realm1\\fred".
 
 .. note:: The format of the realms is defined in
    ``/etc/freeradius/modules/realm`` as "suffix" and "ntdomain". I.e. you could
@@ -74,7 +74,7 @@ FreeRADIUS to identify this as a REALM you need to add this to the file
 Realm processing in FreeRADIUS
 ..............................
 
-A ``User-Name`` "fred@realmRadius" or "realmRadius\fred" is sent to the
+A ``User-Name`` "fred@realmRadius" or "realmRadius\\fred" is sent to the
 FreeRADIUS server.
 
 If "realmRadius" can not be identified as RADIUS realm (missing entry in
@@ -82,7 +82,7 @@ proxy.conf), then no realm can be split and the complete ``User-Name`` will be
 sent to privacyIDEA for validation.
 This can work out with "fred@realmRadius", since privacyIDEA
 might split the @-sign. But this probably will not work out for
-"realmRadius\fred".
+"realmRadius\\fred".
 
 If the "realmRadius" can be identified as RADIUS realm (entry in proxy.conf),
 then FreeRADIUS will split the ``User-Name`` into the RADIUS attributes


### PR DESCRIPTION
We need to escape \ to get the desired result.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/578%23issuecomment-268876735%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/578%23issuecomment-268896693%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/578%23issuecomment-268916661%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/578%23issuecomment-268876735%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/578%3Fsrc%3Dpr%29%20is%2095.81%25%20%28diff%3A%20100%25%29%5Cn%3E%20Merging%20%5B%23578%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/578%3Fsrc%3Dpr%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%29%20will%20not%20change%20coverage%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23578%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20118%20%20%20%20%20%20%20%20118%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2014182%20%20%20%20%20%2014182%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%2013588%20%20%20%20%20%2013588%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20594%20%20%20%20%20%20%20%20594%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20update%20%5Ba680af5...4dfc413%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/a680af51f061a94de60e81ad050e05ae5f6db5b8...4dfc413bf799b0ebcf22e4f81a9416546feb7ba3%3Fsrc%3Dpr%29%22%2C%20%22created_at%22%3A%20%222016-12-22T19%3A50%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Cornelius%20K%5Cu00f6lbel%20%3Cnotifications%40github.com%3E%20writes%3A%5Cn%5Cn%3E%20cornelinux%20commented%20on%20this%20pull%20request.%5Cn%3E%5Cn%3E%20Thanks%20for%20the%20PR.%5Cn%3E%20I%20suppose%20you%20ran%20into%20this%3F%5Cn%5CnWhile%20verifying%20my%20RADIUS...%5Cn%5Cn%3E%20Are%20you%20sure%2C%20the%20user%20actually%20has%20to%20enter%20two%20backslashes%3F%5Cn%5CnOf%20course%20not.%20Have%20a%20look%20at%5Cnhttp%3A//privacyidea.readthedocs.io/en/latest/application_plugins/radius.html%5Cn%5CnThere%20we%20have%20in%20section%20%5C%22Radius%20and%20Realms%5C%22%3A%5Cn%5Cn%2C----%5Cn%7C%20A%20user%20can%20authenticate%20to%20the%20FreeRADIUS%20either%20with%20a%20simple%20username%5Cn%7C%20%5Cu201cfred%5Cu201d%2C%20or%20a%20username%20combined%20with%20a%20RADIUS%20realm%20in%20the%20format%20like%5Cn%7C%20%5Cu201cfred%40realm1%5Cu201d%20or%20%5Cu201crealm1fred%5Cu201d.%5Cn%60----%5Cn%5CnThe%20last%20word%20is%20%5C%22realm1fred%5C%22%2C%20but%20should%20be%20%5C%22realm1%5C%5Cfred%5C%22.%20%20We%20need%20to%5Cnhave%20%5C%22%5C%5C%5C%5C%5C%22%20in%20markdown%20to%20get%20a%20%5C%22%5C%5C%5C%22%20in%20the%20output.%20At%20least%20the%20preview%5Cnin%20github%20was%20fine%20after%20my%20change%20%3A-%29%5Cn%5CnJochen%5Cn%5Cn--%20%5CnThe%20only%20problem%20with%20troubleshooting%20is%20that%20the%20trouble%20shoots%20back.%5Cn%22%2C%20%22created_at%22%3A%20%222016-12-22T21%3A41%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20being%20patient.%20I%20am%20a%20bit%20slow%20today.%20%3B-%29%22%2C%20%22created_at%22%3A%20%222016-12-22T23%3A55%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/578#issuecomment-268876735'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage](https://codecov.io/gh/privacyidea/privacyidea/pull/578?src=pr) is 95.81% (diff: 100%)
> Merging [#578](https://codecov.io/gh/privacyidea/privacyidea/pull/578?src=pr) into [master](https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr) will not change coverage
```diff
@@             master       #578   diff @@
==========================================
Files           118        118
Lines         14182      14182
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
Hits          13588      13588
Misses          594        594
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last update [a680af5...4dfc413](https://codecov.io/gh/privacyidea/privacyidea/compare/a680af51f061a94de60e81ad050e05ae5f6db5b8...4dfc413bf799b0ebcf22e4f81a9416546feb7ba3?src=pr)
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars.githubusercontent.com/u/4837658?v=3' height=16 width=16'></a> Cornelius Kölbel <notifications@github.com> writes:
> cornelinux commented on this pull request.
>
> Thanks for the PR.
> I suppose you ran into this?
While verifying my RADIUS...
> Are you sure, the user actually has to enter two backslashes?
Of course not. Have a look at
http://privacyidea.readthedocs.io/en/latest/application_plugins/radius.html
There we have in section "Radius and Realms":
,----
| A user can authenticate to the FreeRADIUS either with a simple username
| “fred”, or a username combined with a RADIUS realm in the format like
| “fred@realm1” or “realm1fred”.
`----
The last word is "realm1fred", but should be "realm1\fred".  We need to
have "\\" in markdown to get a "\" in the output. At least the preview
in github was fine after my change :-)
Jochen
--
The only problem with troubleshooting is that the trouble shoots back.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Thanks for being patient. I am a bit slow today. ;-)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/578?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/578?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/578'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>