### PR TITLE
Added token_validity_period condition for event handler (#618)

### DIFF
--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -48,6 +48,7 @@ class CONDITION(object):
     """
     TOKEN_HAS_OWNER = "token_has_owner"
     TOKEN_IS_ORPHANED = "token_is_orphaned"
+    TOKEN_VALIDITY_PERIOD = "token_validity_period"
     USER_TOKEN_NUMBER = "user_token_number"
     OTP_COUNTER = "otp_counter"
     TOKENTYPE = "tokentype"
@@ -138,6 +139,11 @@ class BaseEventHandler(object):
                 "type": "str",
                 "desc": _("The token has a user assigned, but the user does "
                           "not exist in the userstore anymore."),
+                "value": ("True", "False")
+            },
+            CONDITION.TOKEN_VALIDITY_PERIOD: {
+                "type": "str",
+                "desc": _("Check if the token is within its validity period."),
                 "value": ("True", "False")
             },
             "serial": {
@@ -332,6 +338,11 @@ class BaseEventHandler(object):
                     log.debug("Condition token_is_orphaned for token {0!r} not "
                               "fulfilled.".format(token_obj))
                     res = False
+
+            if CONDITION.TOKEN_VALIDITY_PERIOD in conditions and res:
+                valid = token_obj.check_validity_period()
+                res = (conditions.get(CONDITION.TOKEN_VALIDITY_PERIOD)
+                       in ["True", True]) == valid
 
             if CONDITION.OTP_COUNTER in conditions and res:
                 res = token_obj.token.count == \


### PR DESCRIPTION
#618
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99069002%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99069106%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99069702%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99073756%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99075291%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99076988%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99099322%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99379592%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99462022%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99462023%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99462024%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2069f91fcc5b15a814c1d54279d9d7fdfc048067cc%20tests/test_lib_events.py%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99379592%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20needs%20to%20be%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20datetime.now%28%29%20-%20timedelta%281%29%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-02-03T17%3A07%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222017-02-04T07%3A49%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_events.py%3AL1161-1224%22%7D%2C%20%22Pull%2001be2b31d10fa5b89a0d00213af12f9463fc60cf%20privacyidea/lib/eventhandler/base.py%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99069106%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20it%20could%20also%20be%2C%20that%20the%20token%20is%20not%20valid%2C%20yet.%20So%20%5C%22expired%5C%22%20might%20be%20the%20wrong%20word%20here.%5Cr%5CnDo%20you%20think%20this%20may%20lead%20to%20confusions%3F%5Cr%5Cn%5Cr%5CnBecause%20this%20condition%20could%20also%20be%20used%2C%20if%20the%20validity%20period%20of%20the%20token%20starts%20next%20week...%22%2C%20%22created_at%22%3A%20%222017-02-02T08%3A20%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20makes%20sense.%20I%20think%20it%20can%20be%20changed%20to%20%5C%22token_validity_period%5C%22%20instead.%5Cr%5CnThat%20reminds%20me%20of%20unexpected%20use%20cases%2C%20and%20I%20think%20it%20should%20now%20be%20more%20detailed%20than%20just%20true%20and%20false.%5Cr%5Cn%5Cr%5CnI%20would%20like%20to%20update%20the%20%5C%22check_validity_period%5C%22%20function%20definition%20to%20return%20-1%20%28before%20valid%20period%29%2C%200%20%28valid%29%2C%20and%201%20%28expired%29%2C%20and%20update%20the%20condition%20to%20reflect%20accordingly.%20This%20also%20requires%20to%20update%20other%20test%20calls%20%28not%20too%20complicated%29.%5Cr%5Cn%5Cr%5CnWhat%20do%20you%20think%3F%20Or%20we%20can%20just%20keep%20the%20current%20simplicity%20with%20true%20and%20false%20if%20there%20is%20no%20need%20yet.%20%22%2C%20%22created_at%22%3A%20%222017-02-02T08%3A54%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/23221438%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quynh-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20I%20am%20wondering%2C%20what%20timezone%20you%20are%20in%21%20%3B-%29%5Cr%5Cn%5Cr%5CnIt%20might%20be%20interesting%20one%20day%20to%20distinguish%20between%20%5Cr%5Cn1.%20token%20not%20valid%2C%20yet%20or%5Cr%5Cn2.%20token%20not%20valid%20anymore.%5Cr%5Cn%5Cr%5CnAt%20the%20moment%20tokenclass.check_validity_period%28%29%20does%20not%20distinguish%20that.%5Cr%5CnMaybe%20I%20should%20add%20two%20additional%20tokenclass%20methods%20like%5Cr%5Cn%5Cr%5Cn%20%2A%20is_token_valid_yet%28%29%5Cr%5Cn%20%2A%20is_token_still_valid%28%29%5Cr%5Cn%5Cr%5CnThen%20the%20event%20condition%20could%20use%20these%20methods%20instead%20of%20%60%60check_validity_period%60%60.%5Cr%5Cn%5Cr%5CnI%20think%20we%20should%20avoid%20cryptic%20numbers%20in%20the%20conditions.%20We%20should%20really%20use%5Cr%5Cn%5Cr%5Cn%20%20%2A%20not%20valid%20yet%20%20%28before%20the%20validity%20period%29%5Cr%5Cn%20%20%2A%20valid%20%28inside%20the%20validity%20period%29%5Cr%5Cn%20%20%2A%20not%20valid%20%28not%20inside%20the%20validity%20period%29%5Cr%5Cn%20%20%2A%20not%20valid%20anymore%20%28behind%20the%20validity%20period%29%5Cr%5Cn%5Cr%5CnI%20am%20not%20a%20native%20speaker%2C%20so%20maybe%20these%20names%20are%20not%20yet%20optimal.%22%2C%20%22created_at%22%3A%20%222017-02-02T09%3A04%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20will%20go%20with%20the%20simplicity%20for%20now%20%3B-%29%5Cr%5CnI%20will%20go%20with%20the%20condition%20name%20%5C%22token_validity_period%5C%22%2C%20and%20value%20true/false%2C%20and%20will%20also%20update%20the%20test%20cases.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-02-02T09%3A15%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/23221438%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quynh-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20a%20lot.%20This%20is%20just%20fine%20for%20the%20PR%21%5Cr%5CnI%20might%20add%20the%20more%20detailed%20thingy%20later...%22%2C%20%22created_at%22%3A%20%222017-02-02T11%3A21%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222017-02-04T07%3A49%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/base.py%3AL141-152%22%7D%2C%20%22Pull%2001be2b31d10fa5b89a0d00213af12f9463fc60cf%20privacyidea/lib/eventhandler/base.py%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/619%23discussion_r99069002%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20do%20the%20complete%20%60%60res%60%60%20assignment%20like%20this%3A%5Cr%5Cn%28see%20line%20281%29%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20res%20%3D%20%28conditions.get%28CONDITION.TOKEN_IS_EXPIRED%29%20in%20%5B%5C%22True%5C%22%2C%20True%5D%29%20%3D%3D%20expired%5Cr%5Cn%20%20%20%20%20%20%20if%20not%20res%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20log.debug%28%5C%22Condition%20token_is_expired%20not%20fulfilled....%5C%22%29%5Cr%5Cn%5Cr%5CnThis%20will%20replace%20lines%20344%20-%20352%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-02-02T08%3A19%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20will%20also%20increase%20the%20code%20coverage.%20At%20the%20moment%20the%20elsid%20and%20else%20are%20not%20covered%20%3B-%29%5Cr%5CnHm%2C%20you%20could%20also%20add%20a%20negative%20test%20to%20cover%20the%20log%20output.%22%2C%20%22created_at%22%3A%20%222017-02-02T08%3A23%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222017-02-04T07%3A49%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/base.py%3AL339-357%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 01be2b31d10fa5b89a0d00213af12f9463fc60cf privacyidea/lib/eventhandler/base.py 34'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/619#discussion_r99069002'>File: privacyidea/lib/eventhandler/base.py:L339-357</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Please do the complete ``res`` assignment like this:
(see line 281)
res = (conditions.get(CONDITION.TOKEN_IS_EXPIRED) in ["True", True]) == expired
if not res:
log.debug("Condition token_is_expired not fulfilled....")
This will replace lines 344 - 352
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> This will also increase the code coverage. At the moment the elsid and else are not covered ;-)
Hm, you could also add a negative test to cover the log output.
- [x] <a href='#crh-comment-Pull 01be2b31d10fa5b89a0d00213af12f9463fc60cf privacyidea/lib/eventhandler/base.py 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/619#discussion_r99069106'>File: privacyidea/lib/eventhandler/base.py:L141-152</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> I think it could also be, that the token is not valid, yet. So "expired" might be the wrong word here.
Do you think this may lead to confusions?
Because this condition could also be used, if the validity period of the token starts next week...
- <a href='https://github.com/quynh-axiadids'><img border=0 src='https://avatars.githubusercontent.com/u/23221438?v=3' height=16 width=16></a> That makes sense. I think it can be changed to "token_validity_period" instead.
That reminds me of unexpected use cases, and I think it should now be more detailed than just true and false.
I would like to update the "check_validity_period" function definition to return -1 (before valid period), 0 (valid), and 1 (expired), and update the condition to reflect accordingly. This also requires to update other test calls (not too complicated).
What do you think? Or we can just keep the current simplicity with true and false if there is no need yet.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> I think I am wondering, what timezone you are in! ;-)
It might be interesting one day to distinguish between
1. token not valid, yet or
2. token not valid anymore.
At the moment tokenclass.check_validity_period() does not distinguish that.
Maybe I should add two additional tokenclass methods like
* is_token_valid_yet()
* is_token_still_valid()
Then the event condition could use these methods instead of ``check_validity_period``.
I think we should avoid cryptic numbers in the conditions. We should really use
* not valid yet  (before the validity period)
* valid (inside the validity period)
* not valid (not inside the validity period)
* not valid anymore (behind the validity period)
I am not a native speaker, so maybe these names are not yet optimal.
- <a href='https://github.com/quynh-axiadids'><img border=0 src='https://avatars.githubusercontent.com/u/23221438?v=3' height=16 width=16></a> I will go with the simplicity for now ;-)
I will go with the condition name "token_validity_period", and value true/false, and will also update the test cases.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Thanks a lot. This is just fine for the PR!
I might add the more detailed thingy later...
- [x] <a href='#crh-comment-Pull 69f91fcc5b15a814c1d54279d9d7fdfc048067cc tests/test_lib_events.py 35'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/619#discussion_r99379592'>File: tests/test_lib_events.py:L1161-1224</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> This needs to be
datetime.now() - timedelta(1)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/619?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/619?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/619'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>