### PR TITLE
TOTP/HOTP 2step enrollment: Don't overwrite parameters with default values

### DIFF
--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -295,7 +295,7 @@ class HotpTokenClass(TokenClass):
         if val is not None:
             hashlibStr = val
         else:
-            hashlibStr = 'sha1'
+            hashlibStr = self.hashlib
 
         # check if the key_size is provided
         # if not, we could derive it from the hashlib
@@ -315,13 +315,7 @@ class HotpTokenClass(TokenClass):
         # raised here.
         TokenClass.update(self, upd_param, reset_failcount)
 
-        # add_tokeninfo and set_otplen save the token object to the database.
         self.add_tokeninfo("hashlib", hashlibStr)
-        val = getParam(upd_param, "otplen", optional)
-        if val is not None:
-            self.set_otplen(int(val))
-        else:
-            self.set_otplen(get_from_config("DefaultOtpLen", 6))
 
     @property
     def hashlib(self):

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -181,18 +181,12 @@ class TotpTokenClass(HotpTokenClass):
         """
         HotpTokenClass.update(self, param, reset_failcount=reset_failcount)
 
-        timeStep = param.get("timeStep",
-                             get_from_config("totp.timeStep") or 30)
-
-        timeWindow = param.get("timeWindow",
-                               get_from_config("totp.timeWindow") or 180)
-
-        timeShift = param.get("timeShift",
-                              get_from_config("totp.timeShift") or 0)
+        timeStep = param.get("timeStep", self.timestep)
+        timeWindow = param.get("timeWindow", self.timewindow)
+        timeShift = param.get("timeShift", self.timeshift)
         # we support various hashlib methods, but only on create
         # which is effectively set in the update
-        hashlibStr = param.get("hashlib", get_from_config("totp.hashlib",
-                                                          u'sha1'))
+        hashlibStr = param.get("hashlib", self.hashlib)
 
         self.add_tokeninfo("timeWindow", timeWindow)
         self.add_tokeninfo("timeShift", timeShift)

--- a/tests/test_api_2stepinit.py
+++ b/tests/test_api_2stepinit.py
@@ -143,7 +143,7 @@ class TwoStepInitTestCase(MyTestCase):
 
     def test_02_force_parameters(self):
         set_policy(
-            name="force_twostep",
+            name="force_2step",
             action=["hotp_2step=force", "enrollHOTP=1", "delete"],
             scope=SCOPE.ADMIN,
         )
@@ -255,10 +255,10 @@ class TwoStepInitTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
 
-        delete_policy("force_twostep")
-        delete_policy("twostep_params")
+        delete_policy("force_2step")
+        delete_policy("2step_params")
 
-    def test_02_custom_parameters(self):
+    def test_03_custom_parameters(self):
         set_policy(
             name="enrollhotp",
             action=["enrollHOTP=1", "delete", "hotp_2step=allow"],
@@ -351,9 +351,9 @@ class TwoStepInitTestCase(MyTestCase):
 
         delete_policy("enrollhotp")
 
-    def test_03_no_2stepinit(self):
+    def test_04_no_2stepinit(self):
         set_policy(
-            name="disallow_twostep",
+            name="disallow_2step",
             action=["enrollHOTP=1", "delete"], # no 2step policy => disallow by default
             scope=SCOPE.ADMIN,
         )
@@ -377,6 +377,7 @@ class TwoStepInitTestCase(MyTestCase):
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey_bin = binascii.unhexlify(otpkey_url.split("/")[2])
+            self.assertEqual(detail.get("rollout_state"), "")
 
         # Now try to authenticate
         otp_value = HmacOtp().generate(key=otpkey_bin, counter=1)
@@ -390,9 +391,9 @@ class TwoStepInitTestCase(MyTestCase):
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
-        delete_policy("disallow_twostep")
+        delete_policy("disallow_2step")
 
-    def test_04_init_totp_token(self):
+    def test_05_init_totp_token(self):
         set_policy(
             name="allow_2step",
             action=["totp_2step=allow", "enrollTOTP=1", "delete"],
@@ -511,9 +512,9 @@ class TwoStepInitTestCase(MyTestCase):
             self.assertTrue(res.status_code == 200, res)
         delete_policy("allow_2step")
 
-    def test_05_force_totp_parameters(self):
+    def test_06_force_totp_parameters(self):
         set_policy(
-            name="force_twostep",
+            name="force_2step",
             action=["totp_2step=force", "enrollTOTP=1", "delete"],
             scope=SCOPE.ADMIN,
         )
@@ -625,5 +626,5 @@ class TwoStepInitTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
 
-        delete_policy("force_twostep")
-        delete_policy("twostep_params")
+        delete_policy("force_2step")
+        delete_policy("2step_params")

--- a/tests/test_lib_tokens_totp.py
+++ b/tests/test_lib_tokens_totp.py
@@ -457,7 +457,8 @@ class TOTPTokenTestCase(MyTestCase):
         res = token.get_multi_otp()
         self.assertTrue(res[0] is False, res)
         token.update({"otpkey": self.otpkey,
-                      "otplen": 6})
+                      "otplen": 6,
+                      "timeShift": 0})
         token.token.count = 0
         res = token.get_multi_otp(count=5)
         self.assertTrue(res[0], res)


### PR DESCRIPTION
This should fix #863. I've also added some comments.

However, I'm not sure if this is the way to go: These are changes to a pretty central section of privacyIDEA and I suspect there may be unwanted side-effects. Maybe we should fix #863 differently and modify only the WebUI (such that it re-sends all parameters in the second ``/token/init`` request)?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041028%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041084%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041107%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041116%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041117%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041131%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26045352%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26045413%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26045422%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26045423%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/864%23issuecomment-349131255%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/864%23issuecomment-349136303%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/864%23issuecomment-349131255%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good%20to%20me.%20%3A-%29%5Cr%5CnDo%20the%20tests%2C%20I%20added%20make%20sense%20to%20you%3F%22%2C%20%22created_at%22%3A%20%222017-12-04T22%3A41%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23864%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/42ac5b5c8e5aa2abd6e921faa6b46e638d705222%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23864%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.34%25%20%20%2095.35%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015696%20%20%20%2015692%20%20%20%20%20%20%20-4%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2014965%20%20%20%2014963%20%20%20%20%20%20%20-2%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20731%20%20%20%20%20%20729%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/hotptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/totptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90b3RwdG9rZW4ucHk%3D%29%20%7C%20%6098.82%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.79%25%20%3C0%25%3E%20%28%2B1.68%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B42ac5b5...738dca2%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/864%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-12-04T23%3A03%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%2045a7bf34616e26dcc7d6608a7dd3bfaa214832aa%20privacyidea/lib/tokens/totptoken.py%2019%20189%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041131%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20is%20with%20the%20get_from_config%3F%22%2C%20%22created_at%22%3A%20%222017-12-04T19%3A21%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22same%20above%22%2C%20%22created_at%22%3A%20%222017-12-04T22%3A39%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/totptoken.py%3AL189%20%2845a7bf3%29%22%7D%2C%20%22Commit%2045a7bf34616e26dcc7d6608a7dd3bfaa214832aa%20privacyidea/lib/tokens/totptoken.py%2014%20186%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041117%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22same%20as%20above%22%2C%20%22created_at%22%3A%20%222017-12-04T19%3A20%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/totptoken.py%3AL186%20%2845a7bf3%29%22%7D%2C%20%22Commit%2045a7bf34616e26dcc7d6608a7dd3bfaa214832aa%20privacyidea/lib/tokens/totptoken.py%2012%20184%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041107%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22But%20were%20is%20the%20%60%60get_from_config%60%60%20and%20the%20%60%6030%60%60%20gone%3F%5Cr%5Cn%5Cr%5CnIf%20totp.timeStep%20in%20the%20config%20is%20set%20to%2060%20this%20will%20fail.%22%2C%20%22created_at%22%3A%20%222017-12-04T19%3A20%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20I%20understand.%20The%20property%20provides%20the%20get_from_config%20and%20the%2030%20automatically.%22%2C%20%22created_at%22%3A%20%222017-12-04T22%3A39%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/totptoken.py%3AL184%20%2845a7bf3%29%22%7D%2C%20%22Commit%2045a7bf34616e26dcc7d6608a7dd3bfaa214832aa%20privacyidea/lib/tokens/hotptoken.py%2019%20324%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041084%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20could%20add%20some%20tests%20in%20api_token%20with%20setting%20different%20OTPlen.%5Cr%5CnTHen%20we%20would%20know%21%20%3B-%29%5Cr%5Cn%5Cr%5Cn1.%20DefaultOtpLen%20%3D%208%20without%20otplen%20in%20the%20API%20call%5Cr%5Cn2.%20DefaultOtpLen%20%3D%206%20with%20otplen%3D8%20in%20the%20API%20call%5Cr%5Cn%5Cr%5CnI%20very%20much%20appreciate%2C%20if%20we%20can%20drop%20this%20redundant%20code.%22%2C%20%22created_at%22%3A%20%222017-12-04T19%3A19%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done.%22%2C%20%22created_at%22%3A%20%222017-12-04T22%3A35%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/hotptoken.py%3AL324%20%2845a7bf3%29%22%7D%2C%20%22Commit%2045a7bf34616e26dcc7d6608a7dd3bfaa214832aa%20privacyidea/lib/tokens/totptoken.py%2013%20185%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041116%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22same%20as%20above%22%2C%20%22created_at%22%3A%20%222017-12-04T19%3A20%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22same%20above%22%2C%20%22created_at%22%3A%20%222017-12-04T22%3A39%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/totptoken.py%3AL185%20%2845a7bf3%29%22%7D%2C%20%22Commit%2045a7bf34616e26dcc7d6608a7dd3bfaa214832aa%20privacyidea/lib/tokens/hotptoken.py%205%20298%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa%23commitcomment-26041028%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22perfect.%22%2C%20%22created_at%22%3A%20%222017-12-04T19%3A16%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/hotptoken.py%3AL298%20%2845a7bf3%29%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Commit 45a7bf34616e26dcc7d6608a7dd3bfaa214832aa privacyidea/lib/tokens/hotptoken.py 5 298'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa#commitcomment-26041028'>File: privacyidea/lib/tokens/hotptoken.py:L298 (45a7bf3)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> perfect.
- [x] <a href='#crh-comment-Commit 45a7bf34616e26dcc7d6608a7dd3bfaa214832aa privacyidea/lib/tokens/hotptoken.py 19 324'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa#commitcomment-26041084'>File: privacyidea/lib/tokens/hotptoken.py:L324 (45a7bf3)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We could add some tests in api_token with setting different OTPlen.
THen we would know! ;-)
1. DefaultOtpLen = 8 without otplen in the API call
2. DefaultOtpLen = 6 with otplen=8 in the API call
I very much appreciate, if we can drop this redundant code.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done.
- [x] <a href='#crh-comment-Commit 45a7bf34616e26dcc7d6608a7dd3bfaa214832aa privacyidea/lib/tokens/totptoken.py 12 184'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa#commitcomment-26041107'>File: privacyidea/lib/tokens/totptoken.py:L184 (45a7bf3)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> But were is the ``get_from_config`` and the ``30`` gone?
If totp.timeStep in the config is set to 60 this will fail.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Oh, I understand. The property provides the get_from_config and the 30 automatically.
- [x] <a href='#crh-comment-Commit 45a7bf34616e26dcc7d6608a7dd3bfaa214832aa privacyidea/lib/tokens/totptoken.py 13 185'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa#commitcomment-26041116'>File: privacyidea/lib/tokens/totptoken.py:L185 (45a7bf3)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> same as above
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> same above
- [x] <a href='#crh-comment-Commit 45a7bf34616e26dcc7d6608a7dd3bfaa214832aa privacyidea/lib/tokens/totptoken.py 14 186'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa#commitcomment-26041117'>File: privacyidea/lib/tokens/totptoken.py:L186 (45a7bf3)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> same as above
- [x] <a href='#crh-comment-Commit 45a7bf34616e26dcc7d6608a7dd3bfaa214832aa privacyidea/lib/tokens/totptoken.py 19 189'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/45a7bf34616e26dcc7d6608a7dd3bfaa214832aa#commitcomment-26041131'>File: privacyidea/lib/tokens/totptoken.py:L189 (45a7bf3)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> what is with the get_from_config?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> same above
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/864#issuecomment-349131255'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Looks good to me. :-)
Do the tests, I added make sense to you?
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/864?src=pr&el=h1) Report
> Merging [#864](https://codecov.io/gh/privacyidea/privacyidea/pull/864?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/42ac5b5c8e5aa2abd6e921faa6b46e638d705222?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/864/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/864?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #864      +/-   ##
==========================================
+ Coverage   95.34%   95.35%   +0.01%
==========================================
Files         126      126
Lines       15696    15692       -4
==========================================
- Hits        14965    14963       -2
+ Misses        731      729       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/864?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/hotptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/864/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/totptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/864/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90b3RwdG9rZW4ucHk=) | `98.82% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/864/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.79% <0%> (+1.68%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/864?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/864?src=pr&el=footer). Last update [42ac5b5...738dca2](https://codecov.io/gh/privacyidea/privacyidea/pull/864?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/864?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/864?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/864'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>