### PR TITLE
Fix some policies which were honored even if inactive

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -487,14 +487,16 @@ def get_webui_settings(request, response):
             policy_object.get_policies(action=ACTION.TOKENWIZARD2ND,
                                        scope=SCOPE.WEBUI,
                                        realm=realm,
-                                       client=client))
+                                       client=client,
+                                       active=True))
         token_wizard = False
         if role == ROLE.USER:
             token_wizard_pol = policy_object.get_policies(
                 action=ACTION.TOKENWIZARD,
                 scope=SCOPE.WEBUI,
                 realm=realm,
-                client=client
+                client=client,
+                active=True
             )
 
             # We also need to check, if the user has not tokens assigned.
@@ -507,19 +509,22 @@ def get_webui_settings(request, response):
             action=ACTION.USERDETAILS,
             scope=SCOPE.WEBUI,
             realm=realm,
-            client=client
+            client=client,
+            active=True
         )
         search_on_enter = policy_object.get_policies(
             action=ACTION.SEARCH_ON_ENTER,
             scope=SCOPE.WEBUI,
             realm=realm,
-            client=client
+            client=client,
+            active=True
         )
         hide_welcome = policy_object.get_policies(
             action=ACTION.HIDE_WELCOME,
             scope=SCOPE.WEBUI,
             realm=realm,
-            client=client
+            client=client,
+            active=True
         )
         hide_welcome = bool(hide_welcome)
         default_tokentype_pol = policy_object.get_action_values(

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -190,7 +190,8 @@ def realmadmin(request=None, action=None):
             po = policy_object.get_policies(
                 action=action, scope=SCOPE.ADMIN,
                 user=g.logged_in_user.get("username"),
-                adminrealm=g.logged_in_user.get("realm"), client=g.client_ip)
+                adminrealm=g.logged_in_user.get("realm"), client=g.client_ip,
+                active=True)
             # TODO: fix this: there could be a list of policies with a list
             # of realms!
             if po and po[0].get("realm"):
@@ -1103,7 +1104,8 @@ def allowed_audit_realm(request=None, action=None):
         action=ACTION.AUDIT,
         scope=SCOPE.ADMIN,
         user=admin_user.get("username"),
-        client=g.client_ip)
+        client=g.client_ip,
+        active=True)
 
     if pols:
         # get all values in realm:

--- a/privacyidea/lib/passwordreset.py
+++ b/privacyidea/lib/passwordreset.py
@@ -145,7 +145,8 @@ def is_password_reset():
     policy_at_all = Policy.get_policies(scope=SCOPE.USER, active=True)
     log.debug("Policy at all: {0!s}".format(policy_at_all))
     policy_reset_pw = Policy.get_policies(scope=SCOPE.USER,
-                                          action=ACTION.PASSWORDRESET)
+                                          action=ACTION.PASSWORDRESET,
+                                          active=True)
     log.debug("Password reset policy: {0!s}".format(policy_reset_pw))
     pwreset = (policy_at_all and policy_reset_pw) or not policy_at_all
     log.debug("Password reset allowed via policy: {0!s}".format(pwreset))

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -82,7 +82,8 @@ def single_page_application():
         request.remote_addr
     realm_dropdown = policy_object.get_policies(action=ACTION.REALMDROPDOWN,
                                                 scope=SCOPE.WEBUI,
-                                                client=client_ip)
+                                                client=client_ip,
+                                                active=True)
     if realm_dropdown:
         try:
             realm_dropdown_values = policy_object.get_action_values(

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1160,6 +1160,17 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         self.assertTrue("realm2" in req.all_data.get("allowed_audit_realm"))
         self.assertTrue("realm3" in req.all_data.get("allowed_audit_realm"))
 
+        # check that the policy is not honored if inactive
+        set_policy(name="auditrealm2",
+                   active=False)
+        g.policy_object = PolicyClass()
+
+        # request, that matches the policy
+        req.all_data = {}
+        req.User = User()
+        allowed_audit_realm(req)
+        self.assertEqual(req.all_data.get("allowed_audit_realm"), ["realm1"])
+
         # finally delete policy
         delete_policy("auditrealm1")
         delete_policy("auditrealm2")
@@ -1636,6 +1647,15 @@ class PostPolicyDecoratorTestCase(MyTestCase):
         jresult = json.loads(new_response.data)
         self.assertEqual(jresult.get("result").get("value").get(
             "token_wizard"), True)
+
+        # Assert the policy is not honored if inactive
+        set_policy(name="pol_wizard",
+                   active=False)
+        g.policy_object = PolicyClass()
+        new_response = get_webui_settings(req, resp)
+        jresult = json.loads(new_response.data)
+        self.assertEqual(jresult.get("result").get("value").get(
+            "token_wizard"), False)
 
         delete_policy("pol_wizard")
 


### PR DESCRIPTION
Closes #825
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/826%23discussion_r147416253%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/826%23discussion_r147419459%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20f338d787f87a58eb4f82ce2105ad4e62c68fe263%20privacyidea/lib/passwordreset.py%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/826%23discussion_r147416253%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20100%25%20sure%20I%20understand%20the%20logic%20here%3A%5Cr%5CnDoesn%27t%20%60%60policy_reset_pw%20%3D%3D%20True%60%60%20automatically%20imply%20%60%60policy_at_all%20%3D%3D%20True%60%60%3F%22%2C%20%22created_at%22%3A%20%222017-10-27T13%3A50%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20logic%20is%3A%5Cr%5Cn%5Cr%5CnI%20there%20are%20not%20any%20user%20policies%2C%20the%20user%20is%20allowed%20to%20do%20everything%20-%20also%20reset%20the%20password.%5Cr%5Cn%5Cr%5CnIf%20there%20is%20ANY%20password%20policy%2C%20the%20user%20is%20only%20allowed%20to%20reset%20the%20password%2C%20if%20there%20is%20a%20password%20reset%20policy.%22%2C%20%22created_at%22%3A%20%222017-10-27T14%3A03%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/passwordreset.py%3AL145-153%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f338d787f87a58eb4f82ce2105ad4e62c68fe263 privacyidea/lib/passwordreset.py 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/826#discussion_r147416253'>File: privacyidea/lib/passwordreset.py:L145-153</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I'm not 100% sure I understand the logic here:
Doesn't ``policy_reset_pw == True`` automatically imply ``policy_at_all == True``?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The logic is:
I there are not any user policies, the user is allowed to do everything - also reset the password.
If there is ANY password policy, the user is only allowed to reset the password, if there is a password reset policy.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/826?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/826?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/826'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>