### PR TITLE
LDAP resolver/STARTTLS: Read server info only once

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -1038,9 +1038,9 @@ class IdResolver (UserIdResolver):
             raise Exception("Authtype {0!s} not supported".format(authtype))
 
         if start_tls:
-            l.open()
+            l.open(read_server_info=False)
             log.debug("Doing start_tls")
-            r = l.start_tls()
+            r = l.start_tls(read_server_info=False)
 
         return l
 


### PR DESCRIPTION
Previously, `refresh_server_info` was called for `open()`, `start_tls()` and `bind()`. With this patch, it is only called for `bind()`. See #655.

Apparently, `bind()` calls `refresh_server_info()`, so assuming that every call to `create_connection()` is followed by a call to `bind()`, the LDAP resolver should still fetch the schema information properly. (But we should probably document that somewhere?)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/665%23issuecomment-288718489%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/665%23issuecomment-288718489%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/665%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23665%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/665%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%600%25%60.%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23665%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.37%25%20%20%2095.4%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20120%20%20%20%20%20120%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014545%20%20%2014545%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2013873%20%20%2013876%20%20%20%20%20%20%20%2B3%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20672%20%20%20%20%20669%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/665%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93...a397a9e33f91467e22f769cc72822a9c2b0fe7aa%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6091.86%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93...a397a9e33f91467e22f769cc72822a9c2b0fe7aa%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.68%25%20%3C0%25%3E%20%28%2B2.58%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/665%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/665%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bb69c7b4...a397a9e%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/compare/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93...a397a9e33f91467e22f769cc72822a9c2b0fe7aa%3Fsrc%3Dpr%26el%3Dfooter%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%22%2C%20%22created_at%22%3A%20%222017-03-23T13%3A26%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/665#issuecomment-288718489'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/665?src=pr&el=h1) Report
> Merging [#665](https://codecov.io/gh/privacyidea/privacyidea/pull/665?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `0%`.
```diff
@@            Coverage Diff            @@
##           master    #665      +/-   ##
=========================================
+ Coverage   95.37%   95.4%   +0.02%
=========================================
Files         120     120
Lines       14545   14545
=========================================
+ Hits        13873   13876       +3
+ Misses        672     669       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/665?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/compare/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93...a397a9e33f91467e22f769cc72822a9c2b0fe7aa?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `91.86% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/compare/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93...a397a9e33f91467e22f769cc72822a9c2b0fe7aa?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.68% <0%> (+2.58%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/665?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/665?src=pr&el=footer). Last update [b69c7b4...a397a9e](https://codecov.io/gh/privacyidea/privacyidea/compare/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93...a397a9e33f91467e22f769cc72822a9c2b0fe7aa?src=pr&el=footer&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/665?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/665?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/665'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>