### PR TITLE
Implement refresh button

### DIFF
--- a/privacyidea/static/components/audit/views/audit.log.html
+++ b/privacyidea/static/components/audit/views/audit.log.html
@@ -27,51 +27,63 @@
                 <th translate>number</th>
                 <th><translate>date</translate>
                     <pi-filter ng-model="dateFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:dateFilter">
                 </th>
                 <th><translate>action</translate>
                     <pi-filter ng-model="actionFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:actionFilter">
                 </th>
                 <th><translate>success</translate>
                     <pi-filter ng-model="successFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:successFilter">
                 </th>
                 <th><translate>action detail</translate>
                     <pi-filter ng-model="action_detailFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:detailFilter">
                 </th>
                 <th><translate>serial</translate>
                     <pi-filter ng-model="serialFilter"
-                               ng-change="getAuditList()"></pi-filter>
+                               ng-change="getAuditList()"
+                               persist-as="audit:serialFilter"></pi-filter>
                 </th>
                 <th><translate>token type</translate>
                     <pi-filter ng-model="typeFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:typeFilter">
                 </th>
                 <th><translate>administrator</translate>
                     <pi-filter ng-model="administratorFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:administratorFilter">
                 </th>
                 <th><translate>user</translate>
                     <pi-filter ng-model="userFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:userFilter">
                 </th>
                 <th><translate>realm</translate>
                     <pi-filter ng-model="realmFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:realmFilter">
                 </th>
                 <th><translate>resolver</translate>
                     <pi-filter ng-model="resolverFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:resolverFilter">
                 </th>
                 <th><translate>client</translate>
                     <pi-filter ng-model="clientFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:clientFilter">
                 </th>
                 <th><translate>info</translate>
                     <pi-filter ng-model="infoFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:infoFilter">
                 </th>
                 <th translate>sig_check</th>
                 <th translate>missing_line</th>
@@ -79,7 +91,8 @@
                 <th translate>log level</th>
                 <th><translate>privacyidea server</translate>
                     <pi-filter ng-model="serverFilter"
-                               ng-change="getAuditList()">
+                               ng-change="getAuditList()"
+                               persist-as="audit:serverFilter">
                 </th>
             </tr>
             </thead>

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -357,7 +357,7 @@ myApp.directive('spinner', function() {
         },
         template: [
             '<div ng-show="show">',
-            '<span class="glyphicon glyphicon-refresh spin" style="margin: 50% 5px 0 0; font-size:120%; color: #787878;" aria-hidden="true"></span>',
+            '<span class="glyphicon glyphicon-refresh spin" style="margin: 0 5px 0 0; font-size:120%; color: #787878; padding: 15px 0px;" aria-hidden="true"></span>',
             '</div>'
         ].join(''),
         controller: function($scope) {

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -381,3 +381,39 @@ myApp.directive('spinner', function() {
         }
     };
 });
+
+myApp.directive('refreshbutton', function() {
+    return {
+        scope: {
+            name: '@?',
+            show: '=?',
+            onRefresh: '&'
+        },
+        template: [
+            '<a ng-click="onRefresh()" ng-show="show" style="cursor: pointer">',
+            '<span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>\n',
+            '<translate>Refresh</translate>',
+            '</a>'
+        ].join(''),
+        replace: true,
+        controller: function($scope) {
+            $scope.loading_queue = 0;
+            $scope.$watch('loading_queue', function(loading_queue) {
+                if (loading_queue > 0) {
+                    $scope.show = false;
+                } else if (loading_queue < 0) {
+                    $scope.loading_queue = 0;
+                } else {
+                    $scope.show = true;
+                }
+            });
+            $scope.$on('spinnerEvent', function(event, data) {
+                if(data.action === 'increment') {
+                    $scope.loading_queue++;
+                } else if(data.action === 'decrement') {
+                    $scope.loading_queue--;
+                }
+            });
+        }
+    };
+});

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -44,15 +44,46 @@ myApp.directive("piFilter", function (instanceUrl) {
     return {
         require: 'ngModel',
         restrict: 'E',
-        scope: {},
+        scope: {
+            'persistAs': '@?'
+        },
         templateUrl: instanceUrl + "/static/components/directives/views/directive.filter.table.html",
         link: function (scope, element, attr, ctrl) {
+            // make it possible to persist filters per session
+            if(scope.hasOwnProperty("persistAs")
+                && !angular.isUndefined(Storage)) {
+                scope.storageItem = "piFilter:" + scope.persistAs;
+            }
+
+            scope.retrieveFilter = function () {
+                if(scope.hasOwnProperty("storageItem")) {
+                    var stored = sessionStorage.getItem(scope.storageItem);
+                    if(stored) {
+                        scope.filterValue = stored;
+                        scope.filterVisible = true;
+                        scope.updateFilter();
+                    }
+                }
+            };
+
+            scope.persistFilter = function () {
+                if(scope.hasOwnProperty("storageItem")) {
+                    sessionStorage.setItem(scope.storageItem, scope.filterValue);
+                }
+            };
+
             scope.updateFilter = function() {
                 ctrl.$setViewValue(scope.filterValue);
+                if(!angular.isUndefined(scope.filterValue)) {
+                    scope.persistFilter();
+                }
             };
+
             ctrl.$viewChangeListeners.push(function(){
               scope.$eval(attr.ngChange);
             });
+
+            scope.retrieveFilter();
         }
     };
 });

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -55,6 +55,7 @@ myApp.directive("piFilter", function (instanceUrl) {
                 scope.storageItem = "piFilter:" + scope.persistAs;
             }
 
+            // retrieve and display a persisted filter (if any)
             scope.retrieveFilter = function () {
                 if(scope.hasOwnProperty("storageItem")) {
                     var stored = sessionStorage.getItem(scope.storageItem);
@@ -66,6 +67,7 @@ myApp.directive("piFilter", function (instanceUrl) {
                 }
             };
 
+            // persist the current filter
             scope.persistFilter = function () {
                 if(scope.hasOwnProperty("storageItem")) {
                     sessionStorage.setItem(scope.storageItem, scope.filterValue);

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -381,7 +381,7 @@ myApp.directive('csvDownload', function(AuthFactory, $http, instanceUrl) {
     }
 });
 
-myApp.directive('spinner', function() {
+myApp.directive('spinner', function($rootScope) {
     return {
         scope: {
             name: '@?',
@@ -394,28 +394,28 @@ myApp.directive('spinner', function() {
             '</div>'
         ].join(''),
         controller: function($scope) {
-            $scope.loading_queue = 0;
-            $scope.$watch('loading_queue', function(loading_queue) {
+            $rootScope.loading_queue = 0;
+            $rootScope.$watch('loading_queue', function(loading_queue) {
                 if (loading_queue > 0) {
                     $scope.show = true;
-                } else if (loading_queue < 0) {
-                    $scope.loading_queue = 0;
+                } else if ($rootScope.loading_queue < 0) {
+                    $rootScope.loading_queue = 0;
                 } else {
                     $scope.show = false;
                 }
             });
-            $scope.$on('spinnerEvent', function(event, data) {
+            $rootScope.$on('spinnerEvent', function(event, data) {
                 if(data.action === 'increment') {
-                    $scope.loading_queue++;
+                    $rootScope.loading_queue++;
                 } else if(data.action === 'decrement') {
-                    $scope.loading_queue--;
+                    $rootScope.loading_queue--;
                 }
             });
         }
     };
 });
 
-myApp.directive('refreshbutton', function() {
+myApp.directive('refreshbutton', function($rootScope) {
     return {
         scope: {
             name: '@?',
@@ -430,21 +430,11 @@ myApp.directive('refreshbutton', function() {
         ].join(''),
         replace: true,
         controller: function($scope) {
-            $scope.loading_queue = 0;
-            $scope.$watch('loading_queue', function(loading_queue) {
+            $rootScope.$watch('loading_queue', function(loading_queue) {
                 if (loading_queue > 0) {
                     $scope.show = false;
-                } else if (loading_queue < 0) {
-                    $scope.loading_queue = 0;
-                } else {
+                }  else {
                     $scope.show = true;
-                }
-            });
-            $scope.$on('spinnerEvent', function(event, data) {
-                if(data.action === 'increment') {
-                    $scope.loading_queue++;
-                } else if(data.action === 'decrement') {
-                    $scope.loading_queue--;
                 }
             });
         }

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -372,6 +372,10 @@ angular.module("privacyideaApp")
         $('html,body').scrollTop(0);
     };
 
+    $scope.refresh = function () {
+        $state.reload();
+    };
+
     $scope.lock_screen = function () {
         // We need to destroy the auth_token
         $scope.loggedInUser.auth_token = null;

--- a/privacyidea/static/components/machine/views/machine.list.html
+++ b/privacyidea/static/components/machine/views/machine.list.html
@@ -14,19 +14,23 @@
         <tr>
             <th><translate>hostname</translate>
                 <pi-filter ng-model="params.hostnameFilter"
-                         ng-change="_getMachines()"></pi-filter>
+                         ng-change="_getMachines()"
+                         persist-as="machines:hostnameFilter"></pi-filter>
             </th>
             <th><translate>IP Address</translate>
                 <pi-filter ng-model="params.ipFilter"
-                         ng-change="_getMachines()"></pi-filter>
+                         ng-change="_getMachines()"
+                         persist-as="machines:ipFilter"></pi-filter>
             </th>
             <th><translate>Id</translate>
                 <pi-filter ng-model="params.idFilter"
-                         ng-change="_getMachines()"></pi-filter>
+                         ng-change="_getMachines()"
+                         persist-as="machines:idFilter"></pi-filter>
             </th>
             <th><translate>Machine Resolver</translate>
                 <pi-filter ng-model="params.resolverFilter"
-                         ng-change="_getMachines()"></pi-filter>
+                         ng-change="_getMachines()"
+                         persist-as="machines:resolverFilter"></pi-filter>
             </th>
         </tr>
         </thead>

--- a/privacyidea/static/components/token/views/token.challenges.html
+++ b/privacyidea/static/components/token/views/token.challenges.html
@@ -30,7 +30,8 @@
                         translate>serial
                 </button>
                 <pi-filter ng-model="serialFilter"
-                           ng-change="get()"></pi-filter>
+                           ng-change="get()"
+                           persist-as="challenges:serialFilter"></pi-filter>
             </th>
             <th>
                 <button pi-sort-by="transaction_id"

--- a/privacyidea/static/components/token/views/token.list.html
+++ b/privacyidea/static/components/token/views/token.list.html
@@ -23,6 +23,7 @@
                 <pi-filter ng-model="serialFilter"
                            ng-change="get('livesearch')"
                            ng-keypress="($event.which==13)?get():return"
+                           persist-as="tokens:serialFilter"
                 ></pi-filter>
             </th>
             <th>
@@ -33,6 +34,7 @@
                 <pi-filter ng-model="typeFilter"
                            ng-change="get('livesearch')"
                            ng-keypress="($event.which==13)?get():return"
+                           persist-as="tokens:typeFilter"
                 ></pi-filter>
             </th>
             <th>
@@ -51,6 +53,7 @@
                 <pi-filter ng-model="descriptionFilter"
                            ng-change="get('livesearch')"
                            ng-keypress="($event.which==13)?get():return"
+                           persist-as="tokens:descriptionFilter"
                 ></pi-filter>
             </th>
             <th>
@@ -72,6 +75,7 @@
                 <pi-filter ng-model="userIdFilter"
                            ng-change="get('livesearch')"
                            ng-keypress="($event.which==13)?get():return"
+                           persist-as="tokens:userIdFilter"
                 ></pi-filter>
             </th>
             <th ng-show="loggedInUser.role == 'admin' &&
@@ -84,6 +88,7 @@
                 <pi-filter ng-model="resolverFilter"
                            ng-change="get('livesearch')"
                            ng-keypress="($event.which==13)?get():return"
+                           persist-as="tokens:resolverFilter"
                 ></pi-filter>
             </th>
         </tr>

--- a/privacyidea/static/components/user/views/user.list.html
+++ b/privacyidea/static/components/user/views/user.list.html
@@ -12,24 +12,28 @@
                 <pi-filter ng-model="params.usernameFilter"
                            ng-change="_getUsers('livesearch')"
                            ng-keypress="($event.which==13)?_getUsers():return"
+                           persist-as="usernameFilter"
                            ></pi-filter>
             </th>
             <th><translate>surname</translate>
                 <pi-filter ng-model="params.surnameFilter"
                            ng-change="_getUsers('livesearch')"
                            ng-keypress="($event.which==13)?_getUsers():return"
+                           persist-as="surnameFilter"
                 ></pi-filter>
             </th>
             <th><translate>givenname</translate>
                 <pi-filter ng-model="params.givennameFilter"
                            ng-change="_getUsers('livesearch')"
                            ng-keypress="($event.which==13)?_getUsers():return"
+                           persist-as="givennameFilter"
                 ></pi-filter>
             </th>
             <th><translate>email</translate>
                 <pi-filter ng-model="params.emailFilter"
                            ng-change="_getUsers('livesearch')"
                            ng-keypress="($event.which==13)?_getUsers():return"
+                           persist-as="emailFilter"
                 ></pi-filter>
             </th>
             <th translate>phone</th>

--- a/privacyidea/static/components/user/views/user.list.html
+++ b/privacyidea/static/components/user/views/user.list.html
@@ -12,28 +12,28 @@
                 <pi-filter ng-model="params.usernameFilter"
                            ng-change="_getUsers('livesearch')"
                            ng-keypress="($event.which==13)?_getUsers():return"
-                           persist-as="usernameFilter"
+                           persist-as="users:usernameFilter"
                            ></pi-filter>
             </th>
             <th><translate>surname</translate>
                 <pi-filter ng-model="params.surnameFilter"
                            ng-change="_getUsers('livesearch')"
                            ng-keypress="($event.which==13)?_getUsers():return"
-                           persist-as="surnameFilter"
+                           persist-as="users:surnameFilter"
                 ></pi-filter>
             </th>
             <th><translate>givenname</translate>
                 <pi-filter ng-model="params.givennameFilter"
                            ng-change="_getUsers('livesearch')"
                            ng-keypress="($event.which==13)?_getUsers():return"
-                           persist-as="givennameFilter"
+                           persist-as="users:givennameFilter"
                 ></pi-filter>
             </th>
             <th><translate>email</translate>
                 <pi-filter ng-model="params.emailFilter"
                            ng-change="_getUsers('livesearch')"
                            ng-keypress="($event.which==13)?_getUsers():return"
-                           persist-as="emailFilter"
+                           persist-as="users:emailFilter"
                 ></pi-filter>
             </th>
             <th translate>phone</th>

--- a/privacyidea/static/templates/menu.html
+++ b/privacyidea/static/templates/menu.html
@@ -94,11 +94,7 @@
                     <spinner name="spinner" show="false"></spinner>
                 </li>
                 <li ng-show="loggedInUser.username">
-                    <a ng-click="refresh()" style="cursor: pointer">
-                        <span class="glyphicon glyphicon-refresh"
-                              aria-hidden="true"></span>
-                        <translate>Refresh</translate>
-                    </a>
+                    <refreshbutton name="refresh" show="true" on-refresh="refresh()"></refreshbutton>
                 </li>
                 <li ng-class="{active: $state.includes('register')}"
                     ng-show="registrationAllowed">

--- a/privacyidea/static/templates/menu.html
+++ b/privacyidea/static/templates/menu.html
@@ -87,10 +87,18 @@
                         <translate>Components</translate>
                     </a>
                 </li>
+
             </ul>
             <ul class="nav navbar-nav navbar-right">
                 <li>
                     <spinner name="spinner" show="false"></spinner>
+                </li>
+                <li ng-show="loggedInUser.username">
+                    <a ng-click="refresh()" style="cursor: pointer">
+                        <span class="glyphicon glyphicon-refresh"
+                              aria-hidden="true"></span>
+                        <translate>Refresh</translate>
+                    </a>
                 </li>
                 <li ng-class="{active: $state.includes('register')}"
                     ng-show="registrationAllowed">

--- a/privacyidea/static/templates/menu.html
+++ b/privacyidea/static/templates/menu.html
@@ -87,7 +87,6 @@
                         <translate>Components</translate>
                     </a>
                 </li>
-
             </ul>
             <ul class="nav navbar-nav navbar-right">
                 <li>


### PR DESCRIPTION
This implements #715.

However, filter persistance currently only appears to work for the user list: For tokens, audit entries and machines, the filter is displayed accordingly after the refresh, but has no effect on the list (I didn't test token challenges yet).

I'm also not sure if using ``sessionStorage`` is a good solution.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/775%23issuecomment-326523320%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/775%23issuecomment-326523481%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/775%23issuecomment-326527573%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/775%23issuecomment-326887725%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/775%23issuecomment-326901731%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/775%23issuecomment-326985993%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/775%23issuecomment-327098263%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/775%23issuecomment-326523320%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%2C%20so%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-09-01T08%3A33%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20so%20apparently%20we%20can%20get%20filter%20persistance%20to%20work%20if%20we%20change%20%5Bthis%20line%5D%28https%3A//github.com/privacyidea/privacyidea/pull/775/commits/829a058efd11fdd4dc49b68bf3af201a8aae81c1%23diff-8f4912288cb04d33f884b515f8432ec0R85%29%20to%20%5Cr%5Cn%60%60%60js%5Cr%5Cnscope.%24parent.%24eval%28attr.ngChange%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cnbut%20don%27t%20ask%20me%20why%20%3A-%29%22%2C%20%22created_at%22%3A%20%222017-09-01T08%3A34%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23775%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/f619a5ecdace90be0c4dc74f3f0c164973e6c3c1%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.32%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23775%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.43%25%20%20%2095.76%25%20%20%20%2B0.32%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015416%20%20%20%2017938%20%20%20%20%2B2522%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2014713%20%20%20%2017179%20%20%20%20%2B2466%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20703%20%20%20%20%20%20759%20%20%20%20%20%20%2B56%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/caconnectors/localca.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NhY29ubmVjdG9ycy9sb2NhbGNhLnB5%29%20%7C%20%6067.27%25%20%3C0%25%3E%20%28-3.77%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/before%5C%5C_after.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ%3D%3D%29%20%7C%20%6096.13%25%20%3C0%25%3E%20%28-1.21%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/event.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50LnB5%29%20%7C%20%6099.16%25%20%3C0%25%3E%20%28-0.84%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/tiqrtoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90aXFydG9rZW4ucHk%3D%29%20%7C%20%6099.55%25%20%3C0%25%3E%20%28-0.45%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/ocra.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9vY3JhLnB5%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/config.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvY29uZmlnLnB5%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/config.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ%3D%3D%29%20%7C%20%6096.6%25%20%3C0%25%3E%20%28%2B0.18%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.97%25%20%3C0%25%3E%20%28%2B0.24%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6096.17%25%20%3C0%25%3E%20%28%2B0.25%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/SQLIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TUUxJZFJlc29sdmVyLnB5%29%20%7C%20%6097.69%25%20%3C0%25%3E%20%28%2B0.28%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20...%20and%20%5B11%20more%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dtree-more%29%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bf619a5e...829a058%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/775%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-09-01T08%3A53%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Here%20are%20some%20observations%20regarding%20the%20difference%20between%20%60%60userlist%60%60%20%28which%20works%29%20and%20%60%60token%60%60%2C%20%60%60audit%60%60%2C%20which%20doe%20not%20work.%5Cr%5Cn%5Cr%5CnThe%20Usercontroller%20initializes%20the%20%60%60%24scope.params%60%60%20dictionary%20in%20the%20javascript%20contoller.%20Then%20the%20filters%20are%20used%20as%20elements%20in%20this%20dictionary%20like%3A%5Cr%5Cn%5Cr%5Cn%20%20%20ng-model%20%3D%20params.usernameFilter%5Cr%5Cn%5Cr%5CnIn%20token%20and%20audit%20the%20filter%20variables%20are%20_not_%20initialized%20in%20the%20javascript%20controller.%20The%20view%20simply%20uses%20%5Cr%5Cn%5Cr%5Cn%20%20%20ng-mode%20%3D%20serialFilter%5Cr%5Cn%5Cr%5CnAnd%20the%20javascript%20code%20later%20refers%20to%20this%20only%20once%20%60%60%24scope.serialFilter%60%60.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-09-04T07%3A35%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20regards%20to%20the%20double%20controller/spinner%20code%20in%20the%20refreshbutton%20directive%2C%20we%20can%20simply%20remove%20the%20controller.%20%5Cr%5CnThen%20the%20spinner%20from%20the%20spinner%20directive%20would%20spin%20anyway.%5Cr%5CnWe%20would%20simply%20have%20to%20hide%20the%20refreshbutton.%22%2C%20%22created_at%22%3A%20%222017-09-04T08%3A38%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Today%20I%20tried%20to%20wrap%20my%20head%20around%20this%20and%20this%20and%20I%20was%20asking%20myself%2C%20why%20this%20would%20have%20to%20so%20so%20complicated.%20We%20have%20nasty%20side%20effects%3A%20In%20the%20user%20tab%20you%20get%20unexpected%20results%2C%20when%20viewing%20users%20in%20a%20non-default%20realm.%20This%20will%20result%20in%20appliying%20the%20right%20filters%20but%20in%20the%20wrong%20realm.%5Cr%5Cn%5Cr%5CnThe%20audit%20tab%20already%20provides%20a%20%5C%22Reload%5C%22%20button%20within%20the%20audit%20list%20scope.%20It%20works%20well.%20It%20just%20calls%20%60%60getAuditList%60%60.%20https%3A//github.com/privacyidea/privacyidea/blob/master/privacyidea/static/components/audit/controllers/auditControllers.js%23L74%5Cr%5Cn%5Cr%5CnThe%20directive%20approach%20will%20always%20call%20the%20controller%20from%20the%20beginning%20and%20not%20the%20necessary%20%60%60get%60%60%20function.%20This%20is%20what%20causes%20problems%20in%20the%20tokenController.%5Cr%5Cn%5Cr%5CnI%20would%20prefer%20the%20approach%20of%20having%20a%20%60%60refresh%60%60%20or%20%60%60reload%60%60%20function%20in%20the%20scope.%20And%20if%20the%20scope%20%2Ahas%2A%20a%20%60%60reload%60%60%20function%2C%20the%20reload%20button%20is%20displayed%20and%20the%20reload%20function%20is%20called.%5Cr%5Cn%5Cr%5CnUnfortunately%20the%20reload%20button%20is%20located%20in%20a%20parent%20scope%20which%20raises%20some%20difficulties...%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-09-04T15%3A17%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Today%20I%20found%20a%20much%20easier%20approach%20with%20%60%60broadcasts%60%60%20and%20%60%60listeners%60%60.%20%5Cr%5CnIt%20is%20working%20very%20smooth%20with%20a%20few%20lines%20of%20code.%5Cr%5Cn%5Cr%5CnI%20am%20just%20checking%20how%20to%20hide%20the%20reload%20button%20if%20a%20state%20has%20not%20listener%2C%20i.e.%20has%20no%20reload%20function.%5Cr%5Cn%5Cr%5CnI%20will%20push%20another%20PR%20and%20close%20this%20one%2C%20when%20the%20other%20one%20is%20online.%22%2C%20%22created_at%22%3A%20%222017-09-05T07%3A46%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/775#issuecomment-326523320'>General Comment</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> OK, so
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> OK, so apparently we can get filter persistance to work if we change [this line](https://github.com/privacyidea/privacyidea/pull/775/commits/829a058efd11fdd4dc49b68bf3af201a8aae81c1#diff-8f4912288cb04d33f884b515f8432ec0R85) to
```js
scope.$parent.$eval(attr.ngChange);
```
but don't ask me why :-)
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=h1) Report
> Merging [#775](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/f619a5ecdace90be0c4dc74f3f0c164973e6c3c1?src=pr&el=desc) will **increase** coverage by `0.32%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/775/graphs/tree.svg?width=650&height=150&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #775      +/-   ##
==========================================
+ Coverage   95.43%   95.76%   +0.32%
==========================================
Files         126      126
Lines       15416    17938    +2522
==========================================
+ Hits        14713    17179    +2466
- Misses        703      759      +56
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/caconnectors/localca.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NhY29ubmVjdG9ycy9sb2NhbGNhLnB5) | `67.27% <0%> (-3.77%)` | :arrow_down: |
| [privacyidea/api/before\_after.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ==) | `96.13% <0%> (-1.21%)` | :arrow_down: |
| [privacyidea/lib/event.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50LnB5) | `99.16% <0%> (-0.84%)` | :arrow_down: |
| [privacyidea/lib/tokens/tiqrtoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90aXFydG9rZW4ucHk=) | `99.55% <0%> (-0.45%)` | :arrow_down: |
| [privacyidea/lib/tokens/ocra.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9vY3JhLnB5) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/config.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvY29uZmlnLnB5) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/config.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ==) | `96.6% <0%> (+0.18%)` | :arrow_up: |
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.97% <0%> (+0.24%)` | :arrow_up: |
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `96.17% <0%> (+0.25%)` | :arrow_up: |
| [privacyidea/lib/resolvers/SQLIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TUUxJZFJlc29sdmVyLnB5) | `97.69% <0%> (+0.28%)` | :arrow_up: |
| ... and [11 more](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=tree-more) | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=footer). Last update [f619a5e...829a058](https://codecov.io/gh/privacyidea/privacyidea/pull/775?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Here are some observations regarding the difference between ``userlist`` (which works) and ``token``, ``audit``, which doe not work.
The Usercontroller initializes the ``$scope.params`` dictionary in the javascript contoller. Then the filters are used as elements in this dictionary like:
ng-model = params.usernameFilter
In token and audit the filter variables are _not_ initialized in the javascript controller. The view simply uses
ng-mode = serialFilter
And the javascript code later refers to this only once ``$scope.serialFilter``.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> In regards to the double controller/spinner code in the refreshbutton directive, we can simply remove the controller.
Then the spinner from the spinner directive would spin anyway.
We would simply have to hide the refreshbutton.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Today I tried to wrap my head around this and this and I was asking myself, why this would have to so so complicated. We have nasty side effects: In the user tab you get unexpected results, when viewing users in a non-default realm. This will result in appliying the right filters but in the wrong realm.
The audit tab already provides a "Reload" button within the audit list scope. It works well. It just calls ``getAuditList``. https://github.com/privacyidea/privacyidea/blob/master/privacyidea/static/components/audit/controllers/auditControllers.js#L74
The directive approach will always call the controller from the beginning and not the necessary ``get`` function. This is what causes problems in the tokenController.
I would prefer the approach of having a ``refresh`` or ``reload`` function in the scope. And if the scope *has* a ``reload`` function, the reload button is displayed and the reload function is called.
Unfortunately the reload button is located in a parent scope which raises some difficulties...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Today I found a much easier approach with ``broadcasts`` and ``listeners``.
It is working very smooth with a few lines of code.
I am just checking how to hide the reload button if a state has not listener, i.e. has no reload function.
I will push another PR and close this one, when the other one is online.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/775?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/775?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/775'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>