### PR TITLE
638/ldap machine resolver

### DIFF
--- a/privacyidea/lib/machines/ldap.py
+++ b/privacyidea/lib/machines/ldap.py
@@ -257,8 +257,7 @@ class LdapMachineResolver(BaseMachineResolver):
         self.search_filter = config.get("SEARCHFILTER",
                                         "(objectClass=computer)")
 
-        self.noreferrals = config.get("NOREFERRALS", False)
-        self.editable = config.get("EDITABLE", False)
+        self.noreferrals = is_true(config.get("NOREFERRALS", False))
         self.authtype = config.get("AUTHTYPE", AUTHTYPE.SIMPLE)
         self.start_tls = is_true(config.get("START_TLS", False))
         self.tls_verify = is_true(config.get("TLS_VERIFY", False))
@@ -284,7 +283,6 @@ class LdapMachineResolver(BaseMachineResolver):
                                              "IPATTRIBUTE": "string",
                                              "SEARCHFILTER": "string",
                                              "NOREFERRALS": "bool",
-                                             "EDITABLE": "bool",
                                              "AUTHTYPE": "string",
                                              "TLS_VERIFY": "bool",
                                              "TLS_CA_FILE": "string",

--- a/privacyidea/static/components/config/controllers/ldapMachineResolverController.js
+++ b/privacyidea/static/components/config/controllers/ldapMachineResolverController.js
@@ -38,6 +38,8 @@ myApp.controller("ldapMachineResolverController", function ($scope,
             $scope.params = resolver.data;
             $scope.params.type = 'ldap';
             $scope.params.NOREFERRALS = isTrue($scope.params.NOREFERRALS);
+            $scope.params.TLS_VERIFY = isTrue($scope.params.TLS_VERIFY);
+            $scope.params.START_TLS = isTrue($scope.params.START_TLS);
         });
     }
 

--- a/privacyidea/static/components/config/controllers/ldapMachineResolverController.js
+++ b/privacyidea/static/components/config/controllers/ldapMachineResolverController.js
@@ -24,7 +24,9 @@ myApp.controller("ldapMachineResolverController", function ($scope,
                                                       $state, $stateParams) {
     $scope.params = {
         type: 'ldap',
-        AUTHTYPE: "Simple"
+        AUTHTYPE: "Simple",
+        TLS_VERIFY: true,
+        START_TLS: true
     };
     $scope.authtypes = ["Simple", "SASL Digest-MD5"];
 

--- a/privacyidea/static/components/config/views/config.mresolvers.ldap.html
+++ b/privacyidea/static/components/config/views/config.mresolvers.ldap.html
@@ -33,6 +33,49 @@
                    placeholder="ldap://privacyidea.server1, ldap://privacyidea.server2"/>
         </div>
     </div>
+    <div class="form-group"
+        ng_show="params.LDAPURI.toLowerCase().substring(0,5) ==='ldap:'">
+        <label for="starttls"
+            class="col-sm-3 control-label" translate>
+            STARTTLS
+        </label>
+        <div class="col-sm-9">
+            <input name="starttls" id="starttls"
+                   ng-model="params.START_TLS"
+                   type="checkbox"/>
+            <p class="help-block" translate>
+                Use STARTTLS on a plain LDAP connection usually on port 389.
+            </p>
+        </div>
+    </div>
+    <div class="form-group"
+        ng-show="params.LDAPURI.toLowerCase().substring(0,5) === 'ldaps' ||
+                 params.START_TLS">
+        <label for="tls"
+            class="col-sm-3 control-label" translate>
+            Verify TLS
+        </label>
+        <div class="col-sm-9">
+            <input name="tls" id="tls"
+                   ng-model="params.TLS_VERIFY"
+                   type="checkbox"/>
+            <p class="help-block" translate>
+                Verify the TLS cerificate of the server.
+            </p>
+            <div class="well" ng-show="params.TLS_VERIFY">
+                <label for="tls_ca_file" class="control-label" translate>
+                    The file containing the CA certificate which signed the
+                    LDAP TLS certificate.
+                </label>
+                <input name="tls_ca_file" id="tls_ca_file"
+                       ng-model="params.TLS_CA_FILE"
+                       type="text"
+                       class="form-control"
+                       ng-show="params.TLS_VERIFY"
+                       placeholder="/etc/privacyidea/ldap-ca.crt"/>
+            </div>
+        </div>
+    </div>
     <div class="form-group">
         <label for="basedn" class="col-sm-3 control-label"
                 translate>Base DN</label>

--- a/tests/test_lib_machine_resolver_ldap.py
+++ b/tests/test_lib_machine_resolver_ldap.py
@@ -136,3 +136,37 @@ class LdapMachineTestCase(MyTestCase):
         self.assertTrue(success)
         self.assertTrue("3" in desc)
         # "Your LDAP config seems to be OK, 3 machine objects found."
+
+    @ldap3mock.activate
+    def test_08_start_tls(self):
+        # Check that START_TLS and TLS_VERIFY are actually passed to the ldap3 Connection
+        ldap3mock.setLDAPDirectory(LDAPDirectory)
+        config = MYCONFIG.copy()
+        config['START_TLS'] = '1'
+        config['TLS_VERIFY'] = '1'
+        start_tls_resolver = LdapMachineResolver("myResolver", config=config)
+        machines = start_tls_resolver.get_machines()
+        self.assertEqual(len(machines), 3)
+        # We check two things:
+        # 1) start_tls has actually been called!
+        self.assertTrue(start_tls_resolver.l.start_tls_called)
+        # 2) All Server objects were constructed with a non-None TLS context, but use_ssl=False
+        for _, kwargs in ldap3mock.get_server_mock().call_args_list:
+            self.assertIsNotNone(kwargs['tls'])
+            self.assertFalse(kwargs['use_ssl'])
+
+
+    @ldap3mock.activate
+    def test_09_ldaps(self):
+        # Check that use_ssl and tls are actually passed to the Connection
+        ldap3mock.setLDAPDirectory(LDAPDirectory)
+        config = MYCONFIG.copy()
+        config['LDAPURI'] = 'ldaps://1.2.3.4'
+        config['TLS_VERIFY'] = '1'
+        ldaps_resolver = LdapMachineResolver("myResolver", config=config)
+        machines = ldaps_resolver.get_machines()
+        self.assertEqual(len(machines), 3)
+        # We check that all Server objects were constructed with a non-None TLS context and use_ssl=True
+        for _, kwargs in ldap3mock.get_server_mock().call_args_list:
+            self.assertIsNotNone(kwargs['tls'])
+            self.assertTrue(kwargs['use_ssl'])


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/689%23issuecomment-297366921%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/689%23issuecomment-297366921%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23689%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/3d9d5df729bcfe1dd03a25d9b34c0fd48e15199a%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.11%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6090.9%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689/graphs/tree.svg%3Fsrc%3Dpr%26token%3D7nHLZki60B%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23689%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.31%25%20%20%2095.42%25%20%20%20%2B0.11%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20121%20%20%20%20%20%20121%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014744%20%20%20%2014768%20%20%20%20%20%20%2B24%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2014053%20%20%20%2014093%20%20%20%20%20%20%2B40%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20691%20%20%20%20%20%20675%20%20%20%20%20%20-16%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/machines/ldap.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmVzL2xkYXAucHk%3D%29%20%7C%20%6086.8%25%20%3C90.9%25%3E%20%28-0.42%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/subscriptions.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk%3D%29%20%7C%20%6093.13%25%20%3C0%25%3E%20%28%2B0.06%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6092.72%25%20%3C0%25%3E%20%28%2B0.93%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/log.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2xvZy5weQ%3D%3D%29%20%7C%20%6068.23%25%20%3C0%25%3E%20%28%2B24.39%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B3d9d5df...aa267cc%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/689%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-04-26T11%3A26%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/689#issuecomment-297366921'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=h1) Report
> Merging [#689](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/3d9d5df729bcfe1dd03a25d9b34c0fd48e15199a?src=pr&el=desc) will **increase** coverage by `0.11%`.
> The diff coverage is `90.9%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/689/graphs/tree.svg?src=pr&token=7nHLZki60B&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #689      +/-   ##
==========================================
+ Coverage   95.31%   95.42%   +0.11%
==========================================
Files         121      121
Lines       14744    14768      +24
==========================================
+ Hits        14053    14093      +40
+ Misses        691      675      -16
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/machines/ldap.py](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmVzL2xkYXAucHk=) | `86.8% <90.9%> (-0.42%)` | :arrow_down: |
| [privacyidea/lib/subscriptions.py](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk=) | `93.13% <0%> (+0.06%)` | :arrow_up: |
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `92.72% <0%> (+0.93%)` | :arrow_up: |
| [privacyidea/lib/log.py](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2xvZy5weQ==) | `68.23% <0%> (+24.39%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=footer). Last update [3d9d5df...aa267cc](https://codecov.io/gh/privacyidea/privacyidea/pull/689?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/689?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/689?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/689'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>