### PR TITLE
Return more information of tokentype

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -76,6 +76,11 @@ for the RADIUS server.
    The authentication request of users without a token is forwarded to the
    specified RADIUS server.
 
+.. note:: The passthru policy overrides the authorization policy
+   for :ref:`tokentype_policy`. I.e. a user may authenticate due
+   to the passthru    policy (since he has no token)
+   although a tokentype policy is active!
+
 .. warning:: If the user has the right to delete his
    tokens in selfservice portal, the user could 
    delete all his tokens and then authenticate with

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -204,14 +204,13 @@ def check_tokentype(request, response):
         resolver=user_object.resolver,
         realm=user_object.realm,
         client=g.client_ip)
-    if allowed_tokentypes:
-        if not tokentype or (tokentype not in allowed_tokentypes):
-            # If we have tokentype policies, but either no tokentypes
-            # or the tokentype is not allowed, we raise an exception
-            g.audit_object.log({"success": False,
-                                'action_detail': "Tokentype {0!r} not allowed for "
-                                                 "authentication".format(tokentype)})
-            raise PolicyError("Tokentype not allowed for authentication!")
+    if tokentype and allowed_tokentypes and tokentype not in allowed_tokentypes:
+        # If we have tokentype policies, but
+        # the tokentype is not allowed, we raise an exception
+        g.audit_object.log({"success": False,
+                            'action_detail': "Tokentype {0!r} not allowed for "
+                                             "authentication".format(tokentype)})
+        raise PolicyError("Tokentype not allowed for authentication!")
     return response
 
 

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2016,6 +2016,10 @@ def check_token_list(tokenobject_list, passw, user=None, options=None):
             if token_obj.check_all(message_list):
                 # The token is active and the auth counters are ok.
                 res = True
+                if not reply_dict.get("type"):
+                    reply_dict["type"] = token_obj.token.tokentype
+                if reply_dict["type"] != token_obj.token.tokentype:
+                    reply_dict["type"] = "undetermined"
                 # reset the failcounter of valid token
                 try:
                     token_obj.reset()

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1227,7 +1227,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
         jresult = json.loads(r.data)
         self.assertTrue(jresult.get("result").get("value"))
 
-    def test_01_check_tokentype_no_type(self):
+    def test_01_check_undetermined_tokentype(self):
         # If there is a tokentype policy but the type can not be
         # determined, authentication fails.
         builder = EnvironBuilder(method='POST',
@@ -1245,7 +1245,8 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                           "value": True},
                "version": "privacyIDEA test",
                "id": 1,
-               "detail": {"message": "matching 2 tokens"}}
+               "detail": {"message": "matching 2 tokens",
+                          "type": "undetermined"}}
         resp = Response(json.dumps(res))
 
         # Set a policy, that does not allow the tokentype


### PR DESCRIPTION
and thus resolve the clash between
tokentype policy, multiple tokens and
passthru policy.

Closes #846
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/847%23issuecomment-344301075%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/847%23issuecomment-344931666%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/847%23issuecomment-345163473%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/847%23issuecomment-345172335%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/847%23issuecomment-344301075%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23847%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/7a4dba4f97a2e385c906cedf1b141fcf17c3c159%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23847%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.29%25%20%20%2095.31%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015551%20%20%20%2015554%20%20%20%20%20%20%20%2B3%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2014820%20%20%20%2014826%20%20%20%20%20%20%20%2B6%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20731%20%20%20%20%20%20728%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6095.95%25%20%3C100%25%3E%20%28-0.02%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6094.52%25%20%3C100%25%3E%20%28%2B0.02%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.79%25%20%3C0%25%3E%20%28%2B2.52%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B7a4dba4...c113a3b%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/847%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-11-14T15%3A47%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20PR%20looks%20good%20to%20me%21%20Just%20to%20be%20sure%20I%20understand%20correctly%20--%20this%20changes%20two%20things%3A%5Cr%5Cn%2A%20If%20the%20user%20is%20authenticated%20with%20not%20only%20one%2C%20but%20two%20tokens%2C%20the%20response%20now%20contains%20a%20%60%60type%60%60%20value.%20If%20the%20two%20tokens%20are%20of%20the%20same%20type%2C%20this%20type%20is%20written%20to%20the%20response.%20If%20the%20two%20tokens%20are%20of%20different%20types%2C%20the%20type%20is%20%60%60undetermined%60%60.%20This%20case%20is%20highly%20unlikely%2C%20but%20it%20could%20e.g.%20happen%20if%20the%20user%20has%20a%20HOTP%20token%20and%20a%20SPASS%20token%20with%20PIN%20%60%60HOTP-PIN%20%2B%20HOTP-OTP%60%60.%5Cr%5Cn%2A%20The%20tokentype%20policy%20doesn%27t%20throw%20an%20error%20anymore%20if%20the%20user%20is%20authenticated%20with%20no%20token%20at%20all.%20This%20resolves%20a%20conflict%20between%20the%20tokentype%20and%20the%20passthrough%20policy.%5Cr%5Cn%5Cr%5CnPlease%20correct%20me%20if%20I%27m%20wrong%21%22%2C%20%22created_at%22%3A%20%222017-11-16T14%3A03%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%221.%20Yes.%20It%20is%20to%20be%20noted%2C%20that%20the%20respnose%20contains%20the%20%2Atype%2A%20if%20the%20authentication%20was%20successful%20with%20%2Aone%2A%20token.%20The%20problem%20was%2C%20that%20if%20the%20user%20authenticated%20successfully%20with%20two%20tokens%20%28like%20having%20two%20spass%20tokens%20with%20the%20same%20password%29%20the%20authentication%20was%20successful%2C%20but%20it%20would%20contain%20no%20type.%20This%20is%20why%20the%20check_policy%20would%20not%20work%20correctly.%5Cr%5CnSo%20now%20the%20response%20will%20always%20contain%20the%20%2Atype%2A%20in%20case%20of%20a%20successful%20authentication%3A%5Cr%5Cn%20%20%20%2A%201%20token%20that%20matches%20-%3E%20destinct%20token%20type%5Cr%5Cn%20%20%20%2A%20several%20tokens%20of%20the%20same%20type%20-%3E%20destinct%20token%20type%5Cr%5Cn%20%20%20%2A%20several%20tokens%20of%20different%20type%20-%3E%20%60%60type%3Dundetermined%60%60.%5Cr%5Cn%5Cr%5Cn2.%20The%20%60%60check_tokentype%60%60%20was%20changed%20in%202f1357412f9bfeae8e7e0c8a9e54175960e7d87d%2C%20to%20cope%20with%20the%20originial%20problem.%20This%20is%20where%20I%20added%20the%20condition%20%5C%22throw%20an%20exception%5C%22%2C%20if%20the%20response%20does%20not%20contain%20a%20type.%20The%20problem%20then%20was%2C%20that%20if%20the%20policy%20would%20say%3A%20%5C%22use%20spass%5C%22%2C%20and%20the%20user%20has%20two%20spass%20tokens%2C%20the%20response%20would%20contain%20no%20tokentype%20and%20the%20PolicyError%20would%20be%20raised.%20This%20was%20wrong.%20So%20I%20changed%20the%20policy%20condition%20back%20to%20the%20orignial%20condition%20and%20assured%20in%20the%20first%20place%2C%20that%20a%20successful%20authentication%20response%20will%20contain%20%2Aany%2A%20of%20the%20above%20mentioned%20tokentypes.%22%2C%20%22created_at%22%3A%20%222017-11-17T07%3A09%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20clarification%21%22%2C%20%22created_at%22%3A%20%222017-11-17T08%3A01%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/847#issuecomment-344301075'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=h1) Report
> Merging [#847](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/7a4dba4f97a2e385c906cedf1b141fcf17c3c159?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/847/graphs/tree.svg?token=7nHLZki60B&src=pr&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #847      +/-   ##
==========================================
+ Coverage   95.29%   95.31%   +0.02%
==========================================
Files         126      126
Lines       15551    15554       +3
==========================================
+ Hits        14820    14826       +6
+ Misses        731      728       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `95.95% <100%> (-0.02%)` | :arrow_down: |
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `94.52% <100%> (+0.02%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.79% <0%> (+2.52%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=footer). Last update [7a4dba4...c113a3b](https://codecov.io/gh/privacyidea/privacyidea/pull/847?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> The PR looks good to me! Just to be sure I understand correctly -- this changes two things:
* If the user is authenticated with not only one, but two tokens, the response now contains a ``type`` value. If the two tokens are of the same type, this type is written to the response. If the two tokens are of different types, the type is ``undetermined``. This case is highly unlikely, but it could e.g. happen if the user has a HOTP token and a SPASS token with PIN ``HOTP-PIN + HOTP-OTP``.
* The tokentype policy doesn't throw an error anymore if the user is authenticated with no token at all. This resolves a conflict between the tokentype and the passthrough policy.
Please correct me if I'm wrong!
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> 1. Yes. It is to be noted, that the respnose contains the *type* if the authentication was successful with *one* token. The problem was, that if the user authenticated successfully with two tokens (like having two spass tokens with the same password) the authentication was successful, but it would contain no type. This is why the check_policy would not work correctly.
So now the response will always contain the *type* in case of a successful authentication:
* 1 token that matches -> destinct token type
* several tokens of the same type -> destinct token type
* several tokens of different type -> ``type=undetermined``.
2. The ``check_tokentype`` was changed in 2f1357412f9bfeae8e7e0c8a9e54175960e7d87d, to cope with the originial problem. This is where I added the condition "throw an exception", if the response does not contain a type. The problem then was, that if the policy would say: "use spass", and the user has two spass tokens, the response would contain no tokentype and the PolicyError would be raised. This was wrong. So I changed the policy condition back to the orignial condition and assured in the first place, that a successful authentication response will contain *any* of the above mentioned tokentypes.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Thanks for the clarification!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/847?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/847?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/847'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>