### PR TITLE
Disable live search in load serial/user with search_on_enter policy

### DIFF
--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -82,7 +82,7 @@ myApp.directive("piSortBy", function(){
 });
 
 
-myApp.directive('assignUser', function($http, userUrl, AuthFactory, instanceUrl) {
+myApp.directive('assignUser', function($http, $rootScope, userUrl, AuthFactory, instanceUrl) {
     /*
     This directive is used to select a user from a realm
 
@@ -98,7 +98,27 @@ myApp.directive('assignUser', function($http, userUrl, AuthFactory, instanceUrl)
             console.log("Entering assignUser directive");
             console.log(scope.realms);
             console.log(scope.newUserObject);
+
+            // toggle enable/disable loadUsers calls
+            scope.toggleLoadUsers = function($toggle) {
+                // only trigger if the search_on_enter policy is active
+                if ($rootScope.search_on_enter) {
+                    var $viewValue = scope.newUserObject.user;
+                    scope.newUserObject.toggle = $toggle;
+                    // update field value with a placeholder to trigger typeahead
+                    if (scope.newUserObject.toggle
+                        && $viewValue.charAt($viewValue.length - 1) != "*") {
+                        var ctrl = element.find('input').controller('ngModel');
+                        ctrl.$setViewValue($viewValue + "*");
+                    }
+                }
+            };
+
             scope.loadUsers = function($viewValue) {
+            if ($rootScope.search_on_enter && (!$viewValue || $viewValue == "*" || !scope.newUserObject.toggle)) {
+                // only use existing result if any, and if search_on_enter policy is active
+                return scope.newUserObject.loadedUsers;
+            }
             var auth_token = AuthFactory.getAuthToken();
             return $http({
                 method: 'GET',
@@ -106,20 +126,21 @@ myApp.directive('assignUser', function($http, userUrl, AuthFactory, instanceUrl)
                     "&realm=" + scope.newUserObject.realm,
                 headers: {'PI-Authorization': auth_token}
             }).then(function ($response) {
-                return $response.data.result.value.map(function (item) {
+                scope.newUserObject.loadedUsers = $response.data.result.value.map(function (item) {
                     scope.newUserObject.email = item.email;
                     scope.newUserObject.mobile = item.mobile;
                     scope.newUserObject.phone = item.phone;
                     return "[" + item.userid + "] " + item.username +
                         " (" + item.givenname + " " + item.surname + ")";
                 });
+                return scope.newUserObject.loadedUsers;
             });
             };
         }
     };
 });
 
-myApp.directive('assignToken', function($http, tokenUrl,
+myApp.directive('assignToken', function($http, $rootScope, tokenUrl,
                                         AuthFactory, instanceUrl) {
     /*
     This directive is used to select a serial number and assign it
@@ -133,7 +154,25 @@ myApp.directive('assignToken', function($http, tokenUrl,
         },
         templateUrl: instanceUrl + "/static/components/directives/views/directive.assigntoken.html",
         link: function (scope, element, attr) {
+            // Toggle enable/disable loadSerials call
+            scope.toggleLoadSerials = function($toggle) {
+                // only trigger if the search_on_enter policy is active
+                if ($rootScope.search_on_enter) {
+                    var $viewValue = scope.newTokenObject.serial;
+                    scope.newTokenObject.toggle = $toggle;
+                    // update field value with a placeholder to trigger typeahead
+                    if (scope.newTokenObject.toggle
+                        && $viewValue.charAt($viewValue.length - 1) != "*") {
+                        var ctrl = element.find('input').controller('ngModel');
+                        ctrl.$setViewValue($viewValue + "*");
+                    }
+                }
+            };
             scope.loadSerials = function($viewValue) {
+            if ($rootScope.search_on_enter && (!$viewValue || $viewValue == "*" || !scope.newTokenObject.toggle)) {
+                // only use existing result if any, and if search_on_enter policy is active
+                return scope.newTokenObject.loadedSerials;
+            }
             var auth_token = AuthFactory.getAuthToken();
             return $http({
                 method: 'GET',
@@ -142,9 +181,10 @@ myApp.directive('assignToken', function($http, tokenUrl,
                 params: {assigned: "False",
                 serial: "*" + $viewValue + "*"}
             }).then(function ($response) {
-                return $response.data.result.value.tokens.map(function (item) {
+                scope.newTokenObject.loadedSerials = $response.data.result.value.tokens.map(function (item) {
                     return item.serial + " (" + item.tokentype + ")";
                 });
+                return scope.newTokenObject.loadedSerials;
             });
             };
         }

--- a/privacyidea/static/components/directives/views/directive.assigntoken.html
+++ b/privacyidea/static/components/directives/views/directive.assigntoken.html
@@ -6,7 +6,10 @@ This is the directive for assigning tokens to users.
     <input name="serial" type="text" ng-model="newTokenObject.serial"
            autocomplete="off"
            placeholder="{{ 'start typing a serial number of a token that is notassigned, yet.'|translate}} "
-           typeahead="serial for serial in loadSerials($viewValue)"
+           ng-keypress="toggleLoadSerials($event.which==13)"
+           typeahead-wait-ms="100"
+           typeahead-focus-first="false"
+           typeahead="serial for serial in loadSerials($viewValue) | filter: $viewValue"
            typeahead-loading="loadingSerials" class="form-control" >
     <i ng-show="loadingSerials" class="glyphicon glyphicon-refresh"
             translate>Loading serials...</i>

--- a/privacyidea/static/components/directives/views/directive.assignuser.html
+++ b/privacyidea/static/components/directives/views/directive.assignuser.html
@@ -15,7 +15,10 @@ This is the directive for assigning users.
     <input name="username" type="text" ng-model="newUserObject.user"
            autocomplete="off"
            placeholder="{{ 'start typing a username'|translate }}"
-           typeahead="newuser for newuser in loadUsers($viewValue)"
+           ng-keypress="toggleLoadUsers($event.which==13)"
+           typeahead-wait-ms="100"
+           typeahead-focus-first="false"
+           typeahead="newuser for newuser in loadUsers($viewValue) | filter: $viewValue"
            typeahead-loading="loadingUsers" class="form-control" >
     <i ng-show="loadingUsers" class="glyphicon glyphicon-refresh"
             translate>Loading users...</i>

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -127,7 +127,7 @@ angular.module("privacyideaApp")
         $scope.logoutWarning = false;
     });
     */
-                                
+
     // helper function
     $scope.isChecked = function (val) {
         // check if val is set
@@ -259,7 +259,7 @@ angular.module("privacyideaApp")
             $scope.user_page_size = data.result.value.user_page_size;
             $scope.user_details_in_tokenlist = data.result.value.user_details;
             $scope.default_tokentype = data.result.value.default_tokentype;
-            $scope.search_on_enter = data.result.value.search_on_enter;
+            $rootScope.search_on_enter = data.result.value.search_on_enter;
             var timeout = data.result.value.logout_time;
             PolicyTemplateFactory.setUrl(data.result.value.policy_template_url);
             console.log(timeout);

--- a/privacyidea/static/components/token/views/token.assign.html
+++ b/privacyidea/static/components/token/views/token.assign.html
@@ -9,7 +9,7 @@
 <form name="formAssignToken" role="form" validate>
     <div assign-token new-token-object="newToken"></div>
     <div class="text-center">
-        <button ng-click="assignToken()"
+        <button type="button" ng-click="assignToken()"
                 ng-disabled="formAssignToken.$invalid"
                 class="btn btn-primary" translate>Assign Token
         </button>

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -424,7 +424,7 @@
     <div assign-user new-user-object="newUser" realms="realms"></div>
 
     <div class="text-center">
-        <button ng-click="assignUser()"
+        <button type="button" ng-click="assignUser()"
                 id="assignButton"
                 ng-disabled="formAssignToken.$invalid"
                 class="btn btn-primary">

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -101,7 +101,7 @@
         </accordion>
 
         <div class="text-center">
-            <button ng-click="enrollToken()"
+            <button type="button" ng-click="enrollToken()"
                     ng-disabled="formEnrollToken.$invalid"
                     class="btn btn-primary" translate>Enroll Token
             </button>

--- a/privacyidea/static/components/user/views/user.details.html
+++ b/privacyidea/static/components/user/views/user.details.html
@@ -131,7 +131,7 @@
         <form name="formAssignToken" role="form" validate>
             <div assign-token new-token-object="newToken"></div>
             <div class="text-center">
-                <button ng-click="assignToken()"
+                <button type="button" ng-click="assignToken()"
                         id="assignButton"
                         ng-disabled="formAssignToken.$invalid"
                         class="btn btn-primary" translate>Assign Token


### PR DESCRIPTION
Hello @cornelinux 

There were still some occurrences of live searching when loading a serial or username, and this commit utilizes the search_on_enter policy for those instances.

3747d31

- Quoc
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/611%23issuecomment-274983238%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/611%23issuecomment-275139073%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/611%23issuecomment-274983238%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/611%3Fsrc%3Dpr%29%20is%2095.89%25%20%28diff%3A%20100%25%29%5Cn%3E%20Merging%20%5B%23611%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/611%3Fsrc%3Dpr%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%29%20will%20increase%20coverage%20by%20%2A%2A0.04%25%2A%2A%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23611%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20118%20%20%20%20%20%20%20%20118%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2014265%20%20%20%20%20%2014265%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%2013673%20%20%20%20%20%2013679%20%20%20%20%20%2B6%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20%20%20592%20%20%20%20%20%20%20%20586%20%20%20%20%20-6%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20update%20%5Bd8fc05c...3747d31%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/d8fc05cc795bad1a10af8526381975c6063047e2...3747d31a3f9c9b194c88577c85b86aa12e59092b%3Fsrc%3Dpr%29%22%2C%20%22created_at%22%3A%20%222017-01-25T00%3A26%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40quoc-axiadids%20%5Cr%5Cnthanks%20a%20lot%20for%20the%20pull%20request.%20%5Cr%5CnPlease%20give%20me%20some%20time%20to%20review%20this%2C%20since%20it%20is%20important%20to%20me%20to%20keep%20the%20default%20behaviour/user%20experience.%22%2C%20%22created_at%22%3A%20%222017-01-25T15%3A31%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/611#issuecomment-274983238'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage](https://codecov.io/gh/privacyidea/privacyidea/pull/611?src=pr) is 95.89% (diff: 100%)
> Merging [#611](https://codecov.io/gh/privacyidea/privacyidea/pull/611?src=pr) into [master](https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr) will increase coverage by **0.04%**
```diff
@@             master       #611   diff @@
==========================================
Files           118        118
Lines         14265      14265
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
+ Hits          13673      13679     +6
+ Misses          592        586     -6
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last update [d8fc05c...3747d31](https://codecov.io/gh/privacyidea/privacyidea/compare/d8fc05cc795bad1a10af8526381975c6063047e2...3747d31a3f9c9b194c88577c85b86aa12e59092b?src=pr)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Hi @quoc-axiadids
thanks a lot for the pull request.
Please give me some time to review this, since it is important to me to keep the default behaviour/user experience.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/611?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/611?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/611'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>