### PR TITLE
773: Fix /ttype/<ttype> getting logged instead of /ttype/email in aud…

### DIFF
--- a/privacyidea/api/ttype.py
+++ b/privacyidea/api/ttype.py
@@ -113,11 +113,13 @@ def token(ttype=None):
     res = tokenc.api_endpoint(request, g)
     serial = getParam(request.all_data, "serial")
     user = get_user_from_param(request.all_data)
+    url_rule = str(request.url_rule)
     g.audit_object.log({"success": 1,
                         "user": user.login,
                         "realm": user.realm,
                         "serial": serial,
-                        "tokentype": ttype})
+                        "token_type": ttype,
+                        "action": "{0!s} {1!s}".format(request.method, url_rule[:url_rule.rfind('/') + 1] + ttype)})
     if res[0] == "json":
         return jsonify(res[1])
     elif res[0] in ["html", "plain"]:


### PR DESCRIPTION
…it logs
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/781%23issuecomment-328514899%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/781%23issuecomment-329219034%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/781%23issuecomment-329321236%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/781%23issuecomment-329323358%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/781%23issuecomment-328514899%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23781%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/01447e4af196a8a25d0a7f2782843492cb5e8e49%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26height%3D150%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23781%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.38%25%20%20%2095.36%25%20%20%20-0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015415%20%20%20%2015416%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2014703%20%20%20%2014702%20%20%20%20%20%20%20-1%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20712%20%20%20%20%20%20714%20%20%20%20%20%20%20%2B2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/ttype.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3R0eXBlLnB5%29%20%7C%20%6095.65%25%20%3C100%25%3E%20%28%2B0.09%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6094.11%25%20%3C0%25%3E%20%28-1.69%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B01447e4...bd659e5%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/781%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-09-11T12%3A33%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40lavesh-axiadids%20%5Cr%5CnThanks%20a%20lot%20for%20this%20pull%20request.%20%5Cr%5CnBut%20according%20to%20%23773%20we%20would%20not%20include%20this%2C%20as%20the%20token%20type%20should%20be%20contained%20in%20tokentype.%5Cr%5Cn%5Cr%5CnPlease%20respond%20if%20you%20think%20otherwise%20and%20have%20some%20good%20arguments%20%3B-%29%22%2C%20%22created_at%22%3A%20%222017-09-13T16%3A14%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20Cornelius%2C%5Cn%5CnIn%20this%20section%20of%20code%5Cn%5Cng.audit_object.log%28%7B%5C%22success%5C%22%3A%201%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22user%5C%22%3A%20user.login%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22realm%5C%22%3A%20user.realm%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22serial%5C%22%3A%20serial%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22tokentype%5C%22%3A%20ttype%7D%29%5Cn%5CnYou%20are%20using%20%5Cu2018tokentype%5Cu2019%2C%20but%20in%20db%20column%20name%20is%20%5Cu2018token_type%5Cu2019.%20If%20you%20change%20above%20to%20%5Cn%5Cng.audit_object.log%28%7B%5C%22success%5C%22%3A%201%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22user%5C%22%3A%20user.login%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22realm%5C%22%3A%20user.realm%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22serial%5C%22%3A%20serial%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22tokentype%5C%22%3A%20ttype%7D%29%5Cn%5CnThen%20token%20type%20will%20be%20seen%20in%20audit%20logs.%20Currently%2C%20token%20type%20in%20audit%20logs%20does%20not%20show%20anything%2C%20it%20is%20blank.%5Cn%5CnThanks%2C%5CnLavesh%5Cn%5Cn%5Cn%5Cn%3E%20On%2013-Sep-2017%2C%20at%209%3A44%20PM%2C%20Cornelius%20K%5Cu00f6lbel%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%3E%20%5Cn%3E%20Hi%20%40lavesh-axiadids%20%3Chttps%3A//github.com/lavesh-axiadids%3E%5Cn%3E%20Thanks%20a%20lot%20for%20this%20pull%20request.%5Cn%3E%20But%20according%20to%20%23773%20%3Chttps%3A//github.com/privacyidea/privacyidea/issues/773%3E%20we%20would%20not%20include%20this%2C%20as%20the%20token%20type%20should%20be%20contained%20in%20tokentype.%5Cn%3E%20%5Cn%3E%20Please%20respond%20if%20you%20think%20otherwise%20and%20have%20some%20good%20arguments%20%3B-%29%5Cn%3E%20%5Cn%3E%20%5Cu2014%5Cn%3E%20You%20are%20receiving%20this%20because%20you%20were%20mentioned.%5Cn%3E%20Reply%20to%20this%20email%20directly%2C%20view%20it%20on%20GitHub%20%3Chttps%3A//github.com/privacyidea/privacyidea/pull/781%23issuecomment-329219034%3E%2C%20or%20mute%20the%20thread%20%3Chttps%3A//github.com/notifications/unsubscribe-auth/AeA7xNgI1G9vIfLsBqOmIZ7On1GBu20nks5sh_98gaJpZM4PTDk6%3E.%5Cn%3E%20%5Cn%5Cn%22%2C%20%22created_at%22%3A%20%222017-09-13T23%3A02%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/31472580%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lavesh-axiadids%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%2C%5Cn%5CnSorry%20I%20meant%5Cn%5Cng.audit_object.log%28%7B%5C%22success%5C%22%3A%201%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22user%5C%22%3A%20user.login%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22realm%5C%22%3A%20user.realm%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22serial%5C%22%3A%20serial%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22token_type%5C%22%3A%20ttype%7D%29%5Cn%5CnThanks%2C%5CnLavesh%5Cn%3E%20On%2014-Sep-2017%2C%20at%204%3A31%20AM%2C%20Lavesh%20Gupta%20%3Clavesh%40axiadids.com%3E%20wrote%3A%5Cn%3E%20%5Cn%3E%20Hi%20Cornelius%2C%5Cn%3E%20%5Cn%3E%20In%20this%20section%20of%20code%5Cn%3E%20%5Cn%3E%20g.audit_object.log%28%7B%5C%22success%5C%22%3A%201%2C%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22user%5C%22%3A%20user.login%2C%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22realm%5C%22%3A%20user.realm%2C%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22serial%5C%22%3A%20serial%2C%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22tokentype%5C%22%3A%20ttype%7D%29%5Cn%3E%20%5Cn%3E%20You%20are%20using%20%5Cu2018tokentype%5Cu2019%2C%20but%20in%20db%20column%20name%20is%20%5Cu2018token_type%5Cu2019.%20If%20you%20change%20above%20to%20%5Cn%3E%20%5Cn%3E%20g.audit_object.log%28%7B%5C%22success%5C%22%3A%201%2C%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22user%5C%22%3A%20user.login%2C%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22realm%5C%22%3A%20user.realm%2C%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22serial%5C%22%3A%20serial%2C%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22tokentype%5C%22%3A%20ttype%7D%29%5Cn%3E%20%5Cn%3E%20Then%20token%20type%20will%20be%20seen%20in%20audit%20logs.%20Currently%2C%20token%20type%20in%20audit%20logs%20does%20not%20show%20anything%2C%20it%20is%20blank.%5Cn%3E%20%5Cn%3E%20Thanks%2C%5Cn%3E%20Lavesh%5Cn%3E%20%5Cn%3E%20%5Cn%3E%20%5Cn%3E%3E%20On%2013-Sep-2017%2C%20at%209%3A44%20PM%2C%20Cornelius%20K%5Cu00f6lbel%20%3Cnotifications%40github.com%20%3Cmailto%3Anotifications%40github.com%3E%3E%20wrote%3A%5Cn%3E%3E%20%5Cn%3E%3E%20Hi%20%40lavesh-axiadids%20%3Chttps%3A//github.com/lavesh-axiadids%3E%5Cn%3E%3E%20Thanks%20a%20lot%20for%20this%20pull%20request.%5Cn%3E%3E%20But%20according%20to%20%23773%20%3Chttps%3A//github.com/privacyidea/privacyidea/issues/773%3E%20we%20would%20not%20include%20this%2C%20as%20the%20token%20type%20should%20be%20contained%20in%20tokentype.%5Cn%3E%3E%20%5Cn%3E%3E%20Please%20respond%20if%20you%20think%20otherwise%20and%20have%20some%20good%20arguments%20%3B-%29%5Cn%3E%3E%20%5Cn%3E%3E%20%5Cu2014%5Cn%3E%3E%20You%20are%20receiving%20this%20because%20you%20were%20mentioned.%5Cn%3E%3E%20Reply%20to%20this%20email%20directly%2C%20view%20it%20on%20GitHub%20%3Chttps%3A//github.com/privacyidea/privacyidea/pull/781%23issuecomment-329219034%3E%2C%20or%20mute%20the%20thread%20%3Chttps%3A//github.com/notifications/unsubscribe-auth/AeA7xNgI1G9vIfLsBqOmIZ7On1GBu20nks5sh_98gaJpZM4PTDk6%3E.%5Cn%3E%3E%20%5Cn%3E%20%5Cn%5Cn%22%2C%20%22created_at%22%3A%20%222017-09-13T23%3A15%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/31472580%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lavesh-axiadids%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/781#issuecomment-328514899'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=h1) Report
> Merging [#781](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/01447e4af196a8a25d0a7f2782843492cb5e8e49?src=pr&el=desc) will **decrease** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/781/graphs/tree.svg?token=7nHLZki60B&src=pr&height=150&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #781      +/-   ##
==========================================
- Coverage   95.38%   95.36%   -0.02%
==========================================
Files         126      126
Lines       15415    15416       +1
==========================================
- Hits        14703    14702       -1
- Misses        712      714       +2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/ttype.py](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3R0eXBlLnB5) | `95.65% <100%> (+0.09%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `94.11% <0%> (-1.69%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=footer). Last update [01447e4...bd659e5](https://codecov.io/gh/privacyidea/privacyidea/pull/781?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Hi @lavesh-axiadids
Thanks a lot for this pull request.
But according to #773 we would not include this, as the token type should be contained in tokentype.
Please respond if you think otherwise and have some good arguments ;-)
- <a href='https://github.com/lavesh-axiadids'><img border=0 src='https://avatars0.githubusercontent.com/u/31472580?v=4' height=16 width=16></a> Hi Cornelius,
In this section of code
g.audit_object.log({"success": 1,
"user": user.login,
"realm": user.realm,
"serial": serial,
"tokentype": ttype})
You are using ‘tokentype’, but in db column name is ‘token_type’. If you change above to
g.audit_object.log({"success": 1,
"user": user.login,
"realm": user.realm,
"serial": serial,
"tokentype": ttype})
Then token type will be seen in audit logs. Currently, token type in audit logs does not show anything, it is blank.
Thanks,
Lavesh
> On 13-Sep-2017, at 9:44 PM, Cornelius Kölbel <notifications@github.com> wrote:
>
> Hi @lavesh-axiadids <https://github.com/lavesh-axiadids>
> Thanks a lot for this pull request.
> But according to #773 <https://github.com/privacyidea/privacyidea/issues/773> we would not include this, as the token type should be contained in tokentype.
>
> Please respond if you think otherwise and have some good arguments ;-)
>
> —
> You are receiving this because you were mentioned.
> Reply to this email directly, view it on GitHub <https://github.com/privacyidea/privacyidea/pull/781#issuecomment-329219034>, or mute the thread <https://github.com/notifications/unsubscribe-auth/AeA7xNgI1G9vIfLsBqOmIZ7On1GBu20nks5sh_98gaJpZM4PTDk6>.
>
- <a href='https://github.com/lavesh-axiadids'><img border=0 src='https://avatars0.githubusercontent.com/u/31472580?v=4' height=16 width=16></a> Hi,
Sorry I meant
g.audit_object.log({"success": 1,
"user": user.login,
"realm": user.realm,
"serial": serial,
"token_type": ttype})
Thanks,
Lavesh
> On 14-Sep-2017, at 4:31 AM, Lavesh Gupta <lavesh@axiadids.com> wrote:
>
> Hi Cornelius,
>
> In this section of code
>
> g.audit_object.log({"success": 1,
>                     "user": user.login,
>                     "realm": user.realm,
>                     "serial": serial,
>                     "tokentype": ttype})
>
> You are using ‘tokentype’, but in db column name is ‘token_type’. If you change above to
>
> g.audit_object.log({"success": 1,
>                     "user": user.login,
>                     "realm": user.realm,
>                     "serial": serial,
>                     "tokentype": ttype})
>
> Then token type will be seen in audit logs. Currently, token type in audit logs does not show anything, it is blank.
>
> Thanks,
> Lavesh
>
>
>
>> On 13-Sep-2017, at 9:44 PM, Cornelius Kölbel <notifications@github.com <mailto:notifications@github.com>> wrote:
>>
>> Hi @lavesh-axiadids <https://github.com/lavesh-axiadids>
>> Thanks a lot for this pull request.
>> But according to #773 <https://github.com/privacyidea/privacyidea/issues/773> we would not include this, as the token type should be contained in tokentype.
>>
>> Please respond if you think otherwise and have some good arguments ;-)
>>
>> —
>> You are receiving this because you were mentioned.
>> Reply to this email directly, view it on GitHub <https://github.com/privacyidea/privacyidea/pull/781#issuecomment-329219034>, or mute the thread <https://github.com/notifications/unsubscribe-auth/AeA7xNgI1G9vIfLsBqOmIZ7On1GBu20nks5sh_98gaJpZM4PTDk6>.
>>
>


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/781?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/781?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/781'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>