### PR TITLE
Fix some more remaining unicode issues

### DIFF
--- a/privacyidea/api/register.py
+++ b/privacyidea/api/register.py
@@ -172,14 +172,14 @@ def register_post():
         "Your privacyIDEA registration",
         body.format(regkey=registration_key))
     if not email_sent:
-        log.warning("Failed to send registration email to {0!s}".format(email))
+        log.warning("Failed to send registration email to {0!r}".format(email))
         # delete registration token
         token.delete()
         # delete user
         user.delete()
         raise RegistrationError("Failed to send email!")
 
-    log.debug("Registration email sent to {0!s}".format(email))
+    log.debug("Registration email sent to {0!r}".format(email))
 
     g.audit_object.log({"success": email_sent})
     return send_result(email_sent)

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -977,7 +977,7 @@ def lost_api(serial=None):
     if userobj:
         toks = get_tokens(serial=serial, user=userobj)
         if not toks:
-            raise TokenAdminError("The user {0!s} does not own the token {1!s}".format(
+            raise TokenAdminError("The user {0!r} does not own the token {1!s}".format(
                 userobj, serial))
 
     options = {"g": g,

--- a/privacyidea/lib/eventhandler/tokenhandler.py
+++ b/privacyidea/lib/eventhandler/tokenhandler.py
@@ -331,7 +331,7 @@ class TokenEventHandler(BaseEventHandler):
                         phone_type='mobile')
                     if not init_param['phone']:
                         log.warning("Enrolling SMS token. But the user "
-                                    "{0!s} has no mobile number!".format(user))
+                                    "{0!r} has no mobile number!".format(user))
                 elif tokentype == "email":
                     init_param['email'] = user.info.get("email", "")
                     if not init_param['email']:

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -427,7 +427,7 @@ class PolicyClass(object):
                 # list
                 # check regular expression only for exact matches
                 # avoid matching user1234 -> user1
-                if re.search("^{0!s}$".format(value), searchvalue):
+                if re.search(u"^{0!s}$".format(value), searchvalue):
                     value_found = True
 
         return value_found, value_excluded

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -118,7 +118,7 @@ def get_ad_timestamp_now():
 
 
 def trim_objectGUID(userId):
-    userId = uuid.UUID("{{{0!s}}}".format(userId)).bytes_le
+    userId = uuid.UUID(u"{{{0!s}}}".format(userId)).bytes_le
     userId = escape_bytes(userId)
     return userId
 

--- a/privacyidea/lib/smtpserver.py
+++ b/privacyidea/lib/smtpserver.py
@@ -115,7 +115,7 @@ class SMTPServer(object):
             res_id, res_text = r.get(one_recipient, (200, "OK"))
             if res_id != 200 and res_text != "OK":
                 success = False
-                log.error("Failed to send email to {0!s}: {1!s}, {2!s}".format(one_recipient,
+                log.error("Failed to send email to {0!r}: {1!r}, {2!r}".format(one_recipient,
                                                                   res_id,
                                                                   res_text))
         mail.quit()

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -235,8 +235,8 @@ class TokenClass(object):
         """
         user_object = self.user
         user_info = user_object.info
-        user_identifier = "{0!s}_{1!s}".format(user_object.login, user_object.realm)
-        user_displayname = "{0!s} {1!s}".format(user_info.get("givenname", "."),
+        user_identifier = u"{0!s}_{1!s}".format(user_object.login, user_object.realm)
+        user_displayname = u"{0!s} {1!s}".format(user_info.get("givenname", "."),
                                       user_info.get("surname", "."))
         return user_identifier, user_displayname
 

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -383,7 +383,7 @@ class EmailTokenClass(HotpTokenClass):
         subject = subject.replace("<otp>", otp)
         subject = subject.replace("<serial>", serial)
 
-        log.debug("sending Email to {0!s} ".format(recipient))
+        log.debug("sending Email to {0!r} ".format(recipient))
 
         identifier = get_from_config("email.identifier")
         if identifier:

--- a/privacyidea/lib/tokens/sshkeytoken.py
+++ b/privacyidea/lib/tokens/sshkeytoken.py
@@ -138,4 +138,4 @@ class SSHkeyTokenClass(TokenClass):
         key_comment = ti.get("ssh_comment")
         # get the ssh key directly, otherwise it will not be decrypted
         sshkey = self.get_tokeninfo("ssh_key")
-        return "{0!s} {1!s} {2!s}".format(key_type, sshkey, key_comment)
+        return u"{0!s} {1!s} {2!s}".format(key_type, sshkey, key_comment)

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -74,6 +74,8 @@ the token in challenge response.
 This code is tested in tests/test_lib_tokens_tiqr.
 """
 
+import urllib
+
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.config import get_from_config
 from privacyidea.lib.tokenclass import TokenClass
@@ -392,10 +394,10 @@ class TiqrTokenClass(OcraTokenClass):
                                  validitytime=validity)
         db_challenge.save()
 
-        # TODO: How are non-ascii characters handled in tiqrauth URLs?
-        # qrcode implicitly converts them to UTF-8 before creating the
-        # QR code, but is this understood by TiQR apps?
-        authurl = u"tiqrauth://{0!s}@{1!s}/{2!s}/{3!s}".format(user_identifier,
+        # Encode the user to UTF-8 and quote the result
+        encoded_user_identifier = urllib.quote_plus(user_identifier.encode('utf-8'))
+        authurl = u"tiqrauth://{0!s}@{1!s}/{2!s}/{3!s}".format(
+                                              encoded_user_identifier,
                                               service_identifier,
                                               db_challenge.transaction_id,
                                               challenge)

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -392,7 +392,10 @@ class TiqrTokenClass(OcraTokenClass):
                                  validitytime=validity)
         db_challenge.save()
 
-        authurl = "tiqrauth://{0!s}@{1!s}/{2!s}/{3!s}".format(user_identifier,
+        # TODO: How are non-ascii characters handled in tiqrauth URLs?
+        # qrcode implicitly converts them to UTF-8 before creating the
+        # QR code, but is this understood by TiQR apps?
+        authurl = u"tiqrauth://{0!s}@{1!s}/{2!s}/{3!s}".format(user_identifier,
                                               service_identifier,
                                               db_challenge.transaction_id,
                                               challenge)

--- a/privacyidea/lib/tokens/u2f.py
+++ b/privacyidea/lib/tokens/u2f.py
@@ -112,7 +112,7 @@ def parse_registration_data(reg_data):
                                            attestation_cert))
     # TODO: Check the issuer of the certificate
     issuer = attestation_cert.get_issuer()
-    log.debug("The attestation certificate is signed by {0!s}".format(issuer))
+    log.debug("The attestation certificate is signed by {0!r}".format(issuer))
     not_after = attestation_cert.get_notAfter()
     not_before = attestation_cert.get_notBefore()
     log.debug("The attestation certificate "

--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -392,7 +392,7 @@ class U2fTokenClass(TokenClass):
         additional ``attributes``, which are displayed in the JSON response.
         """
         options = options or {}
-        message = 'Please confirm with your U2F token ({0!s})'.format( \
+        message = u'Please confirm with your U2F token ({0!s})'.format( \
                   self.token.description)
 
         validity = int(get_from_config('DefaultChallengeValidityTime', 120))

--- a/privacyidea/static/templates/documentation.rst
+++ b/privacyidea/static/templates/documentation.rst
@@ -36,7 +36,7 @@ System Base Configuration
 -------------------------
 
 {% for k, v in context.systemconfig.items() %}
-{{k.decode("utf-8")}}: **{{v.decode("utf-8")}}**
+{{k}}: **{{v}}**
 {% endfor %}
 
 Resolver Configuration
@@ -53,7 +53,7 @@ To learn more about resolvers read [#resolvers]_.
 Configuration
 .............
 {% for k, v in reso.data.items() %}
-{{k.decode("utf-8")}}: **{{v.decode("utf-8")}}**
+{{k}}: **{{v}}**
 {% endfor %}
 
 {% endfor %}
@@ -98,7 +98,7 @@ The following policies are defined in your system:
 ~~~~~~~~~~~~~~~~~
 {% for k, v in policy.items(): %}
 {% if k != "name": %}
-{{k.decode("utf-8")}}: **{{v}}**
+{{k}}: **{{v}}**
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """
 This test file tests the lib.policy.py
 
@@ -698,3 +699,15 @@ class PolicyTestCase(MyTestCase):
             rid = delete_resolver(reso)
             self.assertTrue(rid > 0, rid)
 
+    def test_22_non_ascii_user(self):
+        set_policy(name="polnonascii",
+                   action="enroll, otppin=1",
+                   user=u'nönäscii',
+                   scope='s')
+
+        P = PolicyClass()
+        p = P.get_policies(action="enroll", user='somebodyelse')
+        self.assertEqual(len(p), 0)
+
+        p = P.get_policies(action="enroll", user=u'nönäscii')
+        self.assertEqual(len(p), 1)

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -1607,6 +1607,16 @@ class ResolverTestCase(MyTestCase):
         self.assertTrue(y.getUserId(u"cornelius") == "1000",
                         y.getUserId("cornelius"))
         self.assertTrue(y.getUserId("user does not exist") == "")
+        # Check that non-ASCII user was read successfully
+        self.assertEqual(y.getUsername("1116"), u"nönäscii")
+        self.assertEqual(y.getUserId(u"nönäscii"), "1116")
+        self.assertEqual(y.getUserInfo("1116").get('givenname'),
+                         u"Nön")
+        self.assertFalse(y.checkPass("1116", "wrong"))
+        self.assertTrue(y.checkPass("1116", u"pässwörd"))
+        r = y.getUserList({"username": u"*ö*"})
+        self.assertEqual(len(r), 1)
+
         sF = y.getSearchFields({"username": "*"})
         self.assertTrue(sF.get("username") == "text", sF)
         # unknown search fields. We get an empty userlist

--- a/tests/test_lib_tokens_ssh.py
+++ b/tests/test_lib_tokens_ssh.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """
 This test file tests the lib.tokens.sshkeytoken
 This depends on lib.tokenclass
@@ -12,20 +13,20 @@ class SSHTokenTestCase(MyTestCase):
 
     otppin = "topsecret"
     serial1 = "ser1"
-    sshkey = "ssh-rsa " \
-             "AAAAB3NzaC1yc2EAAAADAQABAAACAQDJy0rLoxqc8SsY8DVAFijMsQyCv" \
-             "hBu4K40hdZOacXK4O6OgnacnSKN56MP6pzz2+4svzvDzwvkFsvf34pbsgD" \
-             "F67PPSCsimmjEQjf0UfamBKh0cl181CbPYsph3UTBOCgHh3FFDXBduPK4DQz" \
-             "EVQpmqe80h+lsvQ81qPYagbRW6fpd0uWn9H7a/qiLQZsiKLL07HGB+NwWue4os" \
-             "0r9s4qxeG76K6QM7nZKyC0KRAz7CjAf+0X7YzCOu2pzyxVdj/T+KArFcMmq8V" \
-             "dz24mhcFFXTzU3wveas1A9rwamYWB+Spuohh/OrK3wDsrryStKQv7yofgnPMs" \
-             "TdaL7XxyQVPCmh2jVl5ro9BPIjTXsre9EUxZYFVr3EIECRDNWy3xEnUHk7Rzs" \
-             "734Rp6XxGSzcSLSju8/MBzUVe35iXfXDRcqTcoA0700pIb1ANYrPUO8Up05v4" \
-             "EjIyBeU61b4ilJ3PNcEVld6FHwP3Z7F068ef4DXEC/d7pibrp4Up61WYQIXV/" \
-             "utDt3NDg/Zf3iqoYcJNM/zIZx2j1kQQwqtnbGqxJMrL6LtClmeWteR4420uZx" \
-             "afLE9AtAL4nnMPuubC87L0wJ88un9teza/N02KJMHy01Yz3iJKt3Ou9eV6kqO" \
-             "ei3kvLs5dXmriTHp6g9whtnN6/Liv9SzZPJTs8YfThi34Wccrw== " \
-             "NetKnights GmbH"
+    sshkey = u"ssh-rsa " \
+             u"AAAAB3NzaC1yc2EAAAADAQABAAACAQDJy0rLoxqc8SsY8DVAFijMsQyCv" \
+             u"hBu4K40hdZOacXK4O6OgnacnSKN56MP6pzz2+4svzvDzwvkFsvf34pbsgD" \
+             u"F67PPSCsimmjEQjf0UfamBKh0cl181CbPYsph3UTBOCgHh3FFDXBduPK4DQz" \
+             u"EVQpmqe80h+lsvQ81qPYagbRW6fpd0uWn9H7a/qiLQZsiKLL07HGB+NwWue4os" \
+             u"0r9s4qxeG76K6QM7nZKyC0KRAz7CjAf+0X7YzCOu2pzyxVdj/T+KArFcMmq8V" \
+             u"dz24mhcFFXTzU3wveas1A9rwamYWB+Spuohh/OrK3wDsrryStKQv7yofgnPMs" \
+             u"TdaL7XxyQVPCmh2jVl5ro9BPIjTXsre9EUxZYFVr3EIECRDNWy3xEnUHk7Rzs" \
+             u"734Rp6XxGSzcSLSju8/MBzUVe35iXfXDRcqTcoA0700pIb1ANYrPUO8Up05v4" \
+             u"EjIyBeU61b4ilJ3PNcEVld6FHwP3Z7F068ef4DXEC/d7pibrp4Up61WYQIXV/" \
+             u"utDt3NDg/Zf3iqoYcJNM/zIZx2j1kQQwqtnbGqxJMrL6LtClmeWteR4420uZx" \
+             u"afLE9AtAL4nnMPuubC87L0wJ88un9teza/N02KJMHy01Yz3iJKt3Ou9eV6kqO" \
+             u"ei3kvLs5dXmriTHp6g9whtnN6/Liv9SzZPJTs8YfThi34Wccrw== " \
+             u"NetKnights GmbH Descröption"
     wrong_sshkey = """---- BEGIN SSH2 PUBLIC KEY ----
 AAAAB3NzaC1kc3MAAACBAKrFC6uDvuxl9vnYL/Fu/Vq+12KJF4
 RyMSQe4mn8oHJma2VzepBRBpLt7Q==
@@ -68,3 +69,4 @@ RyMSQe4mn8oHJma2VzepBRBpLt7Q==
         token = SSHkeyTokenClass(db_token)
         sshkey = token.get_sshkey()
         self.assertTrue(sshkey == self.sshkey, sshkey)
+        self.assertIsInstance(sshkey, unicode)

--- a/tests/test_lib_tokens_tiqr.py
+++ b/tests/test_lib_tokens_tiqr.py
@@ -3,7 +3,6 @@
 This test file tests the lib.tokens.tiqrtoken and lib.tokens.ocra
 This depends on lib.tokenclass
 """
-
 from .base import MyTestCase
 from privacyidea.lib.tokens.tiqrtoken import TiqrTokenClass
 from privacyidea.lib.tokens.ocratoken import OcraTokenClass
@@ -13,6 +12,7 @@ from privacyidea.lib.error import ParameterError
 import re
 import binascii
 import hashlib
+from urlparse import urlparse
 from urllib import urlencode
 import json
 from flask import Request, g
@@ -399,7 +399,7 @@ class TiQRTokenTestCase(MyTestCase):
         self.assertTrue("img" in r[3], r[3])
         self.assertTrue("value" in r[3], r[3])
 
-    def _test_api_endpoint(self, user):
+    def _test_api_endpoint(self, user, expected_netloc):
         pin = "tiqr"
         token = init_token({"type": "tiqr",
                             "pin": pin,
@@ -483,6 +483,10 @@ class TiQRTokenTestCase(MyTestCase):
             session = r[3]
             challenge = r[4]
 
+        # check the URL
+        parsed_url = urlparse(image_url)
+        self.assertEqual(parsed_url.netloc, expected_netloc)
+
         ocrasuite = token.get_tokeninfo("ocrasuite")
         ocra_object = OCRA(ocrasuite, key=binascii.unhexlify(KEY20))
         # Calculate Response with the challenge.
@@ -532,10 +536,10 @@ class TiQRTokenTestCase(MyTestCase):
         self._test_create_token('cornelius')
 
     def test_02_api_endpoint(self):
-        self._test_api_endpoint('cornelius')
+        self._test_api_endpoint('cornelius', 'cornelius_realm1@org.privacyidea')
 
     def test_03_create_token_nonascii(self):
         self._test_create_token(u'nönäscii')
 
     def test_04_api_endpoint_nonascii(self):
-        self._test_api_endpoint(u'nönäscii')
+        self._test_api_endpoint(u'nönäscii', 'n%C3%B6n%C3%A4scii_realm1@org.privacyidea')

--- a/tests/testdata/passwords
+++ b/tests/testdata/passwords
@@ -12,4 +12,4 @@ disableduser:DgT1djMaFfpEs:1112:1112:::
 lockeduser:DgT1djMaFfpEs:1113:1113:::
 usernotoken::1114:1114:::
 multichal::1115:1115:::
-nönäscii::1116:1116:::
+nönäscii:IXsH4ttQlw2xA:1116:1116:Nön,field2,field3,field4,field5::

--- a/tests/testdata/passwords
+++ b/tests/testdata/passwords
@@ -12,3 +12,4 @@ disableduser:DgT1djMaFfpEs:1112:1112:::
 lockeduser:DgT1djMaFfpEs:1113:1113:::
 usernotoken::1114:1114:::
 multichal::1115:1115:::
+nönäscii::1116:1116:::


### PR DESCRIPTION
This fixes some issues with non-ASCII data (some of them pretty obscure).

I think this should finally close #754. I've opened #811 and #812 for two remaining UTF-8 issues that are somewhat more complicated to fix.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/813%23issuecomment-339310588%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23discussion_r146837302%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23discussion_r147077840%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23issuecomment-339612984%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23discussion_r147151132%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23issuecomment-339689201%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23issuecomment-339310588%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23813%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/99b99446c363a7ed3349c371eaf3497dc382d422%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6094.73%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23813%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%20%2095.3%25%20%20%2095.29%25%20%20%20-0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015499%20%20%20%2015500%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2014772%20%20%20%2014770%20%20%20%20%20%20%20-2%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20727%20%20%20%20%20%20730%20%20%20%20%20%20%20%2B3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/tokenhandler.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci90b2tlbmhhbmRsZXIucHk%3D%29%20%7C%20%6092.1%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.27%25%20%3C100%25%3E%20%28-2.53%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/PasswdIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9QYXNzd2RJZFJlc29sdmVyLnB5%29%20%7C%20%6099.14%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/sshkeytoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9zc2hrZXl0b2tlbi5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/emailtoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9lbWFpbHRva2VuLnB5%29%20%7C%20%6099.34%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokenclass.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk%3D%29%20%7C%20%6098.92%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.11%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5%29%20%7C%20%6098.13%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/tiqrtoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90aXFydG9rZW4ucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6093.22%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20...%20and%20%5B4%20more%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dtree-more%29%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B99b9944...4539ec0%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/813%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-10-25T12%3A16%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Basically%20I%20am%20fine%20with%20that.%20%5Cr%5CnWe%20should%20add%20a%20thought%20about%20the%20urlencoding%20of%20the%20TiQR%20url.%22%2C%20%22created_at%22%3A%20%222017-10-26T09%3A48%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20went%20with%20urlquoting%20the%20user%20part%20and%20manually%20checked%20that%20the%20flow%20using%20the%20TiQR%20app%20works%20fine%20with%20the%20user%20%60%60k%5Cu00f6lbel%60%60%20%3A-%29%22%2C%20%22created_at%22%3A%20%222017-10-26T14%3A43%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204539ec065cdacf8d40325941208000fe9d712fcd%20privacyidea/static/templates/documentation.rst%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23discussion_r146837302%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20about%20these%3A%5Cr%5Cn%40cornelinux%2C%20you%20explicitly%20added%20them%20in%207a6fef5f7a5b8f79cf1edc82208905776feeb07f%20to%20fix%20encoding%20issues.%20But%20with%20the%20%60%60.decode%28%5C%22utf-8%5C%22%29%60%60%2C%20generating%20the%20system%20documentation%20fails%20when%20I%20use%20non-ASCII%20values%20somewhere%20%28e.g.%20in%20the%20LDAP%20search%20filter%29.%20%5Cud83e%5Cudd14%20%22%2C%20%22created_at%22%3A%20%222017-10-25T12%3A19%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/templates/documentation.rst%3AL36-43%22%7D%2C%20%22Pull%204539ec065cdacf8d40325941208000fe9d712fcd%20tests/testdata/passwords%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23discussion_r147151132%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hah%20yeah%2C%20I%20just%20remembered%20we%20talked%20about%20adding%20unicode%20support%20to%20the%20passwd%20id%20resolver%20in%20%23754%2C%20so%20I%20figured%20why%20not%20just%20do%20it%20now%20%3A%29%22%2C%20%22created_at%22%3A%20%222017-10-26T14%3A04%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/testdata/passwords%3AL12-16%22%7D%2C%20%22Pull%204539ec065cdacf8d40325941208000fe9d712fcd%20privacyidea/lib/tokens/tiqrtoken.py%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/813%23discussion_r147077840%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20if%20we%20really%20have%20special%20characters%20here%20this%20would%20have%20to%20be%20urlencoded%21%22%2C%20%22created_at%22%3A%20%222017-10-26T08%3A40%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/tiqrtoken.py%3AL392-402%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/813#issuecomment-339310588'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=h1) Report
> Merging [#813](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/99b99446c363a7ed3349c371eaf3497dc382d422?src=pr&el=desc) will **decrease** coverage by `0.01%`.
> The diff coverage is `94.73%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/813/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #813      +/-   ##
==========================================
- Coverage    95.3%   95.29%   -0.02%
==========================================
Files         126      126
Lines       15499    15500       +1
==========================================
- Hits        14772    14770       -2
- Misses        727      730       +3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/eventhandler/tokenhandler.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci90b2tlbmhhbmRsZXIucHk=) | `92.1% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.27% <100%> (-2.53%)` | :arrow_down: |
| [privacyidea/lib/resolvers/PasswdIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9QYXNzd2RJZFJlc29sdmVyLnB5) | `99.14% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/sshkeytoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9zc2hrZXl0b2tlbi5weQ==) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/emailtoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9lbWFpbHRva2VuLnB5) | `99.34% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokenclass.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk=) | `98.92% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.11% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5) | `98.13% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/tiqrtoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90aXFydG9rZW4ucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `93.22% <100%> (ø)` | :arrow_up: |
| ... and [4 more](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=tree-more) | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=footer). Last update [99b9944...4539ec0](https://codecov.io/gh/privacyidea/privacyidea/pull/813?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Basically I am fine with that.
We should add a thought about the urlencoding of the TiQR url.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I went with urlquoting the user part and manually checked that the flow using the TiQR app works fine with the user ``kölbel`` :-)
- [x] <a href='#crh-comment-Pull 4539ec065cdacf8d40325941208000fe9d712fcd privacyidea/static/templates/documentation.rst 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/813#discussion_r146837302'>File: privacyidea/static/templates/documentation.rst:L36-43</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I'm not sure about these:
@cornelinux, you explicitly added them in 7a6fef5f7a5b8f79cf1edc82208905776feeb07f to fix encoding issues. But with the ``.decode("utf-8")``, generating the system documentation fails when I use non-ASCII values somewhere (e.g. in the LDAP search filter). 🤔
- [ ] <a href='#crh-comment-Pull 4539ec065cdacf8d40325941208000fe9d712fcd privacyidea/lib/tokens/tiqrtoken.py 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/813#discussion_r147077840'>File: privacyidea/lib/tokens/tiqrtoken.py:L392-402</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think if we really have special characters here this would have to be urlencoded!
- [ ] <a href='#crh-comment-Pull 4539ec065cdacf8d40325941208000fe9d712fcd tests/testdata/passwords 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/813#discussion_r147151132'>File: tests/testdata/passwords:L12-16</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hah yeah, I just remembered we talked about adding unicode support to the passwd id resolver in #754, so I figured why not just do it now :)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/813?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/813?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/813'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>