### PR TITLE
Fix offline OTP counter

### DIFF
--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -145,7 +145,7 @@ class MachineApplication(MachineApplicationBase):
                 # token_obj.enable(False)
                 # increase the counter by the consumed values and
                 # also store it in tokeninfo.
-                token_obj.inc_otp_counter(counter=count)
+                token_obj.inc_otp_counter(increment=count)
                 token_obj.add_tokeninfo(key="offline_counter",
                                         value=count)
                 ret["response"] = otps

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1097,23 +1097,27 @@ class TokenClass(object):
 
     @log_with(log)
     @check_token_locked
-    def inc_otp_counter(self, counter=None, reset=True):
+    def inc_otp_counter(self, counter=None, increment=1, reset=True):
         """
         Increase the otp counter and store the token in the database
-        :param counter: the new counter value. If counter is given, than
-                        the counter is increased by (counter+1)
-                        If the counter is not given, the counter is increased
-                        by +1
+
+        Before increasing the token.count the token.count can be set using the
+        parameter counter.
+
+        :param counter: if given, the token counter is first set to counter and then
+                increased by increment
         :type counter: int
+        :param increment: increase the counter by this amount
+        :type increment: int
         :param reset: reset the failcounter if set to True
         :type reset: bool
         :return: the new counter value
         """
         reset_counter = False
         if counter:
-            self.token.count = counter + 1
-        else:
-            self.token.count += 1
+            self.token.count = counter
+
+        self.token.count += increment
 
         if reset is True and get_from_config("DefaultResetFailCount") == "True":
             reset_counter = True

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -493,7 +493,7 @@ class HotpTokenClass(TokenClass):
             return ret
 
         ret = True
-        self.inc_otp_counter(counter + 1, True)
+        self.inc_otp_counter(counter + 1, reset=True)
 
         log.debug("end. resync was successful: ret: {0!r}".format((ret)))
         return ret

--- a/tests/test_lib_applications.py
+++ b/tests/test_lib_applications.py
@@ -131,6 +131,15 @@ class OfflineApplicationTestCase(MyTestCase):
         # 2, because we used the otp value with count = 2 initially
         # 100, because we obtained 100 offline OTPs
         self.assertEqual(tok.token.count, 1 + 2 + 100)
+        # Assert that we cannot authenticate with the last offline OTP we got
+        self.assertEqual(len(auth_item.get("response")), 100)
+        self.assertTrue(passlib.hash.\
+                        pbkdf2_sha512.verify("629694", # count = 102
+                                             auth_item.get("response").get(99)))
+        res = tok.check_otp("629694") # count = 102
+        self.assertEqual(res, -1)
+        res = tok.check_otp("378717")  # count = 103
+        self.assertEqual(res, 103)
 
     def test_03_get_auth_item_unsupported(self):
         # unsupported token type

--- a/tests/test_lib_applications.py
+++ b/tests/test_lib_applications.py
@@ -127,10 +127,9 @@ class OfflineApplicationTestCase(MyTestCase):
                         pbkdf2_sha512.verify("399871", # count = 8
                                              auth_item.get("response").get(5)))
         # After calling auth_item the token counter should be increased
-        # 1, because the counter initially points to 1
-        # 2, because we used the otp value with count = 2 initially
+        # 3, because we used the otp value with count = 2 initially
         # 100, because we obtained 100 offline OTPs
-        self.assertEqual(tok.token.count, 1 + 2 + 100)
+        self.assertEqual(tok.token.count, 3 + 100)
         # Assert that we cannot authenticate with the last offline OTP we got
         self.assertEqual(len(auth_item.get("response")), 100)
         self.assertTrue(passlib.hash.\


### PR DESCRIPTION
Closes #840
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149953103%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23issuecomment-343152708%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149980757%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149980554%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149985740%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149985998%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149986199%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23issuecomment-343152708%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23842%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/730e9d0c3f3454fc665cf713a411e3397c015025%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842/graphs/tree.svg%3Fheight%3D150%26width%3D650%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23842%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%20%2095.3%25%20%20%2095.29%25%20%20%20-0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015542%20%20%20%2015542%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2014813%20%20%20%2014810%20%20%20%20%20%20%20-3%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20729%20%20%20%20%20%20732%20%20%20%20%20%20%20%2B3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/hotptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/applications/offline.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2FwcGxpY2F0aW9ucy9vZmZsaW5lLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokenclass.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk%3D%29%20%7C%20%6098.92%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.27%25%20%3C0%25%3E%20%28-2.53%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B730e9d0...c366786%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/842%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-11-09T13%3A22%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c3667864b2c2c6143af244f840bbf0fcdc0fe60d%20privacyidea/lib/tokens/hotptoken.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149980554%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%20%20%20%20self.inc_otp_counter%28reset%3DTrue%29%5Cr%5Cn%5Cr%5Cnshould%20also%20work.%22%2C%20%22created_at%22%3A%20%222017-11-09T14%3A45%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20I%20am.%20Wrong.%20I%20could%20be%20the%20not%20latest%20OTP%20value.%20Thanks%21%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-11-09T15%3A03%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/hotptoken.py%3AL493-500%22%7D%2C%20%22Pull%20c3667864b2c2c6143af244f840bbf0fcdc0fe60d%20tests/test_api_lib_policy.py%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149953103%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20the%20count%20should%20be%20at%20100%20rather%20than%20101%20here%3A%5Cr%5CnWe%20use%20a%20fresh%20token%20which%20is%20created%20with%20%60count%20%3D%200%60.%20Then%2C%20we%20obtain%20100%20offline%20OTPs.%20Thus%2C%20the%20resulting%20%60count%60%20value%20should%20be%20100.%22%2C%20%22created_at%22%3A%20%222017-11-09T12%3A55%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20token.count%20in%20the%20database%20is%20the%20next%20value%2C%20that%20the%20user%20is%20allowed%20to%20use%21%20Not%20the%20last%20value%2C%20which%20was%20used%20by%20the%20user%21%5Cr%5Cn%5Cr%5CnI.e.%20if%20the%20%60%60token.count%60%60%20is%20%20set%20ot%200%20initially%2C%20then%20the%20user%20can%20use%20count%3D0%20and%20%20%60%60token.count%60%60%20will%20be%20set%20to%201.%5Cr%5Cn%5Cr%5CnSo%20if%20the%20offline%20token%20issues%20100%20values...%20are%20these%20the%20values%200..99%3F%20%5Cr%5CnThen%20the%20last%20value%2C%20which%20the%20user%20can%20use%20is%20the%20value%2099%20and%20if%20he%20does%20so%20the%20%60%60token.count%60%60%20will%20be%20set%20in%20the%20database%20to%20100.%20100%20would%20be%20the%20next%20OTP%20value%2C%20which%20would%20be%20accepted%2C%20but%20which%20is%20%2A%2Anot%2A%2A%20contained%20on%20the%20list.%5Cr%5Cn%5Cr%5CnYou%20can%20check%20this%20with%20the%20PAPER%20token.%5Cr%5CnI%20am%20not%20sure%2C%20why%20it%20is%20set%20to%20101%2C%20it%20should%20happen%20here%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/pull/842/files%23diff-c32ef9ce1beb3a0a39d033ecdc356ca0R148%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-11-09T14%3A46%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oops%20yes%2C%20this%20testcase%20is%20confusing%3A%20In%20reality%2C%20the%20user%20uses%20%60count%3D0%60%20%28i.e.%20OTP%20%5C%22287082%5C%22%29%20to%20request%20100%20offline%20OTPs%2C%20so%20the%20counter%20would%20indeed%20be%20%60count%3D101%60%20after%20that.%5Cr%5CnHowever%2C%20this%20testcase%20does%20not%20actually%20invoke%20the%20%60%60/validate/check%60%60%20endpoint%2C%20but%20only%20the%20%60%60offline_info%60%60%20function%2C%20so%20%5C%22287082%5C%22%20is%20not%20actually%20consumed.%5Cr%5CnI%20should%20probably%20extend%20the%20%60%60test_12_auth_items_offline%60%60%20testcase%20in%20%60%60test_api_machines.py%60%60%20so%20that%20we%20have%20a%20real%20API-level%20testcase%20for%20the%20offline%20OTP.%22%2C%20%22created_at%22%3A%20%222017-11-09T15%3A04%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_api_lib_policy.py%3AL1598-1614%22%7D%2C%20%22Pull%20c3667864b2c2c6143af244f840bbf0fcdc0fe60d%20tests/test_api_lib_policy.py%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/842%23discussion_r149985740%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ah%2C%20ok.%20THanks%21%22%2C%20%22created_at%22%3A%20%222017-11-09T15%3A02%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_api_lib_policy.py%3AL1598-1614%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull c3667864b2c2c6143af244f840bbf0fcdc0fe60d tests/test_api_lib_policy.py 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/842#discussion_r149953103'>File: tests/test_api_lib_policy.py:L1598-1614</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think the count should be at 100 rather than 101 here:
We use a fresh token which is created with `count = 0`. Then, we obtain 100 offline OTPs. Thus, the resulting `count` value should be 100.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The token.count in the database is the next value, that the user is allowed to use! Not the last value, which was used by the user!
I.e. if the ``token.count`` is  set ot 0 initially, then the user can use count=0 and  ``token.count`` will be set to 1.
So if the offline token issues 100 values... are these the values 0..99?
Then the last value, which the user can use is the value 99 and if he does so the ``token.count`` will be set in the database to 100. 100 would be the next OTP value, which would be accepted, but which is **not** contained on the list.
You can check this with the PAPER token.
I am not sure, why it is set to 101, it should happen here:
https://github.com/privacyidea/privacyidea/pull/842/files#diff-c32ef9ce1beb3a0a39d033ecdc356ca0R148
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Oops yes, this testcase is confusing: In reality, the user uses `count=0` (i.e. OTP "287082") to request 100 offline OTPs, so the counter would indeed be `count=101` after that.
However, this testcase does not actually invoke the ``/validate/check`` endpoint, but only the ``offline_info`` function, so "287082" is not actually consumed.
I should probably extend the ``test_12_auth_items_offline`` testcase in ``test_api_machines.py`` so that we have a real API-level testcase for the offline OTP.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/842#issuecomment-343152708'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=h1) Report
> Merging [#842](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/730e9d0c3f3454fc665cf713a411e3397c015025?src=pr&el=desc) will **decrease** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/842/graphs/tree.svg?height=150&width=650&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #842      +/-   ##
==========================================
- Coverage    95.3%   95.29%   -0.02%
==========================================
Files         126      126
Lines       15542    15542
==========================================
- Hits        14813    14810       -3
- Misses        729      732       +3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/hotptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/applications/offline.py](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2FwcGxpY2F0aW9ucy9vZmZsaW5lLnB5) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokenclass.py](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk=) | `98.92% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.27% <0%> (-2.53%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=footer). Last update [730e9d0...c366786](https://codecov.io/gh/privacyidea/privacyidea/pull/842?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull c3667864b2c2c6143af244f840bbf0fcdc0fe60d privacyidea/lib/tokens/hotptoken.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/842#discussion_r149980554'>File: privacyidea/lib/tokens/hotptoken.py:L493-500</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> self.inc_otp_counter(reset=True)
should also work.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> No I am. Wrong. I could be the not latest OTP value. Thanks!
- [ ] <a href='#crh-comment-Pull c3667864b2c2c6143af244f840bbf0fcdc0fe60d tests/test_api_lib_policy.py 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/842#discussion_r149985740'>File: tests/test_api_lib_policy.py:L1598-1614</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Ah, ok. THanks!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/842?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/842?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/842'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>