### PR TITLE
Fixes #834: Only remove apache host definitions on first installation

### DIFF
--- a/deploy/debian-ubuntu/privacyidea-apache2.postinst
+++ b/deploy/debian-ubuntu/privacyidea-apache2.postinst
@@ -95,6 +95,7 @@ create_database() {
 }
 
 enable_apache() {
+    if [ ! -h /etc/apache2/sites-enabled/privacyidea.conf ]; then
         rm -f /etc/apache2/sites-enabled/*
         a2enmod wsgi
         a2enmod headers
@@ -102,6 +103,7 @@ enable_apache() {
         a2ensite privacyidea
         ln -s /etc/ssl/certs/privacyideaserver.pem /etc/ssl/certs/privacyidea-bundle.crt || true
         ln -s /etc/ssl/private/privacyideaserver.key /etc/ssl/private/privacyidea.key || true
+    fi
 }
 
 update_db() {

--- a/deploy/debian-ubuntu/privacyidea-apache2.postrm
+++ b/deploy/debian-ubuntu/privacyidea-apache2.postrm
@@ -12,11 +12,12 @@ if [ -f /usr/share/dbconfig-common/dpkg/postinst.pgsql  ]; then
 fi
 
 unset_sites () {
-	rm -f /etc/apache2/sites-enabled/privacyidea.conf
+    if [ ! "upgrade" = "$1" ]; then
+        rm -f /etc/apache2/sites-enabled/privacyidea.conf
+    fi
 }
 
-
-unset_sites
+unset_sites $1
 
 
 #DEBHELPER#


### PR DESCRIPTION
The key is that postrm gets called on upgrade. In that case we don't remove the link.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/844%23issuecomment-343488303%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/844%23issuecomment-343492868%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/844%23issuecomment-343494595%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/844%23issuecomment-343488303%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20a%20lot.%5Cr%5CnThis%20seems%20to%20work%20reliably.%20Maybe%20I%20had%20problems%20before%20due%20to%20the%20missing%20%2Aupdate%2A%20condition.%5Cr%5Cn%5Cr%5CnWell%20-%20I%20am%20wondering%2C%20if%20this%20is%20really%20the%20behaviour%20you%20want%21%20%3B-%29%5Cr%5Cn%5Cr%5CnIf%20you%20for%20any%20reason%20%2A%2Adisable%2A%2A%20%20the%20privacyidea%20site%20and%20then%20run%20an%20update%20of%20privacyidea-apache2%2C%20then%20the%20privacyidea%20site%20will%20be%20enabled%20and%20all%20other%20sites%20will%20be%20disabled%20again.%5Cr%5Cn%40jean-gui%20What%20do%20you%20think%3F%5Cr%5Cn%5Cr%5CnNevertheless%20it%20is%20still%20more%20convenient%20now%2C%20then%20before...%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-11-10T14%3A32%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20still%20think%20that%20the%20package%20shouldn%27t%20remove%20files%20installed%20by%20other%20means%20%28manually%20or%20other%20packages%29.%5Cr%5Cn%5Cr%5CnI%20think%20it%27s%20ok%20to%20have%20the%20package%20reinstall%20the%20symlink%20and%20remove%20other%20sites%20if%20you%20disabled%20the%20symlink%20previously.%20If%20you%20mess%20with%20a%20package%2C%20the%20package%20will%20mess%20with%20you%20%3A%29.%20It%27s%20the%20same%20for%20any%20package%3A%20if%20you%20modify%20a%20packaged%20file%2C%20the%20next%20upgrade%20will%20at%20best%20ask%20you%20to%20resolve%20a%20conflict%20and%20at%20worst%20revert%20your%20changes.%22%2C%20%22created_at%22%3A%20%222017-11-10T14%3A49%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1479073%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jean-gui%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20I%20take%20this%20as%20%5C%22I%20am%20fine%20this%20this%5C%22%20%3B-%29%22%2C%20%22created_at%22%3A%20%222017-11-10T14%3A56%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/844#issuecomment-343488303'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Thanks a lot.
This seems to work reliably. Maybe I had problems before due to the missing *update* condition.
Well - I am wondering, if this is really the behaviour you want! ;-)
If you for any reason **disable**  the privacyidea site and then run an update of privacyidea-apache2, then the privacyidea site will be enabled and all other sites will be disabled again.
@jean-gui What do you think?
Nevertheless it is still more convenient now, then before...
- <a href='https://github.com/jean-gui'><img border=0 src='https://avatars3.githubusercontent.com/u/1479073?v=4' height=16 width=16></a> I still think that the package shouldn't remove files installed by other means (manually or other packages).
I think it's ok to have the package reinstall the symlink and remove other sites if you disabled the symlink previously. If you mess with a package, the package will mess with you :). It's the same for any package: if you modify a packaged file, the next upgrade will at best ask you to resolve a conflict and at worst revert your changes.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> So I take this as "I am fine this this" ;-)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/844?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/844?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/844'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>