### PR TITLE
Webui: allow multiple (U2F) tokens for authentication

### DIFF
--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -450,8 +450,7 @@ class U2fTokenClass(TokenClass):
             clientdata_dict = json.loads(clientdata)
             client_challenge = clientdata_dict.get("challenge")
             if challenge_url != client_challenge:
-                raise ValidateError("Challenge mismatch. The U2F key did not "
-                                    "send the original challenge.")
+                return ret
             if clientdata_dict.get("typ") != "navigator.id.getAssertion":
                 raise ValidateError("Incorrect navigator.id")
             #client_origin = clientdata_dict.get("origin")

--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -403,7 +403,7 @@ class U2fTokenClass(TokenClass):
         challenge = geturandom(32)
         # Create the challenge in the database
         db_challenge = Challenge(self.token.serial,
-                                 transaction_id=None,
+                                 transaction_id=transactionid,
                                  challenge=binascii.hexlify(challenge),
                                  data=None,
                                  session=options.get("session"),

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -194,6 +194,14 @@ angular.module("privacyideaApp")
                     "Authentication. You" +
                     " are not completely authenticated, yet."),
                     {type: "warning", ttl:5000});
+
+                if (error.detail && error.detail.multi_challenge) {
+                    error.detail.message = 'Please confirm with one of these tokens:'
+                    for (var i in error.detail.multi_challenge) {
+                        error.detail.message = error.detail.message + ' ' + error.detail.multi_challenge[i].serial;
+                    }
+                }
+
                 $scope.challenge_message = error.detail.message;
                 $scope.transactionid = error.detail["transaction_id"];
                 $scope.image = error.detail.attributes.img;

--- a/privacyidea/static/components/login/factories/u2f.js
+++ b/privacyidea/static/components/login/factories/u2f.js
@@ -51,6 +51,12 @@ angular.module("privacyideaAuth")
                 sign_request: function (data, username, transactionid,
                                         login_callback) {
                     var signRequests = [data.detail.attributes.u2fSignRequest];
+                    if (data.detail.multi_challenge) {
+                        var signRequests = [data.detail.attributes.u2fSignRequest];
+                        for (var i in data.detail.multi_challenge) {
+                           signRequests[i] = data.detail.multi_challenge[i].attributes.u2fSignRequest;
+                        }
+                    }
                     u2f.sign(signRequests, function (result) {
                         inform.clear();
                         if (result.errorCode > 0) {


### PR DESCRIPTION
This branch has two patches:

1. fix multi_challenge for U2F tokens
2. add multi_challange handling to the webui login

Implements https://github.com/privacyidea/privacyidea/issues/722
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/725%23issuecomment-309196809%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/725%23issuecomment-309213245%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/725%23issuecomment-309300867%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/725%23issuecomment-312108165%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/725%23issuecomment-309196809%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23725%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/712d5449029ca19835635c2b5873500404ce7003%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725/graphs/tree.svg%3Fheight%3D150%26width%3D650%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23725%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.34%25%20%20%2095.34%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20121%20%20%20%20%20%20121%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014815%20%20%20%2014815%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2014125%20%20%20%2014125%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20690%20%20%20%20%20%20690%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2ftoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmZ0b2tlbi5weQ%3D%3D%29%20%7C%20%6097.46%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B712d544...78e3ad6%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/725%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-06-17T06%3A25%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Cornelius%20K%5Cu00f6lbel%20%3Cnotifications%40github.com%3E%20writes%3A%5Cn%5Cn%3E%20This%20looks%20easy.%5Cn%5CnYes%2C%20I%20too%20was%20surprised%20how%20easy%20it%20was.%20But%20I%20didn%27t%20try%20U2F%20and%20email%5Cntoken%20or%20something%20like%20that.%5Cn%5Cn%3E%20Can%20you%20add%20a%20test%20for%20this%3F%20%28I%20know%2C%20U2F%20tests%20are%20a%20bit%20hard%29%5Cn%5CnI%20think%20I%20found%20the%20correct%20place%20to%20add%2C%20but%20that%20needs%20some%20time%20to%5Cnget%20familiar%20with%20the%20test%20setup%20and%20structure.%20Let%27s%20see%20if%20I%20can%20come%5Cnup%20with%20some%20tests.%5Cn%5Cn%5Cn--%20%5CnThis%20space%20is%20intentionally%20left%20blank.%5Cn%22%2C%20%22created_at%22%3A%20%222017-06-17T12%3A48%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20it%27s%20now%20broken%20again%20for%20me.%20My%20debugging%20brought%20me%20to%20check_otp%20in%20lib/tokens/u2ftoken.py.%5Cr%5CnMy%20current%20guess%20is%20that%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20The%20challenge%20in%20the%20challenge%20DB%20object%20is%20saved%20in%20hex%5Cr%5Cn%20%20%20%20%20%20%20%20challenge%20%3D%20binascii.unhexlify%28options.get%28%5C%22challenge%5C%22%2C%20%5C%22%5C%22%29%29%5Cr%5Cn%5Cr%5Cngives%20me%20only%20one%20part%20of%20the%20multi_challenge%2C%20which%20may%20be%20the%20wrong%20one.%5Cr%5CnSo%20I%20guess%20we%27ll%20need%20all%20challenges%20for%20this%20transaction_id%20from%20the%20database%20and%5Cr%5Cnlook%20for%20a%20matching%20one.%22%2C%20%22created_at%22%3A%20%222017-06-18T20%3A28%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20give%20up%20-%20I%27m%20confused%20what%20might%20be%20needed%20to%20get%20two%20%28valid%29%20U2F%20tokens%20in%20tests/test_api_u2f.py%5Cr%5Cnto%20test%20with.%20I%20think%20I%27ll%20have%20a%20pretty%20good%20idea%20what%20needs%20testing%20once%20I%20have%20two%20tokens%2C%20but%20I%27m%20confused%20in%20the%20setup...%5Cr%5Cn%5Cr%5CnJust%20a%20remark%20for%20now%3A%20/validate/samlcheck%20is%20also%20broken%20with%20multi_challenge.%20But%20that%27s%20for%20another%20day.%22%2C%20%22created_at%22%3A%20%222017-06-29T21%3A04%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/4837658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jh23453%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/725#issuecomment-309196809'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/725?src=pr&el=h1) Report
> Merging [#725](https://codecov.io/gh/privacyidea/privacyidea/pull/725?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/712d5449029ca19835635c2b5873500404ce7003?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/725/graphs/tree.svg?height=150&width=650&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/725?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master     #725   +/-   ##
=======================================
Coverage   95.34%   95.34%
=======================================
Files         121      121
Lines       14815    14815
=======================================
Hits        14125    14125
Misses        690      690
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/725?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2ftoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/725?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmZ0b2tlbi5weQ==) | `97.46% <ø> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/725?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/725?src=pr&el=footer). Last update [712d544...78e3ad6](https://codecov.io/gh/privacyidea/privacyidea/pull/725?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars2.githubusercontent.com/u/4837658?v=3' height=16 width=16></a> Cornelius Kölbel <notifications@github.com> writes:
> This looks easy.
Yes, I too was surprised how easy it was. But I didn't try U2F and email
token or something like that.
> Can you add a test for this? (I know, U2F tests are a bit hard)
I think I found the correct place to add, but that needs some time to
get familiar with the test setup and structure. Let's see if I can come
up with some tests.
--
This space is intentionally left blank.
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars2.githubusercontent.com/u/4837658?v=3' height=16 width=16></a> Hm, it's now broken again for me. My debugging brought me to check_otp in lib/tokens/u2ftoken.py.
My current guess is that
# The challenge in the challenge DB object is saved in hex
challenge = binascii.unhexlify(options.get("challenge", ""))
gives me only one part of the multi_challenge, which may be the wrong one.
So I guess we'll need all challenges for this transaction_id from the database and
look for a matching one.
- <a href='https://github.com/jh23453'><img border=0 src='https://avatars2.githubusercontent.com/u/4837658?v=3' height=16 width=16></a> I'll give up - I'm confused what might be needed to get two (valid) U2F tokens in tests/test_api_u2f.py
to test with. I think I'll have a pretty good idea what needs testing once I have two tokens, but I'm confused in the setup...
Just a remark for now: /validate/samlcheck is also broken with multi_challenge. But that's for another day.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/725?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/725?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/725'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>