### PR TITLE
797/2step totp

### DIFF
--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -115,7 +115,7 @@ class HotpTokenClass(TokenClass):
         desc_two_step_user =_('Specify whether users are allowed or forced to use '
                               'two-step enrollment.')
         desc_two_step_admin = _('Specify whether admins are allowed or forced to use '
-                               'two-step enrollment.')
+                                'two-step enrollment.')
         res = {'type': 'hotp',
                'title': 'HOTP Event Token',
                'description': _('HOTP: Event based One Time Passwords.'),
@@ -138,8 +138,8 @@ class HotpTokenClass(TokenClass):
                        },
                        'hotp_2step_difficulty': {
                            'type': 'int',
-                           'dewsc': _("The difficulty factor used for the OTP seed generation "
-                                      "(should be at least 10000)")
+                           'desc': _("The difficulty factor used for the OTP seed generation "
+                                     "(should be at least 10000)")
                        }
                    },
                    SCOPE.USER: {

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -2,6 +2,8 @@
 #
 #  (c) 2015 Cornelius Kölbel - cornelius@privacyidea.org
 #
+#  2017-12-01 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Add policy for 2step
 #  2016-04-29 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add get_default_settings to change the parameters before
 #             the token is created
@@ -56,6 +58,7 @@ keylen = {'sha1': 20,
           }
 
 log = logging.getLogger(__name__)
+
 
 class TotpTokenClass(HotpTokenClass):
 
@@ -112,29 +115,51 @@ class TotpTokenClass(HotpTokenClass):
                'user': ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy': {'user': {
-                   'totp_timestep': {'type': 'int',
-                                     'value': [30, 60],
-                                     'desc': 'Specify the time step of '
-                                             'the timebased OTP token.'},
-                   'totp_hashlib': {'type': 'str',
-                                    'value': ["sha1",
-                                              "sha256",
-                                              "sha512"],
-                                    'desc': 'Specify the hashlib to be used. '
-                                            'Can be SHA1, SHA256 or SHA512.'},
-                   'totp_otplen': {'type': 'int',
-                                   'value': [6, 8],
-                                   'desc': "Specify the OTP length to be "
-                                           "used."},
-                   'totp_force_server_generate': {'type': 'bool',
-                                                  'desc': _("Force the key to "
-                                                            "be generated on "
-                                                            "the server.")}
-                                          },
-                          },
+               'policy': {
+                   SCOPE.USER: {
+                       'totp_timestep': {'type': 'int',
+                                         'value': [30, 60],
+                                         'desc': 'Specify the time step of '
+                                                 'the timebased OTP token.'},
+                       'totp_hashlib': {'type': 'str',
+                                        'value': ["sha1",
+                                                  "sha256",
+                                                  "sha512"],
+                                        'desc': 'Specify the hashlib to be used. '
+                                                'Can be SHA1, SHA256 or SHA512.'},
+                       'totp_otplen': {'type': 'int',
+                                       'value': [6, 8],
+                                       'desc': "Specify the OTP length to be "
+                                               "used."},
+                       'totp_force_server_generate': {'type': 'bool',
+                                                      'desc': _("Force the key to "
+                                                                "be generated on "
+                                                                "the server.")},
+                       '2step': {'type': 'str',
+                                 'value': ['allow', 'force'],
+                                 'desc': _('Specify whether users are allowed or '
+                                           'forced to use two-step enrollment.')}
+                   },
+                   SCOPE.ADMIN: {
+                       '2step': {'type': 'str',
+                                 'value': ['allow', 'force'],
+                                 'desc': _('Specify whether admins are allowed or '
+                                           'forced to use two-step enrollment.')
+                                 }
+                   },
+                   SCOPE.ENROLL: {
+                       '2step_clientsize': {'type': 'int',
+                                            'desc': _("The size of the OTP seed part contributed "
+                                                      "by the client (in bytes)")},
+                       '2step_serversize': {'type': 'int',
+                                            'desc': _("The size of the OTP seed part "
+                                                      "contributed by the server (in bytes)")},
+                       '2step_difficulty': {'type': 'int',
+                                            'desc': _("The difficulty factor used for the "
+                                                      "OTP seed generation ""(should be at least 10000)")}
+                   }
+               },
                }
-
         if key:
             ret = res.get(key, {})
         else:
@@ -146,7 +171,7 @@ class TotpTokenClass(HotpTokenClass):
     @log_with(log)
     def update(self, param, reset_failcount=True):
         """
-        This is called during initializaton of the token
+        This is called during initialization of the token
         to add additional attributes to the token object.
 
         :param param: dict of initialization parameters

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -321,6 +321,8 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
             for (var tkey in $scope.formInit.tokenTypes) {
                 // set the first key to be the default tokentype
                 $scope.form.type = tkey;
+                // Set the 2step enrollment value
+                $scope.setTwostepEnrollmentDefault();
                 break;
             }
         }

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -390,6 +390,7 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
             "otpkey": $scope.clientpart.replace(/ /g, ""),
             "otpkeyformat": "base32check",
             "serial": $scope.enrolledToken.serial,
+            "type": $scope.form.type
         };
         TokenFactory.enroll($scope.newUser, params, function (data) {
             $scope.clientpart = "";

--- a/privacyidea/static/components/token/views/token.enroll.totp.html
+++ b/privacyidea/static/components/token/views/token.enroll.totp.html
@@ -23,6 +23,13 @@ The TOTP token is a time based token. You can paste a secret key or
         </p>
     </div>
 </div>
+<div class="form-group"
+     ng-show="checkRight('totp_2step=allow') || (!$state.includes('token.wizard') && checkRight('totp_2step=force'))">
+    <input type="checkbox" ng-model="form['2stepinit']"
+           ng-disabled="checkRight('totp_2step=force')"
+           name="twostep_enrollment" id="twostep_enrollment">
+    <label for="twostep_enrollment" translate>Use two-step enrollment with the privacyIDEA Authenticator App</label>
+</div>
 <div class="form-group" ng-hide="form.genkey">
     <label for="otpkey" translate>OTP Key</label>
     <input type="text" ng-pattern="/^[0-9a-fA-F]*$/"

--- a/privacyidea/static/components/token/views/token.enrolled.totp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.totp.html
@@ -1,8 +1,9 @@
 <div class="row">
-    <div class="col-sm-6">
-        <img width="{{ qrCodeWidth }}" src="{{ enrolledToken.googleurl.img }}"/>
+    <div class="col-sm-6" ng-hide="form['2stepinit'] && enrolledToken.rollout_state !== 'clientwait'">
+        <img width="{{ qrCodeWidth }}"
+             src="{{ enrolledToken.googleurl.img }}"/>
     </div>
-    <div class="col-sm-6" ng-hide="$state.includes('token.wizard')">
+    <div class="col-sm-6" ng-hide="$state.includes('token.wizard') || form['2stepinit']">
         <accordion close-others="oneAtATime">
             <accordion-group heading="{{ 'The OTP key'|translate }}">
                 {{ enrolledToken.otpkey.value }}
@@ -22,5 +23,20 @@
         <button ng-click="regenerateToken()" class="btn btn-warning" translate>
             Regenerate QR Code
         </button>
+    </div>
+    <div class="col-sm-4 pull-right" ng-show="form['2stepinit'] && enrolledToken.rollout_state === 'clientwait'">
+        <p translate>
+            Please scan the QR code with the privacyIDEA authenticator app and enter
+            the generated code below.
+        </p>
+        <div class="form-group">
+            <label for="clientpart" translate>Client Part</label>
+            <input type="text" ng-model="$parent.clientpart"
+                   autofocus
+                   class="form-control"
+                   name="clientpart">
+            <button type="button" ng-click="sendClientPart()"
+                    class="btn btn-primary" translate>Submit</button>
+        </div>
     </div>
 </div>

--- a/tests/test_api_2stepinit.py
+++ b/tests/test_api_2stepinit.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import binascii
 import base64
+import time
 
 from passlib.utils.pbkdf2 import pbkdf2
 
@@ -390,3 +391,239 @@ class TwoStepInitTestCase(MyTestCase):
             self.assertEqual(result.get("value"), True)
 
         delete_policy("disallow_twostep")
+
+    def test_04_init_totp_token(self):
+        set_policy(
+            name="allow_2step",
+            action=["totp_2step=allow", "enrollTOTP=1", "delete"],
+            scope=SCOPE.ADMIN,
+        )
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "totp",
+                                                 "genkey": "1",
+                                                 "2stepinit": "1"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertTrue(result.get("status") is True, result)
+            self.assertTrue(result.get("value") is True, result)
+            detail = json.loads(res.data).get("detail")
+            serial = detail.get("serial")
+            otpkey_url = detail.get("otpkey", {}).get("value")
+            server_component = binascii.unhexlify(otpkey_url.split("/")[2])
+            google_url = detail["googleurl"]["value"]
+            self.assertIn('2step_difficulty=10000', google_url)
+            self.assertIn('2step_salt=8', google_url)
+            self.assertIn('2step_output=20', google_url)
+            self.assertEqual(detail['2step_difficulty'], 10000)
+            self.assertEqual(detail['2step_salt'], 8)
+            self.assertEqual(detail['2step_output'], 20)
+
+        client_component = "VRYSECRT"
+        checksum = hashlib.sha1(client_component).digest()[:4]
+        base32check_client_component = base64.b32encode(checksum + client_component).strip("=")
+
+        # Try to do a 2stepinit on a second step will raise an error
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "totp",
+                                                 "2stepinit": "1",
+                                                 "serial": serial,
+                                                 "otpkey": base32check_client_component,
+                                                 "otpkeyformat": "base32check"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400)
+            result = json.loads(res.data).get("result")
+            self.assertIn('2stepinit is only to be used in the first initialization step',
+                          result.get("error").get("message"))
+
+        # Invalid base32check will raise an error
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "totp",
+                                                 "2stepinit": "1",
+                                                 "serial": serial,
+                                                 "otpkey": "A" + base32check_client_component[1:],
+                                                 "otpkeyformat": "base32check"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400)
+            result = json.loads(res.data).get("result")
+            self.assertIn('Malformed base32check data: Incorrect checksum',
+                          result.get("error").get("message"))
+
+        # Authentication does not work yet!
+        wrong_otp_value = HmacOtp().generate(key=server_component, counter=int(time.time()/30))
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"serial": serial,
+                                                 "pass": wrong_otp_value}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data)
+            self.assertTrue(result.get("result").get("status"))
+            self.assertFalse(result.get("result").get("value"))
+            self.assertEqual(result.get("detail").get("message"),
+                         u'matching 1 tokens, Token is disabled')
+
+        # Now doing the correct 2nd step
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "totp",
+                                                 "serial": serial,
+                                                 "otpkey": base32check_client_component,
+                                                 "otpkeyformat": "base32check"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertTrue(result.get("status") is True, result)
+            self.assertTrue(result.get("value") is True, result)
+            detail = json.loads(res.data).get("detail")
+            otpkey_url = detail.get("otpkey", {}).get("value")
+            otpkey = otpkey_url.split("/")[2]
+            self.assertNotIn('2step', detail)
+
+        # Now try to authenticate
+        otpkey_bin = binascii.unhexlify(otpkey)
+        otp_value = HmacOtp().generate(key=otpkey_bin, counter=int(time.time()/30))
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"serial": serial,
+                                                 "pass": otp_value}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(result.get("status"), True)
+            self.assertEqual(result.get("value"), True)
+
+        # Check that the OTP key is what we expected it to be
+        expected_secret = pbkdf2(binascii.hexlify(server_component), client_component, 10000, 20)
+        self.assertEqual(otpkey_bin, expected_secret)
+
+        with self.app.test_request_context('/token/'+ serial,
+                                           method='DELETE',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+        delete_policy("allow_2step")
+
+    def test_05_force_totp_parameters(self):
+        set_policy(
+            name="force_twostep",
+            action=["totp_2step=force", "enrollTOTP=1", "delete"],
+            scope=SCOPE.ADMIN,
+        )
+        set_policy(
+            name="2step_params",
+            action=["totp_2step_difficulty=12345",
+                    "totp_2step_serversize=33",
+                    "totp_2step_clientsize=11"],
+            scope=SCOPE.ENROLL,
+        )
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "totp",
+                                                 "genkey": "1",
+                                                 "2stepinit": "0", # will be forced nevertheless
+                                                 "2step_serversize": "3",
+                                                 "2step_clientsize": "4",
+                                                 "2step_difficulty": "33333"
+                                                 },
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertTrue(result.get("status") is True, result)
+            self.assertTrue(result.get("value") is True, result)
+            detail = json.loads(res.data).get("detail")
+            serial = detail.get("serial")
+            otpkey_url = detail.get("otpkey", {}).get("value")
+            server_component = binascii.unhexlify(otpkey_url.split("/")[2])
+            google_url = detail["googleurl"]["value"]
+            self.assertIn('2step_difficulty=12345', google_url)
+            self.assertIn('2step_salt=11', google_url)
+            self.assertIn('2step_output=20', google_url)
+        # Authentication does not work yet!
+        wrong_otp_value = HmacOtp().generate(key=server_component, counter=int(time.time()/30))
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"serial": serial,
+                                                 "pass": wrong_otp_value}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data)
+            self.assertTrue(result.get("result").get("status"))
+            self.assertFalse(result.get("result").get("value"))
+            self.assertEqual(result.get("detail").get("message"),
+                         u'matching 1 tokens, Token is disabled')
+
+        client_component = "wrongsize" # 9 bytes
+        hex_client_component = binascii.hexlify(client_component)
+
+        # Supply a client secret of incorrect size
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "totp",
+                                                 "serial": serial,
+                                                 "otpkey": hex_client_component,
+                                                 },
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 400, res)
+            result = json.loads(res.data).get("result")
+            self.assertFalse(result.get("status"))
+
+        client_component = "correctsize" # 11 bytes
+        hex_client_component = binascii.hexlify(client_component)
+
+        # Now doing the correct 2nd step
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "totp",
+                                                 "serial": serial,
+                                                 "otpkey": hex_client_component,
+                                                 "2step_serversize": "3", # will have no effect
+                                                 "2step_clientsize": "4",
+                                                 "2step_difficulty": "33333"
+                                                 },
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertTrue(result.get("status") is True, result)
+            self.assertTrue(result.get("value") is True, result)
+            detail = json.loads(res.data).get("detail")
+            otpkey_url = detail.get("otpkey", {}).get("value")
+            otpkey = otpkey_url.split("/")[2]
+
+        # Now try to authenticate
+        otpkey_bin = binascii.unhexlify(otpkey)
+        otp_value = HmacOtp().generate(key=otpkey_bin, counter=int(time.time()/30))
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"serial": serial,
+                                                 "pass": otp_value}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(result.get("status"), True)
+            self.assertEqual(result.get("value"), True)
+
+        # Check serversize
+        self.assertEqual(len(server_component), 33)
+        # Check that the OTP key is what we expected it to be
+        expected_secret = pbkdf2(binascii.hexlify(server_component), client_component, 12345, 20)
+        self.assertEqual(otpkey_bin, expected_secret)
+
+        with self.app.test_request_context('/token/'+ serial,
+                                           method='DELETE',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+
+        delete_policy("force_twostep")
+        delete_policy("twostep_params")


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/861%23issuecomment-348511418%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/861%23issuecomment-348955480%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/861%23issuecomment-348511418%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23861%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/650a11a03dc9517c6cc3c3cf4cb8c27e70fe7048%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861/graphs/tree.svg%3Fheight%3D150%26width%3D650%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23861%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.35%25%20%20%2095.35%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015694%20%20%20%2015694%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2014965%20%20%20%2014965%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20729%20%20%20%20%20%20729%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/hotptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk%3D%29%20%7C%20%60100%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/totptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90b3RwdG9rZW4ucHk%3D%29%20%7C%20%6098.82%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B650a11a...766d1bd%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/861%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-12-01T14%3A40%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22PR%20looks%20good%20to%20me%21%20However%2C%202-step%20enrollment%20of%20TOTP%20tokens%20via%20WebUI%20does%20not%20work%20for%20me%3A%20After%20having%20entered%20the%20client%20secret%2C%20the%20following%20error%20is%20displayed%3A%5Cr%5Cn%60%60%60%5Cr%5Cntoken%20u%27TOTP0005FED1%27%20already%20exist%20with%20type%20u%27totp%27.%20Can%20not%20initialize%20token%20with%20new%20type%20%27hotp%27%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cnwhich%20is%20caused%20by%20%60%60init_token%60%60%20%28%5Bsee%20here%5D%28https%3A//github.com/privacyidea/privacyidea/blob/39dca1819c097a15c217aba78129b3f690142f4e/privacyidea/lib/token.py%23L890%29%29.%20Our%20second%20HTTP%20request%20does%20not%20supply%20the%20token%20type%2C%20so%20it%20is%20assumed%20to%20be%20%5C%22hotp%5C%22%2C%20which%20is%20not%20equal%20to%20the%20type%20of%20the%20token%20object.%5Cr%5Cn%5Cr%5CnI%27ll%20fix%20this.%22%2C%20%22created_at%22%3A%20%222017-12-04T13%3A00%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/861#issuecomment-348511418'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/861?src=pr&el=h1) Report
> Merging [#861](https://codecov.io/gh/privacyidea/privacyidea/pull/861?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/650a11a03dc9517c6cc3c3cf4cb8c27e70fe7048?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/861/graphs/tree.svg?height=150&width=650&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/861?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master     #861   +/-   ##
=======================================
Coverage   95.35%   95.35%
=======================================
Files         126      126
Lines       15694    15694
=======================================
Hits        14965    14965
Misses        729      729
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/861?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/hotptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/861/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk=) | `100% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/totptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/861/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90b3RwdG9rZW4ucHk=) | `98.82% <ø> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/861?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/861?src=pr&el=footer). Last update [650a11a...766d1bd](https://codecov.io/gh/privacyidea/privacyidea/pull/861?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> PR looks good to me! However, 2-step enrollment of TOTP tokens via WebUI does not work for me: After having entered the client secret, the following error is displayed:
```
token u'TOTP0005FED1' already exist with type u'totp'. Can not initialize token with new type 'hotp'
```
which is caused by ``init_token`` ([see here](https://github.com/privacyidea/privacyidea/blob/39dca1819c097a15c217aba78129b3f690142f4e/privacyidea/lib/token.py#L890)). Our second HTTP request does not supply the token type, so it is assumed to be "hotp", which is not equal to the type of the token object.
I'll fix this.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/861?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/861?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/861'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>