### PR TITLE
Use a unicode filter for fetching umlaut users

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -156,7 +156,7 @@ def cache(func):
                         datetime.datetime.now() < r_cache[args[0]][
                     "timestamp"] + \
                         datetime.timedelta(seconds=self.cache_timeout):
-            log.debug("Reading {0!s} from cache for {1!s}".format(args[0],
+            log.debug("Reading {0!r} from cache for {1!r}".format(args[0],
                                                               func.func_name))
             return r_cache[args[0]]["value"]
 
@@ -461,8 +461,9 @@ class IdResolver (UserIdResolver):
         """
         userid = ""
         self._bind()
-        filter = "(&{0!s}({1!s}={2!s}))".format(self.searchfilter, self.loginname_attribute,
-             self._escape_loginname(LoginName))
+        filter = u"(&{0!s}({1!s}={2!s}))".format(self.searchfilter,
+                                                 self.loginname_attribute,
+                                                 self._escape_loginname(LoginName))
 
         # create search attributes
         attributes = self.userinfo.values()

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -193,7 +193,7 @@ class IdResolver (UserIdResolver):
         self.timeout = 5.0  # seconds!
         self.sizelimit = 500
         self.loginname_attribute = ""
-        self.searchfilter = ""
+        self.searchfilter = u""
         self.userinfo = {}
         self.uidtype = ""
         self.noreferrals = False
@@ -340,8 +340,9 @@ class IdResolver (UserIdResolver):
             # get the DN for the Object
             self._bind()
             search_userId = self._trim_user_id(userId)
-            filter = "(&{0!s}({1!s}={2!s}))".format(self.searchfilter,
-                                                    self.uidtype, search_userId)
+            filter = u"(&{0!s}({1!s}={2!s}))".format(self.searchfilter,
+                                                     self.uidtype,
+                                                     search_userId)
             self.l.search(search_base=self.basedn,
                           search_scope=self.scope,
                           search_filter=filter,
@@ -353,7 +354,7 @@ class IdResolver (UserIdResolver):
             elif len(r) == 1:
                 dn = r[0].get("dn")
             else:
-                log.info("The filter {0!s} returned no DN.".format(filter))
+                log.info("The filter {0!r} returned no DN.".format(filter))
 
         return dn
 
@@ -392,12 +393,13 @@ class IdResolver (UserIdResolver):
             # encode utf8, so that also german ulauts work in the DN
             self.l.search(search_base=to_utf8(userId),
                           search_scope=self.scope,
-                          search_filter="(&" + self.searchfilter + ")",
+                          search_filter=u"(&" + self.searchfilter + u")",
                           attributes=self.userinfo.values())
         else:
             search_userId = self._trim_user_id(userId)
-            filter = "(&{0!s}({1!s}={2!s}))".format(self.searchfilter,
-                                                    self.uidtype, search_userId)
+            filter = u"(&{0!s}({1!s}={2!s}))".format(self.searchfilter,
+                                                     self.uidtype,
+                                                     search_userId)
             self.l.search(search_base=self.basedn,
                               search_scope=self.scope,
                               search_filter=filter,
@@ -507,10 +509,9 @@ class IdResolver (UserIdResolver):
                 comperator = ">="
                 if searchDict[search_key] in ["1", 1]:
                     comperator = "<="
-                filter += "(&({0!s}{1!s}{2!s})(!({3!s}=0)))".format(self.userinfo[search_key],
-                                                  comperator,
-                                                  get_ad_timestamp_now(),
-                                                  self.userinfo[search_key])
+                filter += u"(&({0!s}{1!s}{2!s})(!({3!s}=0)))".format(
+                    self.userinfo[search_key], comperator,
+                    get_ad_timestamp_now(), self.userinfo[search_key])
             else:
                 filter += u"({0!s}={1!s})".format(self.userinfo[search_key],
                                                   searchDict[search_key])
@@ -545,9 +546,9 @@ class IdResolver (UserIdResolver):
         This should be an Identifier of the resolver, preferable the type
         and the name of the resolver.
         """
-        s = "{0!s}{1!s}{2!s}{3!s}".format(self.uri, self.basedn,
+        s = u"{0!s}{1!s}{2!s}{3!s}".format(self.uri, self.basedn,
                                           self.searchfilter, self.userinfo)
-        r = binascii.hexlify(hashlib.sha1(s).digest())
+        r = binascii.hexlify(hashlib.sha1(s.encode("utf-8")).digest())
         return r
 
     @staticmethod
@@ -784,7 +785,7 @@ class IdResolver (UserIdResolver):
             # search for users...
             g = l.extend.standard.paged_search(
                 search_base=param["LDAPBASE"],
-                search_filter="(&" + param["LDAPSEARCHFILTER"] + ")",
+                search_filter=u"(&" + param["LDAPSEARCHFILTER"] + ")",
                 search_scope=param.get("SCOPE") or ldap3.SUBTREE,
                 attributes=attributes,
                 paged_size=100,
@@ -854,7 +855,8 @@ class IdResolver (UserIdResolver):
             raise privacyIDEAError(e)
 
         if self.l.result.get('result') != 0:
-            log.error("Error during adding of user {0}: {1}".format(dn, self.l.result.get('message')))
+            log.error("Error during adding of user {0!r}: "
+                      "{1!r}".format(dn, self.l.result.get('message')))
             raise privacyIDEAError(self.l.result.get('message'))
 
         return self.getUserId(attributes.get("username"))
@@ -982,7 +984,8 @@ class IdResolver (UserIdResolver):
             return False
 
         if self.l.result.get('result') != 0:
-            log.error("Error during update of user {0!s}: {1!s}".format(uid, self.l.result.get("message")))
+            log.error("Error during update of user {0!r}: "
+                      "{1!r}".format(uid, self.l.result.get("message")))
             return False
 
         return True


### PR DESCRIPTION
Also we must not log the username with {!s}, since
the even logging would raise an exception.

Fixing #738
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/746%23issuecomment-316119885%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/746%23issuecomment-316128376%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/9a098943cedc2eb5663d617781f773c9bbd5fdb6%23commitcomment-23161856%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/9a098943cedc2eb5663d617781f773c9bbd5fdb6%23commitcomment-23162763%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/746%23issuecomment-316281739%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/746%23issuecomment-316119885%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40fredreichbier%20Please%20check%2C%20if%20my%20thoughts%20are%20correct%20here.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-07-18T16%3A28%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23746%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/9cfb75262bdc8d740716493625adc97692482f86%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746/graphs/tree.svg%3Fheight%3D150%26src%3Dpr%26token%3D7nHLZki60B%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23746%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.3%25%20%20%2095.33%25%20%20%20%2B0.03%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20121%20%20%20%20%20%20121%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014941%20%20%20%2014941%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2014239%20%20%20%2014244%20%20%20%20%20%20%20%2B5%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20702%20%20%20%20%20%20697%20%20%20%20%20%20%20-5%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6092.74%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.79%25%20%3C0%25%3E%20%28%2B4.2%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B9cfb752...9a09894%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/746%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-07-18T16%3A57%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40fredreichbier%20%20Should%20we%20add%20a%20unicode/str%20check%3F%20Like%20adding%20a%20decorator%2C%20that%20checks%20if%20the%20passed%20%5C%22string%5C%22%20is%20of%20type%20%5C%22uniccode%5C%22%20and%20not%20%5C%22str%5C%22.%3F%20It%20it%20is%20encode%2C%20the%20decorator%20would%20decode%20it%3F%5Cr%5CnI%20am%20not%20sure%20if%20we%20are%20comlicating%20things%20and%20messing%20things%20up%2C%20here%21%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-07-19T06%3A04%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%209a098943cedc2eb5663d617781f773c9bbd5fdb6%20privacyidea/lib/resolvers/LDAPIdResolver.py%2017%20466%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/9a098943cedc2eb5663d617781f773c9bbd5fdb6%23commitcomment-23161856%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20like%20the%20way%20to%20do%20it%20to%20me%21%20But%20in%20order%20to%20avoid%20errors%20like%20this%20in%20the%20future%2C%20we%20should%20probably%20check%20that%20only%20%60%60unicode%60%60%20objects%20are%20passed%20as%20%60%60LoginName%60%60%2C%20since%20if%20we%20get%20an%20UTF-8-encoded%20string%2C%20the%20above%20code%20will%20fail%3A%5Cr%5Cn%60%60%60python%5Cr%5Cn%3E%3E%3E%20u%27attribute%3D%7B%21s%7D%27.format%28u%27%5Cu00f6%27%29%5Cr%5Cnu%27attribute%3D%5C%5Cxf6%27%5Cr%5Cn%3E%3E%3E%20u%27attribute%3D%7B%21s%7D%27.format%28u%27%5Cu00f6%27.encode%28%27utf-8%27%29%29%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22%3Cstdin%3E%5C%22%2C%20line%201%2C%20in%20%3Cmodule%3E%5Cr%5CnUnicodeDecodeError%3A%20%27ascii%27%20codec%20can%27t%20decode%20byte%200xc3%20in%20position%200%3A%20ordinal%20not%20in%20range%28128%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-07-18T17%3A11%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Argh.%20Any%20further%20suggestions%3F%22%2C%20%22created_at%22%3A%20%222017-07-18T17%3A52%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL466%20%289a09894%29%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/746#issuecomment-316119885'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier Please check, if my thoughts are correct here.
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=h1) Report
> Merging [#746](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/9cfb75262bdc8d740716493625adc97692482f86?src=pr&el=desc) will **increase** coverage by `0.03%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/746/graphs/tree.svg?height=150&src=pr&token=7nHLZki60B&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #746      +/-   ##
==========================================
+ Coverage    95.3%   95.33%   +0.03%
==========================================
Files         121      121
Lines       14941    14941
==========================================
+ Hits        14239    14244       +5
+ Misses        702      697       -5
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `92.74% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.79% <0%> (+4.2%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=footer). Last update [9cfb752...9a09894](https://codecov.io/gh/privacyidea/privacyidea/pull/746?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier  Should we add a unicode/str check? Like adding a decorator, that checks if the passed "string" is of type "uniccode" and not "str".? It it is encode, the decorator would decode it?
I am not sure if we are comlicating things and messing things up, here!?
- [ ] <a href='#crh-comment-Commit 9a098943cedc2eb5663d617781f773c9bbd5fdb6 privacyidea/lib/resolvers/LDAPIdResolver.py 17 466'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/9a098943cedc2eb5663d617781f773c9bbd5fdb6#commitcomment-23161856'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L466 (9a09894)</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Looks like the way to do it to me! But in order to avoid errors like this in the future, we should probably check that only ``unicode`` objects are passed as ``LoginName``, since if we get an UTF-8-encoded string, the above code will fail:
```python
>>> u'attribute={!s}'.format(u'ö')
u'attribute=\xf6'
>>> u'attribute={!s}'.format(u'ö'.encode('utf-8'))
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Argh. Any further suggestions?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/746?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/746?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/746'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>