### PR TITLE
Add API for tokeninfo modification

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -1000,9 +1000,10 @@ def get_serial_by_otp_api(otp=None):
 
 
 @token_blueprint.route('/info/<serial>/<key>', methods=['POST'])
+@prepolicy(check_base_action, request, action=ACTION.SETTOKENINFO)
 @event("token_info", request, g)
-@admin_required
 @log_with(log)
+@admin_required
 def set_tokeninfo_api(serial, key):
     """
     Add a specific tokeninfo entry to a token. Already existing entries
@@ -1023,9 +1024,10 @@ def set_tokeninfo_api(serial, key):
 
 
 @token_blueprint.route('/info/<serial>/<key>', methods=['DELETE'])
+@prepolicy(check_base_action, request, action=ACTION.SETTOKENINFO)
 @event("token_info", request, g)
-@admin_required
 @log_with(log)
+@admin_required
 def delete_tokeninfo_api(serial, key):
     """
     Delete a specific tokeninfo entry of a token.

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -261,6 +261,7 @@ class ACTION(object):
     SYSTEMDELETE = "configdelete"
     SYSTEMWRITE = "configwrite"
     CONFIGDOCUMENTATION = "system_documentation"
+    SETTOKENINFO = "settokeninfo"
     TOKENISSUER = "tokenissuer"
     TOKENLABEL = "tokenlabel"
     TOKENPAGESIZE = "token_page_size"
@@ -1026,6 +1027,10 @@ def get_static_policy_definitions(scope=None):
                                 'tokens.'),
                             'mainmenu': [MAIN_MENU.TOKENS],
                             'group': GROUP.TOKEN},
+            ACTION.SETTOKENINFO: {'type': 'bool',
+                               'desc': _('Admin is allowed to manually set and delete token info.'),
+                               'mainmenu': [MAIN_MENU.TOKENS],
+                               'group': GROUP.TOKEN},
             ACTION.ENROLLPIN: {'type': 'bool',
                                "desc": _("Admin is allowed to set the OTP "
                                          "PIN during enrollment."),

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1439,6 +1439,30 @@ def add_tokeninfo(serial, info, value=None,
 
 @log_with(log)
 @check_user_or_serial
+def delete_tokeninfo(serial, key, user=None):
+    """
+    Delete a specific token info field in the database.
+
+    :param serial: The serial number of the token
+    :type serial: basestring
+    :param key: The key of the info in the dict
+    :param value: The value of the info
+    :param user: The owner of the tokens, that should be modified
+    :type user: User object
+    :return: the number of tokens matching the serial and user. This number also includes tokens that did not have
+    the token info *key* set in the first place!
+    :rtype: int
+    """
+    tokenobject_list = get_tokens(serial=serial, user=user)
+    for tokenobject in tokenobject_list:
+        tokenobject.del_tokeninfo(key)
+        tokenobject.save()
+
+    return len(tokenobject_list)
+
+
+@log_with(log)
+@check_user_or_serial
 def set_validity_period_start(serial, user, start):
     """
     Set the validity period for the given token.


### PR DESCRIPTION
This adds the ``/token/info/<serial>/<key>`` endpoint (for ``POST`` and ``DELETE``) as well as the ``SETTOKENINFO`` policy.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/699%23discussion_r115208859%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/699%23issuecomment-299826854%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/699%23discussion_r115219865%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/699%23issuecomment-299834876%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/699%23issuecomment-299826854%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23699%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/88170caa36a37bb31299d6b49696c5a92af7e64e%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699/graphs/tree.svg%3Fsrc%3Dpr%26width%3D650%26token%3D7nHLZki60B%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23699%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.29%25%20%20%2095.32%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20121%20%20%20%20%20%20121%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014762%20%20%20%2014792%20%20%20%20%20%20%2B30%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2014068%20%20%20%2014101%20%20%20%20%20%20%2B33%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20694%20%20%20%20%20%20691%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6095.12%25%20%3C100%25%3E%20%28%2B0.04%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5%29%20%7C%20%6098.11%25%20%3C100%25%3E%20%28%2B0.09%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.1%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6094.11%25%20%3C0%25%3E%20%28%2B2.52%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B88170ca...36b5a58%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/699%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-05-08T10%3A07%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closes%20%23691%20%22%2C%20%22created_at%22%3A%20%222017-05-08T10%3A47%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201dac684b27587fae2dcb55108ac387141101a7b7%20privacyidea/api/token.py%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/699%23discussion_r115208859%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20we%20should%20add%20more%20information%20to%20the%20audit%20log%3F%22%2C%20%22created_at%22%3A%20%222017-05-08T09%3A35%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/28243%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22No.%20The%20admin%20%28who%20deletes%20the%20token%20is%20already%20logged%20in%20the%20before%20request%29.%5Cr%5CnSo%20we%20do%20not%20have%20much%20additional%20information.%20I%20think%20the%20serial%20number%20is%20fine.%22%2C%20%22created_at%22%3A%20%222017-05-08T10%3A43%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/token.py%3AL997-1044%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 1dac684b27587fae2dcb55108ac387141101a7b7 privacyidea/api/token.py 55'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/699#discussion_r115208859'>File: privacyidea/api/token.py:L997-1044</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars1.githubusercontent.com/u/28243?v=3' height=16 width=16></a> Maybe we should add more information to the audit log?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> No. The admin (who deletes the token is already logged in the before request).
So we do not have much additional information. I think the serial number is fine.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/699#issuecomment-299826854'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=h1) Report
> Merging [#699](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/88170caa36a37bb31299d6b49696c5a92af7e64e?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/699/graphs/tree.svg?src=pr&width=650&token=7nHLZki60B&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #699      +/-   ##
==========================================
+ Coverage   95.29%   95.32%   +0.02%
==========================================
Files         121      121
Lines       14762    14792      +30
==========================================
+ Hits        14068    14101      +33
+ Misses        694      691       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `95.12% <100%> (+0.04%)` | :arrow_up: |
| [privacyidea/api/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5) | `98.11% <100%> (+0.09%)` | :arrow_up: |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.1% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `94.11% <0%> (+2.52%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=footer). Last update [88170ca...36b5a58](https://codecov.io/gh/privacyidea/privacyidea/pull/699?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> Closes #691


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/699?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/699?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/699'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>