### PR TITLE
Adding support for kerberos credential validation while retaining lda…

### DIFF
--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -505,10 +505,9 @@ def get_resolver_class_dict():
             obj = getattr(module, name)
             # There are other classes like HMAC in the lib.tokens module,
             # which we do not want to load.
-            if inspect.isclass(obj) and (issubclass(obj, UserIdResolver) or
-                                             obj == UserIdResolver):
-                # We must not process imported classes!
-                # if obj.__module__ == module.__name__:
+            # We must not process imported classes!
+            if inspect.isclass(obj) and obj.__module__ == module.__name__ and (issubclass(obj, UserIdResolver) or
+                                                                                   obj == UserIdResolver):
                 try:
                     class_name = "{0!s}.{1!s}".format(module.__name__, obj.__name__)
                     resolverclass_dict[class_name] = obj
@@ -541,6 +540,7 @@ def get_resolver_list():
     module_list.add("privacyidea.lib.resolvers.LDAPIdResolver")
     module_list.add("privacyidea.lib.resolvers.SCIMIdResolver")
     module_list.add("privacyidea.lib.resolvers.SQLIdResolver")
+    module_list.add("privacyidea.lib.resolvers.KerberosIdResolver")
 
     # Dynamic Resolver modules
     # TODO: Migration

--- a/privacyidea/lib/resolvers/KerberosIdResolver.py
+++ b/privacyidea/lib/resolvers/KerberosIdResolver.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#  Copyright (C) 2014 Cornelius Kölbel
+#  contact:  corny@cornelinux.de
+#
+#  2017-04-06 Nickolas Wood <nick@woodden.org>
+#             Initial Kerberos resolver; extends LDAP
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+__doc__ = """This is the resolver to find users in LDAP directories like
+OpenLDAP and Active Directory but authenticates the users against Kerberos.
+
+LDAP functionality can be tested with the existing LDAP tests
+
+Kerberos functionality cannot be tested by straight python
+https://github.com/apple/ccs-pykerberos
+
+A complete and functional kerberos infrastructure is required as the python kerberos
+module only presents bindings and not the entire framework.
+Additionally, the system running the application must have a valid kerberos ticket
+for authenticating with kerberos and the service running this application must
+also have a valid ticket. (See the 'Testing' section of the kerberos python module)
+
+Testing this would require automated kerberos setup and bootstrap within the CI/CD
+pipeline.
+
+The majority of this work comes from Gabriel Faber and this thread:
+https://groups.google.com/forum/#!msg/privacyidea/zr2wepesUnU/kWXYHyPtPQAJ
+"""
+
+import logging
+import kerberos
+from privacyidea.lib.utils import to_utf8
+from .LDAPIdResolver import IdResolver as LDAPIdResolver
+
+log = logging.getLogger(__name__)
+
+
+class IdResolver (LDAPIdResolver):
+
+    def __init__(self):
+        LDAPIdResolver.__init__(self)
+        self.realm = ""
+        self.servicePrincipal = ""
+        log.debug("__init__ called in KerberosIdResolver.py" )
+
+    @staticmethod
+    def getResolverClassType():
+        return 'kerberosresolver'
+
+    @staticmethod
+    def getResolverType():
+        return IdResolver.getResolverClassType()
+
+    @classmethod
+    def getResolverClassDescriptor(cls):
+        """
+        return the descriptor of the resolver, which is
+        - the class name and
+        - the config description
+
+        :return: resolver description dict
+        :rtype:  dict
+        """
+        descriptor = {}
+        typ = cls.getResolverType()
+        descriptor['clazz'] = "useridresolver.KerberosIdResolver.IdResolver"
+        descriptor['config'] = {'REALM': 'string',
+                                'SERVICEPRINCIPAL': 'string',
+                                'LDAPURI': 'string',
+                                'LDAPBASE': 'string',
+                                'BINDDN': 'string',
+                                'BINDPW': 'password',
+                                'TIMEOUT': 'int',
+                                'SIZELIMIT': 'int',
+                                'LOGINNAMEATTRIBUTE': 'string',
+                                'LDAPSEARCHFILTER': 'string',
+                                'LDAPFILTER': 'string',
+                                'USERINFO': 'string',
+                                'UIDTYPE': 'string',
+                                'NOREFERRALS': 'bool',
+                                'CACERTIFICATE': 'string',
+                                'EDITABLE': 'bool',
+                                'SCOPE': 'string',
+                                'AUTHTYPE': 'string'}
+        return {typ: descriptor}
+
+    def checkPass(self, uid, password):
+        """
+        This function checks the password for a given uid.
+        - returns true in case of success
+        -         false if password does not match
+
+        """
+
+        realm = self.realm
+        password = to_utf8(password)
+        service = self.servicePrincipal
+        userId = LDAPIdResolver.getUsername(self, uid)
+
+        try:
+            log.debug("(Kerberos) user: %s; realm: %s; service %s" % (userId, realm, service))
+            kerberos.checkPassword(userId,password,service,realm)
+        except kerberos.BasicAuthError, e:
+            log.warning("failed to check password for %r: %r"
+                        % (userId, e))
+            return False
+
+        return True
+
+    def loadConfig(self, config):
+        LDAPIdResolver.loadConfig(self, config)
+        self.realm = config.get("REALM")
+        self.servicePrincipal = config.get("SERVICEPRINCIPAL")
+        log.debug("loadConfig called in KerberosIdResolver.py" )

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -505,7 +505,7 @@ myApp.controller("configController", function ($scope, $location,
     };
 
     // TODO: This information needs to be fetched from the server
-    $scope.availableResolverTypes = ['passwdresolver', 'ldapresolver', 'sqlresolver', 'scimresolver'];
+    $scope.availableResolverTypes = ['passwdresolver', 'ldapresolver', 'sqlresolver', 'scimresolver', 'kerberosresolver'];
     // TODO: This information needs to be fetched from the server
     $scope.availableMachineResolverTypes = ['hosts', 'ldap'];
     // TODO: This information needs to be fetched from the server

--- a/privacyidea/static/components/config/states/states.js
+++ b/privacyidea/static/components/config/states/states.js
@@ -63,6 +63,14 @@ angular.module('privacyideaApp.configStates', ['ui.router']).config(
                     url: "/ldap/{resolvername:.*}",
                     templateUrl: configpath + "config.resolvers.ldap.html"
                 })
+                .state('config.resolvers.addkerberosresolver', {
+                    url: "/kerberos",
+                    templateUrl: configpath + "config.resolvers.kerberos.html"
+                })
+                .state('config.resolvers.editkerberosresolver', {
+                    url: "/kerberos/{resolvername:.*}",
+                    templateUrl: configpath + "config.resolvers.kerberos.html"
+                })
                 .state('config.resolvers.addscimresolver', {
                     url: "/scim",
                     templateUrl: configpath + "config.resolvers.scim.html"

--- a/privacyidea/static/components/config/views/config.resolvers.kerberos.html
+++ b/privacyidea/static/components/config/views/config.resolvers.kerberos.html
@@ -1,0 +1,247 @@
+<div ng-controller="LdapResolverController">
+
+<h2 class="form-signin-heading"
+        ng-show="resolvername"
+        translate>Edit LDAP Resolver {{ resolvername }}</h2>
+<h2 class="form-signin-heading"
+        ng-hide="resolvername"
+        translate>Create a new LDAP Resolver</h2>
+
+<form name="formResolverAddLdap" role="form" validate
+      class="form-horizontal">
+
+    <div class="form-group">
+        <label for="resolvername" class="col-sm-3 control-label"
+                translate>Resolver name</label>
+
+        <div class="col-sm-9">
+            <input name="resolvername" id="resolvername" class="form-control"
+                   ng-model="resolvername" required placeholder="resolver1"
+                   autofocus/>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="realm" class="col-sm-3 control-label">
+            Kerberos Realm</label>
+
+        <div class="col-sm-9">
+            <input name="realm" class="form-control"
+                   ng-model="params.REALM" required
+                   placeholder="EXAMPLE.COM"/>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="realm" class="col-sm-3 control-label">
+            Kerberos Service Principal</label>
+
+        <div class="col-sm-9">
+            <input name="realm" class="form-control"
+                   ng-model="params.SERVICEPRINCIPAL" required
+                   placeholder="host/example.com"/>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="serveruri" class="col-sm-3 control-label" translate>
+            Server URI</label>
+
+        <div class="col-sm-9">
+            <input name="serveruri" class="form-control"
+                   ng-model="params.LDAPURI" required
+                   placeholder="ldap://privacyidea.server1, ldap://privacyidea.server2"/>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="basedn" class="col-sm-3 control-label"
+               translate>Base DN</label>
+
+        <div class="col-sm-4">
+            <input name="basedn" class="form-control"
+                   ng-model="params.LDAPBASE" required
+                   placeholder="ou=users,dc=domain,dc=tld"/>
+        </div>
+
+        <label for="ldapscope" class="col-sm-2 control-label"
+               translate>Scope</label>
+
+        <div class="col-sm-3">
+            <select class="form-control"
+                        ng-model="params.SCOPE"
+                        name="ldapscope"
+                        ng-options="select for select in scopes">
+            </select>
+        </div>
+
+
+    </div>
+    <div class="form-group">
+        <label for="binddn" class="col-sm-3 control-label" translate>Bind DN</label>
+
+        <div class="col-sm-9">
+            <input name="binddn" class="form-control"
+                   ng-model="params.BINDDN"
+                   placeholder="cn=admin,ou=users,dc=domain,dc=tld"/>
+            <p class="help-block" translate>
+                Leave the Bind DN empty if you want to do anonymous binding.
+            </p>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="bindpw" class="col-sm-3 control-label"
+               translate>Bind Password</label>
+
+        <div class="col-sm-3">
+            <input name="bindpw" class="form-control"
+                   type="password"
+                   ng-model="params.BINDPW"
+                   placeholder="topsecret"/>
+        </div>
+
+        <label for="authtype" class="col-sm-3 control-label"
+                translate>Bind Type</label>
+
+        <div class="col-sm-3">
+            <select class="form-control"
+                    ng-model="params.AUTHTYPE"
+                    name="authtype"
+                    ng-options="select for select in authtypes">
+            </select>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="timeout" class="col-sm-3 control-label"
+                translate>Timeout (seconds)</label>
+
+        <div class="col-sm-3">
+            <input name="timeout" class="form-control"
+                   ng-model="params.TIMEOUT" required
+                   placeholder="5"/>
+        </div>
+
+        <label for="sizelimit" class="col-sm-3 control-label"
+                translate>Size Limit</label>
+
+        <div class="col-sm-3">
+            <input name="sizelimit" class="form-control"
+                   ng-model="params.SIZELIMIT" required
+                   placeholder="500"/>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="editable"
+            class="col-sm-3 control-label" translate>
+            Edit user store
+        </label>
+        <div class="col-sm-9">
+        <input name="editable" id="editable"
+               ng-model="params.EDITABLE"
+               type="checkbox"/>
+            <p class="help-block" translate>
+                The user data in this database can be modified from within
+                privacyIDEA.
+            </p>
+
+            <div class="well" ng-show="params.EDITABLE">
+                <label for="object_classes" class="control-label" translate>
+                    Object classes of a new created user object
+                </label>
+                <input name="object_classes" id="object_classes"
+                       class="form-control"
+                       ng-model="params.OBJECT_CLASSES" />
+                <label for="dn_template" class="control-label" translate>
+                    DN of a new created user object
+                </label>
+                <input name="dn_template" id="dn_template"
+                       class="form-control"
+                       placeholder="CN=<username>,<basendn>"
+                       ng-model="params.DN_TEMPLATE" />
+            </div>
+        </div>
+    </div>
+    <div class="well">
+        <button class="btn btn-info" ng-click="presetLDAP()" translate>
+            Preset OpenLDAP
+        </button>
+        <button class="btn btn-info" ng-click="presetAD()" translate>
+            Preset Active Directory
+        </button>
+        <div class="form-group">
+            <input name="noreferrals" id="noreferrals"
+                   ng-model="params.NOREFERRALS"
+                   type="checkbox"/>
+            <label for="noreferrals"
+                    translate>No anonymous referral chasing</label>
+        </div>
+        <div class="form-group">
+            <label for="loginnameattr"
+                   class="col-sm-3 control-label">Loginname Attribute</label>
+
+            <div class="col-sm-9">
+
+                <input name="loginnameattr" class="form-control"
+                       ng-model="params.LOGINNAMEATTRIBUTE" required
+                       placeholder="sAMAccountName"/>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="ldapsearchfilter"
+                   class="col-sm-3 control-label"
+                    translate>Search Filter</label>
+
+            <div class="col-sm-9">
+                <input name="ldapsearchfilter" class="form-control"
+                       ng-model="params.LDAPSEARCHFILTER" required
+                       placeholder="(sAMAccountName=*)(objectClass=person)"/>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="userfilter"
+                   class="col-sm-3 control-label"
+                    translate>User Filter</label>
+
+            <div class="col-sm-9">
+                <input name="userfilter" class="form-control"
+                       ng-model="params.LDAPFILTER" required
+                       placeholder="(&(sAMAccountName=%s)(objectClass=person))"/>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="mapping"
+                   class="col-sm-3 control-label"
+                    translate>Attribute mapping</label>
+
+            <div class="col-sm-9">
+                <input name="mapping" class="form-control"
+                       ng-model="params.USERINFO" required
+                       placeholder='{ "username": "sAMAccountName", "phone" : "telephoneNumber", "mobile" : "mobile", "email" : "mail", "surname" : "sn", "givenname" : "givenName" }'
+                        />
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="uidtype"
+                   class="col-sm-3 control-label"
+                    translate>UID Type</label>
+
+            <div class="col-sm-9">
+                <input name="uidtype" class="form-control"
+                       ng-model="params.UIDTYPE" required
+                       placeholder='DN'
+                        />
+            </div>
+        </div>
+    </div>
+
+    <div class="text-center">
+        <button ng-click="testResolver()"
+                ng-disabled="formResolverAddLdap.$invalid"
+                class="btn btn-success"
+                translate>Test LDAP Resolver
+        </button>
+        <button ng-click="params.type='kerberosresolver'; setLDAPResolver()"
+                ng-disabled="formResolverAddLdap.$invalid"
+                class="btn btn-primary"
+                translate>Save resolver
+        </button>
+    </div>
+
+</form>
+</div>


### PR DESCRIPTION
This is what I am currently using for my mixed LDAP/kerberos environment. I keep all user attributes like uid/gid/etc in LDAP still, however, passwords are delegated to kerberos. These changes allow privacyidea to authenticate against kerberos and still retrieving user information from LDAP. Essentially, these changes creates a new kerberos resolver class by extending the LDAP resolver class and replacing the checkPass method.

Most of these changes came from:
https://groups.google.com/forum/#!msg/privacyidea/zr2wepesUnU/kWXYHyPtPQAJ

To actually use this, the system running the privacyidea application needs a valid kerberos token displayable via "sudo klist". The user running the privacyidea application itself also needs its own kerberos ticket displayable via "klist". I recommend a service principal. The "Kerberos Service Principal" field needs to be populated with the principal displayed by klist when run as the application user; IE, "otp/example.com". The "Kerberos Realm" field is simply the kerberos realm the ticket is from; IE, "EXAMPLE.COM". The rest of the fields are the normal LDAP ones.

Needless to say, to actually use, or test, this functionality, a fully functional kerberos infrastructure needs to be available.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/678%23discussion_r110717754%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23discussion_r111491414%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23issuecomment-294035898%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23issuecomment-294282615%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23issuecomment-299819666%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23issuecomment-299823579%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23issuecomment-299874722%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2079ddad8fb910ea9ff9208ef9bc44dd0712973b85%20privacyidea/static/components/config/views/config.resolvers.kerberos.html%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23discussion_r111491414%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22SHould%20this%20be%20%60%60Edit%20LDAP%20Resolver%60%60%3F%22%2C%20%22created_at%22%3A%20%222017-04-13T21%3A28%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/config/views/config.resolvers.kerberos.html%3AL1-248%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23issuecomment-294035898%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22How%20to%20integrate%20this%20into%20the%20larger%20project%20is%20most%20certainly%20up%20to%20you%20and%20I%20would%20think%20it%20makes%20sense%20to%20dedup%20the%20code%20whenever%20possible.%20I%20am%20not%20a%20python%20developer%20though%3B%20just%20a%20sys%20admin.%20I%20am%20not%20sure%20how%20to%20%5C%22toggle%5C%22%20between%20the%20ldap%20resolver%20and%20the%20kerberos%20resolver%20if%20they%20are%20in%20the%20same%20class%3B%20IE%2C%20I%20am%20not%20sure%20what%20it%20would%20take%20to%20merge%20the%20two.%5Cr%5Cn%5Cr%5CnThe%20main%20differences%20is%20as%20you%20say%2C%20the%20checkPass%20routine%20and%202%20additional%20configuration%20settings%3B%20in%20the%20view%20and%20the%20resolver%20descriptor.%20%5Cr%5Cn%5Cr%5CnMost%20of%20this%20code%20was%20contributed%20by%20Gabriel.%20I%20added%20the%202%20additional%20configuration%20settings%20needed%20to%20actually%20make%20the%20checkpass%20routine%20work%20in%20a%20locked%20down%20environment%20where%20anonymous%20authentication%20is%20not%20allowed.%22%2C%20%22created_at%22%3A%20%222017-04-13T22%3A16%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5143339%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ignitediris%22%7D%7D%2C%20%7B%22body%22%3A%20%22Integrating%20it%20into%20the%20LDAP%20Resolver%20would%20meen%20to%5Cr%5Cn%5Cr%5Cn%2A%20add%20a%20checkbox%20like%20%60%60authenticate%20the%20user%20via%20kerberos%60%60%5Cr%5Cn%2A%20in%20case%20the%20checkbox%20is%20checked%2C%5Cr%5Cn%20%20%2A%20%20add%20a%20%60%60kerberos-realm%60%60%20%5Cr%5Cn%20%20%2A%20and%20add%20the%20%60%60service-privcipal%60%60%5Cr%5Cn%2A%20in%20the%20%60%60checkPass%60%60%20method%20verify%20the%20user%20pass%20pased%20on%20LDAPauth%20or%20Kerberos.%22%2C%20%22created_at%22%3A%20%222017-04-15T09%3A32%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ignitediris%20We%20were%20looking%20at%20the%20pull%20request%20again%20and%20I%20saw%20this%20comment%20in%20the%20pykerberos%20documentation.%5Cr%5Cnhttps%3A//www.calendarserver.org/PyKerberos.html%5Cr%5Cn%5Cr%5CnThe%20%60%60kerberos.checkPassword%60%60%20method%20should%20not%20be%20used%20in%20productive%20environments...%20...looks%20like%20we%20can%20not%20use%20it%20in%20%60%60Resolver.checkPass%60%60.%5Cr%5Cn%5Cr%5CnMaybe%20it%20makes%20more%20sense%20to%20look%20into%20extending%20the%20existing%20LDAP-Resolver%20with%20the%20ldap3%20capabilities%20of%20SASL/GSSAPI%3F%20http%3A//ldap3.readthedocs.io/bind.html%23sasl%22%2C%20%22created_at%22%3A%20%222017-05-08T09%3A34%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40cornelinux%20%40ignitediris%20IMO%20implementing%20ldap3%20SASL/GSSAPI%20would%20be%20the%20better%20option%20as%20there%20would%20be%20no%20need%20to%20write%20a%20whole%20new%20Kerberos%20mock%20for%20unit%20testing.%20The%20ldap3mock%20could%20be%20extended%20to%20test%20this%20additional%20functionality.%22%2C%20%22created_at%22%3A%20%222017-05-08T09%3A51%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/15330084%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wheldom01%22%7D%7D%2C%20%7B%22body%22%3A%20%22KDC%20spoofing%20is%20a%20worry%20but%20I%20think%20it%20is%20mitigated%20with%20this%20design%20because%20of%20this%3A%5Cr%5Cnhttps%3A//serverfault.com/questions/487838/what-is-the-kerberos-keytab-file-used-for-in-unix-ad-kerberos-authentication%5Cr%5Cn%5Cr%5CnDocumentation%20is%20a%20little%20unclear%20because%20pykerberos%20has%20two%20forms%3B%20basic%20and%20GSSAPI.%20The%20latter%20form%20is%20the%20one%20used%20here%20and%20takes%203%20params.%20This%20is%20why%20I%20added%20the%20principle%20field%20so%20that%20the%20KDC%20can%20be%20verified%20by%20a%20mutually%20trusted%20identity%20%28service%20keytab%29.%20With%203%20params%2C%20the%20library%20should%20use%20it%27s%20own%20service%20identify%20to%20verify%20the%20KDC%20and%20the%20supplied%20credentials%20to%20verify%20the%20user.%5Cr%5Cn%5Cr%5CnI%20am%20unsure%20if%20KDC%20spoofing%20is%20possible%20with%20GSSAPI%20and%20a%20service%20principle%20when%20using%20this%20form%20of%20pykerberos.%5Cr%5Cn%5Cr%5CnI%20am%20not%20against%20switching%20to%20GSSAPI%20against%20ldap.%20I%20actually%20run%20LDAP%20in%20house%20requiring%20GSSAPI%20as%20the%20only%20form%20allowed.%20It%20makes%20the%20most%20sense%20to%20go%20that%20direction%20given%20the%20ambiguity%20of%20the%20pykerberos%20documentation.%22%2C%20%22created_at%22%3A%20%222017-05-08T13%3A59%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5143339%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ignitediris%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2079ddad8fb910ea9ff9208ef9bc44dd0712973b85%20privacyidea/lib/config.py%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/678%23discussion_r110717754%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20obj.__module__%20%3D%3D%20module.__name__%20check%20is%20terribly%20important%20here.%20Since%20the%20kerberos%20resolver%20imports%20and%20extends%20the%20ldap%20resolver%2C%20the%20loop%20that%20populates%20the%20resolver%20list%20will%20over%20ride%20the%20kerberos%20entry%20with%20the%20ldap%20entry%20in%20the%20hash.%20This%20check%20prevents%20that%20and%20also%20removes%20errant%20UserIDResolver%20entries%20%28multiple%20of%20them%29%20from%20the%20computed%20resolver%20list.%22%2C%20%22created_at%22%3A%20%222017-04-10T17%3A42%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5143339%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ignitediris%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/config.py%3AL505-514%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 79ddad8fb910ea9ff9208ef9bc44dd0712973b85 privacyidea/lib/config.py 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/678#discussion_r110717754'>File: privacyidea/lib/config.py:L505-514</a></b>
- <a href='https://github.com/ignitediris'><img border=0 src='https://avatars1.githubusercontent.com/u/5143339?v=3' height=16 width=16></a> The obj.__module__ == module.__name__ check is terribly important here. Since the kerberos resolver imports and extends the ldap resolver, the loop that populates the resolver list will over ride the kerberos entry with the ldap entry in the hash. This check prevents that and also removes errant UserIDResolver entries (multiple of them) from the computed resolver list.
- [ ] <a href='#crh-comment-Pull 79ddad8fb910ea9ff9208ef9bc44dd0712973b85 privacyidea/static/components/config/views/config.resolvers.kerberos.html 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/678#discussion_r111491414'>File: privacyidea/static/components/config/views/config.resolvers.kerberos.html:L1-248</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> SHould this be ``Edit LDAP Resolver``?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/678#issuecomment-294035898'>General Comment</a></b>
- <a href='https://github.com/ignitediris'><img border=0 src='https://avatars1.githubusercontent.com/u/5143339?v=3' height=16 width=16></a> How to integrate this into the larger project is most certainly up to you and I would think it makes sense to dedup the code whenever possible. I am not a python developer though; just a sys admin. I am not sure how to "toggle" between the ldap resolver and the kerberos resolver if they are in the same class; IE, I am not sure what it would take to merge the two.
The main differences is as you say, the checkPass routine and 2 additional configuration settings; in the view and the resolver descriptor.
Most of this code was contributed by Gabriel. I added the 2 additional configuration settings needed to actually make the checkpass routine work in a locked down environment where anonymous authentication is not allowed.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Integrating it into the LDAP Resolver would meen to
* add a checkbox like ``authenticate the user via kerberos``
* in case the checkbox is checked,
*  add a ``kerberos-realm``
* and add the ``service-privcipal``
* in the ``checkPass`` method verify the user pass pased on LDAPauth or Kerberos.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> @ignitediris We were looking at the pull request again and I saw this comment in the pykerberos documentation.
https://www.calendarserver.org/PyKerberos.html
The ``kerberos.checkPassword`` method should not be used in productive environments... ...looks like we can not use it in ``Resolver.checkPass``.
Maybe it makes more sense to look into extending the existing LDAP-Resolver with the ldap3 capabilities of SASL/GSSAPI? http://ldap3.readthedocs.io/bind.html#sasl
- <a href='https://github.com/wheldom01'><img border=0 src='https://avatars1.githubusercontent.com/u/15330084?v=3' height=16 width=16></a> @cornelinux @ignitediris IMO implementing ldap3 SASL/GSSAPI would be the better option as there would be no need to write a whole new Kerberos mock for unit testing. The ldap3mock could be extended to test this additional functionality.
- <a href='https://github.com/ignitediris'><img border=0 src='https://avatars1.githubusercontent.com/u/5143339?v=3' height=16 width=16></a> KDC spoofing is a worry but I think it is mitigated with this design because of this:
https://serverfault.com/questions/487838/what-is-the-kerberos-keytab-file-used-for-in-unix-ad-kerberos-authentication
Documentation is a little unclear because pykerberos has two forms; basic and GSSAPI. The latter form is the one used here and takes 3 params. This is why I added the principle field so that the KDC can be verified by a mutually trusted identity (service keytab). With 3 params, the library should use it's own service identify to verify the KDC and the supplied credentials to verify the user.
I am unsure if KDC spoofing is possible with GSSAPI and a service principle when using this form of pykerberos.
I am not against switching to GSSAPI against ldap. I actually run LDAP in house requiring GSSAPI as the only form allowed. It makes the most sense to go that direction given the ambiguity of the pykerberos documentation.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/678?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/678?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/678'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>