### PR TITLE
open will only write filenames without umlaut

### DIFF
--- a/privacyidea/lib/caconnectors/localca.py
+++ b/privacyidea/lib/caconnectors/localca.py
@@ -399,7 +399,13 @@ class LocalCAConnector(BaseCAConnector):
                 csr_obj.get_subject(), file_extension="pem")
             #csr_extensions = csr_obj.get_extensions()
         csr_filename = csr_filename.replace(" ", "_")
+        if type(csr_filename) == str:
+            csr_filename = csr_filename.decode("utf-8")
+        csr_filename = csr_filename.encode("ascii", "ignore")
         certificate_filename = certificate_filename.replace(" ", "_")
+        if type(certificate_filename) == str:
+            certificate_filename = certificate_filename.decode("utf-8")
+        certificate_filename = certificate_filename.encode("ascii", "ignore")
         # dump the file
         with open(csrdir + "/" + csr_filename, "w") as f:
             f.write(csr)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import stat
 import sys
 
 #VERSION="2.1dev4"
-VERSION="2.20dev1"
+VERSION="2.20dev2"
 
 # Taken from kennethreitz/requests/setup.py
 package_directory = os.path.realpath(os.path.dirname(__file__))


### PR DESCRIPTION
Relates to #754
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/760%23issuecomment-321260813%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/760%23issuecomment-321278369%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/760%23issuecomment-325298665%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/760%23issuecomment-325300715%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/760%23issuecomment-321260813%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20check%2C%20if%20this%20is%20a%20sensible%20way%20to%20write%20the%20CSR%20and%20certificate%20files.%5Cr%5Cn%60%60open%60%60%20will%20not%20write%20a%20file%20like%20%5C%22k%5Cu00f6lbel%5C%22%20%28utf-8%29.%5Cr%5CnReplacing%20the%20%5C%22%5Cu00f6%5C%22%20with%20%5C%22%3F%5C%22%20results%20in%20other%20errors.%5Cr%5CnIt%20would%20be%20great%20to%20replace%20the%20%5C%22%5Cu00f6%5C%22%20with%20%5C%22oe%5C%22%2C%20but%20we%20can%20not%20find%20all%20special%20chracters.%20We%20could%20however%20add%20a%20function%2C%20that%20replaces%20known%20characters%20and%20ignores%20unknown%3F%22%2C%20%22created_at%22%3A%20%222017-08-09T13%3A49%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23760%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/5636f44c78993dabe7862ed0d1b5cc3ae06635bd%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760/graphs/tree.svg%3Fheight%3D150%26width%3D650%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23760%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.33%25%20%20%2095.33%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20121%20%20%20%20%20%20121%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2014968%20%20%20%2014974%20%20%20%20%20%20%20%2B6%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2014269%20%20%20%2014276%20%20%20%20%20%20%20%2B7%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20699%20%20%20%20%20%20698%20%20%20%20%20%20%20-1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/caconnectors/localca.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NhY29ubmVjdG9ycy9sb2NhbGNhLnB5%29%20%7C%20%6071.04%25%20%3C100%25%3E%20%28%2B0.68%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6094.11%25%20%3C0%25%3E%20%28%2B0.84%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B5636f44...672c08b%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/760%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-08-09T14%3A48%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20couldn%27t%20really%20reproduce%20the%20error%20thrown%20by%20%60%60open%60%60.%20On%20my%20system%2C%20both%20commands%20succeed%3A%5Cr%5Cn%60%60%60python%5Cr%5Cn%3E%3E%3E%20open%28%27/home/fred/k%5Cu00f6lbel.txt%27%2C%20%27w%27%29.write%28%27hallo%27%29%5Cr%5Cn%3E%3E%3E%20open%28u%27/home/fred/k%5Cu00f6lbel.txt%27%2C%20%27w%27%29.write%28%27hallo%27%29%5Cr%5Cn%60%60%60%5Cr%5CnMaybe%20this%20has%20something%20to%20do%20with%20the%20system/filesystem%20configuration%3F%5Cr%5Cn%5Cr%5CnBut%20anyway%2C%20I%20guess%20using%20%60%60.encode%28%27ascii%27%2C%20%27ignore%27%29%60%60%20would%20indeed%20be%20the%20way%20to%20go.%22%2C%20%22created_at%22%3A%20%222017-08-28T08%3A53%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20do%20you%20think%2C%20should%20we%20do%20a%20%60%60try%60%60%20%60%60except%60%60%20around%20it%3F%5Cr%5Cn%5Cr%5CnAt%20the%20moment%20an%20exception%20would%20be%20catched%20by%20an%20upper%20layer%20and%20be%20displayed%20in%20the%20UI%20accordingly.%5Cr%5CnIf%20we%20do%20an%20%60%60except%60%60%20we%20would%20have%20to%20re-raise%20an%20exception%20anyway.%22%2C%20%22created_at%22%3A%20%222017-08-28T09%3A03%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/760#issuecomment-321260813'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Please check, if this is a sensible way to write the CSR and certificate files.
``open`` will not write a file like "kölbel" (utf-8).
Replacing the "ö" with "?" results in other errors.
It would be great to replace the "ö" with "oe", but we can not find all special chracters. We could however add a function, that replaces known characters and ignores unknown?
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=h1) Report
> Merging [#760](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/5636f44c78993dabe7862ed0d1b5cc3ae06635bd?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/760/graphs/tree.svg?height=150&width=650&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #760      +/-   ##
==========================================
+ Coverage   95.33%   95.33%   +<.01%
==========================================
Files         121      121
Lines       14968    14974       +6
==========================================
+ Hits        14269    14276       +7
+ Misses        699      698       -1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/caconnectors/localca.py](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NhY29ubmVjdG9ycy9sb2NhbGNhLnB5) | `71.04% <100%> (+0.68%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `94.11% <0%> (+0.84%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=footer). Last update [5636f44...672c08b](https://codecov.io/gh/privacyidea/privacyidea/pull/760?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I couldn't really reproduce the error thrown by ``open``. On my system, both commands succeed:
```python
>>> open('/home/fred/kölbel.txt', 'w').write('hallo')
>>> open(u'/home/fred/kölbel.txt', 'w').write('hallo')
```
Maybe this has something to do with the system/filesystem configuration?
But anyway, I guess using ``.encode('ascii', 'ignore')`` would indeed be the way to go.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What do you think, should we do a ``try`` ``except`` around it?
At the moment an exception would be catched by an upper layer and be displayed in the UI accordingly.
If we do an ``except`` we would have to re-raise an exception anyway.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/760?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/760?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/760'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>