### PR TITLE
Add central reload button

### DIFF
--- a/privacyidea/static/components/audit/controllers/auditControllers.js
+++ b/privacyidea/static/components/audit/controllers/auditControllers.js
@@ -44,7 +44,6 @@ myApp.controller("auditController", function (AuditFactory, $scope,
         $scope.userFilter = $stateParams.user;
     }
 
-    $scope.$on("piReload", $scope.getAuditList);
 
     // get statistics
     $scope.getStatistics = function() {
@@ -103,5 +102,9 @@ myApp.controller("auditController", function (AuditFactory, $scope,
     if ($location.path() === "/audit") {
         $location.path("/audit/log");
     }
+
+    $scope.$on("piReload", function() {
+        $scope.getAuditList();
+    });
 
 });

--- a/privacyidea/static/components/audit/controllers/auditControllers.js
+++ b/privacyidea/static/components/audit/controllers/auditControllers.js
@@ -44,6 +44,8 @@ myApp.controller("auditController", function (AuditFactory, $scope,
         $scope.userFilter = $stateParams.user;
     }
 
+    $scope.$on("piReload", $scope.getAuditList);
+
     // get statistics
     $scope.getStatistics = function() {
         AuditFactory.statistics($scope.params, function(data) {

--- a/privacyidea/static/components/audit/views/audit.log.html
+++ b/privacyidea/static/components/audit/views/audit.log.html
@@ -4,9 +4,6 @@
                   ng-show="loggedInUser.role === 'admin' &&
                         checkRight('auditlog_download')">
     </csv-download>
-    <button class="btn btn-default" ng-click="getAuditList()">
-        <span class="glyphicon glyphicon-refresh"></span>
-        <span translate>Refresh</span></button>
 
     <pagination ng-show="auditdata.count > 10"
                 total-items="auditdata.count" ng-model="params.page"

--- a/privacyidea/static/components/components/controllers/componentControllers.js
+++ b/privacyidea/static/components/components/controllers/componentControllers.js
@@ -42,11 +42,6 @@ myApp.controller("componentController", function (ComponentFactory, $scope,
         $location.path("/component/clienttype");
     }
 
-    // listen to the reload broadcast
-    $scope.$on("piReload", function () {
-        $scope.getSubscriptions();
-        ComponentFactory.getClientType();
-    });
 
     /*
     Functions for subscriptions
@@ -93,4 +88,10 @@ myApp.controller("componentController", function (ComponentFactory, $scope,
      };
 
     $scope.getSubscriptions();
+
+    // listen to the reload broadcast
+    $scope.$on("piReload", function () {
+        $scope.getSubscriptions();
+        ComponentFactory.getClientType();
+    });
 });

--- a/privacyidea/static/components/components/controllers/componentControllers.js
+++ b/privacyidea/static/components/components/controllers/componentControllers.js
@@ -42,6 +42,12 @@ myApp.controller("componentController", function (ComponentFactory, $scope,
         $location.path("/component/clienttype");
     }
 
+    // listen to the reload broadcast
+    $scope.$on("piReload", function () {
+        $scope.getSubscriptions();
+        ComponentFactory.getClientType();
+    });
+
     /*
     Functions for subscriptions
      */

--- a/privacyidea/static/components/components/views/component.clienttype.html
+++ b/privacyidea/static/components/components/views/component.clienttype.html
@@ -1,7 +1,4 @@
 <div class="well">
-    <button class="btn btn-default" ng-click="getClientType()">
-        <span class="glyphicon glyphicon-refresh"></span>
-        <span translate>Refresh</span></button>
 
     <div class="table-responsive">
         <table class="table table-bordered table-striped">

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -489,6 +489,11 @@ myApp.controller("configController", function ($scope, $location,
         $location.path("/config/realms/list");
     }
 
+    // listen to the reload broadcast
+    $scope.$on("piReload", function() {
+        $scope.getSystemConfig();
+    });
+
     $scope.items = ["item1", "item2", "item3"];
     $scope.dragControlListeners = {
       accept: function (sourceItemHandleScope, destSortableScope) {

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -352,23 +352,24 @@ myApp.directive('spinner', function() {
     return {
         scope: {
             name: '@?',
-            show: '=?',
             register: '=?'
         },
         template: [
-            '<div ng-show="show">',
+            '<div ng-show="showSpinner">',
             '<span class="glyphicon glyphicon-refresh spin" style="margin: 50% 5px 0 0; font-size:120%; color: #787878;" aria-hidden="true"></span>',
             '</div>'
         ].join(''),
-        controller: function($scope) {
+        controller: function($scope, $rootScope) {
             $scope.loading_queue = 0;
             $scope.$watch('loading_queue', function(loading_queue) {
                 if (loading_queue > 0) {
-                    $scope.show = true;
+                    $scope.showSpinner = true;
+                    $rootScope.showReload = false;
                 } else if (loading_queue < 0) {
                     $scope.loading_queue = 0;
                 } else {
-                    $scope.show = false;
+                    $scope.showSpinner = false;
+                    $rootScope.showReload = true;
                 }
             });
             $scope.$on('spinnerEvent', function(event, data) {

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -433,31 +433,20 @@ angular.module("privacyideaApp")
     };
 
     $scope.checkReloadListeners = function () {
-        var currentListeners = $scope.$$listenerCount["piReload"];
-        var oldListeners = $scope.reloadListeners;
         /*
-        After a state change the number of listeners can be:
-        2: if the previous state and the current state listen to the event.
-           since the previous state was not deregisteres.
-        1: if the previous state was NOT listeneing and the current IS
-           listening
-           OR if the previous was listening and the current is not
-        0: If the previous and the current state do not listen.
-         */
-        console.log("old Listener: " + oldListeners);
-        console.log("current Listener: " + currentListeners);
-        if ((oldListeners >= 2) && (currentListeners === 1)) {
-            $scope.reloadListeners = 0;
-        } else if ((oldListeners === 1) && (currentListeners === 1)) {
-            // Change to state without reload. Listener is not deregistered
-            $scope.reloadListeners = 0;
-        } else if ((currentListeners === 0) || (currentListeners === undefined)) {
-            // change between states without listeners
-            $scope.reloadListeners = 0;
-        } else {
-            $scope.reloadListeners = 1;
-        }
-        // TODO: The logic is broken!
+         TODO: The a logic, that can hide the reload button.
+         This is not straighforward, since the current number of connected
+         listeners might be confusing:
+
+         connected numbers:
+         var currentListeners = $scope.$$listenerCount["piReload"];
+
+         When the state changes, the scope and thus the current listener is
+         destroyed. But the statechange-success is called, before the scope
+         is destroyed, so there can be two connected listeners, when
+         changing from a state to another state and both have a listener
+         defined.
+        */
         $scope.reloadListeners = 1;
     };
 

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -99,6 +99,8 @@ angular.module("privacyideaApp")
                 state: from.name,
                 params: fromParams
             };
+
+            $scope.checkReloadListeners();
         });
     $scope.$on('IdleStart', function () {
         console.log("start idle");
@@ -423,7 +425,41 @@ angular.module("privacyideaApp")
 
     $scope.welcomeNext = function () {
         $scope.welcomeStep += 1;
-    }
+    };
+
+    $scope.reload = function() {
+        // emit a signal to the scope, that just listens
+        $scope.$broadcast("piReload");
+    };
+
+    $scope.checkReloadListeners = function () {
+        var currentListeners = $scope.$$listenerCount["piReload"];
+        var oldListeners = $scope.reloadListeners;
+        /*
+        After a state change the number of listeners can be:
+        2: if the previous state and the current state listen to the event.
+           since the previous state was not deregisteres.
+        1: if the previous state was NOT listeneing and the current IS
+           listening
+           OR if the previous was listening and the current is not
+        0: If the previous and the current state do not listen.
+         */
+        console.log("old Listener: " + oldListeners);
+        console.log("current Listener: " + currentListeners);
+        if ((oldListeners >= 2) && (currentListeners === 1)) {
+            $scope.reloadListeners = 0;
+        } else if ((oldListeners === 1) && (currentListeners === 1)) {
+            // Change to state without reload. Listener is not deregistered
+            $scope.reloadListeners = 0;
+        } else if ((currentListeners === 0) || (currentListeners === undefined)) {
+            // change between states without listeners
+            $scope.reloadListeners = 0;
+        } else {
+            $scope.reloadListeners = 1;
+        }
+        // TODO: The logic is broken!
+        $scope.reloadListeners = 1;
+    };
 
 });
 

--- a/privacyidea/static/components/machine/controllers/machineController.js
+++ b/privacyidea/static/components/machine/controllers/machineController.js
@@ -37,6 +37,11 @@ angular.module("privacyideaApp")
             $location.path("/machine/list");
         }
 
+        // listen to the reload broadcast
+        $scope.$on("piReload", function() {
+            $scope._getMachines();
+        });
+
         if ($stateParams.resolver) {
             $scope.params.resolverFilter = $stateParams.resolver;
         }

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -29,9 +29,6 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
     $scope.loggedInUser = AuthFactory.getUser();
     $scope.selectedToken = {serial: null};
 
-    // listen to the reload broadcast
-    $scope.$on("piReload", $scope.get);
-
     // Change the pagination
     $scope.pageChanged = function () {
         console.log('Page changed to: ' + $scope.params.page);
@@ -113,6 +110,9 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
     if ($scope.pin_change) {
         $location.path("/pinchange");
     }
+
+    // listen to the reload broadcast
+    $scope.$on("piReload", $scope.get);
 
 });
 

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -29,6 +29,9 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
     $scope.loggedInUser = AuthFactory.getUser();
     $scope.selectedToken = {serial: null};
 
+    // listen to the reload broadcast
+    $scope.$on("piReload", $scope.get);
+
     // Change the pagination
     $scope.pageChanged = function () {
         console.log('Page changed to: ' + $scope.params.page);

--- a/privacyidea/static/components/user/controllers/userControllers.js
+++ b/privacyidea/static/components/user/controllers/userControllers.js
@@ -228,10 +228,6 @@ angular.module("privacyideaApp")
             $location.path("/user/list");
         }
 
-        $scope.$on("piReload", function () {
-            $scope._getUsers(false);
-        });
-
         $scope._getUsers = function (live_search) {
             if ((!$rootScope.search_on_enter) || ($rootScope.search_on_enter && !live_search)) {
                 // We shall only search, if either we do not search on enter or
@@ -364,5 +360,9 @@ angular.module("privacyideaApp")
             $scope.leftColumn = userFields.slice(start, middle);
             $scope.rightColumn = userFields.slice(middle, end);
         };
+
+        $scope.$on("piReload", function () {
+            $scope._getUsers(false);
+        });
 
     });

--- a/privacyidea/static/components/user/controllers/userControllers.js
+++ b/privacyidea/static/components/user/controllers/userControllers.js
@@ -228,6 +228,10 @@ angular.module("privacyideaApp")
             $location.path("/user/list");
         }
 
+        $scope.$on("piReload", function () {
+            $scope._getUsers(false);
+        });
+
         $scope._getUsers = function (live_search) {
             if ((!$rootScope.search_on_enter) || ($rootScope.search_on_enter && !live_search)) {
                 // We shall only search, if either we do not search on enter or

--- a/privacyidea/static/templates/menu.html
+++ b/privacyidea/static/templates/menu.html
@@ -92,6 +92,13 @@
                 <li>
                     <spinner name="spinner" show="false"></spinner>
                 </li>
+                <li ng-show="reloadListeners && loggedInUser.role &&
+                showReload">
+                    <a ng-click="reload()" style="cursor: pointer">
+                    <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
+                    <translate>Refresh</translate>
+                    </a>
+                </li>
                 <li ng-class="{active: $state.includes('register')}"
                     ng-show="registrationAllowed">
                     <a ui-sref="register" ng-hide="loggedInUser.username"


### PR DESCRIPTION
This will issue a broadcast event.
Each scope/controller can register its
reload function on this event.

Closes #715
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/776%23issuecomment-327140030%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137022386%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137026774%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137041559%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137041623%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137042037%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23issuecomment-327266591%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23issuecomment-327268030%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23issuecomment-327396264%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137187911%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137188646%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23issuecomment-327469328%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23issuecomment-327140030%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20makes%20the%20pull%20request%20%23775%20obsolete.%22%2C%20%22created_at%22%3A%20%222017-09-05T10%3A46%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right.%20The%20problem%20seems%20to%20be%20with%20all%20tabs.%5Cr%5CnToken-View%3A%5Cr%5Cn%5Cr%5CnIf%20a%20token%20is%20deleted%20in%20another%20browser%20tab%2C%20the%20reload%20button%20fetches%20the%20token%20list%20and%20it%20contains%20one%20token%20less.%20The%20deleted%20token%20is%20gone.%5Cr%5Cn%5Cr%5CnBut%3A%20The%20list%20in%20the%20browser%20view%20is%20not%20updated.%20Maybe%20the%20result%20of%20the%20request%20is%20written%20to%20another%20scope%21%3F%22%2C%20%22created_at%22%3A%20%222017-09-05T18%3A43%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Funny%20thing%2C%20when%20I%20move%20the%20%24scope.%24on%20to%20the%20end%20of%20the%20token%20controller%2C%20the%20token%20view%20gets%20updated%21%22%2C%20%22created_at%22%3A%20%222017-09-05T18%3A48%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20interesting%21%20But%20yes%2C%20reloading%20the%20token%20and%20audit%20list%20now%20works%20properly%20for%20me.%22%2C%20%22created_at%22%3A%20%222017-09-06T07%3A13%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22remove%20unused%20code%20from%20loginController.%5Cr%5CnCreate%20an%20issue%20for%20the%20scopes%2C%20which%20have%20no%20reload%20function.%22%2C%20%22created_at%22%3A%20%222017-09-06T12%3A34%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20d4bc3ac71fee6fe08520e750255fc608de367922%20privacyidea/static/components/token/controllers/tokenControllers.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137041559%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22angular%20does%20not%20care%20about%20this.%20Works%20fine%20this%20way%2C%20since%20the%20listener%20is%20called%20late%20after%20the%20complete%20controller%20definition.%22%2C%20%22created_at%22%3A%20%222017-09-05T16%3A30%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/token/controllers/tokenControllers.js%3AL29-38%22%7D%2C%20%22Pull%20d4bc3ac71fee6fe08520e750255fc608de367922%20privacyidea/static/components/audit/controllers/auditControllers.js%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137022386%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20we%20need%20to%20move%20this%20line%2C%20as%20%60%60%24scope.getAuditList%60%60%20is%20not%20yet%20defined%20at%20this%20place.%22%2C%20%22created_at%22%3A%20%222017-09-05T15%3A24%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22see%20above.%22%2C%20%22created_at%22%3A%20%222017-09-05T16%3A30%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/audit/controllers/auditControllers.js%3AL44-52%22%7D%2C%20%22Pull%20d4bc3ac71fee6fe08520e750255fc608de367922%20privacyidea/static/components/login/controllers/loginControllers.js%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/776%23discussion_r137026774%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20if%20I%20understand%20correctly%20this%20function%20is%20used%20to%20ensure%20that%20the%20reload%20button%20is%20only%20displayed%20if%20there%20are%20any%20reload%20listeners%20listening%20to%20the%20event.%20But%20does%20this%20happen%3F%22%2C%20%22created_at%22%3A%20%222017-09-05T15%3A39%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20There%20are%20several%20sub-scopes%20like%20%60%60Tokendetail%60%60.%20Currently%20there%20are%20not%20listeners%20defined.%5Cr%5CnThe%20reload%20button%20will%20then%20reload%20the%20parent%20scope%20%28the%20token%20list%29...%22%2C%20%22created_at%22%3A%20%222017-09-05T16%3A31%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20okay.%20But%20is%20it%20ever%20the%20case%20that%20the%20reload%20button%20is%20hidden%20because%20%60%60%24scope.reloadListeners%20%3D%3D%200%60%60.%22%2C%20%22created_at%22%3A%20%222017-09-06T07%3A15%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20nevermind%2C%20I%20somehow%20missed%20the%20%60%60TODO%60%60.%20%22%2C%20%22created_at%22%3A%20%222017-09-06T07%3A20%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/login/controllers/loginControllers.js%3AL425-466%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/776#issuecomment-327140030'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This makes the pull request #775 obsolete.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are right. The problem seems to be with all tabs.
Token-View:
If a token is deleted in another browser tab, the reload button fetches the token list and it contains one token less. The deleted token is gone.
But: The list in the browser view is not updated. Maybe the result of the request is written to another scope!?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Funny thing, when I move the $scope.$on to the end of the token controller, the token view gets updated!
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, interesting! But yes, reloading the token and audit list now works properly for me.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> remove unused code from loginController.
Create an issue for the scopes, which have no reload function.
- [x] <a href='#crh-comment-Pull d4bc3ac71fee6fe08520e750255fc608de367922 privacyidea/static/components/audit/controllers/auditControllers.js 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/776#discussion_r137022386'>File: privacyidea/static/components/audit/controllers/auditControllers.js:L44-52</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think we need to move this line, as ``$scope.getAuditList`` is not yet defined at this place.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> see above.
- [ ] <a href='#crh-comment-Pull d4bc3ac71fee6fe08520e750255fc608de367922 privacyidea/static/components/login/controllers/loginControllers.js 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/776#discussion_r137026774'>File: privacyidea/static/components/login/controllers/loginControllers.js:L425-466</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, if I understand correctly this function is used to ensure that the reload button is only displayed if there are any reload listeners listening to the event. But does this happen?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Yes. There are several sub-scopes like ``Tokendetail``. Currently there are not listeners defined.
The reload button will then reload the parent scope (the token list)...
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, okay. But is it ever the case that the reload button is hidden because ``$scope.reloadListeners == 0``.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, nevermind, I somehow missed the ``TODO``.
- [ ] <a href='#crh-comment-Pull d4bc3ac71fee6fe08520e750255fc608de367922 privacyidea/static/components/token/controllers/tokenControllers.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/776#discussion_r137041559'>File: privacyidea/static/components/token/controllers/tokenControllers.js:L29-38</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> angular does not care about this. Works fine this way, since the listener is called late after the complete controller definition.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/776?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/776?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/776'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>