### PR TITLE
Add /validate/radiuscheck endpoint for rlm_rest

### DIFF
--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -83,7 +83,7 @@ from privacyidea.api.lib.postpolicy import (postpolicy,
                                             no_detail_on_fail,
                                             no_detail_on_success, autoassign,
                                             offline_info,
-                                            add_user_detail_to_response)
+                                            add_user_detail_to_response, construct_radius_response)
 from privacyidea.lib.policy import PolicyClass
 from privacyidea.lib.config import ConfigClass
 from privacyidea.lib.event import EventConfiguration
@@ -158,6 +158,8 @@ def after_request(response):
 
 
 @validate_blueprint.route('/check', methods=['POST', 'GET'])
+@validate_blueprint.route('/radiuscheck', methods=['POST', 'GET'])
+@postpolicy(construct_radius_response, request=request)
 @postpolicy(no_detail_on_fail, request=request)
 @postpolicy(no_detail_on_success, request=request)
 @postpolicy(add_user_detail_to_response, request=request)
@@ -178,6 +180,12 @@ def check():
     Either a ``serial`` or a ``user`` is required to authenticate.
     The PIN and OTP value is sent in the parameter ``pass``.
     In case of successful authentication it returns ``result->value: true``.
+
+    In case ``/validate/radiuscheck`` is requested, the responses are
+    modified as follows: A successful authentication returns an empty HTTP
+    204 response. An unsuccessful authentication returns an empty HTTP
+    400 response. Error responses are the same responses as for the
+    ``/validate/check`` endpoint.
 
     :param serial: The serial number of the token, that tries to authenticate.
     :param user: The loginname/username of the user, who tries to authenticate.


### PR DESCRIPTION
Closes #703
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/704%23issuecomment-301527429%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/704%23discussion_r116568582%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/704%23discussion_r116570438%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/704%23discussion_r116570493%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/704%23discussion_r116572571%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/704%23issuecomment-301527429%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23704%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/187d3a4309945e0bf33f6eaa3f62f7cbde2b4865%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704/graphs/tree.svg%3Fsrc%3Dpr%26token%3D7nHLZki60B%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23704%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.33%25%20%20%2095.34%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20121%20%20%20%20%20%20121%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014804%20%20%20%2014815%20%20%20%20%20%20%2B11%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2014114%20%20%20%2014125%20%20%20%20%20%20%2B11%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20690%20%20%20%20%20%20690%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6095.88%25%20%3C100%25%3E%20%28%2B0.14%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/validate.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3ZhbGlkYXRlLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B187d3a4...f91b0b4%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/704%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-05-15T16%3A24%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f91b0b4c1fbe2e2b60537c6ff6636cc5bf087601%20privacyidea/api/lib/postpolicy.py%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/704%23discussion_r116568582%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20always%20/validate/check%3F%20Even%20if%20privacyIDEA%20runs%20in%20a%20subdirectory%20like%20/pi/validate/check%3F%22%2C%20%22created_at%22%3A%20%222017-05-15T18%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20this.%22%2C%20%22created_at%22%3A%20%222017-05-15T18%3A45%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20checked%20this%21%22%2C%20%22created_at%22%3A%20%222017-05-15T18%3A54%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/lib/postpolicy.py%3AL645-669%22%7D%2C%20%22Pull%20f91b0b4c1fbe2e2b60537c6ff6636cc5bf087601%20tests/test_api_validate.py%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/704%23discussion_r116570493%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20have%20added%20this.%22%2C%20%22created_at%22%3A%20%222017-05-15T18%3A46%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_api_validate.py%3AL1582-1618%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/704#issuecomment-301527429'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=h1) Report
> Merging [#704](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/187d3a4309945e0bf33f6eaa3f62f7cbde2b4865?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/704/graphs/tree.svg?src=pr&token=7nHLZki60B&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #704      +/-   ##
==========================================
+ Coverage   95.33%   95.34%   +<.01%
==========================================
Files         121      121
Lines       14804    14815      +11
==========================================
+ Hits        14114    14125      +11
Misses        690      690
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `95.88% <100%> (+0.14%)` | :arrow_up: |
| [privacyidea/api/validate.py](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3ZhbGlkYXRlLnB5) | `100% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=footer). Last update [187d3a4...f91b0b4](https://codecov.io/gh/privacyidea/privacyidea/pull/704?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull f91b0b4c1fbe2e2b60537c6ff6636cc5bf087601 privacyidea/api/lib/postpolicy.py 32'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/704#discussion_r116568582'>File: privacyidea/api/lib/postpolicy.py:L645-669</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> This is always /validate/check? Even if privacyIDEA runs in a subdirectory like /pi/validate/check?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> I've added this.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> I checked this!
- [x] <a href='#crh-comment-Pull f91b0b4c1fbe2e2b60537c6ff6636cc5bf087601 tests/test_api_validate.py 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/704#discussion_r116570493'>File: tests/test_api_validate.py:L1582-1618</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> I have added this.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/704?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/704?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/704'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>