### PR TITLE
Adds support to pi-manage for creating policies from a json-formatted file

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -589,7 +589,7 @@ def create(name, scope, action):
 @policy_manager.command
 def create_from_file(name, filename):
     """
-    create a new policy from file (json formatted)
+    create a new policy from a JSON-file
     """
     import json
 

--- a/pi-manage
+++ b/pi-manage
@@ -586,6 +586,25 @@ def create(name, scope, action):
     return r
 
 
+@policy_manager.command
+def create_from_file(name, filename):
+    """
+    create a new policy from file (json formatted)
+    """
+    import json
+
+    f = open(filename, 'r')
+    contents = f.read()
+    f.close()
+    params = json.loads(contents)
+
+    r = set_policy(name, scope=params["scope"], action=params["action"], realm=params["realm"],
+                   resolver=params["resolver"],
+                   user=params["user"], time=params["time"], client=params["client"], active=params["active"],
+                   adminrealm=params["adminrealm"], check_all_resolvers=params["check_all_resolvers"])
+
+    return r
+
 @api_manager.command
 def createtoken(role=ROLE.ADMIN):
     """

--- a/pi-manage
+++ b/pi-manage
@@ -578,32 +578,44 @@ def delete(name):
     print(r)
 
 @policy_manager.command
-def create(name, scope, action):
+def create(name, scope, action, filename=''):
     """
-    create a new policy
+    create a new policy. 'FILENAME' must be a dictionary and its content takes precedence over cli
     """
-    r = set_policy(name, scope, action)
-    return r
+    import ast
 
+    if filename:
+        try:
+            f = open(filename, 'r')
+            contents = f.read()
+            f.close()
 
-@policy_manager.command
-def create_from_file(name, filename):
-    """
-    create a new policy from a JSON-file
-    """
-    import json
+            params = ast.literal_eval(contents)
 
-    f = open(filename, 'r')
-    contents = f.read()
-    f.close()
-    params = json.loads(contents)
+            if params.get("scope") and params.get("scope")!=scope:
+                print("Found scope '%s' in file, will use that instead of '%s'." %(params.get("scope"), scope))
+            else:
+                print("scope not defined in file, will use the cli value %s" % scope)
+                params["scope"]=scope
 
-    r = set_policy(name, scope=params["scope"], action=params["action"], realm=params["realm"],
-                   resolver=params["resolver"],
-                   user=params["user"], time=params["time"], client=params["client"], active=params["active"],
-                   adminrealm=params["adminrealm"], check_all_resolvers=params["check_all_resolvers"])
+            if params.get("action") and params.get("action")!=action:
+                print("Found action in file: '%s' , will use that instead of: '%s'." %(params.get("action"), action))
+            else:
+                print("action not defined in file, will use the cli value %s" % action)
+                params["action"]=action
 
-    return r
+            r = set_policy(name, scope=params.get("scope"), action=params.get("action"), realm=params.get("realm"),
+                           resolver=params.get("resolver"),
+                           user=params.get("user"), time=params.get("time"), client=params.get("client"), active=params.get("active"),
+                           adminrealm=params.get("adminrealm"), check_all_resolvers=params.get("check_all_resolvers"))
+            return r
+
+        except:
+            print "Unexpected error:", sys.exc_info()[1]
+
+    else:
+        r = set_policy(name, scope, action)
+        return r
 
 @api_manager.command
 def createtoken(role=ROLE.ADMIN):


### PR DESCRIPTION
The same kinda of approach is already used for useridresolvers
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/613%23issuecomment-275137567%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23issuecomment-275139459%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23issuecomment-275231156%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97939151%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97957523%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97958270%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97958333%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97972829%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97981832%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97991406%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r98009446%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r98162144%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23issuecomment-275616554%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23issuecomment-275137567%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/613%3Fsrc%3Dpr%29%20is%2095.89%25%20%28diff%3A%20100%25%29%5Cn%3E%20Merging%20%5B%23613%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/613%3Fsrc%3Dpr%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/branch/master%3Fsrc%3Dpr%29%20will%20increase%20coverage%20by%20%2A%2A0.04%25%2A%2A%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23613%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20118%20%20%20%20%20%20%20%20118%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%2014265%20%20%20%20%20%2014265%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%2013673%20%20%20%20%20%2013679%20%20%20%20%20%2B6%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20%20%20592%20%20%20%20%20%20%20%20586%20%20%20%20%20-6%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20update%20%5Bd8fc05c...0eb28aa%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/d8fc05cc795bad1a10af8526381975c6063047e2...0eb28aab0db45861ec0f07c22463b8266a907b3d%3Fsrc%3Dpr%29%22%2C%20%22created_at%22%3A%20%222017-01-25T15%3A26%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40splashx%20%5Cr%5Cnthanks%20a%20lot.%20I%20think%20there%20are%20many%20ways%20to%20improve%20pi-manage%2C%20since%20it%20can%20be%20used%20to%20bootstrap%20privacyIDEA%20without%20the%20service%20running.%5Cr%5CnPlease%20give%20me%20some%20time%20to%20review%20this%20and%20check%20some%20corner%20cases.%22%2C%20%22created_at%22%3A%20%222017-01-25T15%3A32%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20-%20I%20agree.%20We%20have%20an%20environment%20where%20PI%20is%20being%20configured%20via%20ansible.%5Cr%5CnUsing%20the%20API%20calls%20turned%20out%20to%20be%20quite%20cumbersome%20%28specially%20because%20of%20the%20token%20usage%29.%5Cr%5CnI%20believe%20the%20best%20way%20to%20do%20this%20is%20creating%20an%20ansible%20module%20which%20can%20leverage%20from%20the%20awesome%20pi%20library%2C%20but%20for%20now%20we%20heavily%20use%20pi-manage%20in%20our%20playbooks%20-%20this%20PR%20if%20approved%20will%20help%20a%20lot%20on%20the%20bootstrapping%20and%20automated%20configuration%20maintenance.%22%2C%20%22created_at%22%3A%20%222017-01-25T20%3A59%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20pushed%20the%20final%20version%20-%20ignore%20f05209b%20as%20that%20was%20a%20WIP.%20Anyway%2C%20the%20changes%20should%20all%20be%20as%20we%20agreed%20before.%5Cr%5CnSorry%20for%20not-so-clean%20PR%20%5Cud83d%5Cude1e%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-01-27T08%3A50%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f05209bf0aae3c4131dbaad3c54c7400e17987fa%20pi-manage%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r98162144%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ignore%20this%20commit%2C%20it%20was%20a%20WIP%22%2C%20%22created_at%22%3A%20%222017-01-27T08%3A47%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL578-608%22%7D%2C%20%22Pull%200eb28aab0db45861ec0f07c22463b8266a907b3d%20pi-manage%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97939151%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20consider%20naming%20the%20function%20%5C%22create%5C%22.%20So%20the%20command%20line%20will%20be%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20pi-manage%20policy%20create%20--filename%20pol.json%5Cr%5Cn%5Cr%5CnThe%20%5C%22create%5C%22%20command%20would%20be%20the%20same%20like%20for%20creating%20realms%20or%20resolvers.%22%2C%20%22created_at%22%3A%20%222017-01-26T07%3A02%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Will%20do%22%2C%20%22created_at%22%3A%20%222017-01-26T09%3A41%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20will%20break%20backwards%20compatibility%2C%20is%20that%20okay%3F%22%2C%20%22created_at%22%3A%20%222017-01-26T13%3A21%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20will%20only%20break%20backward%20compatibility%20to%20your%20unofficial%20patch.%20But%20it%20will%20be%20consisten%20in%20the%20parameter%20naming.%22%2C%20%22created_at%22%3A%20%222017-01-26T14%3A56%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL586-611%22%7D%2C%20%22Pull%200eb28aab0db45861ec0f07c22463b8266a907b3d%20pi-manage%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97958270%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20tried%20that%20first%20%28based%20on%20the%20original%20%60create%60%29%20but%20it%20threw%20me%20%60ValueError%3A%20malformed%20string%60%3A%20%5Cr%5Cn%60%60%60%5Cr%5Cn%5Bsplash%40Macintosh%3A%7E/privacyidea%5D%24%20cat%20/tmp/policy.test%20%5Cr%5Cn%7B%5Cr%5Cn%20%20%5C%22action%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%5C%22passthru%3Duserstore%5C%22%2C%5Cr%5Cn%20%20%20%20%5C%22smsautosend%5C%22%5Cr%5Cn%20%20%5D%2C%5Cr%5Cn%20%20%5C%22scope%5C%22%3A%20%5C%22authentication%5C%22%2C%5Cr%5Cn%20%20%5C%22realm%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%5C%22localsql%5C%22%5Cr%5Cn%20%20%5D%2C%5Cr%5Cn%20%20%5C%22resolver%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%5C%22localusers%5C%22%5Cr%5Cn%20%20%5D%2C%5Cr%5Cn%20%20%5C%22user%5C%22%3A%20%5C%22%5C%22%2C%5Cr%5Cn%20%20%5C%22active%5C%22%3A%20true%2C%5Cr%5Cn%20%20%5C%22check_all_resolvers%5C%22%3A%20false%2C%5Cr%5Cn%20%20%5C%22client%5C%22%3A%20%5C%22%5C%22%2C%5Cr%5Cn%20%20%5C%22time%5C%22%3A%20%5C%22%5C%22%2C%5Cr%5Cn%20%20%5C%22adminrealm%5C%22%3A%20%5B%5D%5Cr%5Cn%7D%5Cr%5Cn%5Bsplash%40Macintosh%3A%7E/privacyidea%5D%24%20python%5Cr%5CnPython%202.7.10%20%28default%2C%20Jul%2030%202016%2C%2019%3A40%3A32%29%20%5Cr%5Cn%5BGCC%204.2.1%20Compatible%20Apple%20LLVM%208.0.0%20%28clang-800.0.34%29%5D%20on%20darwin%5Cr%5CnType%20%5C%22help%5C%22%2C%20%5C%22copyright%5C%22%2C%20%5C%22credits%5C%22%20or%20%5C%22license%5C%22%20for%20more%20information.%5Cr%5Cn%3E%3E%3E%20import%20ast%5Cr%5Cn%3E%3E%3E%20f%20%3D%20open%28%5C%22/tmp/policy.test%5C%22%2C%20%27r%27%29%5Cr%5Cn%3E%3E%3E%20contents%20%3D%20f.read%28%29%5Cr%5Cn%3E%3E%3E%20f.close%28%29%5Cr%5Cn%3E%3E%3E%20ast.literal_eval%28contents%29%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22%3Cstdin%3E%5C%22%2C%20line%201%2C%20in%20%3Cmodule%3E%5Cr%5Cn%20%20File%20%5C%22/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ast.py%5C%22%2C%20line%2080%2C%20in%20literal_eval%5Cr%5Cn%20%20%20%20return%20_convert%28node_or_string%29%5Cr%5Cn%20%20File%20%5C%22/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ast.py%5C%22%2C%20line%2063%2C%20in%20_convert%5Cr%5Cn%20%20%20%20in%20zip%28node.keys%2C%20node.values%29%29%5Cr%5Cn%20%20File%20%5C%22/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ast.py%5C%22%2C%20line%2062%2C%20in%20%3Cgenexpr%3E%5Cr%5Cn%20%20%20%20return%20dict%28%28_convert%28k%29%2C%20_convert%28v%29%29%20for%20k%2C%20v%5Cr%5Cn%20%20File%20%5C%22/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ast.py%5C%22%2C%20line%2079%2C%20in%20_convert%5Cr%5Cn%20%20%20%20raise%20ValueError%28%27malformed%20string%27%29%5Cr%5CnValueError%3A%20malformed%20string%5Cr%5Cn%3E%3E%3E%20%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnThe%20same%20works%20with%20%60json%60%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%3E%3E%3E%20import%20json%5Cr%5Cn%3E%3E%3E%20params_json%20%3D%20json.loads%28contents%29%5Cr%5Cn%3E%3E%3E%20params_json%5Cr%5Cn%7Bu%27realm%27%3A%20%5Bu%27localsql%27%5D%2C%20u%27time%27%3A%20u%27%27%2C%20u%27active%27%3A%20True%2C%20u%27client%27%3A%20u%27%27%2C%20u%27user%27%3A%20u%27%27%2C%20u%27resolver%27%3A%20%5Bu%27localusers%27%5D%2C%20u%27check_all_resolvers%27%3A%20False%2C%20u%27action%27%3A%20%5Bu%27passthru%3Duserstore%27%2C%20u%27smsautosend%27%5D%2C%20u%27scope%27%3A%20u%27authentication%27%2C%20u%27adminrealm%27%3A%20%5B%5D%7D%5Cr%5Cn%3E%3E%3E%20%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnI%27ll%20double%20check%20the%20documentation%20for%20%60ast%60%20if%20I%27ve%20not%20missed%20something..%22%2C%20%22created_at%22%3A%20%222017-01-26T09%3A41%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20the%20question%20here%20is%3A%20do%20we%20want%20the%20users%20to%20quickly%20get%20error-free%20json%20format%20from%20browser%20%20and%20throw%20that%20into%20a%20file%20or%20we%20want%20them%20to%20write%20python-formatted%20files%20from%20scratch%20%28then%20%60ast.literal_eval%28%29%60%20%20can%20be%20used%29%3F%20%5Cr%5Cn%5Cr%5Cn%28I%27ll%20have%20to%20first%20convert%20that%20file%20to%20something%20%60ast%60%20can%20understand%20so%20I%20can%20proceed%20with%20testing%20o.O%29%22%2C%20%22created_at%22%3A%20%222017-01-26T11%3A09%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20the%20problem%20was%20that%20%60ast.literal_eval%28%29%60%20requires%20all%20values%20to%20be%20quoted.%20Therefore%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%5C%22active%5C%22%3A%20true%2C%5Cr%5Cn%20%20%5C%22check_all_resolvers%5C%22%3A%20false%2C%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnMust%20be%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%5C%22active%5C%22%3A%20%5C%22true%5C%22%2C%5Cr%5Cn%20%20%5C%22check_all_resolvers%5C%22%3A%20%5C%22false%5C%22%2C%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-01-26T12%3A14%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL586-611%22%7D%2C%20%22Pull%200eb28aab0db45861ec0f07c22463b8266a907b3d%20pi-manage%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/613%23discussion_r97957523%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Will%20do%22%2C%20%22created_at%22%3A%20%222017-01-26T09%3A37%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1154133%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL586-611%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/613#issuecomment-275137567'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage](https://codecov.io/gh/privacyidea/privacyidea/pull/613?src=pr) is 95.89% (diff: 100%)
> Merging [#613](https://codecov.io/gh/privacyidea/privacyidea/pull/613?src=pr) into [master](https://codecov.io/gh/privacyidea/privacyidea/branch/master?src=pr) will increase coverage by **0.04%**
```diff
@@             master       #613   diff @@
==========================================
Files           118        118
Lines         14265      14265
Methods           0          0
Messages          0          0
Branches          0          0
==========================================
+ Hits          13673      13679     +6
+ Misses          592        586     -6
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last update [d8fc05c...0eb28aa](https://codecov.io/gh/privacyidea/privacyidea/compare/d8fc05cc795bad1a10af8526381975c6063047e2...0eb28aab0db45861ec0f07c22463b8266a907b3d?src=pr)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Hi @splashx
thanks a lot. I think there are many ways to improve pi-manage, since it can be used to bootstrap privacyIDEA without the service running.
Please give me some time to review this and check some corner cases.
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> Yes - I agree. We have an environment where PI is being configured via ansible.
Using the API calls turned out to be quite cumbersome (specially because of the token usage).
I believe the best way to do this is creating an ansible module which can leverage from the awesome pi library, but for now we heavily use pi-manage in our playbooks - this PR if approved will help a lot on the bootstrapping and automated configuration maintenance.
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> I've pushed the final version - ignore f05209b as that was a WIP. Anyway, the changes should all be as we agreed before.
Sorry for not-so-clean PR 😞
- [ ] <a href='#crh-comment-Pull 0eb28aab0db45861ec0f07c22463b8266a907b3d pi-manage 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/613#discussion_r97939151'>File: pi-manage:L586-611</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Please consider naming the function "create". So the command line will be
pi-manage policy create --filename pol.json
The "create" command would be the same like for creating realms or resolvers.
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> Will do
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> That will break backwards compatibility, is that okay?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> It will only break backward compatibility to your unofficial patch. But it will be consisten in the parameter naming.
- [ ] <a href='#crh-comment-Pull 0eb28aab0db45861ec0f07c22463b8266a907b3d pi-manage 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/613#discussion_r97957523'>File: pi-manage:L586-611</a></b>
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> Will do
- [ ] <a href='#crh-comment-Pull 0eb28aab0db45861ec0f07c22463b8266a907b3d pi-manage 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/613#discussion_r97958270'>File: pi-manage:L586-611</a></b>
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> I tried that first (based on the original `create`) but it threw me `ValueError: malformed string`:
```
[splash@Macintosh:~/privacyidea]$ cat /tmp/policy.test
{
"action": [
"passthru=userstore",
"smsautosend"
],
"scope": "authentication",
"realm": [
"localsql"
],
"resolver": [
"localusers"
],
"user": "",
"active": true,
"check_all_resolvers": false,
"client": "",
"time": "",
"adminrealm": []
}
[splash@Macintosh:~/privacyidea]$ python
Python 2.7.10 (default, Jul 30 2016, 19:40:32)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ast
>>> f = open("/tmp/policy.test", 'r')
>>> contents = f.read()
>>> f.close()
>>> ast.literal_eval(contents)
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ast.py", line 80, in literal_eval
return _convert(node_or_string)
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ast.py", line 63, in _convert
in zip(node.keys, node.values))
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ast.py", line 62, in <genexpr>
return dict((_convert(k), _convert(v)) for k, v
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ast.py", line 79, in _convert
raise ValueError('malformed string')
ValueError: malformed string
>>>
```
The same works with `json`:
```
>>> import json
>>> params_json = json.loads(contents)
>>> params_json
{u'realm': [u'localsql'], u'time': u'', u'active': True, u'client': u'', u'user': u'', u'resolver': [u'localusers'], u'check_all_resolvers': False, u'action': [u'passthru=userstore', u'smsautosend'], u'scope': u'authentication', u'adminrealm': []}
>>>
```
I'll double check the documentation for `ast` if I've not missed something..
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> I think the question here is: do we want the users to quickly get error-free json format from browser  and throw that into a file or we want them to write python-formatted files from scratch (then `ast.literal_eval()`  can be used)?
(I'll have to first convert that file to something `ast` can understand so I can proceed with testing o.O)
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> So the problem was that `ast.literal_eval()` requires all values to be quoted. Therefore:
```
"active": true,
"check_all_resolvers": false,
```
Must be:
```
"active": "true",
"check_all_resolvers": "false",
```
- [ ] <a href='#crh-comment-Pull f05209bf0aae3c4131dbaad3c54c7400e17987fa pi-manage 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/613#discussion_r98162144'>File: pi-manage:L578-608</a></b>
- <a href='https://github.com/splashx'><img border=0 src='https://avatars.githubusercontent.com/u/1154133?v=3' height=16 width=16'></a> ignore this commit, it was a WIP


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/613?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/613?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/613'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>