### PR TITLE
Update WebUI Policy to have specific idle timeout actions.

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -550,7 +550,7 @@ def get_webui_settings(request, response):
         content["result"]["value"]["token_wizard"] = token_wizard
         content["result"]["value"]["token_wizard_2nd"] = token_wizard_2nd
         content["result"]["value"]["search_on_enter"] = len(search_on_enter) > 0
-        content["result"]["value"]["timeout_action"] = timeout_action[0]['action']['timeout_action']
+        content["result"]["value"]["timeout_action"] = len(timeout_action) > 0
         response.data = json.dumps(content)
     return response
 

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -65,6 +65,7 @@ required = False
 DEFAULT_LOGOUT_TIME = 120
 DEFAULT_PAGE_SIZE = 15
 DEFAULT_TOKENTYPE = "hotp"
+DEFAULT_TIMEOUT_ACTION = "lockscreeen"
 DEFAULT_POLICY_TEMPLATE_URL = "https://raw.githubusercontent.com/privacyidea/" \
                               "policy-templates/master/templates/"
 
@@ -503,7 +504,7 @@ def get_webui_settings(request, response):
             realm=realm,
             client=client
         )
-        timeout_action = policy_object.get_policies(
+        timeout_action_pol = policy_object.get_policies(
             action=ACTION.TIMEOUT_ACTION,
             scope=SCOPE.WEBUI,
             realm=realm,
@@ -531,6 +532,10 @@ def get_webui_settings(request, response):
         if len(logout_time_pol) == 1:
             logout_time = int(logout_time_pol[0])
 
+        timeout_action = DEFAULT_TIMEOUT_ACTION
+        if len(timeout_action_pol) == 1:
+            timeout_action = timeout_action_pol[0]['action']['timeout_action']
+
         policy_template_url_pol = policy_object.get_action_values(
             action=ACTION.POLICYTEMPLATEURL,
             scope=SCOPE.WEBUI,
@@ -550,7 +555,7 @@ def get_webui_settings(request, response):
         content["result"]["value"]["token_wizard"] = token_wizard
         content["result"]["value"]["token_wizard_2nd"] = token_wizard_2nd
         content["result"]["value"]["search_on_enter"] = len(search_on_enter) > 0
-        content["result"]["value"]["timeout_action"] = len(timeout_action) > 0
+        content["result"]["value"]["timeout_action"] = timeout_action
         response.data = json.dumps(content)
     return response
 

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -503,6 +503,12 @@ def get_webui_settings(request, response):
             realm=realm,
             client=client
         )
+        timeout_action = policy_object.get_policies(
+            action=ACTION.TIMEOUT_ACTION,
+            scope=SCOPE.WEBUI,
+            realm=realm,
+            client=client
+        )
         default_tokentype_pol = policy_object.get_action_values(
             action=ACTION.DEFAULT_TOKENTYPE,
             scope=SCOPE.WEBUI,
@@ -544,6 +550,7 @@ def get_webui_settings(request, response):
         content["result"]["value"]["token_wizard"] = token_wizard
         content["result"]["value"]["token_wizard_2nd"] = token_wizard_2nd
         content["result"]["value"]["search_on_enter"] = len(search_on_enter) > 0
+        content["result"]["value"]["timeout_action"] = timeout_action[0]['action']['timeout_action']
         response.data = json.dumps(content)
     return response
 

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -291,6 +291,7 @@ class ACTION(object):
     ENROLLPIN = "enrollpin"
     MANAGESUBSCRIPTION = "managesubscription"
     SEARCH_ON_ENTER = "search_on_enter"
+    TIMEOUT_ACTION = "timeout_action"
 
 
 class GROUP(object):
@@ -344,6 +345,12 @@ class AUTOASSIGNVALUE(object):
     __doc__ = """This is the possible values for autoassign"""
     USERSTORE = "userstore"
     NONE = "any_pin"
+
+
+class TIMEOUT_ACTION(object):
+    __doc__ = """This is a list of actions values for idle users"""
+    LOGOUT = "logout"
+    LOCKSCREEN = 'lockscreen'
 
 
 class PolicyClass(object):
@@ -1566,6 +1573,12 @@ def get_static_policy_definitions(scope=None):
                 'type': 'bool',
                 'desc': _('When searching in the user list, the search will '
                           'only performed when pressing enter.')
+            },
+            ACTION.TIMEOUT_ACTION: {
+                'type': 'str',
+                'desc': _('The action taken when a user is idle '
+                          'beyond the logout_time limit.'),
+                'value': [TIMEOUT_ACTION.LOGOUT, TIMEOUT_ACTION.LOCKSCREEN],
             },
             ACTION.REMOTE_USER: {
                 'type': 'str',

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1577,7 +1577,8 @@ def get_static_policy_definitions(scope=None):
             ACTION.TIMEOUT_ACTION: {
                 'type': 'str',
                 'desc': _('The action taken when a user is idle '
-                          'beyond the logout_time limit.'),
+                          'beyond the logout_time limit. '
+                          'Defaults to "lockscreen".'),
                 'value': [TIMEOUT_ACTION.LOGOUT, TIMEOUT_ACTION.LOCKSCREEN],
             },
             ACTION.REMOTE_USER: {

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -119,10 +119,15 @@ angular.module("privacyideaApp")
     });
 
     $scope.$on('IdleTimeout', function () {
-        console.log("Lock!");
-        $scope.logoutWarning = false;
-        $scope.$apply();
-        $scope.lock_screen();
+        if ($scope.timeout_action == "logout") {
+            console.log("Logout!");
+            $scope.logout();
+        } else if ($scope.timeout_action == "lockscreen") {
+            console.log("Lock!");
+            $scope.logoutWarning = false;
+            $scope.$apply();
+            $scope.lock_screen();
+        }
     });
     /*
      $rootScope.$on('Keepalive', function() {
@@ -270,6 +275,7 @@ angular.module("privacyideaApp")
             $scope.user_page_size = data.result.value.user_page_size;
             $scope.user_details_in_tokenlist = data.result.value.user_details;
             $scope.default_tokentype = data.result.value.default_tokentype;
+            $scope.timeout_action = data.result.value.timeout_action;
             $rootScope.search_on_enter = data.result.value.search_on_enter;
             var timeout = data.result.value.logout_time;
             PolicyTemplateFactory.setUrl(data.result.value.policy_template_url);

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -119,7 +119,7 @@ angular.module("privacyideaApp")
     });
 
     $scope.$on('IdleTimeout', function () {
-        if ($scope.timeout_action == 1) {
+        if ($scope.timeout_action == "logout") {
             console.log("Logout!");
             $scope.logout();
         } else {

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -119,10 +119,10 @@ angular.module("privacyideaApp")
     });
 
     $scope.$on('IdleTimeout', function () {
-        if ($scope.timeout_action == "logout") {
+        if ($scope.timeout_action == 1) {
             console.log("Logout!");
             $scope.logout();
-        } else if ($scope.timeout_action == "lockscreen") {
+        } else {
             console.log("Lock!");
             $scope.logoutWarning = false;
             $scope.$apply();


### PR DESCRIPTION
Hello Cornelius.

This PR is to include a webui configuration to have an option to have logout/lockscreen action when a user is idle pass the timeout threshold.

… #653
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108057636%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108070106%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108073297%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289346837%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289353959%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289359390%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289361146%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289363866%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289363989%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289364865%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289365225%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108098379%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108100214%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108100547%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108100607%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23issuecomment-289346837%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23666%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23666%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.37%25%20%20%2095.4%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20120%20%20%20%20%20120%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014545%20%20%2014552%20%20%20%20%20%20%20%2B7%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2013873%20%20%2013883%20%20%20%20%20%20%2B10%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20672%20%20%20%20%20669%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6096.06%25%20%3C100%25%3E%20%28%2B0.03%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.1%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.68%25%20%3C0%25%3E%20%28%2B2.58%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bb69c7b4...f275bf5%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/666%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%22%2C%20%22created_at%22%3A%20%222017-03-27T03%3A40%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40quoc-axiadids%20%5Cr%5Cnwhy%20did%20you%20close%20this%20PR%3F%22%2C%20%22created_at%22%3A%20%222017-03-27T04%3A56%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40cornelinux%2C%5Cr%5Cn%5Cr%5CnThere%20is%20something%20with%20my%20branch.%20I%20will%20create%20a%20new%20PR.%22%2C%20%22created_at%22%3A%20%222017-03-27T05%3A47%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/24928394%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quoc-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40cornelinux%20%5Cr%5Cn%5Cr%5CnI%20just%20noticed%20a%20problem%20with%20the%20commit.%20I%20will%20need%20to%20append%20a%20small%20change.%20The%20%5Cr%5Cn%60len%28timeout%29%20%3E%200%60%20will%20always%20return%20a%20value%20whether%20or%20not%20the%20user%20specified%20if%20they%20wished%20to%20have%20a%20lockscreen%20or%20a%20logout%20option.%20I%20will%20need%20to%20append%20a%20small%20change%20here.%20I%20apologize.%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A01%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/24928394%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quoc-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40cornelinux%20I%20have%20added%20the%20small%20fix%2C%20please%20let%20me%20know%20if%20you%20have%20any%20questions.%20Thank%20you.%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A22%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/24928394%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quoc-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20have%20an%20%60%60is_true%60%60%20function%20in%20%60%60lib.utils%60%60%20if%20needed.%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A22%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20applied%20the%20same%20conventions%20that%20you%20have%20in%20applying%20the%20%60logout_time%60%20policy.%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A29%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/24928394%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quoc-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20apologize%20for%20the%20not%20so%20clean%20PR%2C%20if%20you%20would%20like.%20I%20can%20create%20a%20cleaner%20PR%20for%20you%3F%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A31%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/24928394%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quoc-axiadids%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2016ba5f75db0fa0ac1adfa969fb0cb54c5a92ca06%20privacyidea/static/components/login/controllers/loginControllers.js%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108057636%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Would%20it%20make%20more%20sense%20to%20actually%20have%20a%20default%3F%20If%20for%20any%20reason%20timeout_action%20is%20not%20set%20correctly%2C%20the%20screen%20will%20neither%20lock%20nor%20logout.%5Cr%5CnWe%20could%20use%20an%20%5C%22else%5C%22%20instead%20of%20an%20%5C%22else%20if%5C%22%2C%20so%20that%20we%20are%20secure%20here%20in%20any%20case.%5Cr%5CnWhat%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222017-03-26T10%3A58%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agree%20with%20that%20idea.%20There%20should%20be%20a%20default%20when%20the%20policy%20is%20not%20set.%20I%20will%20modify%20the%20Pull%20Request.%22%2C%20%22created_at%22%3A%20%222017-03-26T20%3A20%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/24928394%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quoc-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22thx%21%22%2C%20%22created_at%22%3A%20%222017-03-26T22%3A12%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/login/controllers/loginControllers.js%3AL119-134%22%7D%2C%20%22Pull%2014c606ee30f435263f1b1708201e7ad974c0e33d%20privacyidea/api/lib/postpolicy.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/666%23discussion_r108098379%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20recommend%20using%20%60%60get_action_values%60%60%2C%20so%20you%20can%20directly%20receive%20the%20list%20of%20timeout_actions.%20%28see%20logout_time_pol%29.%5Cr%5Cn%5Cr%5CnThis%20way%20you%20later%20do%20not%20need%20to%20do%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20timeout_action%20%3D%20timeout_action_pol%5B0%5D%5B%27action%27%5D%5B%27timeout_action%27%5D%5Cr%5Cn%5Cr%5Cnbut%20only%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20timeout_action%20%3D%20timeout_action_pol%5B0%5D%20%5Cr%5Cn%5Cr%5CnThis%20this%20will%20be%20a%20list%20of%20action%20values.%5Cr%5Cn%5Cr%5CnIf%20using%20%60%60unique%20%3D%20True%60%60%20in%20%60%60get_action_values%60%60you%20will%20get%20an%20exception%20if%20there%20are%20contradicting%20policies.%20As%20this%20is%20also%20done%20with%20logout_time_pol%20at%20the%20moment%2C%20we%20probably%20should%20also%20do%20this%20with%20logout_action.%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A30%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20like%20it%21%20It%27s%20much%20cleaner.%20%3A%29%20%5Cr%5CnI%20can%20append%20that%20to%20the%20PR.%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A48%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/24928394%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/quoc-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20working%20on%20it.%20THanks%20alot%21%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A51%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22...also%20found%20a%20minor%20issue%2C%20if%20the%20logout%20time%20is%20set%20to%20%3C%3D10%20seconds...%20%3A-/%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-27T06%3A52%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/lib/postpolicy.py%3AL504-511%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 16ba5f75db0fa0ac1adfa969fb0cb54c5a92ca06 privacyidea/static/components/login/controllers/loginControllers.js 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/666#discussion_r108057636'>File: privacyidea/static/components/login/controllers/loginControllers.js:L119-134</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Would it make more sense to actually have a default? If for any reason timeout_action is not set correctly, the screen will neither lock nor logout.
We could use an "else" instead of an "else if", so that we are secure here in any case.
What do you think?
- <a href='https://github.com/quoc-axiadids'><img border=0 src='https://avatars2.githubusercontent.com/u/24928394?v=3' height=16 width=16></a> I agree with that idea. There should be a default when the policy is not set. I will modify the Pull Request.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> thx!
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/666#issuecomment-289346837'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=h1) Report
> Merging [#666](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/b69c7b4b0c5c91f14087c9ef39ac22de1c09bd93?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/666/graphs/tree.svg?token=7nHLZki60B&src=pr&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=tree)
```diff
@@            Coverage Diff            @@
##           master    #666      +/-   ##
=========================================
+ Coverage   95.37%   95.4%   +0.02%
=========================================
Files         120     120
Lines       14545   14552       +7
=========================================
+ Hits        13873   13883      +10
+ Misses        672     669       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `96.06% <100%> (+0.03%)` | :arrow_up: |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.1% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.68% <0%> (+2.58%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=footer). Last update [b69c7b4...f275bf5](https://codecov.io/gh/privacyidea/privacyidea/pull/666?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Hi @quoc-axiadids
why did you close this PR?
- <a href='https://github.com/quoc-axiadids'><img border=0 src='https://avatars2.githubusercontent.com/u/24928394?v=3' height=16 width=16></a> Hi @cornelinux,
There is something with my branch. I will create a new PR.
- <a href='https://github.com/quoc-axiadids'><img border=0 src='https://avatars2.githubusercontent.com/u/24928394?v=3' height=16 width=16></a> @cornelinux
I just noticed a problem with the commit. I will need to append a small change. The
`len(timeout) > 0` will always return a value whether or not the user specified if they wished to have a lockscreen or a logout option. I will need to append a small change here. I apologize.
- <a href='https://github.com/quoc-axiadids'><img border=0 src='https://avatars2.githubusercontent.com/u/24928394?v=3' height=16 width=16></a> @cornelinux I have added the small fix, please let me know if you have any questions. Thank you.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> We have an ``is_true`` function in ``lib.utils`` if needed.
- <a href='https://github.com/quoc-axiadids'><img border=0 src='https://avatars2.githubusercontent.com/u/24928394?v=3' height=16 width=16></a> I applied the same conventions that you have in applying the `logout_time` policy.
- <a href='https://github.com/quoc-axiadids'><img border=0 src='https://avatars2.githubusercontent.com/u/24928394?v=3' height=16 width=16></a> I apologize for the not so clean PR, if you would like. I can create a cleaner PR for you?
- [ ] <a href='#crh-comment-Pull 14c606ee30f435263f1b1708201e7ad974c0e33d privacyidea/api/lib/postpolicy.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/666#discussion_r108098379'>File: privacyidea/api/lib/postpolicy.py:L504-511</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> I would recommend using ``get_action_values``, so you can directly receive the list of timeout_actions. (see logout_time_pol).
This way you later do not need to do:
timeout_action = timeout_action_pol[0]['action']['timeout_action']
but only:
timeout_action = timeout_action_pol[0]
This this will be a list of action values.
If using ``unique = True`` in ``get_action_values``you will get an exception if there are contradicting policies. As this is also done with logout_time_pol at the moment, we probably should also do this with logout_action.
- <a href='https://github.com/quoc-axiadids'><img border=0 src='https://avatars2.githubusercontent.com/u/24928394?v=3' height=16 width=16></a> I like it! It's much cleaner. :)
I can append that to the PR.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Just working on it. THanks alot!
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> ...also found a minor issue, if the logout time is set to <=10 seconds... :-/


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/666?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/666?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/666'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>