### PR TITLE
Small performance improvements and benchmarking fixes

### DIFF
--- a/doc/faq/performance.rst
+++ b/doc/faq/performance.rst
@@ -8,8 +8,7 @@ Creating a simple pass token for a user, eases the performance testing.
 
 Then you can run
 
-   ab -n 200 -c 8 -s 30 'https://localhost/validate/check?user=yourUser&pass
- =yourPassword'
+   ab -l -n 200 -c 8 -s 30 'https://localhost/validate/check?user=yourUser&pass=yourPassword'
 
 The performance depends on several aspects like the connection speed to your
 database and the connection speed to your user stores.

--- a/pi-manage
+++ b/pi-manage
@@ -60,7 +60,7 @@ from privacyidea.lib.caconnector import (get_caconnector_list,
                                          save_caconnector)
 from privacyidea.app import create_app
 from privacyidea.lib.auth import ROLE
-from flask_script import Manager
+from flask_script import Manager, Command
 from privacyidea.app import db
 from flask_migrate import MigrateCommand
 # Wee need to import something, so that the models will be created.
@@ -463,7 +463,14 @@ def validate(user, password, realm=None, client=None):
         print("ERROR=%s" % exx)
 
 
-@manager.command
+class CommandOutsideRequestContext(Command):
+    """
+    In contrast to flask_script's `Command`, this command class does
+    not push a request context before running the command.
+    """
+    def __call__(self, app=None, *args, **kwargs):
+        return self.run(*args, **kwargs)
+
 def profile(length=30, profile_dir=None):
     """
     Start the application in profiling mode.
@@ -472,6 +479,11 @@ def profile(length=30, profile_dir=None):
     app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[length],
                                       profile_dir=profile_dir)
     app.run()
+
+# If flask_script's `Command` is used here instead of `CommandOutsideRequestContext`,
+# the request context will persist over requests. Thus, `g` is not
+# cleared properly between requests, which makes privacyIDEA behave unrealistically.
+manager.add_command('profile', CommandOutsideRequestContext(profile))
 
 
 @manager.option('--highwatermark', '--hw', help="If entries exceed this value, "

--- a/privacyidea/lib/log.py
+++ b/privacyidea/lib/log.py
@@ -141,12 +141,18 @@ class log_with(object):
         def log_wrapper(*args, **kwds):
             """
             Wrap the function in log entries. The entry of the function and
-            the exit of the function is logged.
+            the exit of the function is logged using the DEBUG log level.
+            If the logger does not log DEBUG messages, this just returns
+            the result of ``func(*args, **kwds)`` to improve performance.
 
             :param args: The positional arguments starting with index
             :param kwds: The keyword arguemnts
             :return: The wrapped function
             """
+            # Exit early if self.logger disregards DEBUG messages.
+            if not self.logger.isEnabledFor(logging.DEBUG):
+                return func(*args, **kwds)
+
             log_args = args
             log_kwds = kwds
             if self.hide_args or self.hide_kwargs or \

--- a/privacyidea/lib/subscriptions.py
+++ b/privacyidea/lib/subscriptions.py
@@ -184,9 +184,9 @@ def check_subscription(application):
     :param application: the name of the application to check
     :return: bool
     """
-    subscriptions = get_subscription(application) or get_subscription(
-        application.lower())
     if application.lower() in APPLICATIONS.keys():
+        subscriptions = get_subscription(application) or get_subscription(
+            application.lower())
         if len(subscriptions) == 0:
             # get the number of active assigned tokens
             num_tokens = get_tokens(assigned=True, active=True, count=True)


### PR DESCRIPTION
This implements two performance improvements:
* 85390de should save us one database query if the client application is unknown.
* 1122ca3 should speed up `log_wrapper` calls in production environments.
However, I am not sure if they actually result in noticeable speedups -- We could check that when we have a reproducible benchmark environment.

196d4bb fixes the app behavior when using the profiler, and e42db7e contains a small documentation fix.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/686%23issuecomment-296746967%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/686%23discussion_r113004960%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/686%23discussion_r113278065%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/686%23discussion_r113368164%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/686%23issuecomment-296746967%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23686%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/20e0d79fbb77fd8d0b5cfdd56b9b2a5365d6a910%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.12%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26width%3D650%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23686%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.39%25%20%20%2095.26%25%20%20%20-0.13%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20120%20%20%20%20%20%20120%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014619%20%20%20%2014621%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2013946%20%20%20%2013929%20%20%20%20%20%20-17%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20673%20%20%20%20%20%20692%20%20%20%20%20%20%2B19%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/log.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2xvZy5weQ%3D%3D%29%20%7C%20%6043.83%25%20%3C100%25%3E%20%28-28%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/subscriptions.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk%3D%29%20%7C%20%6093.06%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.79%25%20%3C0%25%3E%20%28%2B1.68%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B20e0d79...e42db7e%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/686%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-04-24T17%3A04%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201122ca30a18f92a7a7137470f93dc70d40c14038%20privacyidea/lib/log.py%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/686%23discussion_r113004960%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20please%20elaborate%20on%20this%3F%22%2C%20%22created_at%22%3A%20%222017-04-24T17%3A17%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure%21%20My%20line%20of%20thinking%20was%3A%20%60%60log_wrapper%60%60%20uses%20%60%60self.logger.debug%28...%29%60%60%20to%20log%20function%20entry%20and%20exit%20points.%20Thus%2C%20it%20may%20make%20the%20effort%20to%20hide%20passwords%20from%20%60%60args%60%60%20and%20%60%60kwargs%60%60%20even%20if%20the%20resulting%20message%20logged%20using%20%60%60self.logger.debug%60%60%20will%20never%20make%20it%20to%20the%20log%20%28because%2C%20e.g.%2C%20%60%60PI_LOGLEVEL%60%60%20is%20%60%60logging.INFO%60%60%29.%20So%20with%20this%20change%20%60%60log_wrapper%60%60%20should%20exit%20early%20if%20%60%60self.logger%60%60%20does%20not%20even%20forward%20DEBUG%20messages%20to%20the%20log.%5Cr%5Cn%5Cr%5CnBut%20I%27m%20not%20sure%20whether%20this%20is%20the%20right%20way%20to%20do%20it%2C%20and%20I%27m%20not%20sure%20if%20it%20results%20in%20a%20noticeable%20speedup%20%3A%29%22%2C%20%22created_at%22%3A%20%222017-04-25T18%3A44%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/28243%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see.%20I%20forgot%20that%20the%20whole%20log_with%20will%20only%20have%20effect%20if%20the%20loglevel%20is%20%60%60%3C%3D%20logging.DEBUG.%60%60%5Cr%5Cn%5Cr%5CnBut%20please%20note%2C%20that%20we%20also%20recommend%20setting%20the%20loglevel%20to%20%60%609%60%60%20which%20is%20no%20official%20log%20level%20but%20is%20used%20to%20log%20passwords%20to%20the%20log%20file.%20We%20use%20this%20here%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20level%20%3D%20self.logger.getEffectiveLevel%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Check%20if%20we%20should%20not%20do%20the%20password%20logging.%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20I.e.%20we%20only%20do%20password%20logging%20if%20log_level%20%3C%2010.%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20level%20%21%3D%200%20and%20level%20%3E%3D%2010%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Hide%20specific%20arguments%20or%20keyword%20arguments%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20log_args%20%3D%20deepcopy%28args%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20log_kwds%20%3D%20deepcopy%28kwds%29%5Cr%5Cn%5Cr%5CnSo%20can%20you%20confirm%20that%20the%20log%20level%209%20also%20matches%20%60%60self.logger.isEnabledFor%28logging.DEBUG%29%60%60%3F%22%2C%20%22created_at%22%3A%20%222017-04-26T05%3A27%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/log.py%3AL141-159%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/686#issuecomment-296746967'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=h1) Report
> Merging [#686](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/20e0d79fbb77fd8d0b5cfdd56b9b2a5365d6a910?src=pr&el=desc) will **decrease** coverage by `0.12%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/686/graphs/tree.svg?token=7nHLZki60B&width=650&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #686      +/-   ##
==========================================
- Coverage   95.39%   95.26%   -0.13%
==========================================
Files         120      120
Lines       14619    14621       +2
==========================================
- Hits        13946    13929      -17
- Misses        673      692      +19
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/log.py](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2xvZy5weQ==) | `43.83% <100%> (-28%)` | :arrow_down: |
| [privacyidea/lib/subscriptions.py](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk=) | `93.06% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.79% <0%> (+1.68%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=footer). Last update [20e0d79...e42db7e](https://codecov.io/gh/privacyidea/privacyidea/pull/686?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 1122ca30a18f92a7a7137470f93dc70d40c14038 privacyidea/lib/log.py 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/686#discussion_r113004960'>File: privacyidea/lib/log.py:L141-159</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Can you please elaborate on this?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars1.githubusercontent.com/u/28243?v=3' height=16 width=16></a> Sure! My line of thinking was: ``log_wrapper`` uses ``self.logger.debug(...)`` to log function entry and exit points. Thus, it may make the effort to hide passwords from ``args`` and ``kwargs`` even if the resulting message logged using ``self.logger.debug`` will never make it to the log (because, e.g., ``PI_LOGLEVEL`` is ``logging.INFO``). So with this change ``log_wrapper`` should exit early if ``self.logger`` does not even forward DEBUG messages to the log.
But I'm not sure whether this is the right way to do it, and I'm not sure if it results in a noticeable speedup :)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> I see. I forgot that the whole log_with will only have effect if the loglevel is ``<= logging.DEBUG.``
But please note, that we also recommend setting the loglevel to ``9`` which is no official log level but is used to log passwords to the log file. We use this here:
level = self.logger.getEffectiveLevel()
# Check if we should not do the password logging.
# I.e. we only do password logging if log_level < 10.
if level != 0 and level >= 10:
# Hide specific arguments or keyword arguments
log_args = deepcopy(args)
log_kwds = deepcopy(kwds)
So can you confirm that the log level 9 also matches ``self.logger.isEnabledFor(logging.DEBUG)``?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/686?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/686?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/686'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>