### PR TITLE
/validate/triggerchallenge should write to the audit log

### DIFF
--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -433,6 +433,7 @@ def trigger_challenge():
     user = request.User
     serial = getParam(request.all_data, "serial")
     result_obj = 0
+    triggered_serials = []
     details = {"messages": [],
                "transaction_ids": []}
 
@@ -445,7 +446,18 @@ def trigger_challenge():
             if success:
                 result_obj += 1
                 details.get("transaction_ids").append(transactionid)
+                triggered_serials.append(token_obj.token.serial)
             details.get("messages").append(return_message)
+
+    g.audit_object.log({
+        "transaction_ids": details["transaction_ids"],
+        "given_serial": serial,
+        "triggered_serials": triggered_serials,
+        "user": user.login,
+        "resolver": user.resolver,
+        "realm": user.realm,
+        "success": result_obj > 0,
+    })
 
     return send_result(result_obj, details=details)
 

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -433,7 +433,6 @@ def trigger_challenge():
     user = request.User
     serial = getParam(request.all_data, "serial")
     result_obj = 0
-    triggered_serials = []
     details = {"messages": [],
                "transaction_ids": []}
 
@@ -446,17 +445,18 @@ def trigger_challenge():
             if success:
                 result_obj += 1
                 details.get("transaction_ids").append(transactionid)
-                triggered_serials.append(token_obj.token.serial)
+                # This will write only the serial of the token that was processed last to the audit log
+                g.audit_object.log({
+                    "serial": token_obj.token.serial,
+                })
             details.get("messages").append(return_message)
 
     g.audit_object.log({
-        "transaction_ids": details["transaction_ids"],
-        "given_serial": serial,
-        "triggered_serials": triggered_serials,
         "user": user.login,
         "resolver": user.resolver,
         "realm": user.realm,
         "success": result_obj > 0,
+        "info": "triggered {0!s} challenges".format(result_obj),
     })
 
     return send_result(result_obj, details=details)


### PR DESCRIPTION
This writes relevant information to the audit log.
* A `/validate/triggerchallenge/` request that triggers zero challenges because the user in question does not have any challenge-response tokens is considered a failed request (and `success` is set to `0`).
* In case multiple challenges are triggered, the `serial` attribute only contains the serial number of the last processed token.

See #604.