### PR TITLE
838/federation

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -99,6 +99,7 @@ from .utils import parse_timedelta, parse_legacy_time
 from policy import ACTION
 from dateutil.parser import parse as parse_date_string
 from dateutil.tz import tzlocal, tzutc
+from privacyidea.lib.utils import is_true
 
 
 #DATE_FORMAT = "%d/%m/%y %H:%M"
@@ -474,7 +475,7 @@ class TokenClass(object):
         #      raise param Exception, that we require an otpkey
         #
         otpKey = getParam(param, "otpkey", optional)
-        genkey = int(getParam(param, "genkey", optional) or 0)
+        genkey = is_true(getParam(param, "genkey", optional))
         two_step_init = int(getParam(param, "2stepinit", optional) or 0)
 
         if two_step_init:
@@ -488,15 +489,15 @@ class TokenClass(object):
             self.token.active = False
 
 
-        if genkey not in [0, 1]:
-            raise ParameterError("TokenClass supports only genkey in  range ["
-                                 "0,1] : %r" % genkey)
+        #if genkey not in [0, 1]:
+        #    raise ParameterError("TokenClass supports only genkey in  range ["
+        #                         "0,1] : %r" % genkey)
 
-        if genkey == 1 and otpKey is not None:
+        if genkey and otpKey is not None:
             raise ParameterError('[ParameterError] You may either specify '
                                  'genkey or otpkey, but not both!', id=344)
 
-        if otpKey is None and genkey == 1:
+        if otpKey is None and genkey:
             otpKey = self._genOtpKey_(key_size)
 
         # otpKey still None?? - raise the exception

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -47,7 +47,7 @@ from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.log import log_with
 from privacyidea.lib.apps import create_google_authenticator_url as cr_google
 from privacyidea.lib.apps import create_oathtoken_url as cr_oath
-from privacyidea.lib.utils import create_img
+from privacyidea.lib.utils import create_img, is_true
 from privacyidea.lib.utils import generate_otpkey
 from privacyidea.lib.policydecorators import challenge_response_allowed
 from privacyidea.lib.decorators import check_token_locked
@@ -244,7 +244,7 @@ class HotpTokenClass(TokenClass):
             upd_param['keysize'] = keylen.get(hashlibStr)
 
         otpKey = getParam(upd_param, "otpkey", optional)
-        genkey = int(getParam(upd_param, "genkey", optional) or 0)
+        genkey = is_true(getParam(upd_param, "genkey", optional))
         if genkey and otpKey:
             # The Base TokenClass does not allow otpkey and genkey at the
             # same time

--- a/privacyidea/lib/tokens/motptoken.py
+++ b/privacyidea/lib/tokens/motptoken.py
@@ -45,7 +45,7 @@ from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.log import log_with
 from privacyidea.lib.utils import create_img
 from privacyidea.api.lib.utils import getParam
-from privacyidea.lib.utils import generate_otpkey
+from privacyidea.lib.utils import generate_otpkey, is_true
 from privacyidea.lib.decorators import check_token_locked
 import traceback
 import logging
@@ -159,10 +159,10 @@ class MotpTokenClass(TokenClass):
         :return: nothing
         """
         if self.hKeyRequired is True:
-            genkey = int(getParam(param, "genkey", optional) or 0)
+            genkey = is_true(getParam(param, "genkey", optional))
             if not param.get('keysize'):
                 param['keysize'] = 16
-            if 1 == genkey:
+            if genkey:
                 otpKey = generate_otpkey(param['keysize'])
                 del param['genkey']
             else:

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -511,11 +511,6 @@ class TokenBaseTestCase(MyTestCase):
     def test_17_update_token(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()
         token = TokenClass(db_token)
-        # Failed update: genkey wrong
-        self.assertRaises(Exception,
-                          token.update,
-                          {"description": "new desc",
-                           "genkey": "17"})
         # Failed update: genkey and otpkey used at the same time
         self.assertRaises(Exception,
                           token.update,


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/841%23issuecomment-342801164%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/841%23issuecomment-342811453%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/841%23issuecomment-343137671%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/841%23issuecomment-343168929%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/841%23issuecomment-343172954%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/841%23issuecomment-342801164%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40fredreichbier%20I%20would%20like%20to%20discuss%20this.%5Cr%5Cn%5Cr%5CnUsing%20this%20change%20we%20are%20able%20to%20define%20event%20handlers%2C%20which%20issue%20the%20same%20command%20on%20the%20remote%20server.%20This%20also%20works%20for%20Requests%2C%20which%20need%20an%20authorization%20token%20like%20the%20admin%20who%20is%20enrolling%20a%20token%20or%20a%20user%2C%20who%20is%20viewing%20his%20own%20token.%5Cr%5Cn%5Cr%5CnThe%20problem%20in%20contrast%20to%20all%20other%20event%20handlers%20is%2C%20that%20it%20changes%20the%20response%20for%20the%20user.%5Cr%5CnTHe%20user%20_sees_%20the%20tokens%20from%20the%20remote%20system.%5Cr%5Cn%5Cr%5CnTHe%20user%20_creates_%20a%20token%20on%20the%20remote%20system%20%28but%20also%20on%20the%20local%20system%2C%20which%20he%20will%20not%20see%29%5Cr%5Cn%5Cr%5CnTHis%20would%20close%20%23838%22%2C%20%22created_at%22%3A%20%222017-11-08T12%3A18%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23841%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/d6f608ee43ee41107888bb880c8f10e842fa75da%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6095%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23841%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%20%2095.3%25%20%20%2095.3%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015542%20%20%2015550%20%20%20%20%20%20%20%2B8%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2014813%20%20%2014820%20%20%20%20%20%20%20%2B7%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20729%20%20%20%20%20730%20%20%20%20%20%20%20%2B1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/motptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9tb3RwdG9rZW4ucHk%3D%29%20%7C%20%6096.1%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokenclass.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk%3D%29%20%7C%20%6098.92%25%20%3C100%25%3E%20%28-0.01%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/hotptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/federationhandler.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9mZWRlcmF0aW9uaGFuZGxlci5weQ%3D%3D%29%20%7C%20%6098.48%25%20%3C90.9%25%3E%20%28-1.52%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bd6f608e...3f51728%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/841%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-11-08T13%3A03%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20checked%3A%5Cr%5Cn%5Cr%5CnWe%20can%20have%20the%20first%20handler%5Cr%5Cn%5Cr%5Cn%2A%20token_init%2C%20token-handler%2C%20delete%20%28which%20deletes%20the%20newly%20created%20local%20token%29%5Cr%5Cn%2A%20token_init%2C%20federation-handler%2C%20forward%20%28which%20creates%20a%20token%20on%20the%20remote%20machine%29%5Cr%5Cn%5Cr%5CnFunny%20thing%2C%20works%20like%20a%20charm%20%3A-%29%22%2C%20%22created_at%22%3A%20%222017-11-09T12%3A17%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tried%20this%2C%20and%20indeed%20that%27s%20pretty%20cool%21%5Cr%5CnI%20just%20noticed%20that%20the%20event%20handler%20order%20is%20important%3A%20For%20me%2C%20this%20only%20worked%20if%20the%20order%20value%20of%20the%20federation%20event%20handler%20is%20greater%20than%20the%20order%20value%20of%20the%20delete%20event%20handler.%5Cr%5Cn%5Cr%5CnThe%20solution%20of%20forwarding%20%60%60/token/init%60%60%20and%20having%20the%20delete%20handler%20to%20locally%20delete%20the%20token%20%2Afeels%2A%20a%20bit%20hacky%20to%20me.%20But%20well%2C%20even%20forwarding%20%60%60/token/disable%60%60%20etc%20works%20with%20this%2C%20so%20this%20might%20actually%20be%20an%20elegant%20solution%20%3A-%29%5Cr%5Cn%5Cr%5CnOne%20side-effect%20is%20that%20the%20two%20privacyIDEA%20installations%20need%20to%20use%20the%20same%20JWT%20secret%20key%20for%20this%20to%20work.%20I%27m%20not%20sure%20if%20this%20is%20desirable%3F%22%2C%20%22created_at%22%3A%20%222017-11-09T14%3A22%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20regards%20to%20deleting%20locally%20and%20the%20order.%20The%20event%20handler%20is%20simply%20a%20very%20generic%20way%20to%20do%20anything.%20So%20for%20me%20it%20sounds%20ok%2C%20that%20a%20token%20needs%20to%20be%20deleted%20locally...%5Cr%5Cn%5Cr%5CnYou%20are%20right%20about%20the%20JWT.%5Cr%5CnWell%2C%20if%20we%20do%20not%20use%20the%20same%20JWT%20we%20would%20need%20an%20additional%20new%20authentication.%20And%20then%20we%20either%5Cr%5Cna%29%20need%20to%20fetch%20the%20password%20and%20authenticate%20anew%20or%5Cr%5Cnb%29%20store/cache%20the%20password.%5Cr%5Cn%5Cr%5CnAnd%20sind%20the%20forwarding%20does%20not%20only%20work%20for%20an%20administrator%20but%20is%20also%20supposed%20to%20work%20for%20%2Aany%2A%20user%20-%20how%20should%20we%20handle%20authentication%20anyway%3F%5Cr%5Cn%5Cr%5CnThe%20interesting%20thing%20is%2C%20if%20you%20also%20forward%20%5C%22GET%20/token/%5C%22%20this%20way%20you%20can%20set%20up%20a%20remote%20self%20service%20portal%2C%20which%20will%20only%20forward%20all%20user-specific%20actions%20and%20store%20no%20token%20information%20itself.%22%2C%20%22created_at%22%3A%20%222017-11-09T14%3A36%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/841#issuecomment-342801164'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier I would like to discuss this.
Using this change we are able to define event handlers, which issue the same command on the remote server. This also works for Requests, which need an authorization token like the admin who is enrolling a token or a user, who is viewing his own token.
The problem in contrast to all other event handlers is, that it changes the response for the user.
THe user _sees_ the tokens from the remote system.
THe user _creates_ a token on the remote system (but also on the local system, which he will not see)
THis would close #838
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=h1) Report
> Merging [#841](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/d6f608ee43ee41107888bb880c8f10e842fa75da?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `95%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/841/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=tree)
```diff
@@            Coverage Diff            @@
##           master    #841      +/-   ##
=========================================
- Coverage    95.3%   95.3%   -0.01%
=========================================
Files         126     126
Lines       15542   15550       +8
=========================================
+ Hits        14813   14820       +7
- Misses        729     730       +1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/motptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9tb3RwdG9rZW4ucHk=) | `96.1% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokenclass.py](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk=) | `98.92% <100%> (-0.01%)` | :arrow_down: |
| [privacyidea/lib/tokens/hotptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/eventhandler/federationhandler.py](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9mZWRlcmF0aW9uaGFuZGxlci5weQ==) | `98.48% <90.9%> (-1.52%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=footer). Last update [d6f608e...3f51728](https://codecov.io/gh/privacyidea/privacyidea/pull/841?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I just checked:
We can have the first handler
* token_init, token-handler, delete (which deletes the newly created local token)
* token_init, federation-handler, forward (which creates a token on the remote machine)
Funny thing, works like a charm :-)
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I tried this, and indeed that's pretty cool!
I just noticed that the event handler order is important: For me, this only worked if the order value of the federation event handler is greater than the order value of the delete event handler.
The solution of forwarding ``/token/init`` and having the delete handler to locally delete the token *feels* a bit hacky to me. But well, even forwarding ``/token/disable`` etc works with this, so this might actually be an elegant solution :-)
One side-effect is that the two privacyIDEA installations need to use the same JWT secret key for this to work. I'm not sure if this is desirable?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> In regards to deleting locally and the order. The event handler is simply a very generic way to do anything. So for me it sounds ok, that a token needs to be deleted locally...
You are right about the JWT.
Well, if we do not use the same JWT we would need an additional new authentication. And then we either
a) need to fetch the password and authenticate anew or
b) store/cache the password.
And sind the forwarding does not only work for an administrator but is also supposed to work for *any* user - how should we handle authentication anyway?
The interesting thing is, if you also forward "GET /token/" this way you can set up a remote self service portal, which will only forward all user-specific actions and store no token information itself.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/841?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/841?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/841'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>