### PR TITLE
LDAP resolver: Respect START_TLS and NOREFERRALS config options

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -589,8 +589,8 @@ class IdResolver (UserIdResolver):
         self.userinfo["username"] = self.loginname_attribute
         self.map = yaml.safe_load(userinfo)
         self.uidtype = config.get("UIDTYPE", "DN")
-        self.noreferrals = config.get("NOREFERRALS", False)
-        self.start_tls = config.get("START_TLS", False)
+        self.noreferrals = is_true(config.get("NOREFERRALS", False))
+        self.start_tls = is_true(config.get("START_TLS", False))
         self._editable = config.get("EDITABLE", False)
         self.scope = config.get("SCOPE") or ldap3.SUBTREE
         self.resolverId = self.uri

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -861,6 +861,7 @@ myApp.controller("LdapResolverController", function ($scope, ConfigFactory, $sta
             $scope.params.NOREFERRALS = isTrue($scope.params.NOREFERRALS);
             $scope.params.EDITABLE = isTrue($scope.params.EDITABLE);
             $scope.params.TLS_VERIFY = isTrue($scope.params.TLS_VERIFY);
+            $scope.params.START_TLS = isTrue($scope.params.START_TLS);
             $scope.params.type = 'ldapresolver';
         });
     }


### PR DESCRIPTION
Closes #658.

We might need to think about users who did not actively enable STARTTLS: Up until now, they were (unknowingly) using STARTTLS. After this change, LDAP traffic will be transmitted in the clear. However, I think these users probably didn't validate the certificate anyway?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/659%23issuecomment-287091560%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/659%23issuecomment-287095869%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/659%23issuecomment-287091560%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/659%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23659%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/659%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/536b6d3ee64ed44f15fa83ee0fbf4e631638669d%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23659%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%20%2095.4%25%20%20%2095.4%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20120%20%20%20%20%20120%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014547%20%20%2014547%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2013878%20%20%2013878%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20669%20%20%20%20%20669%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/659%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/536b6d3ee64ed44f15fa83ee0fbf4e631638669d...91238e515a60b3312d297405a180001bdfda169d%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6091.86%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/659%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/659%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B536b6d3...91238e5%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/536b6d3ee64ed44f15fa83ee0fbf4e631638669d...91238e515a60b3312d297405a180001bdfda169d%3Fel%3Dfooter%26src%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%22%2C%20%22created_at%22%3A%20%222017-03-16T15%3A21%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20having%20%23639%20can%20take%20care%20of%20this.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-16T15%3A34%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/659#issuecomment-287091560'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/659?src=pr&el=h1) Report
> Merging [#659](https://codecov.io/gh/privacyidea/privacyidea/pull/659?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/536b6d3ee64ed44f15fa83ee0fbf4e631638669d?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `100%`.
```diff
@@          Coverage Diff           @@
##           master    #659   +/-   ##
======================================
Coverage    95.4%   95.4%
======================================
Files         120     120
Lines       14547   14547
======================================
Hits        13878   13878
Misses        669     669
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/659?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/compare/536b6d3ee64ed44f15fa83ee0fbf4e631638669d...91238e515a60b3312d297405a180001bdfda169d?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `91.86% <100%> (ø)` | :white_check_mark: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/659?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/659?src=pr&el=footer). Last update [536b6d3...91238e5](https://codecov.io/gh/privacyidea/privacyidea/compare/536b6d3ee64ed44f15fa83ee0fbf4e631638669d...91238e515a60b3312d297405a180001bdfda169d?el=footer&src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> I think having #639 can take care of this.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/659?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/659?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/659'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>