### PR TITLE
Add CSS for required fields

### DIFF
--- a/privacyidea/static/components/config/views/config.privacyideaserver.edit.html
+++ b/privacyidea/static/components/config/views/config.privacyideaserver.edit.html
@@ -9,8 +9,7 @@
 <form name="formPrivacyidea" role="form" validate
       class="form-horizontal">
 
-    <div class="form-group"
-        ng-class="{'has-error': !params.identifier}">
+    <div class="form-group">
         <label for="identifier" class="col-sm-3 control-label"
                 translate>Identifier</label>
         <div class="col-sm-9">
@@ -22,8 +21,7 @@
                 of the privacyIDEA server definition.</p>
         </div>
     </div>
-    <div class="form-group"
-        ng-class="{'has-error': !params.url }">
+    <div class="form-group">
         <label for="url" class="col-sm-3 control-label" translate>
             URL of the privacyIDEA server</label>
 

--- a/privacyidea/static/components/config/views/config.radius.edit.html
+++ b/privacyidea/static/components/config/views/config.radius.edit.html
@@ -9,8 +9,7 @@
 <form name="formRadius" role="form" validate
       class="form-horizontal">
 
-    <div class="form-group"
-        ng-class="{'has-error': !params.identifier}">
+    <div class="form-group">
         <label for="identifier" class="col-sm-3 control-label"
                 translate>Identifier</label>
         <div class="col-sm-9">
@@ -22,8 +21,7 @@
                 of the RADIUS server definition.</p>
         </div>
     </div>
-    <div class="form-group"
-        ng-class="{'has-error': !params.server }">
+    <div class="form-group">
         <label for="server" class="col-sm-3 control-label" translate>
             IP or FQDN</label>
 
@@ -44,8 +42,7 @@
         </div>
     </div>
 
-    <div class="form-group"
-        ng-class="{'has-error': !params.secret}">
+    <div class="form-group">
         <label for="secret" class="col-sm-3 control-label"
                translate>Secret</label>
         <div class="col-sm-9">

--- a/privacyidea/static/components/config/views/config.resolvers.ldap.html
+++ b/privacyidea/static/components/config/views/config.resolvers.ldap.html
@@ -143,9 +143,11 @@
         <label for="cachetimeout" class="col-sm-3 control-label"
                 translate>Cache Timeout (seconds)</label>
 
-        <div class="col-sm-3">
+        <div class="col-sm-3"
+             ng-class="{'has-error': !params.CACHE_TIMEOUT }">
             <input name="cachetimeout" class="form-control"
                    ng-model="params.CACHE_TIMEOUT" required
+                   ng-class="{'has-error': !params.CACHE_TIMEOUT }"
                    placeholder="120"/>
         </div>
     </div>

--- a/privacyidea/static/components/config/views/config.smtp.edit.html
+++ b/privacyidea/static/components/config/views/config.smtp.edit.html
@@ -9,8 +9,7 @@
 <form name="formSmtp" role="form" validate
       class="form-horizontal">
 
-    <div class="form-group"
-        ng-class="{'has-error': !params.identifier}">
+    <div class="form-group">
         <label for="identifier" class="col-sm-3 control-label"
                 translate>Identifier</label>
         <div class="col-sm-9">
@@ -22,8 +21,7 @@
                 of the SMTP server definition.</p>
         </div>
     </div>
-    <div class="form-group"
-        ng-class="{'has-error': !params.server }">
+    <div class="form-group">
         <label for="server" class="col-sm-3 control-label" translate>
             IP or FQDN</label>
 
@@ -43,8 +41,7 @@
                    placeholder="25"/>
         </div>
     </div>
-    <div class="form-group"
-        ng-class="{'has-error': !params.sender}">
+    <div class="form-group">
         <label for="sender" class="col-sm-3 control-label"
                translate>Sender Email</label>
 

--- a/privacyidea/static/css/signin.css
+++ b/privacyidea/static/css/signin.css
@@ -103,3 +103,26 @@ body {
 .deactivated {
     text-align: center;
 }
+
+/*
+.ng-invalid.radio label,
+.ng-invalid.checkbox label,
+.ng-invalid.radio-inline label,
+.ng-invalid.checkbox-inline label {
+  color: #a94442;
+}
+*/
+
+input.ng-invalid,
+select.ng-invalid {
+    background: rgba(169, 68, 66, 0.05);
+  border-color: #a94442;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+          box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+}
+input.ng-invalid:focus,
+select.ng-invalid:focus{
+  border-color: #843534;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483;
+          box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483;
+}

--- a/privacyidea/static/css/signin.css
+++ b/privacyidea/static/css/signin.css
@@ -113,15 +113,15 @@ body {
 }
 */
 
-input.ng-invalid,
+input.ng-invalid:not(#username):not(#password),
 select.ng-invalid {
     background: rgba(169, 68, 66, 0.05);
   border-color: #a94442;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
           box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
 }
-input.ng-invalid:focus,
-select.ng-invalid:focus{
+input.ng-invalid:focus:not(#username):not(#password),
+select.ng-invalid:focus:not(#username):not(#password){
   border-color: #843534;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483;
           box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483;


### PR DESCRIPTION
required fields now have a red frame and transparent red
background.

Closes #810
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/816%23issuecomment-339432272%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/816%23issuecomment-339442612%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/816%23issuecomment-339656912%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/816%23issuecomment-339660814%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/816%23discussion_r147147904%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/816%23issuecomment-339432272%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20adds%20a%20red%20outline%20to%20ALL%20%5C%22required%5C%22%20fields.%5Cr%5Cn%5Cr%5CnPlease%20note%3A%20This%20looks%20a%20bit%20funny%20in%20the%20login%20window.%20What%20do%20you%20think%20%40fredreichbier%20%3F%22%2C%20%22created_at%22%3A%20%222017-10-25T18%3A48%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/816%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23816%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/816%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/99b99446c363a7ed3349c371eaf3497dc382d422%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/816/graphs/tree.svg%3Fheight%3D150%26width%3D650%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/816%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23816%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%20%2095.3%25%20%20%2095.3%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015499%20%20%2015499%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2014772%20%20%2014772%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20727%20%20%20%20%20727%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/816%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/816%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B99b9944...a482784%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/816%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-10-25T19%3A24%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20really%20nice%21%5Cr%5CnBut%20it%20indeed%20looks%20a%20bit%20weird%20in%20the%20login%20window%20--%20but%20I%27m%20not%20sure%20if%20that%27s%20only%20out%20of%20habit%20%3A-%29%20I%20guess%20we%20could%20work%20around%20the%20problem%20with%20some%20CSS%20magic%3F%22%2C%20%22created_at%22%3A%20%222017-10-26T12%3A56%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20this%20is%20fun%3A%5Cr%5Cn%5Cr%5Cn%60%60%60css%5Cr%5Cninput.ng-invalid%3Anot%28%23username%29%3Anot%28%23password%29%2C%5Cr%5Cnselect.ng-invalid%20%7B%5Cr%5Cn%20%20%20%20background%3A%20rgba%28169%2C%2068%2C%2066%2C%200.05%29%3B%5Cr%5Cn%20%20border-color%3A%20%23a94442%3B%5Cr%5Cn%20%20-webkit-box-shadow%3A%20inset%200%201px%201px%20rgba%280%2C%200%2C%200%2C%20.075%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20box-shadow%3A%20inset%200%201px%201px%20rgba%280%2C%200%2C%200%2C%20.075%29%3B%5Cr%5Cn%7D%5Cr%5Cninput.ng-invalid%3Afocus%3Anot%28%23username%29%3Anot%28%23password%29%2C%5Cr%5Cnselect.ng-invalid%3Afocus%7B%5Cr%5Cn%20%20border-color%3A%20%23843534%3B%5Cr%5Cn%20%20-webkit-box-shadow%3A%20inset%200%201px%201px%20rgba%280%2C%200%2C%200%2C%20.075%29%2C%200%200%206px%20%23ce8483%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20box-shadow%3A%20inset%200%201px%201px%20rgba%280%2C%200%2C%200%2C%20.075%29%2C%200%200%206px%20%23ce8483%3B%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-10-26T13%3A10%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ed88097e82ad611a90d59e543431bdda7a363b60%20privacyidea/static/css/signin.css%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/816%23discussion_r147147904%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Well%2C%20strictly%20speaking%2C%20I%20think%20we%20do%20not%20need%20the%20%60%60%3Anot...%60%60%20stuff%20for%20%60%60select%60%60%2C%20but%20I%20think%20this%20works%20%3A%29%20%22%2C%20%22created_at%22%3A%20%222017-10-26T13%3A53%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/css/signin.css%3AL103-129%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/816#issuecomment-339432272'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This adds a red outline to ALL "required" fields.
Please note: This looks a bit funny in the login window. What do you think @fredreichbier ?
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/816?src=pr&el=h1) Report
> Merging [#816](https://codecov.io/gh/privacyidea/privacyidea/pull/816?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/99b99446c363a7ed3349c371eaf3497dc382d422?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/816/graphs/tree.svg?height=150&width=650&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/816?src=pr&el=tree)
```diff
@@          Coverage Diff           @@
##           master    #816   +/-   ##
======================================
Coverage    95.3%   95.3%
======================================
Files         126     126
Lines       15499   15499
======================================
Hits        14772   14772
Misses        727     727
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/816?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/816?src=pr&el=footer). Last update [99b9944...a482784](https://codecov.io/gh/privacyidea/privacyidea/pull/816?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> This is really nice!
But it indeed looks a bit weird in the login window -- but I'm not sure if that's only out of habit :-) I guess we could work around the problem with some CSS magic?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Well, this is fun:
```css
input.ng-invalid:not(#username):not(#password),
select.ng-invalid {
background: rgba(169, 68, 66, 0.05);
border-color: #a94442;
-webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
}
input.ng-invalid:focus:not(#username):not(#password),
select.ng-invalid:focus{
border-color: #843534;
-webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483;
box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483;
}
```
- [ ] <a href='#crh-comment-Pull ed88097e82ad611a90d59e543431bdda7a363b60 privacyidea/static/css/signin.css 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/816#discussion_r147147904'>File: privacyidea/static/css/signin.css:L103-129</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Well, strictly speaking, I think we do not need the ``:not...`` stuff for ``select``, but I think this works :)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/816?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/816?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/816'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>