### PR TITLE
Remove redundant open() in LDAP machine resolver

### DIFF
--- a/privacyidea/lib/machines/ldap.py
+++ b/privacyidea/lib/machines/ldap.py
@@ -68,7 +68,6 @@ class LdapMachineResolver(BaseMachineResolver):
                                                   password=self.bindpw,
                                                   auto_referrals=not
                                                   self.noreferrals)
-            self.l.open()
             if not self.l.bind():
                 raise Exception("Wrong credentials")
             self.i_am_bound = True
@@ -299,7 +298,6 @@ class LdapMachineResolver(BaseMachineResolver):
                                              password=params.get("BINDPW"),
                                              auto_referrals=not params.get(
                                                  "NOREFERRALS"))
-            l.open()
             if not l.bind():
                 raise Exception("Wrong credentials")
             # search for users...


### PR DESCRIPTION
This just implements the changes in #651 for the LDAP machine resolver.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/660%23issuecomment-287321840%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/660%23issuecomment-287321840%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/660%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23660%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/660%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/070c4b391df1904a34ba78c45c9049b85b442215%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23660%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.38%25%20%20%2095.37%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20120%20%20%20%20%20%20120%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014547%20%20%20%2014545%20%20%20%20%20%20%20-2%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2013875%20%20%20%2013873%20%20%20%20%20%20%20-2%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20672%20%20%20%20%20%20672%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/660%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/machines/ldap.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/070c4b391df1904a34ba78c45c9049b85b442215...fef8ed548019ec684f9be2ad7d8dff35e78730d8%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmVzL2xkYXAucHk%3D%29%20%7C%20%6087.21%25%20%3C%5Cu00f8%3E%20%28-0.19%25%29%60%20%7C%20%3Ax%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/070c4b391df1904a34ba78c45c9049b85b442215...fef8ed548019ec684f9be2ad7d8dff35e78730d8%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.1%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/660%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/660%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B070c4b3...fef8ed5%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/070c4b391df1904a34ba78c45c9049b85b442215...fef8ed548019ec684f9be2ad7d8dff35e78730d8%3Fel%3Dfooter%26src%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%22%2C%20%22created_at%22%3A%20%222017-03-17T10%3A40%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/660#issuecomment-287321840'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/660?src=pr&el=h1) Report
> Merging [#660](https://codecov.io/gh/privacyidea/privacyidea/pull/660?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/070c4b391df1904a34ba78c45c9049b85b442215?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `n/a`.
```diff
@@            Coverage Diff             @@
##           master     #660      +/-   ##
==========================================
- Coverage   95.38%   95.37%   -0.01%
==========================================
Files         120      120
Lines       14547    14545       -2
==========================================
- Hits        13875    13873       -2
Misses        672      672
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/660?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/machines/ldap.py](https://codecov.io/gh/privacyidea/privacyidea/compare/070c4b391df1904a34ba78c45c9049b85b442215...fef8ed548019ec684f9be2ad7d8dff35e78730d8?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmVzL2xkYXAucHk=) | `87.21% <ø> (-0.19%)` | :x: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/compare/070c4b391df1904a34ba78c45c9049b85b442215...fef8ed548019ec684f9be2ad7d8dff35e78730d8?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.1% <0%> (ø)` | :white_check_mark: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/660?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/660?src=pr&el=footer). Last update [070c4b3...fef8ed5](https://codecov.io/gh/privacyidea/privacyidea/compare/070c4b391df1904a34ba78c45c9049b85b442215...fef8ed548019ec684f9be2ad7d8dff35e78730d8?el=footer&src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/660?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/660?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/660'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>