### PR TITLE
833/rotate

### DIFF
--- a/doc/audit/index.rst
+++ b/doc/audit/index.rst
@@ -53,28 +53,50 @@ Cleaning based on the config file:
 .. index:: retention time
 
 Using a config file you can define different retention times for the audit data.
-E.g. this way you can define, that audit entries about token listings can be deleted after one month,
+E.g. this way you can define, that audit entries about token listings can be deleted after
+one month,
 while the audit information about token creation will only deleted after ten years.
 
 The config file is a YAML format and looks like this:
 
-   - ["POST /token/init.*", "3650"] # Save creation and deletion of tokens for 10 years
-   - ["DELETE /token/.*", "3650"]
-   - ["POST /validate.*", 1825] # Save authentication REQUESTS for 5 years
-   - ["GET /validate.*", 1825] # Save authentication REQUESTS for 5 years
-   - ["POST .*", 750] # Save all POST Reqeusts for 25 months
-   - ["DELETE .*", 1825] # Save all DELETE Requests for 5 years
-   - ["GET .*", "30"]  # Only keep GET requests for 30 days!
-   - [".*", 180] # Everything else for half a year
+    # DELETE auth requests of nils after 10 days
+    - rotate: 10
+      user: nils
+      action: .*/validate/check.*
+
+    # DELETE auth requests of friedricha after 7 days
+    - rotate: 7
+      user: friedrich
+      action: .*/validate/check.*
+
+    # Delete nagios user test auth directly
+    - rotate: 0
+      user: nagiosuser
+      action: POST /validate/check.*
+
+    # Delete token listing after one month
+    - rotate: 30
+      action: ^GET /token
+
+    # Delete audit logs for token creating after 10 years
+    - rotate: 3650
+      action: POST /token/init
+
+    # Delete everything else after 6 months
+    - rotate: 180
+      action: .*
 
 This is a list of rules.
-Each rule has a regular expression for the audit action and an integer, for how many days the specified
-audit log entry should be saved.
+privacyIDEA iterates over *all* audit entries. The first matching rule for an entry wins.
+If the rule matches, the audit entry is deleted if the entry is older than the days
+specified in "rotate".
 
-Note that the order of the list matters. If the action matches an entry, this rule is applied and
-the list is exited.
-In the example the rule in the list is a kind of a catch all entry. If there was no other rule,
-that matched, the entry will be deleted after 5 months.
+If is a good idea to have a *catch-all* rule at the end.
+
+.. note:: The keys "user", "action"... correspond to the column names of the audit table.
+   You can use any column name here like "date", "action", "action_detail", "success", "serial", "administrator",
+   "user", "realm"... for a complete list see the model definition.
+   You may use Python regular expressions for matching.
 
 You can the add a call like
 

--- a/doc/audit/index.rst
+++ b/doc/audit/index.rst
@@ -57,14 +57,14 @@ E.g. this way you can define, that audit entries about token listings can be del
 one month,
 while the audit information about token creation will only deleted after ten years.
 
-The config file is a YAML format and looks like this:
+The config file is a YAML format and looks like this::
 
     # DELETE auth requests of nils after 10 days
     - rotate: 10
       user: nils
       action: .*/validate/check.*
 
-    # DELETE auth requests of friedricha after 7 days
+    # DELETE auth requests of friedrich after 7 days
     - rotate: 7
       user: friedrich
       action: .*/validate/check.*

--- a/pi-manage
+++ b/pi-manage
@@ -592,6 +592,7 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
         with open(config, 'r') as f:
             Config = yaml.load(f)
         auditlogs = session.query(LogEntry).all()
+        delete_list = []
         for log in auditlogs:
             print("investigating log entry {0!s}".format(log.id))
             for rule in Config:
@@ -620,10 +621,15 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
                         # Delete it!
                         print(" + Deleting {0!s} due to rule {1!s}".format(log.id, rule))
                         # Delete it
-                        session.query(LogEntry.id).filter(LogEntry.id == log.id).delete()
+                        delete_list.append(log.id)
                     # skip all other rules and go to the next log entry
                     break
-        session.commit()
+        if dryrun:
+            print("If you only would let me I would clean up {0!s} entries!".format(len(delete_list)))
+        else:
+            print("Cleaning up {0!s} entries.".format(len(delete_list)))
+            engine.execute(LogEntry.__table__.delete().where(LogEntry.id.in_(delete_list)))
+            session.commit()
 
     elif age:
         now = datetime.datetime.now() - datetime.timedelta(days=age)

--- a/pi-manage
+++ b/pi-manage
@@ -574,13 +574,7 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
         raise Exception("We only rotate SQL audit module. You are using %s" %
                         audit_module)
     if config:
-        actions = Audit.query.with_entities(Audit.action).distinct().all()
-        actions = [x[0] for x in actions if x[0]]
-        print("Actions in the log:")
-        for action in actions:
-            print("- action: {0!s}\n"
-                  "  rotate: 3650".format(action))
-        print("There are {0!s} different actions in the audit log.".format(len(actions)))
+        print("Cleaning up with config file.")
     elif age:
         age = int(age)
         print("Cleaning up with age: %s. %s" % (age, audit_db_uri))
@@ -597,24 +591,39 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
     if config:
         with open(config, 'r') as f:
             Config = yaml.load(f)
-        # clean up every action
-        for rule in Config:
-            age = int(rule.get("rotate"))
-            now = datetime.datetime.now() - datetime.timedelta(days=age)
-            sqlquery = session.query(LogEntry.date).\
-                filter(LogEntry.date < now)
-            # add further conditions:
-            for key in rule.keys():
-                if key not in ["rotate"]:
-                    sqlquery = sqlquery.filter(getattr(LogEntry, key).like(rule.get(key)))
-            if dryrun:
-                r = len(sqlquery.all())
-            else:
-                r = sqlquery.delete()
-                session.commit()
-            print("{0!s} entries deleted due to {1!s}.".format(r, rule))
-            # leave the rule set!
-            break
+        auditlogs = session.query(LogEntry).all()
+        for log in auditlogs:
+            print("investigating log entry {0!s}".format(log.id))
+            for rule in Config:
+                age = int(rule.get("rotate"))
+                rotate_date = datetime.datetime.now() - datetime.timedelta(days=age)
+
+                match = False
+                for key in rule.keys():
+                    if key not in ["rotate"]:
+                        search_value = rule.get(key)
+                        print(" + searching for {0!r} in {1!s}".format(search_value, getattr(LogEntry, key)))
+                        audit_value = getattr(log, key) or ""
+                        m = re.search(search_value, audit_value)
+                        if m:
+                            # it matches!
+                            print(" + -- found {0!r}".format(audit_value))
+                            match = True
+                        else:
+                            # It does not match, we continue to next rule
+                            print(" + NO MATCH - SKIPPING rest of conditions!")
+                            match = False
+                            break
+
+                if match:
+                    if log.date < rotate_date:
+                        # Delete it!
+                        print(" + Deleting {0!s} due to rule {1!s}".format(log.id, rule))
+                        # Delete it
+                        session.query(LogEntry.id).filter(LogEntry.id == log.id).delete()
+                    # skip all other rules and go to the next log entry
+                    break
+        session.commit()
 
     elif age:
         now = datetime.datetime.now() - datetime.timedelta(days=age)

--- a/pi-manage
+++ b/pi-manage
@@ -578,7 +578,8 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
         actions = [x[0] for x in actions if x[0]]
         print("Actions in the log:")
         for action in actions:
-            print("- [{0!s}, '']".format(action))
+            print("- action: {0!s}\n"
+                  "  rotate: 3650".format(action))
         print("There are {0!s} different actions in the audit log.".format(len(actions)))
     elif age:
         age = int(age)
@@ -597,22 +598,23 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
         with open(config, 'r') as f:
             Config = yaml.load(f)
         # clean up every action
-        for action in actions:
-            for rule in Config:
-                if re.search(rule[0], action):
-                    age = int(rule[1])
-                    now = datetime.datetime.now() - datetime.timedelta(days=age)
-                    sqlquery = session.query(LogEntry.date).\
-                        filter(LogEntry.action == action).\
-                        filter(LogEntry.date < now)
-                    if dryrun:
-                        r = len(sqlquery.all())
-                    else:
-                        r = sqlquery.delete()
-                        session.commit()
-                    print("{0!s} entries of action {1!s} deleted due to {2!s}.".format(r, action, rule))
-                    # leave the rule set!
-                    break
+        for rule in Config:
+            age = int(rule.get("rotate"))
+            now = datetime.datetime.now() - datetime.timedelta(days=age)
+            sqlquery = session.query(LogEntry.date).\
+                filter(LogEntry.date < now)
+            # add further conditions:
+            for key in rule.keys():
+                if key not in ["rotate"]:
+                    sqlquery = sqlquery.filter(getattr(LogEntry, key).like(rule.get(key)))
+            if dryrun:
+                r = len(sqlquery.all())
+            else:
+                r = sqlquery.delete()
+                session.commit()
+            print("{0!s} entries deleted due to {1!s}.".format(r, rule))
+            # leave the rule set!
+            break
 
     elif age:
         now = datetime.datetime.now() - datetime.timedelta(days=age)


### PR DESCRIPTION
I add this as a pull request, so that we can start closing it.

Closes #833
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/843%23issuecomment-343201961%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/843%23issuecomment-343202505%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/48c68480a89177ebc33d2d8b9322923dc85db5ba%23commitcomment-25516270%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/843%23issuecomment-343475161%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/843%23issuecomment-343476802%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/843%23issuecomment-343482369%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/843%23discussion_r150253923%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/843%23discussion_r150255170%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/843%23issuecomment-343201961%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23843%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/a3a92a236a91a8bf7a7dd5a88bafbfb72d5a456c%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23843%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.29%25%20%20%2095.3%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015542%20%20%2015526%20%20%20%20%20%20-16%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2014811%20%20%2014797%20%20%20%20%20%20-14%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20731%20%20%20%20%20729%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/subscriptions.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk%3D%29%20%7C%20%6086.32%25%20%3C0%25%3E%20%28-0.46%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokenclass.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk%3D%29%20%7C%20%6098.92%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/federationhandler.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9mZWRlcmF0aW9uaGFuZGxlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/subscriptions.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3N1YnNjcmlwdGlvbnMucHk%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/smsprovider/HttpSMSProvider.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Ntc3Byb3ZpZGVyL0h0dHBTTVNQcm92aWRlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%2B1.96%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Ba3a92a2...48c6848%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/843%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-11-09T16%3A04%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20think%20that%20deleting%20a%20list%20of%20specifc%20database%20rows%20in%20the%20end%20will%20be%20faster%3F%5Cr%5CnTHis%20would%20be%20still%20the%20same%20amount%20of%20database%20queries%21%22%2C%20%22created_at%22%3A%20%222017-11-09T16%3A05%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20quickly%20tried%20to%20store%20the%20IDs%20to%20delete%20in%20a%20list%20%60%60to_delete%60%60%20and%20then%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%20%20%20%20stmt%20%3D%20LogEntry.__table__.delete%28%29.where%28LogEntry.id.in_%28to_delete%29%29%5Cr%5Cn%20%20%20%20%20%20%20%20engine.execute%28stmt%29%5Cr%5Cn%20%20%20%20%20%20%20%20session.commit%28%29%5Cr%5Cn%60%60%60%5Cr%5CnAnd%20this%20was%20pretty%20fast%20%3A%29%20I%20think%20this%20should%20also%20give%20the%20same%20results.%5Cr%5Cn%5Cr%5CnOh%2C%20and%20I%20think%20that%20%5C%22dry%20run%5C%22%20does%20not%20work%20when%20using%20the%20config%20file.%22%2C%20%22created_at%22%3A%20%222017-11-10T13%3A37%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20this%20sounds%20promising%21%20I%20will%20implement%20this%20and%20update%20the%20PR%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-11-10T13%3A44%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nice%21%20Well%2C%20currently%20I%20only%20have%20a%20small%20audit%20log%2C%20but%20it%20works%20an%20seems%20pretty%20fast...%22%2C%20%22created_at%22%3A%20%222017-11-10T14%3A07%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205a1ea446a768bb500edc99f372dad99272d70e0d%20doc/audit/index.rst%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/843%23discussion_r150253923%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hm%2C%20shouldn%27t%20we%20use%20%60looks%20like%20this%3A%3A%60%20if%20a%20code%20snippet%20follows%3F%22%2C%20%22created_at%22%3A%20%222017-11-10T14%3A53%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20always%20a%20bit%20confused%20by%20that%21%22%2C%20%22created_at%22%3A%20%222017-11-10T14%3A57%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/audit/index.rst%3AL53-103%22%7D%2C%20%22Commit%2048c68480a89177ebc33d2d8b9322923dc85db5ba%20pi-manage%2066%20623%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/48c68480a89177ebc33d2d8b9322923dc85db5ba%23commitcomment-25516270%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40fredreichbier%20I%20am%20not%20sure%2C%20if%20this%20will%20work%20out.%20You%20will%20end%20up%20with%20a%20list%20of%20arbitrary%20%60%60id%60%60%27s.%20You%20will%20have%20to%20issue%20as%20many%20dedicated%20SQL%20delete%20statements%20as%20before.%22%2C%20%22created_at%22%3A%20%222017-11-09T20%3A12%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL623%20%2848c6848%29%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/843#issuecomment-343201961'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=h1) Report
> Merging [#843](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/a3a92a236a91a8bf7a7dd5a88bafbfb72d5a456c?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/843/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=tree)
```diff
@@            Coverage Diff            @@
##           master    #843      +/-   ##
=========================================
+ Coverage   95.29%   95.3%   +<.01%
=========================================
Files         126     126
Lines       15542   15526      -16
=========================================
- Hits        14811   14797      -14
+ Misses        731     729       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/subscriptions.py](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk=) | `86.32% <0%> (-0.46%)` | :arrow_down: |
| [privacyidea/lib/tokenclass.py](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk=) | `98.92% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/eventhandler/federationhandler.py](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9mZWRlcmF0aW9uaGFuZGxlci5weQ==) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/api/subscriptions.py](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3N1YnNjcmlwdGlvbnMucHk=) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/smsprovider/HttpSMSProvider.py](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Ntc3Byb3ZpZGVyL0h0dHBTTVNQcm92aWRlci5weQ==) | `100% <0%> (+1.96%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=footer). Last update [a3a92a2...48c6848](https://codecov.io/gh/privacyidea/privacyidea/pull/843?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Do you think that deleting a list of specifc database rows in the end will be faster?
THis would be still the same amount of database queries!
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I quickly tried to store the IDs to delete in a list ``to_delete`` and then
```
stmt = LogEntry.__table__.delete().where(LogEntry.id.in_(to_delete))
engine.execute(stmt)
session.commit()
```
And this was pretty fast :) I think this should also give the same results.
Oh, and I think that "dry run" does not work when using the config file.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Oh, this sounds promising! I will implement this and update the PR
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Nice! Well, currently I only have a small audit log, but it works an seems pretty fast...
- [x] <a href='#crh-comment-Commit 48c68480a89177ebc33d2d8b9322923dc85db5ba pi-manage 66 623'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/48c68480a89177ebc33d2d8b9322923dc85db5ba#commitcomment-25516270'>File: pi-manage:L623 (48c6848)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier I am not sure, if this will work out. You will end up with a list of arbitrary ``id``'s. You will have to issue as many dedicated SQL delete statements as before.
- [ ] <a href='#crh-comment-Pull 5a1ea446a768bb500edc99f372dad99272d70e0d doc/audit/index.rst 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/843#discussion_r150253923'>File: doc/audit/index.rst:L53-103</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, shouldn't we use `looks like this::` if a code snippet follows?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I am always a bit confused by that!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/843?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/843?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/843'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>