### PR TITLE
pi-manage backup: Set correct owner if possible

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -209,6 +209,11 @@ def create(directory="/var/lib/privacyidea/backup/",
     BASE_NAME = "privacyidea-backup"
     
     call(["mkdir", "-p", directory])
+    # set correct owner, if possible
+    if os.geteuid() == 0:
+        directory_stat = os.stat(os.path.join(directory, '..'))
+        os.chown(directory, directory_stat.st_uid, directory_stat.st_gid)
+
     sqlfile = "%s/dbdump-%s.sql" % (directory, DATE)
     backup_file = "%s/%s-%s.tgz" % (directory, BASE_NAME, DATE)
 
@@ -262,6 +267,10 @@ user={0!s}
 password={1!s}""".format(username, password))
     f.close()
     os.chmod(filename, 0600)
+    # set correct owner, if possible
+    if os.geteuid() == 0:
+        directory_stat = os.stat(os.path.dirname(filename))
+        os.chown(filename, directory_stat.st_uid, directory_stat.st_gid)
 
 
 @backup_manager.command

--- a/pi-manage
+++ b/pi-manage
@@ -211,8 +211,8 @@ def create(directory="/var/lib/privacyidea/backup/",
     call(["mkdir", "-p", directory])
     # set correct owner, if possible
     if os.geteuid() == 0:
-        directory_stat = os.stat(os.path.join(directory, '..'))
-        os.chown(directory, directory_stat.st_uid, directory_stat.st_gid)
+        encfile_stat = os.stat(app.config.get("PI_ENCFILE"))
+        os.chown(directory, encfile_stat.st_uid, encfile_stat.st_gid)
 
     sqlfile = "%s/dbdump-%s.sql" % (directory, DATE)
     backup_file = "%s/%s-%s.tgz" % (directory, BASE_NAME, DATE)


### PR DESCRIPTION
Working on privacyidea/privacyidea-appliance#23
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/733%23issuecomment-311082314%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/733%23issuecomment-311193856%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/733%23issuecomment-311082314%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/733%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23733%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/733%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/5a82943caf25a86e05031c8d9b14a528aa6ff0bc%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/733/graphs/tree.svg%3Fheight%3D150%26width%3D650%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/733%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23733%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.34%25%20%20%2095.34%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20121%20%20%20%20%20%20121%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014819%20%20%20%2014819%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2014129%20%20%20%2014129%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20690%20%20%20%20%20%20690%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/733%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/733%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B5a82943...c0b6fe8%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/733%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-06-26T14%3A50%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20you%20are%20setting%20the%20right%20user%2C%20if%20%60%60root%60%60%20runs%20the%20command%20manually.%20%5Cr%5CnI%20think%20root%20will%20not%20run%20this%20command%20that%20often%20in%20an%20appliance%20environment.%20Usually%20it%20will%20be%20run%20via%20the%20crontab.%20And%20so%20this%20would%20look%20fine%20to%20me%21%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-06-26T21%3A57%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/733#issuecomment-311082314'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/733?src=pr&el=h1) Report
> Merging [#733](https://codecov.io/gh/privacyidea/privacyidea/pull/733?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/5a82943caf25a86e05031c8d9b14a528aa6ff0bc?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/733/graphs/tree.svg?height=150&width=650&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/733?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master     #733   +/-   ##
=======================================
Coverage   95.34%   95.34%
=======================================
Files         121      121
Lines       14819    14819
=======================================
Hits        14129    14129
Misses        690      690
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/733?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/733?src=pr&el=footer). Last update [5a82943...c0b6fe8](https://codecov.io/gh/privacyidea/privacyidea/pull/733?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars2.githubusercontent.com/u/1908620?v=3' height=16 width=16></a> So you are setting the right user, if ``root`` runs the command manually.
I think root will not run this command that often in an appliance environment. Usually it will be run via the crontab. And so this would look fine to me!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/733?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/733?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/733'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>