### PR TITLE
Make serverpool settings configurable via the web UI

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -754,7 +754,12 @@ class IdResolver (UserIdResolver):
                                 'AUTHTYPE': 'string',
                                 'TLS_VERIFY': 'bool',
                                 'TLS_CA_FILE': 'string',
-                                'START_TLS': 'bool'}
+                                'START_TLS': 'bool',
+                                'CACHE_TIMEOUT': 'int',
+                                'SERVERPOOL_ROUNDS': 'int',
+                                'SERVERPOOL_SKIP': 'int',
+                                'OBJECT_CLASSES': 'string',
+                                'DN_TEMPLATE': 'string'}
         return {typ: descriptor}
 
     @classmethod

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -857,7 +857,9 @@ myApp.controller("LdapResolverController", function ($scope, ConfigFactory, $sta
         CACHE_TIMEOUT: 120,
         NOSCHEMAS: false,
         TLS_VERIFY: true,
-        START_TLS: true
+        START_TLS: true,
+        SERVERPOOL_ROUNDS: 2,
+        SERVERPOOL_SKIP: 30
     };
     $scope.result = {};
     $scope.resolvername = $stateParams.resolvername;

--- a/privacyidea/static/components/config/views/config.resolvers.ldap.html
+++ b/privacyidea/static/components/config/views/config.resolvers.ldap.html
@@ -149,7 +149,7 @@
                    placeholder="120"/>
         </div>
     </div>
-        <div class="form-group">
+    <div class="form-group">
         <label for="serverpool-rounds" class="col-sm-3 control-label"
                 translate>Server pool retry rounds</label>
 

--- a/privacyidea/static/components/config/views/config.resolvers.ldap.html
+++ b/privacyidea/static/components/config/views/config.resolvers.ldap.html
@@ -149,6 +149,24 @@
                    placeholder="120"/>
         </div>
     </div>
+        <div class="form-group">
+        <label for="serverpool-rounds" class="col-sm-3 control-label"
+                translate>Server pool retry rounds</label>
+
+        <div class="col-sm-3">
+            <input name="serverpool-rounds" class="form-control"
+                   ng-model="params.SERVERPOOL_ROUNDS"
+                   placeholder="2" />
+        </div>
+        <label for="serverpool-skip" class="col-sm-3 control-label"
+                translate>Server pool skip timeout (seconds)</label>
+
+        <div class="col-sm-3">
+            <input name="serverpool-skip" class="form-control"
+                   ng-model="params.SERVERPOOL_SKIP"
+                   placeholder="30" />
+        </div>
+    </div>
     <div class="form-group">
         <label for="sizelimit" class="col-sm-3 control-label"
                 translate>Size Limit</label>

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -866,6 +866,15 @@ class LDAPResolverTestCase(MyTestCase):
         self.assertEqual(server_pool.servers[0].name, "ldap://themis:389")
         self.assertEqual(server_pool.servers[1].name, "ldaps://server2:636")
 
+        urilist = "ldap://themis, ldaps://server2"
+        server_pool = LDAPResolver.get_serverpool(urilist, timeout,
+                                                  rounds=5,
+                                                  exhaust=60)
+        self.assertEqual(len(server_pool), 2)
+        self.assertEqual(server_pool.active, 5)
+        self.assertEqual(server_pool.exhaust, 60)
+        self.assertEqual(server_pool.strategy, "ROUND_ROBIN")
+
     @ldap3mock.activate
     def test_08_trimresult(self):
         ldap3mock.setLDAPDirectory(LDAPDirectory)


### PR DESCRIPTION
Closes #802
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/807%23discussion_r145170053%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/807%23issuecomment-337279135%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/807%23issuecomment-337279135%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23807%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.20%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/9b9632325f3bda88d6be4d7152b2f6c22e9d145c%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807/graphs/tree.svg%3Fwidth%3D650%26src%3Dpr%26token%3D7nHLZki60B%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.20%20%20%20%20%20%23807%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%20%20%20%20%20%2095.31%25%20%20%2095.28%25%20%20%20-0.04%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2015446%20%20%20%2015446%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2014722%20%20%20%2014717%20%20%20%20%20%20%20-5%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20724%20%20%20%20%20%20729%20%20%20%20%20%20%20%2B5%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6091.59%25%20%3C0%25%3E%20%28-4.21%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B9b96323...6ab6c58%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/807%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-10-17T15%3A57%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208f5822cb53aced8b3ea2938d2c456881a4937076%20privacyidea/static/components/config/views/config.resolvers.ldap.html%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/807%23discussion_r145170053%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22beautify%2C%20looks%20like%20a%20wrong%20indentation%21%20%3B-%29%22%2C%20%22created_at%22%3A%20%222017-10-17T15%3A38%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/config/views/config.resolvers.ldap.html%3AL149-173%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 8f5822cb53aced8b3ea2938d2c456881a4937076 privacyidea/static/components/config/views/config.resolvers.ldap.html 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/807#discussion_r145170053'>File: privacyidea/static/components/config/views/config.resolvers.ldap.html:L149-173</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> beautify, looks like a wrong indentation! ;-)
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/807#issuecomment-337279135'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/807?src=pr&el=h1) Report
> Merging [#807](https://codecov.io/gh/privacyidea/privacyidea/pull/807?src=pr&el=desc) into [branch-2.20](https://codecov.io/gh/privacyidea/privacyidea/commit/9b9632325f3bda88d6be4d7152b2f6c22e9d145c?src=pr&el=desc) will **decrease** coverage by `0.03%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/807/graphs/tree.svg?width=650&src=pr&token=7nHLZki60B&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/807?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.20     #807      +/-   ##
===============================================
- Coverage        95.31%   95.28%   -0.04%
===============================================
Files              126      126
Lines            15446    15446
===============================================
- Hits             14722    14717       -5
- Misses             724      729       +5
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/807?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/807?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `91.59% <0%> (-4.21%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/807?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/807?src=pr&el=footer). Last update [9b96323...6ab6c58](https://codecov.io/gh/privacyidea/privacyidea/pull/807?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/807?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/807?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/807'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>