### PR TITLE
add primitive support for memberOf as multivalue attribute

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -440,8 +440,8 @@ class IdResolver (UserIdResolver):
                     if ldap_k == "objectGUID":
                         ret[map_k] = ldap_v[0]
                     elif type(ldap_v) == list and map_k not in MULTI_VALUE_ATTRIBUTE:
-                        # All lists (except) mobile and memberOf return the first value as
-                        #  a string. Mobile and memberOf are returned as a list
+                        # lists that are not in MULTI_VALUE_ATTRIBUTE return first value
+                        # as a string. Multi-value-attributes are returned as a list
                         if ldap_v:
                             ret[map_k] = ldap_v[0]
                         else:

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -433,12 +433,13 @@ class IdResolver (UserIdResolver):
         :return: dict with privacyIDEA users.
         """
         ret = {}
+        MULTI_VALUE_ATTRIBUTE = ["mobile", "memberOf"]
         for ldap_k, ldap_v in attributes.items():
             for map_k, map_v in self.userinfo.items():
                 if ldap_k == map_v:
                     if ldap_k == "objectGUID":
                         ret[map_k] = ldap_v[0]
-                    elif type(ldap_v) == list and map_k not in ["mobile"] and map_k not in ["memberOf"]:
+                    elif type(ldap_v) == list and map_k not in MULTI_VALUE_ATTRIBUTE:
                         # All lists (except) mobile and memberOf return the first value as
                         #  a string. Mobile and memberOf are returned as a list
                         if ldap_v:

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -438,9 +438,9 @@ class IdResolver (UserIdResolver):
                 if ldap_k == map_v:
                     if ldap_k == "objectGUID":
                         ret[map_k] = ldap_v[0]
-                    elif type(ldap_v) == list and map_k not in ["mobile"]:
-                        # All lists (except) mobile return the first value as
-                        #  a string. Mobile is returned as a list
+                    elif type(ldap_v) == list and map_k not in ["mobile"] and map_k not in ["memberOf"]:
+                        # All lists (except) mobile and memberOf return the first value as
+                        #  a string. Mobile and memberOf are returned as a list
                         if ldap_v:
                             ret[map_k] = ldap_v[0]
                         else:


### PR DESCRIPTION
This enables passing on membership information from a resolver backend to SAML, see also https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/25
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353587313%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353588066%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353595370%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353598708%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353600442%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353602736%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353609041%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353612886%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23discussion_r158498099%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23discussion_r158502812%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23issuecomment-353587313%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23880%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/2d2db79a8b7d7f73988bf9b784065910624ea001%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23880%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.34%25%20%20%2095.33%25%20%20%20-0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20126%20%20%20%20%20%20126%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015696%20%20%20%2015696%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2014966%20%20%20%2014963%20%20%20%20%20%20%20-3%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20730%20%20%20%20%20%20733%20%20%20%20%20%20%20%2B3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6093.03%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.27%25%20%3C0%25%3E%20%28-2.53%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B2d2db79...ee03b54%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/880%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222017-12-22T12%3A17%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20PR.%5Cr%5CnWhat%20do%20you%20want%20to%20achieve%3F%22%2C%20%22created_at%22%3A%20%222017-12-22T12%3A22%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20we%27re%20trying%20to%20achieve%20is%20SAML%20Service%20Providers%20getting%20full%20membership%20information%20of%20the%20users%2C%20without%20needing%20to%20query%20AD.%5Cr%5Cn%5Cr%5CnWe%20have%20a%20setup%20where%3A%5Cr%5Cn-%20PrivacyIdea%20uses%20an%20AD%20resolver%5Cr%5Cn-%20Simplesamlphp%20authenticates%20to%20PrivacyIdea%5Cr%5Cn%5Cr%5CnWith%20this%20patch%2C%20we%27re%20able%20to%20include%20users%27%20full%20membership-information%20in%20the%20SAML%20responses%20to%20the%20various%20service%20providers%2C%20so%20applications%20can%20use%20the%20AD%20groups%20based%20solely%20on%20the%20information%20they%20get%20from%20SAML.%5Cr%5Cn%5Cr%5CnWithout%20the%20patch%2C%20only%20the%20first%20group%20was%20passed%20on%20and%20the%20applications%20remained%20unaware%20of%20the%20rest%20of%20the%20groups%20the%20user%20is%20a%20member%20of.%22%2C%20%22created_at%22%3A%20%222017-12-22T13%3A08%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/22728411%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nomennesc-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20sounds%20cool%20to%20me.%5Cr%5CnDo%20the%20applications%20need%20the%20full%20%2ADN%2A%20of%20the%20group%20as%20it%20is%20denoted%20in%20the%20%60%60memberOf%60%60%20attribute%3F%5Cr%5Cn%5Cr%5CnIn%20other%20cases%20it%20might%20be%20interesting%20to%20only%20pass%20the%20%2ACN%2A%20of%20the%20group.%20Have%20you%20seen%20that%3F%22%2C%20%22created_at%22%3A%20%222017-12-22T13%3A29%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20I%20saw%20that%2C%20I%20was%20trying%20to%20stay%20as%20close%20as%20possible%20to%20AD%20behaviour%2C%20which%20is%20to%20give%20the%20full%20DN.%20%5Cr%5CnAs%20far%20as%20I%27m%20concerned%20it%27s%20the%20job%20of%20AD%20to%20provide%20membership-information%20in%20a%20manner%20that%20applications%20understand%20%28or%20perhaps%20the%20job%20of%20the%20application%20to%20understand%20AD%20DN%27s%29%2C%20not%20PrivacyIdea%27s%20or%20Simplesaml%27s%20job%20to%20make%20any%20alterations%20there.%22%2C%20%22created_at%22%3A%20%222017-12-22T13%3A41%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/22728411%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nomennesc-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20like%20this%20point%20of%20view%21%20%3B-%29%5Cr%5Cn%5Cr%5CnAnyway%2C%20we%20might%20run%20into%20backward%20compatiblity%20issues.%20%5Cr%5CnIn%20the%20current%20implementation%20privacyIDEA%20will%20return%20a%20string%2C%20if%20the%20attribute%20mapping%20contains%20a%20%5C%22memberof%5C%22.%20The%20first%20group%20as%20a%20%2Astring%2A.%5Cr%5CnWith%20your%20PR%20it%20will%20return%20a%20list%20of%20strings.%20Even%20if%20there%20was%20only%20one%20group%20membership.%5Cr%5Cn%5Cr%5CnThere%20_might_%20be%20applications%20or%20users%2C%20who%20might%20get%20confused%20with%20that.%20So%20do%20you%20have%20any%20idea%20on%20that%20%28besided%20adding%20an%20important%20note%20in%20the%20changelog%29%3F%22%2C%20%22created_at%22%3A%20%222017-12-22T13%3A55%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Making%20this%20completely%20configurable%20sounds%20great%21%22%2C%20%22created_at%22%3A%20%222017-12-22T14%3A32%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/22728411%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nomennesc-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222017-12-22T14%3A53%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/22728411%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nomennesc-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20634e569e231c851cf307f8656a44f7c4a58da212%20privacyidea/lib/resolvers/LDAPIdResolver.py%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/880%23discussion_r158498099%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20change%20this%20to%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20elif%20type%28ldap_v%29%20%3D%3D%20list%20and%20map_k%20not%20in%20%20%5B%5C%22mobile%5C%22%2C%20%5C%22memberOf%5C%22%5D%3A%5Cr%5Cn%5Cr%5CnWe%20could%20even%20define%20a%20list%20of%20Multivalue-Attributes%20in%20the%20resolver.%20This%20way%20we%20could%20be%20more%20flexible%20in%20the%20future.%20%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20MULTI_VALUE_ATTRIBUTE%20%3D%20%5B%5C%22mobile%5C%22%2C%20%5C%22memberOf%5C%22%5D%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20elif%20type%28ldap_v%29%20%3D%3D%20list%20and%20map_k%20not%20in%20MULTI_VALUE_ATTRIBUTE%3A%5Cr%5Cn%5Cr%5Cn...and%20we%20could%20keep%20the%20backward%20compatiblity.%22%2C%20%22created_at%22%3A%20%222017-12-22T14%3A10%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222017-12-22T14%3A40%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/22728411%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nomennesc-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL438-447%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/nomennesc-io%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/22728411%3Fv%3D4%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/nomennesc-io'><img src='https://avatars2.githubusercontent.com/u/22728411?v=4' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/880#issuecomment-353587313'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/880?src=pr&el=h1) Report
> Merging [#880](https://codecov.io/gh/privacyidea/privacyidea/pull/880?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/2d2db79a8b7d7f73988bf9b784065910624ea001?src=pr&el=desc) will **decrease** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/880/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/880?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #880      +/-   ##
==========================================
- Coverage   95.34%   95.33%   -0.02%
==========================================
Files         126      126
Lines       15696    15696
==========================================
- Hits        14966    14963       -3
- Misses        730      733       +3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/880?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/880/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `93.03% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/880/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.27% <0%> (-2.53%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/880?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/880?src=pr&el=footer). Last update [2d2db79...ee03b54](https://codecov.io/gh/privacyidea/privacyidea/pull/880?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Thanks for the PR.
What do you want to achieve?
- <a href='https://github.com/nomennesc-io'><img border=0 src='https://avatars2.githubusercontent.com/u/22728411?v=4' height=16 width=16></a> What we're trying to achieve is SAML Service Providers getting full membership information of the users, without needing to query AD.
We have a setup where:
- PrivacyIdea uses an AD resolver
- Simplesamlphp authenticates to PrivacyIdea
With this patch, we're able to include users' full membership-information in the SAML responses to the various service providers, so applications can use the AD groups based solely on the information they get from SAML.
Without the patch, only the first group was passed on and the applications remained unaware of the rest of the groups the user is a member of.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK, sounds cool to me.
Do the applications need the full *DN* of the group as it is denoted in the ``memberOf`` attribute?
In other cases it might be interesting to only pass the *CN* of the group. Have you seen that?
- <a href='https://github.com/nomennesc-io'><img border=0 src='https://avatars2.githubusercontent.com/u/22728411?v=4' height=16 width=16></a> Yeah, I saw that, I was trying to stay as close as possible to AD behaviour, which is to give the full DN.
As far as I'm concerned it's the job of AD to provide membership-information in a manner that applications understand (or perhaps the job of the application to understand AD DN's), not PrivacyIdea's or Simplesaml's job to make any alterations there.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I like this point of view! ;-)
Anyway, we might run into backward compatiblity issues.
In the current implementation privacyIDEA will return a string, if the attribute mapping contains a "memberof". The first group as a *string*.
With your PR it will return a list of strings. Even if there was only one group membership.
There _might_ be applications or users, who might get confused with that. So do you have any idea on that (besided adding an important note in the changelog)?
- <a href='https://github.com/nomennesc-io'><img border=0 src='https://avatars2.githubusercontent.com/u/22728411?v=4' height=16 width=16></a> Making this completely configurable sounds great!
- [x] <a href='#crh-comment-Pull 634e569e231c851cf307f8656a44f7c4a58da212 privacyidea/lib/resolvers/LDAPIdResolver.py 7'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/880#discussion_r158498099'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L438-447</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Please change this to:
elif type(ldap_v) == list and map_k not in  ["mobile", "memberOf"]:
We could even define a list of Multivalue-Attributes in the resolver. This way we could be more flexible in the future.
MULTI_VALUE_ATTRIBUTE = ["mobile", "memberOf"]
elif type(ldap_v) == list and map_k not in MULTI_VALUE_ATTRIBUTE:
...and we could keep the backward compatiblity.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/880?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/880?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/880?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/880'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>