### PR TITLE
Allow to log non-ascii characters

### DIFF
--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -319,6 +319,8 @@ class Audit(AuditBase):
                                                   le.client,
                                                   le.loglevel,
                                                   le.clearance_level)
+        if type(s) == unicode:
+            s = s.encode("utf-8")
         return s
 
     @staticmethod

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -206,19 +206,3 @@ class AuditTestCase(MyTestCase):
         self.assertEqual(audit_log.total, 1)
         self.assertEqual(audit_log.auditdata[0].get("user"), u"kölbel")
         self.assertEqual(audit_log.auditdata[0].get("sig_check"), "OK")
-
-        # Log a username as utf-8 with a non-ascii character
-        username = u"kölbel".encode("utf-8")
-        # hm, even if we should log a utf8 username...
-        self.Audit.log({"serial": "1234",
-                        "action": "token/assign",
-                        "success": True,
-                        "user": username})
-        self.Audit.finalize_log()
-        # ...we will find a unicode username
-        audit_log = self.Audit.search({"user": u"kölbel"})
-        self.assertEqual(audit_log.total, 1)
-        self.assertEqual(audit_log.auditdata[0].get("user"), u"kölbel")
-        self.assertEqual(audit_log.auditdata[0].get("sig_check"), "OK")
-
-        # TODO: Do we need to be able to find utf8 usernames?


### PR DESCRIPTION
Closes #749 

Please check my TODO question in the tests :-)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/750%23discussion_r128749913%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/750%23discussion_r128752576%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/750%23discussion_r128756852%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%206f9b230bba8ae5be49e5453fb6f98f7013176c35%20tests/test_lib_audit.py%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/750%23discussion_r128749913%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20to%20be%20honest%2C%20I%20think%20passing%20an%20UTF8-encoded%20bytestring%20to%20%60%60log%60%60%20should%20be%20illegal.%20In%20other%20words%2C%20I%20think%20optimally%20%60%60log%60%60%20should%20only%20accept%20%60%60unicode%60%60%20%28or%2C%20in%20%20ASCII%20bytestrings%20which%20can%20be%20implicitly%20converted%20to%20unicode%29.%5Cr%5CnWhat%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222017-07-21T12%3A27%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20looking%20into%20this%2C%20I%20think%20this%20doesn%27t%20actually%20work%20--%20shouldn%27t%20the%20query%20below%20give%20two%20results%3F%5Cr%5Cn%5Cr%5CnThe%20log%20says%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%5B2017-07-21%2014%3A45%3A05%2C539%5D%5B3049%5D%5B140085362857024%5D%5BERROR%5D%5Bprivacyidea.lib.auditmodules.sqlaudit%3A238%5D%20exception%20ProgrammingError%28%27%28sqlite3.ProgrammingError%29%20You%20must%20not%20use%208-bit%20bytestrings%20unless%20you%20use%20a%20text_factory%20that%20can%20interpret%208-bit%20bytestrings%20%28like%20text_factory%20%3D%20str%29.%20It%20is%20highly%20recommended%20that%20you%20instead%20just%20switch%20your%20application%20to%20Unicode%20strings.%27%2C%29%5Cr%5Cn%5B2017-07-21%2014%3A45%3A05%2C540%5D%5B3049%5D%5B140085362857024%5D%5BERROR%5D%5Bprivacyidea.lib.auditmodules.sqlaudit%3A239%5D%20DATA%3A%20%7B%27action%27%3A%20%27token/assign%27%2C%20%27serial%27%3A%20%271234%27%2C%20%27user%27%3A%20%27k%5C%5Cxc3%5C%5Cxb6lbel%27%2C%20%27success%27%3A%20True%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-07-21T12%3A42%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Are%20you%20sure%2C%20noone%20passes%20utf8%3F%22%2C%20%22created_at%22%3A%20%222017-07-21T13%3A06%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_audit.py%3AL194-225%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 6f9b230bba8ae5be49e5453fb6f98f7013176c35 tests/test_lib_audit.py 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/750#discussion_r128749913'>File: tests/test_lib_audit.py:L194-225</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, to be honest, I think passing an UTF8-encoded bytestring to ``log`` should be illegal. In other words, I think optimally ``log`` should only accept ``unicode`` (or, in  ASCII bytestrings which can be implicitly converted to unicode).
What do you think?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, looking into this, I think this doesn't actually work -- shouldn't the query below give two results?
The log says:
```
[2017-07-21 14:45:05,539][3049][140085362857024][ERROR][privacyidea.lib.auditmodules.sqlaudit:238] exception ProgrammingError('(sqlite3.ProgrammingError) You must not use 8-bit bytestrings unless you use a text_factory that can interpret 8-bit bytestrings (like text_factory = str). It is highly recommended that you instead just switch your application to Unicode strings.',)
[2017-07-21 14:45:05,540][3049][140085362857024][ERROR][privacyidea.lib.auditmodules.sqlaudit:239] DATA: {'action': 'token/assign', 'serial': '1234', 'user': 'k\xc3\xb6lbel', 'success': True}
```
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Are you sure, noone passes utf8?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/750?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/750?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/750'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>