### PR TITLE
Add support for crypt() encoded passwords in SQLIdResolver

### DIFF
--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -356,6 +356,9 @@ class IdResolver (UserIdResolver):
             digest = binascii.hexlify(hr.digest())
             return pw_hash == digest
 
+        def _check_crypt(pw_hash, password):
+           return crypt.crypt(password, pw_hash) == pw_hash
+
         res = False
         userinfo = self.getUserInfo(uid)
 
@@ -379,6 +382,8 @@ class IdResolver (UserIdResolver):
         elif len(userinfo.get("password")) == 64:
             # OTRS sha256 password
             res = _otrs_sha256(database_pw, password)
+        else:
+            res = _check_crypt(database_pw, password)
 
         return res
 


### PR DESCRIPTION
We store our passwords in crypt() format in the database, i.e. the hashes start with $1$ or $6$ or similar. This PR adds password checking using the crypt() function as last resort, i.e. when all other password checks did not apply. The SQLIdResolver thus supports all algorithms the platform dependent crypt()-function supports.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-270628057%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-270652899%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-270959641%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-270969389%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-271084395%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-271087303%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-271090505%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-271101847%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-271115488%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-271495902%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/586%23issuecomment-270628057%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/586%3Fsrc%3Dpr%29%20is%2095.81%25%20%28diff%3A%2033.33%25%29%5Cn%3E%20Merging%20%5B%23586%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/586%3Fsrc%3Dpr%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%29%20will%20decrease%20coverage%20by%20%2A%2A0.01%25%2A%2A%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23586%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20118%20%20%20%20%20%20%20%20118%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2014182%20%20%20%20%20%2014185%20%20%20%20%20%2B3%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%2013591%20%20%20%20%20%2013592%20%20%20%20%20%2B1%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20591%20%20%20%20%20%20%20%20593%20%20%20%20%20%2B2%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20update%20%5B21b0884...1f0b503%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/21b08848c05d8b468c3add78c4c905d40df98524...1f0b503f004cbcc655c47998ad372d18cb4e272e%3Fsrc%3Dpr%29%22%2C%20%22created_at%22%3A%20%222017-01-05T11%3A55%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20Andy%2C%5Cr%5CnThanks%20a%20lot%20for%20the%20pull%20request%21%5Cr%5Cn%5Cr%5CnDatabase%20entries%20starting%20with%20%246%24%20or%20%241%24%20are%20no%20valid%20crypted%20passwords%20to%20my%20understanding.%20The%20crypted%20password%20contains%20the%20salt%20in%20the%20first%20two%20characters%20-%20doesn%27t%20it%3F%5Cr%5Cn%5Cr%5CnI%20would%20like%20to%20clarifiy%20this.%5Cr%5CnCould%20we%20also%20add%20an%20if%20statement%20instead%20of%20using%20it%20as%20last%20resort%20-%20like%20%60%60len%28%29%3D%3D13%60%60.%5Cr%5Cn%5Cr%5CnAlso%3A%20We%20should%20add%20some%20tests%20for%20this%20type%20of%20crypted%20passwords%20here%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/master/tests/test_lib_resolver.py%23L180%5Cr%5Cn%5Cr%5CnThanks%20a%20lot%5Cr%5CnCornelius%22%2C%20%22created_at%22%3A%20%222017-01-05T14%3A14%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right%20in%20that%20older%20crypt%283%29%20implementations%20only%20support%20DES%2C%20where%20the%20hashes%20start%20with%20the%20salt%20directly.%20However%2C%20other%20%28newer%29%20implementations%20support%20a%20very%20wide%20range%20of%20hash%20functions%20where%20the%20hashes%20start%20with%20%241%24%20or%20%246%24.%20Python%27s%20crypt%28%29%20implementation%20depends%20on%20the%20platform%27s%20implementation%2C%20so%20it%20might%20support%20%241%24%20only%20on%20specific%20platforms.%20%5Cr%5CnThe%20following%20Wikipedia%20article%20gives%20a%20tabular%20overview%3A%20https%3A//en.wikipedia.org/wiki/Crypt_%28C%29%5Cr%5Cn%5Cr%5CnIMHO%20this%20makes%20specific%20checks%20quite%20challenging%20and%20is%20the%20reason%20why%20I%20simply%20added%20an%20%60else%3A%60clause.%22%2C%20%22created_at%22%3A%20%222017-01-06T17%3A43%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3099753%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20do%20not%20recommend%20using%20a%20default%20behaviour%20here.%20I%20rather%20recommend%20adding%20checks%2C%20that%20work%20for%20you%20like%5Cr%5Cn%5Cr%5Cn%20%20%20%20if%20len%28passwd%29%20%3D%3D%2013%20or%20passwd%5B0%3A2%5D%20in%20%5B%5C%22%241%24%5C%22%2C%20%5C%22%246%24%5C%22%5D%3A%5Cr%5Cn%5Cr%5CnProbably%20the%20important%20part%20is%2C%20that%20the%20funcionality%20%2A%2Afor%20you%2A%2A%20will%20not%20change%20during%20updates.%20This%20can%20not%20be%20guaranteed%20with%20a%20default%20behaviour%20and%20this%20can%20especially%20not%20guarantteed%20without%20tests%21%5Cr%5Cn%5Cr%5CnSo%20either%20you%20should%20write%20some%20tests%20or%20provide%20test%20data%2C%20which%20work%20in%20%2Ayour%2A%20scenario.%22%2C%20%22created_at%22%3A%20%222017-01-06T18%3A26%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20I%20still%20see%20the%20problem%20with%20the%20platform%20dependency%3A%20it%20might%20happen%20that%20we%20check%20for%20%241%24%20because%20it%27s%20supported%20by%20crypt%28%29%20on%20one%20system%20but%20doesn%27t%20work%20on%20another.%5Cr%5Cn%5Cr%5CnI%20can%20think%20of%20two%20other%20possibilites%2C%20to%20support%20just%20%241%24%3A%5Cr%5Cn1.%20Using%20a%20pure-pyhon%20implementation%20of%20md5crypt%5Cr%5Cn2.%20Using%20passlib%20%28with%20the%20downside%20of%20an%20added%20dependency%29%22%2C%20%22created_at%22%3A%20%222017-01-07T13%3A39%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3099753%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%2C%20%7B%22body%22%3A%20%22Don%27t%20bother%20other%27s%20problems.%20Take%20care%20of%20yours.%5Cr%5Cn%5Cr%5CnWhat%20do%20you%20mean%2C%20when%20you%20talk%20of%20%5C%22platform%5C%22.%20Which%20platforms%20are%20you%20talking%20of%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-01-07T14%3A37%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20I%20took%20care%20of%20my%20problems%20only%2C%20this%20PR%20wouldn%27t%20exist%20-%20I%20can%20always%20add%20the%20few%20lines%20of%20code%20back%20whenever%20I%20do%20an%20update.%5Cr%5Cn%5Cr%5CnI%20mean%20its%20implementation%20differs%20from%20BSD%20to%20Linux%20to%20Windows%20and%2C%20in%20some%20cases%2C%20even%20from%20Linux%20distribution%20to%20Linux%20distribution.%22%2C%20%22created_at%22%3A%20%222017-01-07T15%3A38%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3099753%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20we%20lost%20each%20other%20here.%20privacyIDEA%20will%20always%20run%20on%20a%20linux%20distribution.%20Thus%20the%20crypt%20implementation%20will%20always%20be%20the%20same%20on%20the%20privacyIDEA/Server%20side.%5Cr%5Cn%5Cr%5CnIf%20the%20client%20side%20%28or%20the%20side%20of%20the%20SQL%20server%29%20has%20a%20totally%20other%20implementation%20of%20crypt%2C%20and%20stores%20something%20different%2C%20privacyIDEA%20%28or%20the%20linux%20crypt%20implementation%29%20will%20not%20understand%2C%20than%20it%20will%20fail%20anyway.%20%5Cr%5Cn%5Cr%5CnThus%20a%20catchall/else%20does%20not%20make%20sense%20in%20my%20eyes.%5Cr%5Cn%5Cr%5CnI%20very%20much%20prefer%20to%20add%20tests%20-%20as%20mentioned%20above%20-%20this%20way%2C%20we%20explicitly%20know%2C%20which%20formats%20are%20supported%20and%20are%20known%20to%20work.%22%2C%20%22created_at%22%3A%20%222017-01-07T18%3A44%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20completely%20agree%20regarding%20tests.%20%5Cr%5Cn%5Cr%5CnBefore%20implementing%20this%20any%20further%2C%20I%20just%20noticed%20another%20problem%20related%20to%20passwords%2C%20see%20%23589%22%2C%20%22created_at%22%3A%20%222017-01-07T22%3A45%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3099753%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20you%20can%20provide%20some%20crypted%20values%20how%20they%20look%20in%20your%20scenario%2C%20I%20can%20add%20those%20tests.%22%2C%20%22created_at%22%3A%20%222017-01-10T06%3A18%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/586#issuecomment-270628057'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage](https://codecov.io/gh/privacyidea/privacyidea/pull/586?src=pr) is 95.81% (diff: 33.33%)
> Merging [#586](https://codecov.io/gh/privacyidea/privacyidea/pull/586?src=pr) into [master](https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr) will decrease coverage by **0.01%**
```diff
@@             master       #586   diff @@
==========================================
Files           118        118
Lines         14182      14185     +3
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
+ Hits          13591      13592     +1
- Misses          591        593     +2
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last update [21b0884...1f0b503](https://codecov.io/gh/privacyidea/privacyidea/compare/21b08848c05d8b468c3add78c4c905d40df98524...1f0b503f004cbcc655c47998ad372d18cb4e272e?src=pr)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Hi Andy,
Thanks a lot for the pull request!
Database entries starting with $6$ or $1$ are no valid crypted passwords to my understanding. The crypted password contains the salt in the first two characters - doesn't it?
I would like to clarifiy this.
Could we also add an if statement instead of using it as last resort - like ``len()==13``.
Also: We should add some tests for this type of crypted passwords here:
https://github.com/privacyidea/privacyidea/blob/master/tests/test_lib_resolver.py#L180
Thanks a lot
Cornelius
- <a href='https://github.com/andyboeh'><img border=0 src='https://avatars.githubusercontent.com/u/3099753?v=3' height=16 width=16'></a> You are right in that older crypt(3) implementations only support DES, where the hashes start with the salt directly. However, other (newer) implementations support a very wide range of hash functions where the hashes start with $1$ or $6$. Python's crypt() implementation depends on the platform's implementation, so it might support $1$ only on specific platforms.
The following Wikipedia article gives a tabular overview: https://en.wikipedia.org/wiki/Crypt_(C)
IMHO this makes specific checks quite challenging and is the reason why I simply added an `else:`clause.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> I do not recommend using a default behaviour here. I rather recommend adding checks, that work for you like
if len(passwd) == 13 or passwd[0:2] in ["$1$", "$6$"]:
Probably the important part is, that the funcionality **for you** will not change during updates. This can not be guaranteed with a default behaviour and this can especially not guarantteed without tests!
So either you should write some tests or provide test data, which work in *your* scenario.
- <a href='https://github.com/andyboeh'><img border=0 src='https://avatars.githubusercontent.com/u/3099753?v=3' height=16 width=16'></a> Hm, I still see the problem with the platform dependency: it might happen that we check for $1$ because it's supported by crypt() on one system but doesn't work on another.
I can think of two other possibilites, to support just $1$:
1. Using a pure-pyhon implementation of md5crypt
2. Using passlib (with the downside of an added dependency)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Don't bother other's problems. Take care of yours.
What do you mean, when you talk of "platform". Which platforms are you talking of?
- <a href='https://github.com/andyboeh'><img border=0 src='https://avatars.githubusercontent.com/u/3099753?v=3' height=16 width=16'></a> If I took care of my problems only, this PR wouldn't exist - I can always add the few lines of code back whenever I do an update.
I mean its implementation differs from BSD to Linux to Windows and, in some cases, even from Linux distribution to Linux distribution.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> I think we lost each other here. privacyIDEA will always run on a linux distribution. Thus the crypt implementation will always be the same on the privacyIDEA/Server side.
If the client side (or the side of the SQL server) has a totally other implementation of crypt, and stores something different, privacyIDEA (or the linux crypt implementation) will not understand, than it will fail anyway.
Thus a catchall/else does not make sense in my eyes.
I very much prefer to add tests - as mentioned above - this way, we explicitly know, which formats are supported and are known to work.
- <a href='https://github.com/andyboeh'><img border=0 src='https://avatars.githubusercontent.com/u/3099753?v=3' height=16 width=16'></a> I completely agree regarding tests.
Before implementing this any further, I just noticed another problem related to passwords, see #589
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> If you can provide some crypted values how they look in your scenario, I can add those tests.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/586?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/586?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/586'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>