### PR TITLE
Handle situation where boolean "True" is used

### DIFF
--- a/authmodules/apache2/privacyidea_apache.py
+++ b/authmodules/apache2/privacyidea_apache.py
@@ -133,6 +133,8 @@ def _get_config():
         SSLVERIFY = config_file.get("DEFAULT", "sslverify") or DEFAULT_SSLVERIFY
         if SSLVERIFY == "False":
             SSLVERIFY = False
+        if SSLVERIFY == "True":
+            SSLVERIFY = True
         REDIS = config_file.get("DEFAULT", "redis") or DEFAULT_REDIS
     except ConfigParser.NoOptionError as exx:
         syslog.syslog(syslog.LOG_ERR, "{0!s}".format(exx))

--- a/authmodules/apache2/privacyidea_apache.py
+++ b/authmodules/apache2/privacyidea_apache.py
@@ -133,7 +133,7 @@ def _get_config():
         SSLVERIFY = config_file.get("DEFAULT", "sslverify") or DEFAULT_SSLVERIFY
         if SSLVERIFY == "False":
             SSLVERIFY = False
-        if SSLVERIFY == "True":
+        elif SSLVERIFY == "True":
             SSLVERIFY = True
         REDIS = config_file.get("DEFAULT", "redis") or DEFAULT_REDIS
     except ConfigParser.NoOptionError as exx:


### PR DESCRIPTION
In configuration file /etc/privacyidea/apache.conf for application plugin Apache2 it exists the configuration line 'sslverify = False'. Currently /usr/share/pyshared/privacyidea_apache.py only handle the boolean value False or a path to CA file. With this commit it will be possible to use the boolean value True and let the python library handle the trust chain.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/667%23issuecomment-289423122%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/667%23discussion_r108196738%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/667%23issuecomment-289423122%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23667%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/ca10999f137f71df0197e97701418f6004f660ab%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667/graphs/tree.svg%3Fwidth%3D650%26src%3Dpr%26token%3D7nHLZki60B%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23667%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.37%25%20%20%2095.37%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20120%20%20%20%20%20%20120%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014555%20%20%20%2014555%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2013882%20%20%20%2013882%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20673%20%20%20%20%20%20673%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.1%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bca10999...2325d20%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/667%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%22%2C%20%22created_at%22%3A%20%222017-03-27T11%3A10%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%202325d20f226d4c02cbbfcac014bd15b3d95eb979%20authmodules/apache2/privacyidea_apache.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/667%23discussion_r108196738%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20could%20do%20an%20%60%60elif%60%60%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20elif%20SSLVERIFY%20%3D%3D%20%5C%22True%5C%22%3A%22%2C%20%22created_at%22%3A%20%222017-03-27T15%3A15%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20authmodules/apache2/privacyidea_apache.py%3AL133-141%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/667#issuecomment-289423122'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/667?src=pr&el=h1) Report
> Merging [#667](https://codecov.io/gh/privacyidea/privacyidea/pull/667?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/ca10999f137f71df0197e97701418f6004f660ab?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/667/graphs/tree.svg?width=650&src=pr&token=7nHLZki60B&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/667?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master     #667   +/-   ##
=======================================
Coverage   95.37%   95.37%
=======================================
Files         120      120
Lines       14555    14555
=======================================
Hits        13882    13882
Misses        673      673
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/667?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/667?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.1% <0%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/667?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/667?src=pr&el=footer). Last update [ca10999...2325d20](https://codecov.io/gh/privacyidea/privacyidea/pull/667?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 2325d20f226d4c02cbbfcac014bd15b3d95eb979 authmodules/apache2/privacyidea_apache.py 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/667#discussion_r108196738'>File: authmodules/apache2/privacyidea_apache.py:L133-141</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> We could do an ``elif``:
elif SSLVERIFY == "True":


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/667?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/667?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/667'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>