### PR TITLE
Simplify token owner retrieval.

### DIFF
--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -255,18 +255,14 @@ class BaseEventHandler(object):
         if serial:
             # We have determined the serial number from the request.
             token_obj_list = get_tokens(serial=serial)
-            if token_obj_list:
-                token_obj = token_obj_list[0]
-                tokenrealms = token_obj.get_realms()
-                tokentype = token_obj.get_tokentype()
         else:
             # We have to determine the token via the user object. But only if
             #  the user has only one token
             token_obj_list = get_tokens(user=user)
-            if len(token_obj_list) == 1:
-                token_obj = token_obj_list[0]
-                tokenrealms = token_obj.get_realms()
-                tokentype = token_obj.get_tokentype()
+        if len(token_obj_list) == 1:
+            token_obj = token_obj_list[0]
+            tokenrealms = token_obj.get_realms()
+            tokentype = token_obj.get_tokentype()
 
         if "realm" in conditions:
             res = user.realm == conditions.get("realm")

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -549,6 +549,9 @@ def get_token_owner(serial):
     the token is identified and retrieved by it's serial number
 
     If the token has no owner, None is returned
+    
+    In case the serial number matches several tokens (like when havin a 
+    wildcard), also None is returned.
 
     :param serial: serial number of the token
     :type serial: basestring

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -550,7 +550,7 @@ def get_token_owner(serial):
 
     If the token has no owner, None is returned
     
-    In case the serial number matches several tokens (like when havin a 
+    In case the serial number matches several tokens (like when containing a 
     wildcard), also None is returned.
 
     :param serial: serial number of the token

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -543,14 +543,6 @@ def token_exist(serial):
 
 
 @log_with(log)
-def token_has_owner(serial):
-    """
-    returns true if the token is owned by any user
-    """
-    return get_tokens(serial=serial, count=True, assigned=True) > 0
-
-
-@log_with(log)
 def get_token_owner(serial):
     """
     returns the user object, to which the token is assigned.
@@ -568,7 +560,7 @@ def get_token_owner(serial):
 
     tokenobject_list = get_tokens(serial=serial)
 
-    if tokenobject_list and token_has_owner(serial):
+    if len(tokenobject_list) == 1:
         tokenobject = tokenobject_list[0]
         user = tokenobject.user
 

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -171,15 +171,16 @@ class TokenClass(object):
         """
         user_object = None
         realmname = ""
-        username = get_username(self.token.user_id, self.token.resolver)
-        rlist = self.token.realm_list
-        # FIXME: What if the token has more than one realm assigned?
-        if len(rlist) == 1:
-            realmname = rlist[0].realm.name
-        if username and realmname:
-            user_object = User(login=username,
-                               resolver=self.token.resolver,
-                               realm=realmname)
+        if self.token.user_id and self.token.resolver:
+            username = get_username(self.token.user_id, self.token.resolver)
+            rlist = self.token.realm_list
+            # FIXME: What if the token has more than one realm assigned?
+            if len(rlist) == 1:
+                realmname = rlist[0].realm.name
+            if username and realmname:
+                user_object = User(login=username,
+                                   resolver=self.token.resolver,
+                                   realm=realmname)
         return user_object
 
     def is_orphaned(self):

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -29,8 +29,7 @@ from privacyidea.lib.token import (create_tokenclass_object,
                                    get_token_type, check_serial,
                                    get_num_tokens_in_realm,
                                    get_realms_of_token,
-                                   token_exist, token_has_owner,
-                                   get_token_owner, is_token_owner,
+                                   token_exist, get_token_owner, is_token_owner,
                                    get_tokenclass_info,
                                    get_tokens_in_resolver,
                                    get_all_token_users, get_otp,
@@ -200,10 +199,6 @@ class TokenTestCase(MyTestCase):
         self.assertFalse(token_exist(""))
 
     def test_08_token_owner(self):
-        # token_has_owner
-        self.assertTrue(token_has_owner("hotptoken"))
-        self.assertFalse(token_has_owner(self.serials[0]))
-
         # get_token_owner
         user = get_token_owner("hotptoken")
         self.assertTrue(user.login == "cornelius", user)


### PR DESCRIPTION
Avoid one SQL call and remove
a none-Owner, if more than one token
was found for the serial number.

Working on #694
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/695%23issuecomment-298545931%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/ec0b14185fa76546877421daa9afc821a6dfd5b7%23commitcomment-21984095%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/ec0b14185fa76546877421daa9afc821a6dfd5b7%23commitcomment-21984646%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/695%23issuecomment-298545931%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23695%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/de7ed353a9a3b1c43945c26fdd4801241a6ebacd%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23695%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.33%25%20%20%2095.32%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20121%20%20%20%20%20%20121%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014755%20%20%20%2014750%20%20%20%20%20%20%20-5%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2014066%20%20%20%2014061%20%20%20%20%20%20%20-5%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20689%20%20%20%20%20%20689%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6095.07%25%20%3C100%25%3E%20%28-0.02%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokenclass.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk%3D%29%20%7C%20%6099.42%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/base.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9iYXNlLnB5%29%20%7C%20%6094.96%25%20%3C100%25%3E%20%28-0.13%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bde7ed35...ec0b141%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/695%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-05-02T08%3A12%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%20ec0b14185fa76546877421daa9afc821a6dfd5b7%20privacyidea/lib/token.py%2020%20563%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/ec0b14185fa76546877421daa9afc821a6dfd5b7%23commitcomment-21984095%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Minor%20nitpick%3A%20Maybe%20we%20should%20add%20something%20like%20%5C%22In%20case%20multiple%20token%20objects%20matching%20%60%60serial%60%60%20are%20found%2C%20None%20is%20returned%5C%22%20to%20the%20docstring%3F%22%2C%20%22created_at%22%3A%20%222017-05-02T14%3A59%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/28243%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22done.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-05-02T15%3A26%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL563%20%28ec0b141%29%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/695#issuecomment-298545931'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=h1) Report
> Merging [#695](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/de7ed353a9a3b1c43945c26fdd4801241a6ebacd?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/695/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #695      +/-   ##
==========================================
- Coverage   95.33%   95.32%   -0.01%
==========================================
Files         121      121
Lines       14755    14750       -5
==========================================
- Hits        14066    14061       -5
Misses        689      689
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `95.07% <100%> (-0.02%)` | :arrow_down: |
| [privacyidea/lib/tokenclass.py](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk=) | `99.42% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/eventhandler/base.py](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9iYXNlLnB5) | `94.96% <100%> (-0.13%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=footer). Last update [de7ed35...ec0b141](https://codecov.io/gh/privacyidea/privacyidea/pull/695?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Commit ec0b14185fa76546877421daa9afc821a6dfd5b7 privacyidea/lib/token.py 20 563'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/ec0b14185fa76546877421daa9afc821a6dfd5b7#commitcomment-21984095'>File: privacyidea/lib/token.py:L563 (ec0b141)</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars1.githubusercontent.com/u/28243?v=3' height=16 width=16></a> Minor nitpick: Maybe we should add something like "In case multiple token objects matching ``serial`` are found, None is returned" to the docstring?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> done.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/695?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/695?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/695'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>