### PR TITLE
Pin proxy settings for http and https

### DIFF
--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -101,8 +101,7 @@ class HttpSMSProvider(ISMSProvider):
 
         proxies = None
         if proxy:
-            protocol = proxy.split(":")[0]
-            proxies = {protocol: proxy}
+            proxies = { 'http': proxy, 'https': proxy}
 
         # url, parameter, username, password, method
         requestor = requests.get


### PR DESCRIPTION
This pins the proxy support for http and https using the same proxy setting and remove relativity to proxy schema
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/837%23issuecomment-341374380%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/837%23issuecomment-341374380%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20a%20user%20has%3A%5Cr%5Cn%5Cr%5Cn%3E%20URL%20%3D%20https%3A//mygateway/...%5Cr%5Cn%3E%20PROXY%20%3D%20https%3A//10.0.0.1%3A3128%5Cr%5Cn%5Cr%5Cn%60proxies%60%20will%20be%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%7B%5C%22http%5C%22%3A%20%5C%22https%3A//10.0.0.1...%5C%22%2C%20%5C%22https%5C%22%3A%20%5C%22https%3A//10.0.0.1...%5C%22%20%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cnand%20it%20most%20likely%20it%20won%27t%20work%20because%20the%20user%20won%27t%20have%20a%20secure-proxy%20%28that%27s%20a%20misconfiguration%20on%20the%20user%20side%20-%20it%20shouldn%27t%20add%20%60https%60%20in%20the%20proxy%20scheme%20if%20the%20user%20doesn%27t%20have%20a%20proxy%20that%20support%20that%29.%5Cr%5Cn%5Cr%5CnNow%2C%20%5Cr%5Cn%5Cr%5Cn%3E%20If%20a%20user%20has%20for%20whichever%20reason%3A%5Cr%5Cn%3E%20URL%20%3D%20https%3A//mygateway%5Cr%5Cn%3E%20PROXY%3D%20http%3A//10.0.0.1%3A3128%5Cr%5Cn%5Cr%5Cn%60proxies%60%20will%20be%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%7B%5C%22http%5C%22%3A%20%5C%22http%3A//10.0.0.1...%5C%22%2C%20%5C%22https%5C%22%3A%20%5C%22http%3A//10.0.0.1...%5C%22%20%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnAnd%20that%20should%20work.%20%5Cr%5Cn%5Cr%5CnI%20agree%20this%20patch%20may%20break%20some%20configuration%2C%20but%20that%20configuration%20is%20wrong%20in%20the%20first%20place%20so%20it%20must%20be%20fixed%20-%20a%20warning%20in%20the%20CHANGELOG%20should%20be%20enough.%20%22%2C%20%22created_at%22%3A%20%222017-11-02T10%3A08%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1154133%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/splashx%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/837#issuecomment-341374380'>General Comment</a></b>
- <a href='https://github.com/splashx'><img border=0 src='https://avatars2.githubusercontent.com/u/1154133?v=4' height=16 width=16></a> If a user has:
> URL = https://mygateway/...
> PROXY = https://10.0.0.1:3128
`proxies` will be:
```
{"http": "https://10.0.0.1...", "https": "https://10.0.0.1..." }
```
and it most likely it won't work because the user won't have a secure-proxy (that's a misconfiguration on the user side - it shouldn't add `https` in the proxy scheme if the user doesn't have a proxy that support that).
Now,
> If a user has for whichever reason:
> URL = https://mygateway
> PROXY= http://10.0.0.1:3128
`proxies` will be:
```
{"http": "http://10.0.0.1...", "https": "http://10.0.0.1..." }
```
And that should work.
I agree this patch may break some configuration, but that configuration is wrong in the first place so it must be fixed - a warning in the CHANGELOG should be enough.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/837?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/837?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/837'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>