### PR TITLE
Allow MariaDB as database when installing from packages

### DIFF
--- a/deploy/debian-ubuntu/control
+++ b/deploy/debian-ubuntu/control
@@ -86,7 +86,7 @@ Description: two-factor authenticaion system. This is a metapackage to install e
 Package: privacyidea-nginx
 Architecture: all
 Depends: ${misc:Depends}, python-privacyidea, python-mysqldb, nginx-full, uwsgi, 
- uwsgi-plugin-python, mysql-server, mysql-client
+ uwsgi-plugin-python, mysql-server|mariadb-server, mysql-client|mariadb-client
 Conflicts: apache2, privacyidea-apache2
 Description: 2FA system. This is a meta package to install privacyidea with nginx
  privacyIDEA: identity, multifactor authentication, authorization.
@@ -97,7 +97,7 @@ Description: 2FA system. This is a meta package to install privacyidea with ngin
 Package: privacyidea-apache2
 Architecture: all
 Depends: ${misc:Depends}, python-privacyidea, python-mysqldb, apache2,
- mysql-server, mysql-client, libapache2-mod-wsgi
+ mysql-server|mariadb-server, mysql-client|mariadb-client, libapache2-mod-wsgi
 Conflicts: nginx, nginx-full, privacyidea-nginx
 Description: 2FA system. This is a meta package to install privacyidea with apache2
  privacyIDEA: identity, multifactor authentication, authorization.
@@ -107,7 +107,7 @@ Description: 2FA system. This is a meta package to install privacyidea with apac
 
 Package: privacyidea-mysql
 Architecture: all
-Depends: ${misc:Depends}, python-privacyidea, python-mysqldb, mysql-server, mysql-client
+Depends: ${misc:Depends}, python-privacyidea, python-mysqldb, mysql-server|mariadb-server, mysql-client|mariadb-client
 Conflicts: nginx, nginx-full, privacyidea-nginx, privacyidea-apache2
 Description: 2FA system. privacyIDEA application and MySQL configuration
  privacyIDEA: identity, multifactor authentication, authorization.


### PR DESCRIPTION
MariaDB is a drop in replacement (as they like to say) for Oracle MySQL. Debian and other distributions has made it clear that MariaDB will be the default database instead of Oracle MySQL.
This patch makes it possible to install PrivacyIDEA with MariaDB.

It needs to be tested so dependencies in the package python-mysqldb does not create any conflicts or problem in PrivacyIDEA. On my Ubuntu 16.04 it does not create any problem but am not testing on a clean system.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/671%23issuecomment-291159515%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/671%23issuecomment-292005941%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/671%23issuecomment-292095520%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/671%23issuecomment-296528655%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/671%23issuecomment-291159515%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23671%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/862aa746b9f59ec79f0134b622fc384b566c2920%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671/graphs/tree.svg%3Fsrc%3Dpr%26width%3D650%26token%3D7nHLZki60B%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23671%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%20%2095.4%25%20%20%2095.39%25%20%20%20-0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%2092%20%20%20%20%20%20120%20%20%20%20%20%20%2B28%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014016%20%20%20%2014569%20%20%20%20%20%2B553%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2013372%20%20%20%2013898%20%20%20%20%20%2B526%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20644%20%20%20%20%20%20671%20%20%20%20%20%20%2B27%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/audit.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2F1ZGl0LnB5%29%20%7C%20%6080%25%20%3C0%25%3E%20%28-10.15%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/resolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Jlc29sdmVyLnB5%29%20%7C%20%6092.15%25%20%3C0%25%3E%20%28-5.02%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ%3D%3D%29%20%7C%20%6092%25%20%3C0%25%3E%20%28-3.56%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/realm.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3JlYWxtLnB5%29%20%7C%20%6098.61%25%20%3C0%25%3E%20%28-1.39%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/machine.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL21hY2hpbmUucHk%3D%29%20%7C%20%6095.69%25%20%3C0%25%3E%20%28-0.18%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/user.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3VzZXIucHk%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/machineresolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL21hY2hpbmVyZXNvbHZlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bauthmodules/%5C%5C_%5C%5C_init%5C%5C_%5C%5C_.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-YXV0aG1vZHVsZXMvX19pbml0X18ucHk%3D%29%20%7C%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/applications/%5C%5C_%5C%5C_init%5C%5C_%5C%5C_.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2FwcGxpY2F0aW9ucy9fX2luaXRfXy5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/machines/base.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmVzL2Jhc2UucHk%3D%29%20%7C%20%6094%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20...%20and%20%5B38%20more%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dtree-more%29%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B862aa74...0f8f5e4%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/671%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%22%2C%20%22created_at%22%3A%20%222017-04-03T14%3A26%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20the%20post%20install%20script%20we%20are%20using%20the%20%60%60mysql%60%60%20command%20line%20client%20to%20set%20up%20the%20database%20automatically.%20Can%20you%20confirm%20that%20this%20works%20out%20with%20the%20mariadb-server/client%3F%22%2C%20%22created_at%22%3A%20%222017-04-05T21%3A42%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Today%20I%20installed%20a%20new%20virtual%20machine%20and%20did%20not%20get%20it%20to%20work.%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cnapt%20install%20software-properties-common%5Cr%5Cn%5Cr%5Cn%23%20Installing%20MariaDB%5Cr%5Cnapt-key%20adv%20--recv-keys%20--keyserver%20hkp%3A//keyserver.ubuntu.com%3A80%200xF1656F24C74CD1D8%5Cr%5Cnadd-apt-repository%20%27deb%20%5Barch%3Damd64%2Ci386%2Cppc64el%5D%20http%3A//ftp.ddg.lth.se/mariadb/repo/10.2/ubuntu%20xenial%20main%27%5Cr%5Cnapt%20update%5Cr%5Cnapt%20install%20mariadb-server%20mariadb-client%5Cr%5Cn%5Cr%5Cn%23%20Installing%20PrivacyIDEA%5Cr%5Cnadd-apt-repository%20ppa%3Aprivacyidea/privacyidea%5Cr%5Cnapt%20update%5Cr%5Cnapt%20install%20python-privacyidea%20privacyideaadm%5Cr%5Cn%5Cr%5Cn%23%20Modify%20control%20file%20to%20allow%20mariadb%5Cr%5Cncd%20/tmp%5Cr%5Cnapt%20download%20privacyidea-apache2%5Cr%5Cnar%20x%20privacyidea-apache2_2.18.1-1xenial_all.deb%5Cr%5Cnsed%20-i%20s/mysql-server/mysql-server%5C%5C%7Cmariadb-server/g%20control%5Cr%5Cnsed%20-i%20s/mysql-server/mysql-client%5C%5C%7Cmariadb-client/g%20control%5Cr%5Cntar%20czf%20control.tar.gz%20postrm%20md5sums%20postinst%20control%20conffiles%5Cr%5Cnar%20r%20privacyidea-apache2_2.18.1-1xenial_all.custom.deb%20debian-binary%20control.tar.gz%20data.tar.xz%5Cr%5Cn%5Cr%5Cn%23%20Install%20privacyidea-apache2%5Cr%5Cn%5Cr%5Cn%23%20For%20some%20reason%20dependencies%20needs%20to%20be%20installed%20before%20so%20the%20dpkg%20line%20below%20does%20not%20fail.%5Cr%5Cn%23%20Otherwise%20it%20seems%20like%20%5C%22apt%20install%20-f%5C%22%20is%20not%20using%20my%20custom%20deb%20file%20but%20the%20one%20from%20repository.%5Cr%5Cnapt%20install%20apache2%20libapache2-mod-wsgi%20python-mysqldb%5Cr%5Cndpkg%20-i%20privacyidea-apache2_2.18.1-1xenial_all.custom.deb%5Cr%5Cn%5Cr%5Cn%23%20-----------------------------------------%5Cr%5Cn%5Cr%5CnSelecting%20previously%20unselected%20package%20privacyidea-apache2.%5Cr%5Cn%28Reading%20database%20...%20124129%20files%20and%20directories%20currently%20installed.%29%5Cr%5CnPreparing%20to%20unpack%20privacyidea-apache2_2.18.1-1xenial_all.custom.deb%20...%5Cr%5CnUnpacking%20privacyidea-apache2%20%282.18.1-1xenial%29%20...%5Cr%5CnSetting%20up%20privacyidea-apache2%20%282.18.1-1xenial%29%20...%5Cr%5CnEnabling%20module%20wsgi.%5Cr%5CnTo%20activate%20the%20new%20configuration%2C%20you%20need%20to%20run%3A%5Cr%5Cn%20%20service%20apache2%20restart%5Cr%5CnEnabling%20module%20headers.%5Cr%5CnTo%20activate%20the%20new%20configuration%2C%20you%20need%20to%20run%3A%5Cr%5Cn%20%20service%20apache2%20restart%5Cr%5CnConsidering%20dependency%20setenvif%20for%20ssl%3A%5Cr%5CnModule%20setenvif%20already%20enabled%5Cr%5CnConsidering%20dependency%20mime%20for%20ssl%3A%5Cr%5CnModule%20mime%20already%20enabled%5Cr%5CnConsidering%20dependency%20socache_shmcb%20for%20ssl%3A%5Cr%5CnEnabling%20module%20socache_shmcb.%5Cr%5CnEnabling%20module%20ssl.%5Cr%5CnSee%20/usr/share/doc/apache2/README.Debian.gz%20on%20how%20to%20configure%20SSL%20and%20create%20self-signed%20certificates.%5Cr%5CnTo%20activate%20the%20new%20configuration%2C%20you%20need%20to%20run%3A%5Cr%5Cn%20%20service%20apache2%20restart%5Cr%5CnEnabling%20site%20privacyidea.%5Cr%5CnTo%20activate%20the%20new%20configuration%2C%20you%20need%20to%20run%3A%5Cr%5Cn%20%20service%20apache2%20reload%5Cr%5CnNo%20handlers%20could%20be%20found%20for%20logger%20%5C%22privacyidea.lib.stats%5C%22%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20_%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_______%20%20_______%5Cr%5Cn%20%20%20___%20%20____%28_%29%20%20_____%20_______%20__/%20%20_/%20_%20%5C%5C/%20__/%20_%20%7C%5Cr%5Cn%20%20/%20_%20%5C%5C/%20__/%20/%20%7C/%20/%20_%20%60/%20__/%20//%20//%20//%20//%20/%20_//%20__%20%7C%5Cr%5Cn%20/%20.__/_/%20/_/%7C___/%5C%5C_%2C_/%5C%5C__/%5C%5C_%2C%20/___/____/___/_/%20%7C_%7C%5Cr%5Cn/_/%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20/___/%5Cr%5Cn%20%20%20%5Cr%5Cn%5Cr%5CnEncryption%20key%20written%20to%20/etc/privacyidea/enckey%5Cr%5CnThe%20file%20permission%20of%20/etc/privacyidea/enckey%20was%20set%20to%20400%21%5Cr%5CnPlease%20ensure%2C%20that%20it%20is%20owned%20by%20the%20right%20user.%20%20%20%5Cr%5CnNo%20handlers%20could%20be%20found%20for%20logger%20%5C%22privacyidea.lib.stats%5C%22%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20_%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_______%20%20_______%5Cr%5Cn%20%20%20___%20%20____%28_%29%20%20_____%20_______%20__/%20%20_/%20_%20%5C%5C/%20__/%20_%20%7C%5Cr%5Cn%20%20/%20_%20%5C%5C/%20__/%20/%20%7C/%20/%20_%20%60/%20__/%20//%20//%20//%20//%20/%20_//%20__%20%7C%5Cr%5Cn%20/%20.__/_/%20/_/%7C___/%5C%5C_%2C_/%5C%5C__/%5C%5C_%2C%20/___/____/___/_/%20%7C_%7C%5Cr%5Cn/_/%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20/___/%5Cr%5Cn%20%20%20%5Cr%5Cn%3CSQLAlchemy%20engine%3D%27mysql%3A//pi%3ArYFnTdcrHe38%40localhost/pi%27%3E%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22/usr/bin/pi-manage%5C%22%2C%20line%20779%2C%20in%20%3Cmodule%3E%5Cr%5Cn%20%20%20%20manager.run%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_script/__init__.py%5C%22%2C%20line%20423%2C%20in%20run%5Cr%5Cn%20%20%20%20result%20%3D%20self.handle%28sys.argv%5B0%5D%2C%20sys.argv%5B1%3A%5D%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_script/__init__.py%5C%22%2C%20line%20402%2C%20in%20handle%5Cr%5Cn%20%20%20%20return%20handle%28app%2C%20%2Apositional_args%2C%20%2A%2Akwargs%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_script/commands.py%5C%22%2C%20line%20145%2C%20in%20handle%5Cr%5Cn%20%20%20%20return%20self.run%28%2Aargs%2C%20%2A%2Akwargs%29%5Cr%5Cn%20%20File%20%5C%22/usr/bin/pi-manage%5C%22%2C%20line%20428%2C%20in%20createdb%5Cr%5Cn%20%20%20%20db.create_all%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_sqlalchemy/__init__.py%5C%22%2C%20line%20856%2C%20in%20create_all%5Cr%5Cn%20%20%20%20self._execute_for_all_tables%28app%2C%20bind%2C%20%27create_all%27%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_sqlalchemy/__init__.py%5C%22%2C%20line%20848%2C%20in%20_execute_for_all_tables%5Cr%5Cn%20%20%20%20op%28bind%3Dself.get_engine%28app%2C%20bind%29%2C%20tables%3Dtables%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/sql/schema.py%5C%22%2C%20line%203695%2C%20in%20create_all%5Cr%5Cn%20%20%20%20tables%3Dtables%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201856%2C%20in%20_run_visitor%5Cr%5Cn%20%20%20%20conn._run_visitor%28visitorcallable%2C%20element%2C%20%2A%2Akwargs%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201481%2C%20in%20_run_visitor%5Cr%5Cn%20%20%20%20%2A%2Akwargs%29.traverse_single%28element%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/sql/visitors.py%5C%22%2C%20line%20121%2C%20in%20traverse_single%5Cr%5Cn%20%20%20%20return%20meth%28obj%2C%20%2A%2Akw%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/sql/ddl.py%5C%22%2C%20line%20709%2C%20in%20visit_metadata%5Cr%5Cn%20%20%20%20%5Bt%20for%20t%20in%20tables%20if%20self._can_create_table%28t%29%5D%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/sql/ddl.py%5C%22%2C%20line%20686%2C%20in%20_can_create_table%5Cr%5Cn%20%20%20%20table.name%2C%20schema%3Dtable.schema%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/dialects/mysql/base.py%5C%22%2C%20line%202612%2C%20in%20has_table%5Cr%5Cn%20%20%20%20skip_user_error_events%3DTrue%29.execute%28st%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%20906%2C%20in%20execute%5Cr%5Cn%20%20%20%20return%20self._execute_text%28object%2C%20multiparams%2C%20params%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201054%2C%20in%20_execute_text%5Cr%5Cn%20%20%20%20statement%2C%20parameters%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201146%2C%20in%20_execute_context%5Cr%5Cn%20%20%20%20context%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201341%2C%20in%20_handle_dbapi_exception%5Cr%5Cn%20%20%20%20exc_info%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/util/compat.py%5C%22%2C%20line%20200%2C%20in%20raise_from_cause%5Cr%5Cn%20%20%20%20reraise%28type%28exception%29%2C%20exception%2C%20tb%3Dexc_tb%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201139%2C%20in%20_execute_context%5Cr%5Cn%20%20%20%20context%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/default.py%5C%22%2C%20line%20450%2C%20in%20do_execute%5Cr%5Cn%20%20%20%20cursor.execute%28statement%2C%20parameters%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/cursors.py%5C%22%2C%20line%20158%2C%20in%20execute%5Cr%5Cn%20%20%20%20result%20%3D%20self._query%28query%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/cursors.py%5C%22%2C%20line%20308%2C%20in%20_query%5Cr%5Cn%20%20%20%20conn.query%28q%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%20820%2C%20in%20query%5Cr%5Cn%20%20%20%20self._affected_rows%20%3D%20self._read_query_result%28unbuffered%3Dunbuffered%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%201002%2C%20in%20_read_query_result%5Cr%5Cn%20%20%20%20result.read%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%201285%2C%20in%20read%5Cr%5Cn%20%20%20%20first_packet%20%3D%20self.connection._read_packet%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%20966%2C%20in%20_read_packet%5Cr%5Cn%20%20%20%20packet.check_error%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%20394%2C%20in%20check_error%5Cr%5Cn%20%20%20%20err.raise_mysql_exception%28self._data%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/err.py%5C%22%2C%20line%20120%2C%20in%20raise_mysql_exception%5Cr%5Cn%20%20%20%20_check_mysql_exception%28errinfo%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/err.py%5C%22%2C%20line%20115%2C%20in%20_check_mysql_exception%5Cr%5Cn%20%20%20%20raise%20InternalError%28errno%2C%20errorvalue%29%5Cr%5Cnsqlalchemy.exc.InternalError%3A%20%28pymysql.err.InternalError%29%20%281%2C%20u%27Can%5C%5C%27t%20create/write%20to%20file%20%5C%5C%27/tmp/%23sql_126d_0.MAI%5C%5C%27%20%28Errcode%3A%2013%20%5C%22Permission%20denied%5C%22%29%27%29%20%5BSQL%3A%20u%27DESCRIBE%20%60smsgateway%60%27%5D%5Cr%5CnNo%20handlers%20could%20be%20found%20for%20logger%20%5C%22privacyidea.lib.stats%5C%22%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20_%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_______%20%20_______%5Cr%5Cn%20%20%20___%20%20____%28_%29%20%20_____%20_______%20__/%20%20_/%20_%20%5C%5C/%20__/%20_%20%7C%5Cr%5Cn%20%20/%20_%20%5C%5C/%20__/%20/%20%7C/%20/%20_%20%60/%20__/%20//%20//%20//%20//%20/%20_//%20__%20%7C%5Cr%5Cn%20/%20.__/_/%20/_/%7C___/%5C%5C_%2C_/%5C%5C__/%5C%5C_%2C%20/___/____/___/_/%20%7C_%7C%5Cr%5Cn/_/%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20/___/%5Cr%5Cn%20%20%20%5Cr%5CnSigning%20keys%20written%20to%20/etc/privacyidea/private.pem%20and%20/etc/privacyidea/public.pem%5Cr%5CnThe%20file%20permission%20of%20/etc/privacyidea/private.pem%20was%20set%20to%20400%21%5Cr%5CnPlease%20ensure%2C%20that%20it%20is%20owned%20by%20the%20right%20user.%5Cr%5CnGenerating%20RSA%20private%20key%2C%202048%20bit%20long%20modulus%5Cr%5Cn................%2B%2B%2B%5Cr%5Cn..............................................%2B%2B%2B%5Cr%5Cne%20is%2065537%20%280x10001%29%5Cr%5CnSignature%20ok%5Cr%5Cnsubject%3D/CN%3Dprivacyidea%5Cr%5CnGetting%20Private%20key%5Cr%5CnGenerating%20RSA%20private%20key%2C%202048%20bit%20long%20modulus%5Cr%5Cn.......................................%2B%2B%2B%5Cr%5Cn.................%2B%2B%2B%5Cr%5Cne%20is%2065537%20%280x10001%29%5Cr%5CnSignature%20ok%5Cr%5Cnsubject%3D/CN%3Dkey2%5Cr%5CnGetting%20Private%20key%5Cr%5CnNo%20handlers%20could%20be%20found%20for%20logger%20%5C%22privacyidea.lib.stats%5C%22%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22/usr/bin/pi-manage%5C%22%2C%20line%20779%2C%20in%20%3Cmodule%3E%5Cr%5Cn%20%20%20%20manager.run%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_script/__init__.py%5C%22%2C%20line%20423%2C%20in%20run%5Cr%5Cn%20%20%20%20result%20%3D%20self.handle%28sys.argv%5B0%5D%2C%20sys.argv%5B1%3A%5D%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_script/__init__.py%5C%22%2C%20line%20402%2C%20in%20handle%5Cr%5Cn%20%20%20%20return%20handle%28app%2C%20%2Apositional_args%2C%20%2A%2Akwargs%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_script/commands.py%5C%22%2C%20line%20145%2C%20in%20handle%5Cr%5Cn%20%20%20%20return%20self.run%28%2Aargs%2C%20%2A%2Akwargs%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/flask_migrate/__init__.py%5C%22%2C%20line%20354%2C%20in%20stamp%5Cr%5Cn%20%20%20%20command.stamp%28config%2C%20revision%2C%20sql%3Dsql%2C%20tag%3Dtag%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/alembic/command.py%5C%22%2C%20line%20355%2C%20in%20stamp%5Cr%5Cn%20%20%20%20script.run_env%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/alembic/script/base.py%5C%22%2C%20line%20397%2C%20in%20run_env%5Cr%5Cn%20%20%20%20util.load_python_file%28self.dir%2C%20%27env.py%27%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/alembic/util/pyfiles.py%5C%22%2C%20line%2081%2C%20in%20load_python_file%5Cr%5Cn%20%20%20%20module%20%3D%20load_module_py%28module_id%2C%20path%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/alembic/util/compat.py%5C%22%2C%20line%2079%2C%20in%20load_module_py%5Cr%5Cn%20%20%20%20mod%20%3D%20imp.load_source%28module_id%2C%20path%2C%20fp%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/privacyidea/migrations/env.py%5C%22%2C%20line%2087%2C%20in%20%3Cmodule%3E%5Cr%5Cn%20%20%20%20run_migrations_online%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/privacyidea/migrations/env.py%5C%22%2C%20line%2078%2C%20in%20run_migrations_online%5Cr%5Cn%20%20%20%20context.run_migrations%28%29%5Cr%5Cn%20%20File%20%5C%22%3Cstring%3E%5C%22%2C%20line%208%2C%20in%20run_migrations%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/alembic/runtime/environment.py%5C%22%2C%20line%20797%2C%20in%20run_migrations%5Cr%5Cn%20%20%20%20self.get_context%28%29.run_migrations%28%2A%2Akw%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/alembic/runtime/migration.py%5C%22%2C%20line%20297%2C%20in%20run_migrations%5Cr%5Cn%20%20%20%20heads%20%3D%20self.get_current_heads%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/alembic/runtime/migration.py%5C%22%2C%20line%20243%2C%20in%20get_current_heads%5Cr%5Cn%20%20%20%20if%20not%20self._has_version_table%28%29%3A%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/alembic/runtime/migration.py%5C%22%2C%20line%20254%2C%20in%20_has_version_table%5Cr%5Cn%20%20%20%20self.connection%2C%20self.version_table%2C%20self.version_table_schema%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/dialects/mysql/base.py%5C%22%2C%20line%202612%2C%20in%20has_table%5Cr%5Cn%20%20%20%20skip_user_error_events%3DTrue%29.execute%28st%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%20906%2C%20in%20execute%5Cr%5Cn%20%20%20%20return%20self._execute_text%28object%2C%20multiparams%2C%20params%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201054%2C%20in%20_execute_text%5Cr%5Cn%20%20%20%20statement%2C%20parameters%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201146%2C%20in%20_execute_context%5Cr%5Cn%20%20%20%20context%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201341%2C%20in%20_handle_dbapi_exception%5Cr%5Cn%20%20%20%20exc_info%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/util/compat.py%5C%22%2C%20line%20200%2C%20in%20raise_from_cause%5Cr%5Cn%20%20%20%20reraise%28type%28exception%29%2C%20exception%2C%20tb%3Dexc_tb%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py%5C%22%2C%20line%201139%2C%20in%20_execute_context%5Cr%5Cn%20%20%20%20context%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/sqlalchemy/engine/default.py%5C%22%2C%20line%20450%2C%20in%20do_execute%5Cr%5Cn%20%20%20%20cursor.execute%28statement%2C%20parameters%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/cursors.py%5C%22%2C%20line%20158%2C%20in%20execute%5Cr%5Cn%20%20%20%20result%20%3D%20self._query%28query%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/cursors.py%5C%22%2C%20line%20308%2C%20in%20_query%5Cr%5Cn%20%20%20%20conn.query%28q%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%20820%2C%20in%20query%5Cr%5Cn%20%20%20%20self._affected_rows%20%3D%20self._read_query_result%28unbuffered%3Dunbuffered%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%201002%2C%20in%20_read_query_result%5Cr%5Cn%20%20%20%20result.read%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%201285%2C%20in%20read%5Cr%5Cn%20%20%20%20first_packet%20%3D%20self.connection._read_packet%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%20966%2C%20in%20_read_packet%5Cr%5Cn%20%20%20%20packet.check_error%28%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/connections.py%5C%22%2C%20line%20394%2C%20in%20check_error%5Cr%5Cn%20%20%20%20err.raise_mysql_exception%28self._data%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/err.py%5C%22%2C%20line%20120%2C%20in%20raise_mysql_exception%5Cr%5Cn%20%20%20%20_check_mysql_exception%28errinfo%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python2.7/dist-packages/pymysql/err.py%5C%22%2C%20line%20115%2C%20in%20_check_mysql_exception%5Cr%5Cn%20%20%20%20raise%20InternalError%28errno%2C%20errorvalue%29%5Cr%5Cnsqlalchemy.exc.InternalError%3A%20%28pymysql.err.InternalError%29%20%281%2C%20u%27Can%5C%5C%27t%20create/write%20to%20file%20%5C%5C%27/tmp/%23sql_126d_0.MAI%5C%5C%27%20%28Errcode%3A%2013%20%5C%22Permission%20denied%5C%22%29%27%29%20%5BSQL%3A%20%27DESCRIBE%20%60alembic_version%60%27%5D%5Cr%5Cndpkg%3A%20error%20processing%20package%20privacyidea-apache2%20%28--install%29%3A%5Cr%5Cn%20subprocess%20installed%20post-installation%20script%20returned%20error%20exit%20status%201%5Cr%5CnErrors%20were%20encountered%20while%20processing%3A%5Cr%5Cn%20privacyidea-apache2%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%23%20-----------------------------------------%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%23%20mysql%20-u%20pi%20-prYFnTdcrHe38%5Cr%5CnWelcome%20to%20the%20MariaDB%20monitor.%20%20Commands%20end%20with%20%3B%20or%20%5C%5Cg.%5Cr%5CnYour%20MariaDB%20connection%20id%20is%2013%5Cr%5CnServer%20version%3A%2010.2.5-MariaDB-10.2.5%2Bmaria%7Exenial-log%20mariadb.org%20binary%20distribution%5Cr%5Cn%5Cr%5CnCopyright%20%28c%29%202000%2C%202016%2C%20Oracle%2C%20MariaDB%20Corporation%20Ab%20and%20others.%5Cr%5Cn%5Cr%5CnType%20%27help%3B%27%20or%20%27%5C%5Ch%27%20for%20help.%20Type%20%27%5C%5Cc%27%20to%20clear%20the%20current%20input%20statement.%5Cr%5Cn%5Cr%5CnMariaDB%20%5B%28none%29%5D%3E%20use%20pi%3B%5Cr%5CnDatabase%20changed%5Cr%5CnMariaDB%20%5Bpi%5D%3E%20show%20tables%3B%5Cr%5CnEmpty%20set%20%280.00%20sec%29%5Cr%5Cn%5Cr%5CnMariaDB%20%5Bpi%5D%3E%20%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-04-06T07%3A45%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/4345073%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/blinkiz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20your%20PR.%20Looks%20good%20anyway.%22%2C%20%22created_at%22%3A%20%222017-04-24T05%3A36%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/671#issuecomment-291159515'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=h1) Report
> Merging [#671](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/862aa746b9f59ec79f0134b622fc384b566c2920?src=pr&el=desc) will **decrease** coverage by `0.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/671/graphs/tree.svg?src=pr&width=650&token=7nHLZki60B&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #671      +/-   ##
==========================================
- Coverage    95.4%   95.39%   -0.02%
==========================================
Files          92      120      +28
Lines       14016    14569     +553
==========================================
+ Hits        13372    13898     +526
- Misses        644      671      +27
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/audit.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2F1ZGl0LnB5) | `80% <0%> (-10.15%)` | :arrow_down: |
| [privacyidea/api/resolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Jlc29sdmVyLnB5) | `92.15% <0%> (-5.02%)` | :arrow_down: |
| [privacyidea/api/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ==) | `92% <0%> (-3.56%)` | :arrow_down: |
| [privacyidea/api/realm.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3JlYWxtLnB5) | `98.61% <0%> (-1.39%)` | :arrow_down: |
| [privacyidea/api/machine.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL21hY2hpbmUucHk=) | `95.69% <0%> (-0.18%)` | :arrow_down: |
| [privacyidea/api/user.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3VzZXIucHk=) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/api/machineresolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL21hY2hpbmVyZXNvbHZlci5weQ==) | `100% <0%> (ø)` | :arrow_up: |
| [authmodules/\_\_init\_\_.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-YXV0aG1vZHVsZXMvX19pbml0X18ucHk=) | | |
| [privacyidea/lib/applications/\_\_init\_\_.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2FwcGxpY2F0aW9ucy9fX2luaXRfXy5weQ==) | `100% <0%> (ø)` | |
| [privacyidea/lib/machines/base.py](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmVzL2Jhc2UucHk=) | `94% <0%> (ø)` | |
| ... and [38 more](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=tree-more) | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=footer). Last update [862aa74...0f8f5e4](https://codecov.io/gh/privacyidea/privacyidea/pull/671?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> In the post install script we are using the ``mysql`` command line client to set up the database automatically. Can you confirm that this works out with the mariadb-server/client?
- <a href='https://github.com/blinkiz'><img border=0 src='https://avatars1.githubusercontent.com/u/4345073?v=3' height=16 width=16></a> Today I installed a new virtual machine and did not get it to work.
```
apt install software-properties-common
# Installing MariaDB
apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://ftp.ddg.lth.se/mariadb/repo/10.2/ubuntu xenial main'
apt update
apt install mariadb-server mariadb-client
# Installing PrivacyIDEA
add-apt-repository ppa:privacyidea/privacyidea
apt update
apt install python-privacyidea privacyideaadm
# Modify control file to allow mariadb
cd /tmp
apt download privacyidea-apache2
ar x privacyidea-apache2_2.18.1-1xenial_all.deb
sed -i s/mysql-server/mysql-server\|mariadb-server/g control
sed -i s/mysql-server/mysql-client\|mariadb-client/g control
tar czf control.tar.gz postrm md5sums postinst control conffiles
ar r privacyidea-apache2_2.18.1-1xenial_all.custom.deb debian-binary control.tar.gz data.tar.xz
# Install privacyidea-apache2
# For some reason dependencies needs to be installed before so the dpkg line below does not fail.
# Otherwise it seems like "apt install -f" is not using my custom deb file but the one from repository.
apt install apache2 libapache2-mod-wsgi python-mysqldb
dpkg -i privacyidea-apache2_2.18.1-1xenial_all.custom.deb
# -----------------------------------------
Selecting previously unselected package privacyidea-apache2.
(Reading database ... 124129 files and directories currently installed.)
Preparing to unpack privacyidea-apache2_2.18.1-1xenial_all.custom.deb ...
Unpacking privacyidea-apache2 (2.18.1-1xenial) ...
Setting up privacyidea-apache2 (2.18.1-1xenial) ...
Enabling module wsgi.
To activate the new configuration, you need to run:
service apache2 restart
Enabling module headers.
To activate the new configuration, you need to run:
service apache2 restart
Considering dependency setenvif for ssl:
Module setenvif already enabled
Considering dependency mime for ssl:
Module mime already enabled
Considering dependency socache_shmcb for ssl:
Enabling module socache_shmcb.
Enabling module ssl.
See /usr/share/doc/apache2/README.Debian.gz on how to configure SSL and create self-signed certificates.
To activate the new configuration, you need to run:
service apache2 restart
Enabling site privacyidea.
To activate the new configuration, you need to run:
service apache2 reload
No handlers could be found for logger "privacyidea.lib.stats"
_                    _______  _______
___  ____(_)  _____ _______ __/  _/ _ \/ __/ _ |
/ _ \/ __/ / |/ / _ `/ __/ // // // // / _// __ |
/ .__/_/ /_/|___/\_,_/\__/\_, /___/____/___/_/ |_|
/_/                       /___/
Encryption key written to /etc/privacyidea/enckey
The file permission of /etc/privacyidea/enckey was set to 400!
Please ensure, that it is owned by the right user.
No handlers could be found for logger "privacyidea.lib.stats"
_                    _______  _______
___  ____(_)  _____ _______ __/  _/ _ \/ __/ _ |
/ _ \/ __/ / |/ / _ `/ __/ // // // // / _// __ |
/ .__/_/ /_/|___/\_,_/\__/\_, /___/____/___/_/ |_|
/_/                       /___/
<SQLAlchemy engine='mysql://pi:rYFnTdcrHe38@localhost/pi'>
Traceback (most recent call last):
File "/usr/bin/pi-manage", line 779, in <module>
manager.run()
File "/usr/lib/python2.7/dist-packages/flask_script/__init__.py", line 423, in run
result = self.handle(sys.argv[0], sys.argv[1:])
File "/usr/lib/python2.7/dist-packages/flask_script/__init__.py", line 402, in handle
return handle(app, *positional_args, **kwargs)
File "/usr/lib/python2.7/dist-packages/flask_script/commands.py", line 145, in handle
return self.run(*args, **kwargs)
File "/usr/bin/pi-manage", line 428, in createdb
db.create_all()
File "/usr/lib/python2.7/dist-packages/flask_sqlalchemy/__init__.py", line 856, in create_all
self._execute_for_all_tables(app, bind, 'create_all')
File "/usr/lib/python2.7/dist-packages/flask_sqlalchemy/__init__.py", line 848, in _execute_for_all_tables
op(bind=self.get_engine(app, bind), tables=tables)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/sql/schema.py", line 3695, in create_all
tables=tables)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1856, in _run_visitor
conn._run_visitor(visitorcallable, element, **kwargs)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1481, in _run_visitor
**kwargs).traverse_single(element)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/sql/visitors.py", line 121, in traverse_single
return meth(obj, **kw)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/sql/ddl.py", line 709, in visit_metadata
[t for t in tables if self._can_create_table(t)])
File "/usr/lib/python2.7/dist-packages/sqlalchemy/sql/ddl.py", line 686, in _can_create_table
table.name, schema=table.schema)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/dialects/mysql/base.py", line 2612, in has_table
skip_user_error_events=True).execute(st)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 906, in execute
return self._execute_text(object, multiparams, params)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1054, in _execute_text
statement, parameters
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1146, in _execute_context
context)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1341, in _handle_dbapi_exception
exc_info
File "/usr/lib/python2.7/dist-packages/sqlalchemy/util/compat.py", line 200, in raise_from_cause
reraise(type(exception), exception, tb=exc_tb)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1139, in _execute_context
context)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/default.py", line 450, in do_execute
cursor.execute(statement, parameters)
File "/usr/lib/python2.7/dist-packages/pymysql/cursors.py", line 158, in execute
result = self._query(query)
File "/usr/lib/python2.7/dist-packages/pymysql/cursors.py", line 308, in _query
conn.query(q)
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 820, in query
self._affected_rows = self._read_query_result(unbuffered=unbuffered)
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 1002, in _read_query_result
result.read()
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 1285, in read
first_packet = self.connection._read_packet()
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 966, in _read_packet
packet.check_error()
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 394, in check_error
err.raise_mysql_exception(self._data)
File "/usr/lib/python2.7/dist-packages/pymysql/err.py", line 120, in raise_mysql_exception
_check_mysql_exception(errinfo)
File "/usr/lib/python2.7/dist-packages/pymysql/err.py", line 115, in _check_mysql_exception
raise InternalError(errno, errorvalue)
sqlalchemy.exc.InternalError: (pymysql.err.InternalError) (1, u'Can\'t create/write to file \'/tmp/#sql_126d_0.MAI\' (Errcode: 13 "Permission denied")') [SQL: u'DESCRIBE `smsgateway`']
No handlers could be found for logger "privacyidea.lib.stats"
_                    _______  _______
___  ____(_)  _____ _______ __/  _/ _ \/ __/ _ |
/ _ \/ __/ / |/ / _ `/ __/ // // // // / _// __ |
/ .__/_/ /_/|___/\_,_/\__/\_, /___/____/___/_/ |_|
/_/                       /___/
Signing keys written to /etc/privacyidea/private.pem and /etc/privacyidea/public.pem
The file permission of /etc/privacyidea/private.pem was set to 400!
Please ensure, that it is owned by the right user.
Generating RSA private key, 2048 bit long modulus
................+++
..............................................+++
e is 65537 (0x10001)
Signature ok
subject=/CN=privacyidea
Getting Private key
Generating RSA private key, 2048 bit long modulus
.......................................+++
.................+++
e is 65537 (0x10001)
Signature ok
subject=/CN=key2
Getting Private key
No handlers could be found for logger "privacyidea.lib.stats"
Traceback (most recent call last):
File "/usr/bin/pi-manage", line 779, in <module>
manager.run()
File "/usr/lib/python2.7/dist-packages/flask_script/__init__.py", line 423, in run
result = self.handle(sys.argv[0], sys.argv[1:])
File "/usr/lib/python2.7/dist-packages/flask_script/__init__.py", line 402, in handle
return handle(app, *positional_args, **kwargs)
File "/usr/lib/python2.7/dist-packages/flask_script/commands.py", line 145, in handle
return self.run(*args, **kwargs)
File "/usr/lib/python2.7/dist-packages/flask_migrate/__init__.py", line 354, in stamp
command.stamp(config, revision, sql=sql, tag=tag)
File "/usr/lib/python2.7/dist-packages/alembic/command.py", line 355, in stamp
script.run_env()
File "/usr/lib/python2.7/dist-packages/alembic/script/base.py", line 397, in run_env
util.load_python_file(self.dir, 'env.py')
File "/usr/lib/python2.7/dist-packages/alembic/util/pyfiles.py", line 81, in load_python_file
module = load_module_py(module_id, path)
File "/usr/lib/python2.7/dist-packages/alembic/util/compat.py", line 79, in load_module_py
mod = imp.load_source(module_id, path, fp)
File "/usr/lib/privacyidea/migrations/env.py", line 87, in <module>
run_migrations_online()
File "/usr/lib/privacyidea/migrations/env.py", line 78, in run_migrations_online
context.run_migrations()
File "<string>", line 8, in run_migrations
File "/usr/lib/python2.7/dist-packages/alembic/runtime/environment.py", line 797, in run_migrations
self.get_context().run_migrations(**kw)
File "/usr/lib/python2.7/dist-packages/alembic/runtime/migration.py", line 297, in run_migrations
heads = self.get_current_heads()
File "/usr/lib/python2.7/dist-packages/alembic/runtime/migration.py", line 243, in get_current_heads
if not self._has_version_table():
File "/usr/lib/python2.7/dist-packages/alembic/runtime/migration.py", line 254, in _has_version_table
self.connection, self.version_table, self.version_table_schema)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/dialects/mysql/base.py", line 2612, in has_table
skip_user_error_events=True).execute(st)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 906, in execute
return self._execute_text(object, multiparams, params)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1054, in _execute_text
statement, parameters
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1146, in _execute_context
context)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1341, in _handle_dbapi_exception
exc_info
File "/usr/lib/python2.7/dist-packages/sqlalchemy/util/compat.py", line 200, in raise_from_cause
reraise(type(exception), exception, tb=exc_tb)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/base.py", line 1139, in _execute_context
context)
File "/usr/lib/python2.7/dist-packages/sqlalchemy/engine/default.py", line 450, in do_execute
cursor.execute(statement, parameters)
File "/usr/lib/python2.7/dist-packages/pymysql/cursors.py", line 158, in execute
result = self._query(query)
File "/usr/lib/python2.7/dist-packages/pymysql/cursors.py", line 308, in _query
conn.query(q)
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 820, in query
self._affected_rows = self._read_query_result(unbuffered=unbuffered)
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 1002, in _read_query_result
result.read()
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 1285, in read
first_packet = self.connection._read_packet()
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 966, in _read_packet
packet.check_error()
File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 394, in check_error
err.raise_mysql_exception(self._data)
File "/usr/lib/python2.7/dist-packages/pymysql/err.py", line 120, in raise_mysql_exception
_check_mysql_exception(errinfo)
File "/usr/lib/python2.7/dist-packages/pymysql/err.py", line 115, in _check_mysql_exception
raise InternalError(errno, errorvalue)
sqlalchemy.exc.InternalError: (pymysql.err.InternalError) (1, u'Can\'t create/write to file \'/tmp/#sql_126d_0.MAI\' (Errcode: 13 "Permission denied")') [SQL: 'DESCRIBE `alembic_version`']
dpkg: error processing package privacyidea-apache2 (--install):
subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
privacyidea-apache2
# -----------------------------------------
# mysql -u pi -prYFnTdcrHe38
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 13
Server version: 10.2.5-MariaDB-10.2.5+maria~xenial-log mariadb.org binary distribution
Copyright (c) 2000, 2016, Oracle, MariaDB Corporation Ab and others.
Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
MariaDB [(none)]> use pi;
Database changed
MariaDB [pi]> show tables;
Empty set (0.00 sec)
MariaDB [pi]>
```
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Thanks for your PR. Looks good anyway.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/671?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/671?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/671'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>