### PR TITLE
Implement VASCO Token Type

### DIFF
--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -21,7 +21,7 @@ class Config(object):
     # PI_GNUPG_HOME = "gpg"
     # PI_LOGO = "otherlogo.png"
     # PI_AUDIT_SQL_URI = sqlite://
-    VASCO_LIBRARY = None
+    PI_VASCO_LIBRARY = None
 
 
 class DevelopmentConfig(Config):

--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -21,6 +21,7 @@ class Config(object):
     # PI_GNUPG_HOME = "gpg"
     # PI_LOGO = "otherlogo.png"
     # PI_AUDIT_SQL_URI = sqlite://
+    VASCO_LIBRARY = None
 
 
 class DevelopmentConfig(Config):

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -610,6 +610,7 @@ def get_token_list():
     module_list.add("privacyidea.lib.tokens.u2ftoken")
     module_list.add("privacyidea.lib.tokens.papertoken")
     module_list.add("privacyidea.lib.tokens.questionnairetoken")
+    module_list.add("privacyidea.lib.tokens.vascotoken")
 
     #module_list.add(".tokens.tagespassworttoken")
     #module_list.add(".tokens.vascotoken")

--- a/privacyidea/lib/tokens/vasco.py
+++ b/privacyidea/lib/tokens/vasco.py
@@ -49,12 +49,12 @@ log = logging.getLogger(__name__)
 vasco_dll = None
 
 try:
-    vasco_library_path = current_app.config.get("VASCO_LIBRARY")
+    vasco_library_path = current_app.config.get("PI_VASCO_LIBRARY")
     if vasco_library_path is not None: # pragma: no cover
         log.info(u"Loading VASCO library from {!s} ...".format(vasco_library_path))
         vasco_dll = CDLL(vasco_library_path)
     else:
-        log.info(u"VASCO_LIBRARY option is not set, functionality disabled")
+        log.info(u"PI_VASCO_LIBRARY option is not set, functionality disabled")
 except Exception as exx:
     log.warning(u"Could not load VASCO library: {!r}".format(exx))
 

--- a/privacyidea/lib/tokens/vasco.py
+++ b/privacyidea/lib/tokens/vasco.py
@@ -50,7 +50,7 @@ vasco_dll = None
 
 try:
     vasco_library_path = current_app.config.get("VASCO_LIBRARY")
-    if vasco_library_path is not None:
+    if vasco_library_path is not None: # pragma: no cover
         log.info(u"Loading VASCO library from {!s} ...".format(vasco_library_path))
         vasco_dll = CDLL(vasco_library_path)
     else:

--- a/privacyidea/lib/tokens/vasco.py
+++ b/privacyidea/lib/tokens/vasco.py
@@ -1,0 +1,463 @@
+# -*- coding: utf-8 -*-
+#
+#    LinOTP - the open source solution for two factor authentication
+#    Copyright (C) 2010 - 2017 KeyIdentity GmbH
+#
+#    This program is free software: you can redistribute it and/or
+#    modify it under the terms of the GNU Affero General Public
+#    License, version 3, as published by the Free Software Foundation.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the
+#               GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+#    E-mail: linotp@keyidentity.com
+#    Contact: www.linotp.org
+#    Support: www.keyidentity.com
+""" Import tokens from the vasco dpx files """
+
+import pickle
+import zlib
+import os
+import logging
+
+# from ctypes import *
+from ctypes import CDLL
+from ctypes import Structure
+
+from ctypes import pointer
+from ctypes import c_void_p
+from ctypes import c_char_p
+
+from ctypes import c_int
+from ctypes import c_ulong
+from ctypes import c_char
+from ctypes import c_byte
+
+from tempfile import NamedTemporaryFile
+
+
+from pylons import config
+
+
+__all__ = ["parseVASCOdata", "vasco_otp_check"]
+
+
+log = logging.getLogger(__name__)
+
+vasco_dll = None
+vasco_libs = []
+
+# get the Vacman Controller lib
+fallbacks = ["/opt/vasco/Vacman_Controller/lib/libaal2sdk.so"]
+
+vasco_lib = config.get("linotpImport.vasco_dll")
+if not vasco_lib:
+    log.info("Missing linotpImport.vasco_dll in config file")
+else:
+    vasco_libs.append(vasco_lib)
+
+vasco_libs.extend(fallbacks)
+for vasco_lib in vasco_libs:
+    try:
+        log.debug("loading vasco lib %r", vasco_lib)
+        vasco_dll = CDLL(vasco_lib)
+        break
+    except Exception as exx:
+        log.info("cannot load vasco library: %r", exx)
+
+
+# decorator: check_vasco
+def check_vasco(fn):
+    '''
+    This is a decorator:
+    checks if vasco dll is defined,
+    it then runs the function otherwise returns NONE
+
+    :param fn: function - the to be called function
+    :return: return the function call result
+    '''
+    def new(*args, **kw):
+        if not vasco_dll:
+            log.error("[check_vasco] No vasco dll available!")
+            return None
+        else:
+            return fn(*args, **kw)
+    return new
+
+
+class TDPXHandle(Structure):
+    """
+    Handle struct
+    """
+    _fields_ = [("pHandleDpxContext", c_void_p),
+                ("pHandleDpxInitKey", c_void_p)]
+
+
+class TKernelParams(Structure):
+    """
+    KernelParams struct
+    """
+    _fields_ = [("ParmCount", c_ulong),
+                ("ITimeWindow", c_ulong),
+                ("STimeWindow", c_ulong),
+                ("DiagLevel", c_ulong),
+                ("GMTAdjust", c_ulong),
+                ("CheckChallenge", c_ulong),
+                ("IThreshold", c_ulong),
+                ("SThreshold", c_ulong),
+                ("ChkInactDays", c_ulong),
+                ("DeriveVector", c_ulong),
+                ("SyncWindow", c_ulong),
+                ("OnLineSG", c_ulong),
+                ("EventWindow", c_ulong),
+                ("HSMSlotId", c_ulong),
+                ("StorageKeyId", c_ulong),
+                ("TransportKeyId", c_ulong),
+                ("StorageDeriveKey1", c_ulong),
+                ("StorageDeriveKey2", c_ulong),
+                ("StorageDeriveKey3", c_ulong),
+                ("StorageDeriveKey4", c_ulong), ]
+
+
+class TDigipassBlob(Structure):
+    """
+    Digi Pass Token Blob struct
+    """
+    _fields_ = [("Serial", c_char * 10),
+                ("AppName", c_char * 12),
+                ("DPFlags", c_byte * 2),
+                ("Blob", c_char * 224)]
+
+
+def vasco_dpxinit(filename="demovdp.dpx", transportkey=None):
+    '''
+    This function returns
+     - error code
+     - filehandle (TDPXHandle)
+     - application count
+     - application names
+     - token counts
+    '''
+    if not transportkey:
+        transportkey = "1" * 32
+
+    c_filename = c_char_p(filename)
+    c_transportkey = c_char_p(transportkey)
+    # string with 97 bytes
+    appl_names = "." * 97
+    p_names = c_char_p(appl_names)
+
+    filehandle = TDPXHandle()
+    p_fh = pointer(filehandle)
+
+    appl_count = c_int(0)
+    p_acount = pointer(appl_count)
+
+    token_count = c_int(0)
+    p_tcount = pointer(token_count)
+
+    res = vasco_dll.AAL2DPXInit(p_fh,
+                                c_filename,
+                                c_transportkey,
+                                p_acount,
+                                p_names,
+                                p_tcount)
+
+    return (res, filehandle, appl_count, appl_names, token_count)
+
+
+def vasco_getstatic_vector(handle, params):
+    """
+
+    """
+    vector = "." * 113
+    p_vector = c_char_p(vector)
+    vector_len = c_int(112)
+    p_vector_len = pointer(vector_len)
+    res = vasco_dll.AAL2DPXGetStaticVector(pointer(handle),
+                                           pointer(params),
+                                           p_vector,
+                                           p_vector_len)
+
+    return (res, vector, vector_len)
+
+
+def vasco_gettoken(handle, params, select_appl):
+    """
+    access the vasco token data object
+    """
+    dpdata = TDigipassBlob()
+    serial = "\0" * 23
+    typ = "\0" * 6
+    authmode = "\0" * 3
+    res = vasco_dll.AAL2DPXGetToken(pointer(handle),
+                                    pointer(params),
+                                    c_char_p(select_appl),
+                                    c_char_p(serial),
+                                    c_char_p(typ),
+                                    c_char_p(authmode),
+                                    pointer(dpdata))
+
+    return (res, serial, typ, authmode, dpdata)
+
+
+def vasco_dpxclose(handle):
+    """
+    close the vasco blob
+    """
+    res = vasco_dll.AAL2DPXClose(pointer(handle))
+    return res
+
+
+def vasco_genpassword(data, params, challenge="\0" * 16):
+    password = "\0" * 41
+    res = vasco_dll.AAL2GenPassword(pointer(data),
+                                    pointer(params),
+                                    c_char_p(password),
+                                    c_char_p(challenge))
+    return (res, password)
+
+
+def vasco_verify(data, params, password, challenge="\0" * 16):
+    res = vasco_dll.AAL2VerifyPassword(pointer(data),
+                                       pointer(params),
+                                       c_char_p(password),
+                                       c_char_p(challenge))
+
+    return (res, data)
+
+
+def vasco_settokenproperty(data, params, prop, value):
+    '''
+    can be used to do not use a static PIN
+    pin_supported (6) : enable=1, disable=2
+    '''
+    res = vasco_dll.AAL2SetTokenProperty(pointer(data),
+                                         pointer(params),
+                                         c_ulong(prop),
+                                         c_ulong(value))
+    return (res, data)
+
+
+def vasco_gettokenproperty(data, params, prop):
+    '''
+    This function returns token properties.
+    PIN_LEN: property = 10
+    '''
+    value = 0
+    res = vasco_dll.AAL2GetTokenProperty(pointer(data),
+                                         pointer(params),
+                                         c_ulong(prop),
+                                         pointer(c_ulong(value)))
+    return (res, value)
+
+
+def vasco_compress(datablob):
+    '''
+    Compresses the data to be stored in the token database.
+    The data object is pickled and compressed.
+
+    :param datablob: Vasco Data Blob
+    :return: compressed data to be stored in Token database
+    '''
+    return zlib.compress(pickle.dumps(datablob))
+
+
+def vasco_decompress(tokendata):
+    '''
+    De-compresses the data when loaded from the token database.
+    The data object is pickled and compressed.
+
+    :param tokendata: The encrypted OTP Key from the database
+    :return: The Vasco data blob
+    '''
+    return pickle.loads(zlib.decompress(tokendata))
+
+
+@check_vasco
+def parseVASCOdata(fileString=None, arg_otplen=6, transportkey=None):
+    '''
+    Parses the DPX data and returns the dictionary with the token description
+    for the token_init:
+
+       parsed_tokens[serial] = { hmac_key, type, otplen, . . }
+
+    :param fileString: the dpx file as strings
+    :param arg_otplen: the otplen of the imported tokens
+    :param transportkey: the decryption key for crypted token files
+
+    :return: the dict with tokenserial and token description
+             to create the token
+    '''
+
+    parsed_tokens = {}
+
+    kp = TKernelParams()
+    kp.ParmCount = 19
+    kp.ITimeWindow = 100
+    kp.STimeWindow = 24
+    kp.DiagLevel = 0
+    kp.GMTAdjust = 0
+    kp.CheckChallenge = 0
+    # -- --- --
+    # This is the failcounter! The failcounter needs to be reset manually
+    # When we set the failcounter=0 then we can rule the failcounter in LinOTP
+    # -- -- --
+    kp.IThreshold = 0
+    kp.SThreshold = 1
+    kp.ChkInactDays = 0
+    kp.DeriveVector = 0
+    kp.SyncWindow = 2
+    kp.OnLineSG = 1
+    kp.EventWindow = 100
+    kp.HSMSlotId = 0
+
+    # the vasco dpx parser requires an physical input file :-(
+    with NamedTemporaryFile("w", delete=False) as dpxfile:
+        dpxfile.write(fileString)
+    filename = dpxfile.name
+
+    # we have to use a try - finally to guarante, that the tempfile is
+    # removed on completion
+    try:
+        (res, filehandle, _appl_count,
+         appl_names, tokens) = vasco_dpxinit(filename=filename,
+                                             transportkey=transportkey)
+
+        if res != 0:
+
+            # handle some known dedicated errors
+            ret = res
+            if res in [-15, -14]:
+                ret = "Error initkey"
+
+            err = "Failed to initialize the import process! %r" % ret
+            log.error("[parseVASCOdata] %r", err)
+            raise Exception(err)
+
+        log.debug("found %s tokens.", tokens)
+
+        (res, _vec, _vec_len) = vasco_getstatic_vector(filehandle, kp)
+        log.debug("getstaticvector: %d", res)
+
+        # start getting tokens
+        res = 100
+        data = TDigipassBlob()
+
+        while res == 100:
+            (res, serial, typ, auth, data) = vasco_gettoken(filehandle,
+                                                            kp, appl_names)
+
+            if res == 107:
+                log.debug("SUCCESSfully reached the end of the dpx file")
+
+            if res == 100:
+                (pres, data) = vasco_settokenproperty(data, kp, 6, 2)
+                if pres != 0:
+                    log.error("Failed to set token properties %r", pres)
+                    log.debug("Failing token properties %r", kp)
+                    continue
+
+                # TODO: Each token could have another OTP-length.
+                # At the moment we take this as parameter
+                otplen = arg_otplen
+                if 'APPL' in serial:
+                    idx = serial.index('APPL')
+                elif 'DEFAULT' in serial:
+                    idx = serial.index('DEFAULT')
+                else:
+                    idx = len(serial)
+
+                lin_serial = serial[:idx]
+
+                if auth[:2] in ["RO"]:
+                    # yes, we support DPGO6 and we support the
+                    # response only (no signature and challenge)
+                    otpkey = vasco_compress(data)
+
+                    token_init = {'type': "vasco",
+                                  'hmac_key': otpkey,
+                                  "description": typ.strip("\0"),
+                                  'otplen': otplen,
+                                  'tokeninfo': {
+                                      # "data_Serial" : data.Serial,
+                                      # "data_AppName" : data.AppName,
+                                      # "data_DPFlags" : data.DPFlags
+                                      "application": serial.strip("\0"),
+                                      "type": typ.strip("\0"),
+                                      "auth": auth.strip("\0"), }, }
+
+                    parsed_tokens["vc" + lin_serial] = token_init
+                else:
+                    log.warning("The tokentype %s, auth %s is not tested! "
+                                "The Token %s is not imported!",
+                                typ, auth, lin_serial)
+
+        res = vasco_dpxclose(filehandle)
+
+    finally:
+        os.remove(filename)
+
+    return parsed_tokens
+
+
+@check_vasco
+def vasco_otp_check(otpkey, otp):
+    """
+    check the otp value
+
+    :param data: the vasco_token_data, stored in LinOTP database as otpkey
+    :param otp: the otp value
+    :return: tuple of (success and new_vasco_token_data)
+    """
+    kp = TKernelParams()
+    kp.ParmCount = 19
+    kp.ITimeWindow = 100
+    kp.STimeWindow = 24
+    kp.DiagLevel = 0
+    kp.GMTAdjust = 0
+    kp.CheckChallenge = 0
+    #
+    # This is the failcounter! The failcounter needs to be reset manually
+    # When we set the failcounter=0 then we can rule the failcounter in LinOTP
+    #
+    kp.IThreshold = 0
+    kp.SThreshold = 1
+    kp.ChkInactDays = 0
+    kp.DeriveVector = 0
+    kp.SyncWindow = 2
+    kp.OnLineSG = 1
+    kp.EventWindow = 100
+    kp.HSMSlotId = 0
+
+    data = vasco_decompress(otpkey)
+    (res, data) = vasco_verify(data, kp, otp)
+    otpkey = vasco_compress(data)
+
+    return (res, otpkey)
+
+
+@check_vasco
+def test():
+    tokens = parseVASCOdata("Demo_GO6.DPX")
+
+    for token, token_data in tokens.items():
+        print token
+        print token_data
+        data = pickle.loads(token_data['hmac_key'])
+        passw = "000000"
+        while passw != "X":
+            print "=========== Verify Password ============"
+            passw = raw_input("Enter OTP:")
+            (res, data) = vasco_otp_check(data, passw)
+
+            print res
+
+# eof #######################################################################

--- a/privacyidea/lib/tokens/vasco.py
+++ b/privacyidea/lib/tokens/vasco.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 #
+# 2018-01-15 friedrich.weber@netknights.it
+#            Remove unused routines, redesign serialization step,
+#            adapt to privacyIDEA, refactoring
+#
 #    LinOTP - the open source solution for two factor authentication
 #    Copyright (C) 2010 - 2017 KeyIdentity GmbH
 #
@@ -20,33 +24,23 @@
 #    E-mail: linotp@keyidentity.com
 #    Contact: www.linotp.org
 #    Support: www.keyidentity.com
-""" Import tokens from the vasco dpx files """
+""" VASCO library binding """
 
-import pickle
-import zlib
 import os
 import logging
 
 # from ctypes import *
-from ctypes import CDLL
+from ctypes import CDLL, create_string_buffer
 from ctypes import Structure
 
-from ctypes import pointer
-from ctypes import c_void_p
-from ctypes import c_char_p
-
-from ctypes import c_int
+from ctypes import byref
 from ctypes import c_ulong
 from ctypes import c_char
 from ctypes import c_byte
 
-from tempfile import NamedTemporaryFile
+from privacyidea.lib.error import ParameterError
 
-
-from pylons import config
-
-
-__all__ = ["parseVASCOdata", "vasco_otp_check"]
+__all__ = ["vasco_otp_check"]
 
 
 log = logging.getLogger(__name__)
@@ -57,47 +51,34 @@ vasco_libs = []
 # get the Vacman Controller lib
 fallbacks = ["/opt/vasco/Vacman_Controller/lib/libaal2sdk.so"]
 
-vasco_lib = config.get("linotpImport.vasco_dll")
-if not vasco_lib:
-    log.info("Missing linotpImport.vasco_dll in config file")
-else:
-    vasco_libs.append(vasco_lib)
-
 vasco_libs.extend(fallbacks)
 for vasco_lib in vasco_libs:
     try:
-        log.debug("loading vasco lib %r", vasco_lib)
-        vasco_dll = CDLL(vasco_lib)
-        break
+        if os.path.isfile(vasco_lib):
+            log.debug(u"Trying to load VASCO library from {!s}".format(vasco_lib))
+            vasco_dll = CDLL(vasco_lib)
+            break
     except Exception as exx:
-        log.info("cannot load vasco library: %r", exx)
+        log.warning(u"Could not load VASCO library: {!r}".format(exx))
+else:
+    log.info(u"No suitable VASCO library could be found, functionality is disabled")
 
 
-# decorator: check_vasco
 def check_vasco(fn):
     '''
     This is a decorator:
     checks if vasco dll is defined,
-    it then runs the function otherwise returns NONE
+    it then runs the function otherwise raises RuntimeError
 
     :param fn: function - the to be called function
     :return: return the function call result
     '''
     def new(*args, **kw):
         if not vasco_dll:
-            log.error("[check_vasco] No vasco dll available!")
-            return None
+            raise RuntimeError("No VASCO library available")
         else:
             return fn(*args, **kw)
     return new
-
-
-class TDPXHandle(Structure):
-    """
-    Handle struct
-    """
-    _fields_ = [("pHandleDpxContext", c_void_p),
-                ("pHandleDpxInitKey", c_void_p)]
 
 
 class TKernelParams(Structure):
@@ -136,276 +117,38 @@ class TDigipassBlob(Structure):
                 ("Blob", c_char * 224)]
 
 
-def vasco_dpxinit(filename="demovdp.dpx", transportkey=None):
-    '''
-    This function returns
-     - error code
-     - filehandle (TDPXHandle)
-     - application count
-     - application names
-     - token counts
-    '''
-    if not transportkey:
-        transportkey = "1" * 32
-
-    c_filename = c_char_p(filename)
-    c_transportkey = c_char_p(transportkey)
-    # string with 97 bytes
-    appl_names = "." * 97
-    p_names = c_char_p(appl_names)
-
-    filehandle = TDPXHandle()
-    p_fh = pointer(filehandle)
-
-    appl_count = c_int(0)
-    p_acount = pointer(appl_count)
-
-    token_count = c_int(0)
-    p_tcount = pointer(token_count)
-
-    res = vasco_dll.AAL2DPXInit(p_fh,
-                                c_filename,
-                                c_transportkey,
-                                p_acount,
-                                p_names,
-                                p_tcount)
-
-    return (res, filehandle, appl_count, appl_names, token_count)
-
-
-def vasco_getstatic_vector(handle, params):
-    """
-
-    """
-    vector = "." * 113
-    p_vector = c_char_p(vector)
-    vector_len = c_int(112)
-    p_vector_len = pointer(vector_len)
-    res = vasco_dll.AAL2DPXGetStaticVector(pointer(handle),
-                                           pointer(params),
-                                           p_vector,
-                                           p_vector_len)
-
-    return (res, vector, vector_len)
-
-
-def vasco_gettoken(handle, params, select_appl):
-    """
-    access the vasco token data object
-    """
-    dpdata = TDigipassBlob()
-    serial = "\0" * 23
-    typ = "\0" * 6
-    authmode = "\0" * 3
-    res = vasco_dll.AAL2DPXGetToken(pointer(handle),
-                                    pointer(params),
-                                    c_char_p(select_appl),
-                                    c_char_p(serial),
-                                    c_char_p(typ),
-                                    c_char_p(authmode),
-                                    pointer(dpdata))
-
-    return (res, serial, typ, authmode, dpdata)
-
-
-def vasco_dpxclose(handle):
-    """
-    close the vasco blob
-    """
-    res = vasco_dll.AAL2DPXClose(pointer(handle))
-    return res
-
-
-def vasco_genpassword(data, params, challenge="\0" * 16):
-    password = "\0" * 41
-    res = vasco_dll.AAL2GenPassword(pointer(data),
-                                    pointer(params),
-                                    c_char_p(password),
-                                    c_char_p(challenge))
-    return (res, password)
-
-
 def vasco_verify(data, params, password, challenge="\0" * 16):
-    res = vasco_dll.AAL2VerifyPassword(pointer(data),
-                                       pointer(params),
-                                       c_char_p(password),
-                                       c_char_p(challenge))
+    # Construct actual buffers in case the library writes to ``password`` or ``challenge``
+    password_buffer = create_string_buffer(password)
+    challenge_buffer = create_string_buffer(challenge)
+    res = vasco_dll.AAL2VerifyPassword(byref(data),
+                                       byref(params),
+                                       password_buffer,
+                                       challenge_buffer)
 
     return (res, data)
 
 
-def vasco_settokenproperty(data, params, prop, value):
+def vasco_serialize(datablob):
+    """
+    Convert the given ``TDigipassBlob`` object to a bytestring and return it
+    :param datablob: Digipass blob
+    :return: bytestring
+    """
+    tokendata = buffer(datablob)[:]
+    assert len(tokendata) == 248
+    return tokendata
+
+def vasco_deserialize(tokendata):
     '''
-    can be used to do not use a static PIN
-    pin_supported (6) : enable=1, disable=2
-    '''
-    res = vasco_dll.AAL2SetTokenProperty(pointer(data),
-                                         pointer(params),
-                                         c_ulong(prop),
-                                         c_ulong(value))
-    return (res, data)
+    Convert the given bytestring to a ``TDigipassBlob`` object and return it
 
-
-def vasco_gettokenproperty(data, params, prop):
-    '''
-    This function returns token properties.
-    PIN_LEN: property = 10
-    '''
-    value = 0
-    res = vasco_dll.AAL2GetTokenProperty(pointer(data),
-                                         pointer(params),
-                                         c_ulong(prop),
-                                         pointer(c_ulong(value)))
-    return (res, value)
-
-
-def vasco_compress(datablob):
-    '''
-    Compresses the data to be stored in the token database.
-    The data object is pickled and compressed.
-
-    :param datablob: Vasco Data Blob
-    :return: compressed data to be stored in Token database
-    '''
-    return zlib.compress(pickle.dumps(datablob))
-
-
-def vasco_decompress(tokendata):
-    '''
-    De-compresses the data when loaded from the token database.
-    The data object is pickled and compressed.
-
-    :param tokendata: The encrypted OTP Key from the database
+    :param tokendata: A string of 248 bytes
     :return: The Vasco data blob
     '''
-    return pickle.loads(zlib.decompress(tokendata))
-
-
-@check_vasco
-def parseVASCOdata(fileString=None, arg_otplen=6, transportkey=None):
-    '''
-    Parses the DPX data and returns the dictionary with the token description
-    for the token_init:
-
-       parsed_tokens[serial] = { hmac_key, type, otplen, . . }
-
-    :param fileString: the dpx file as strings
-    :param arg_otplen: the otplen of the imported tokens
-    :param transportkey: the decryption key for crypted token files
-
-    :return: the dict with tokenserial and token description
-             to create the token
-    '''
-
-    parsed_tokens = {}
-
-    kp = TKernelParams()
-    kp.ParmCount = 19
-    kp.ITimeWindow = 100
-    kp.STimeWindow = 24
-    kp.DiagLevel = 0
-    kp.GMTAdjust = 0
-    kp.CheckChallenge = 0
-    # -- --- --
-    # This is the failcounter! The failcounter needs to be reset manually
-    # When we set the failcounter=0 then we can rule the failcounter in LinOTP
-    # -- -- --
-    kp.IThreshold = 0
-    kp.SThreshold = 1
-    kp.ChkInactDays = 0
-    kp.DeriveVector = 0
-    kp.SyncWindow = 2
-    kp.OnLineSG = 1
-    kp.EventWindow = 100
-    kp.HSMSlotId = 0
-
-    # the vasco dpx parser requires an physical input file :-(
-    with NamedTemporaryFile("w", delete=False) as dpxfile:
-        dpxfile.write(fileString)
-    filename = dpxfile.name
-
-    # we have to use a try - finally to guarante, that the tempfile is
-    # removed on completion
-    try:
-        (res, filehandle, _appl_count,
-         appl_names, tokens) = vasco_dpxinit(filename=filename,
-                                             transportkey=transportkey)
-
-        if res != 0:
-
-            # handle some known dedicated errors
-            ret = res
-            if res in [-15, -14]:
-                ret = "Error initkey"
-
-            err = "Failed to initialize the import process! %r" % ret
-            log.error("[parseVASCOdata] %r", err)
-            raise Exception(err)
-
-        log.debug("found %s tokens.", tokens)
-
-        (res, _vec, _vec_len) = vasco_getstatic_vector(filehandle, kp)
-        log.debug("getstaticvector: %d", res)
-
-        # start getting tokens
-        res = 100
-        data = TDigipassBlob()
-
-        while res == 100:
-            (res, serial, typ, auth, data) = vasco_gettoken(filehandle,
-                                                            kp, appl_names)
-
-            if res == 107:
-                log.debug("SUCCESSfully reached the end of the dpx file")
-
-            if res == 100:
-                (pres, data) = vasco_settokenproperty(data, kp, 6, 2)
-                if pres != 0:
-                    log.error("Failed to set token properties %r", pres)
-                    log.debug("Failing token properties %r", kp)
-                    continue
-
-                # TODO: Each token could have another OTP-length.
-                # At the moment we take this as parameter
-                otplen = arg_otplen
-                if 'APPL' in serial:
-                    idx = serial.index('APPL')
-                elif 'DEFAULT' in serial:
-                    idx = serial.index('DEFAULT')
-                else:
-                    idx = len(serial)
-
-                lin_serial = serial[:idx]
-
-                if auth[:2] in ["RO"]:
-                    # yes, we support DPGO6 and we support the
-                    # response only (no signature and challenge)
-                    otpkey = vasco_compress(data)
-
-                    token_init = {'type': "vasco",
-                                  'hmac_key': otpkey,
-                                  "description": typ.strip("\0"),
-                                  'otplen': otplen,
-                                  'tokeninfo': {
-                                      # "data_Serial" : data.Serial,
-                                      # "data_AppName" : data.AppName,
-                                      # "data_DPFlags" : data.DPFlags
-                                      "application": serial.strip("\0"),
-                                      "type": typ.strip("\0"),
-                                      "auth": auth.strip("\0"), }, }
-
-                    parsed_tokens["vc" + lin_serial] = token_init
-                else:
-                    log.warning("The tokentype %s, auth %s is not tested! "
-                                "The Token %s is not imported!",
-                                typ, auth, lin_serial)
-
-        res = vasco_dpxclose(filehandle)
-
-    finally:
-        os.remove(filename)
-
-    return parsed_tokens
+    if len(tokendata) != 248:
+        raise ParameterError("Data blob has incorrect size")
+    return TDigipassBlob.from_buffer_copy(tokendata)
 
 
 @check_vasco
@@ -437,27 +180,8 @@ def vasco_otp_check(otpkey, otp):
     kp.EventWindow = 100
     kp.HSMSlotId = 0
 
-    data = vasco_decompress(otpkey)
+    data = vasco_deserialize(otpkey)
     (res, data) = vasco_verify(data, kp, otp)
-    otpkey = vasco_compress(data)
+    otpkey = vasco_serialize(data)
 
     return (res, otpkey)
-
-
-@check_vasco
-def test():
-    tokens = parseVASCOdata("Demo_GO6.DPX")
-
-    for token, token_data in tokens.items():
-        print token
-        print token_data
-        data = pickle.loads(token_data['hmac_key'])
-        passw = "000000"
-        while passw != "X":
-            print "=========== Verify Password ============"
-            passw = raw_input("Enter OTP:")
-            (res, data) = vasco_otp_check(data, passw)
-
-            print res
-
-# eof #######################################################################

--- a/privacyidea/lib/tokens/vasco.py
+++ b/privacyidea/lib/tokens/vasco.py
@@ -26,7 +26,6 @@
 #    Support: www.keyidentity.com
 """ VASCO library binding """
 
-import os
 import logging
 
 # from ctypes import *
@@ -38,6 +37,8 @@ from ctypes import c_ulong
 from ctypes import c_char
 from ctypes import c_byte
 
+from flask import current_app
+
 from privacyidea.lib.error import ParameterError
 
 __all__ = ["vasco_otp_check"]
@@ -46,23 +47,16 @@ __all__ = ["vasco_otp_check"]
 log = logging.getLogger(__name__)
 
 vasco_dll = None
-vasco_libs = []
 
-# get the Vacman Controller lib
-fallbacks = ["/opt/vasco/Vacman_Controller/lib/libaal2sdk.so"]
-
-vasco_libs.extend(fallbacks)
-for vasco_lib in vasco_libs:
-    try:
-        if os.path.isfile(vasco_lib):
-            log.debug(u"Trying to load VASCO library from {!s}".format(vasco_lib))
-            vasco_dll = CDLL(vasco_lib)
-            break
-    except Exception as exx:
-        log.warning(u"Could not load VASCO library: {!r}".format(exx))
-else:
-    log.info(u"No suitable VASCO library could be found, functionality is disabled")
-
+try:
+    vasco_library_path = current_app.config.get("VASCO_LIBRARY")
+    if vasco_library_path is not None:
+        log.info(u"Loading VASCO library from {!s} ...".format(vasco_library_path))
+        vasco_dll = CDLL(vasco_library_path)
+    else:
+        log.info(u"VASCO_LIBRARY option is not set, functionality disabled")
+except Exception as exx:
+    log.warning(u"Could not load VASCO library: {!r}".format(exx))
 
 def check_vasco(fn):
     '''

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -130,6 +130,9 @@ class VascoTokenClass(TokenClass):
         if result == 0:
             # Successful authentication
             return 0
+        elif result == 201:
+            log.warning("A previous OTP value was used again!")
+            return -1
         else:
             log.warning("VASCO token failed to authenticate, result: {!r}".format(result))
             return -1

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -152,6 +152,8 @@ class VascoTokenClass(TokenClass):
                 pass
             elif result == 201:
                 log.warning("A previous OTP value was used again!")
+            elif result == 202:
+                log.warning("Token-internal fail counter reached its maximum!")
             else:
                 log.warning("VASCO token failed to authenticate, result: {!r}".format(result))
             return -1

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+#
+#  License:  AGPLv3
+#  contact:  http://www.privacyidea.org
+#
+#  2018-01-15   Friedrich Weber <friedrich.weber@netknights.it>
+#               Initial version of the VASCO token
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+__doc__ = """This is the implementation of the VASCO token"""
+
+import logging
+from privacyidea.api.lib.utils import getParam
+from privacyidea.lib.utils import is_true
+from privacyidea.lib.decorators import check_token_locked
+from privacyidea.lib.error import ParameterError
+from privacyidea.lib.log import log_with
+from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib import _
+
+optional = True
+required = False
+
+log = logging.getLogger(__name__)
+
+
+class VascoTokenClass(TokenClass):
+    """
+    TODO
+    """
+
+    def __init__(self, db_token):
+        """
+        constructor - create a token class object with its db token binding
+
+        :param aToken: the db bound token
+        """
+        TokenClass.__init__(self, db_token)
+        self.set_type(u"vasco")
+        self.hKeyRequired = True
+
+    @staticmethod
+    def get_class_type():
+        """
+        return the class type identifier
+        """
+        return "vasco"
+
+    @staticmethod
+    def get_class_prefix():
+        """
+        return the token type prefix
+        """
+        return "VASC"
+
+    @staticmethod
+    @log_with(log)
+    def get_class_info(key=None, ret='all'):
+        """
+        :param key: subsection identifier
+        :type key: string
+        :param ret: default return value, if nothing is found
+        :type ret: user defined
+        :return: subsection if key exists or user defined
+        :rtype: dict or string
+        """
+        res = {'type': 'vasco',
+               'title': 'VASCO Token',
+               'description': _('VASCO Token: Authentication using VASCO tokens'),
+               'user': ["enroll"],
+               'ui_enroll': ["admin", "user"],
+               'policy': {},
+               }
+
+        if key:
+            ret = res.get(key, {})
+        else:
+            if ret == 'all':
+                ret = res
+        return ret
+
+    @log_with(log)
+    def update(self, param, reset_failcount=True):
+        """
+        update - process initialization parameters
+
+        :param param: dict of initialization parameters
+        :type param: dict
+
+        :return: nothing
+        """
+        if is_true(getParam(param, 'genkey', optional)):
+            raise ParameterError("Generating OTP keys is not supported")
+
+        TokenClass.update(self, param, reset_failcount)
+
+        return
+
+    @check_token_locked
+    def check_otp(self, otpval, counter=None, window=None, options=None):
+        from .vasco import vasco_otp_check
+
+        secret = self.token.get_otpkey().getKey()
+        result, new_secret = vasco_otp_check(secret, otpval)
+        self.token.set_otpkey(new_secret)
+
+        if result == 0:
+            # Successful authentication
+            return 0
+        else:
+            log.warning("VASCO token failed to authenticate, result: {!r}".format(result))
+            return -1

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -31,6 +31,7 @@ from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.error import ParameterError
 from privacyidea.lib.log import log_with
 from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.tokens.vasco import vasco_otp_check
 from privacyidea.lib import _
 
 optional = True
@@ -119,8 +120,6 @@ class VascoTokenClass(TokenClass):
 
     @check_token_locked
     def check_otp(self, otpval, counter=None, window=None, options=None):
-        from .vasco import vasco_otp_check
-
         secret = self.token.get_otpkey().getKey()
         result, new_secret = vasco_otp_check(secret, otpval)
         self.token.set_otpkey(new_secret)

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -140,7 +140,10 @@ class VascoTokenClass(TokenClass):
     def check_otp(self, otpval, counter=None, window=None, options=None):
         secret = self.token.get_otpkey().getKey()
         result, new_secret = vasco_otp_check(secret, otpval)
-        self.token.set_otpkey(new_secret)
+        # By default, setting a new OTP key resets the failcounter. In case of the VASCO token,
+        # this would mean that the failcounter is reset at every authentication attempt
+        # (regardless of success or failure), which must be avoided.
+        self.token.set_otpkey(new_secret, reset_failcount=False)
         self.save()
 
         if result == 0:

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -42,7 +42,9 @@ log = logging.getLogger(__name__)
 
 class VascoTokenClass(TokenClass):
     """
-    TODO
+    Token class for VASCO Digipass tokens. Relies on vendor-specific
+    shared library, whose location needs to be set in the VASCO_LIBRARY
+    config option.
     """
 
     def __init__(self, db_token):

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -130,9 +130,12 @@ class VascoTokenClass(TokenClass):
         if result == 0:
             # Successful authentication
             return 0
-        elif result == 201:
-            log.warning("A previous OTP value was used again!")
-            return -1
         else:
-            log.warning("VASCO token failed to authenticate, result: {!r}".format(result))
+            if result == 1:
+                # wrong OTP value, no log message
+                pass
+            elif result == 201:
+                log.warning("A previous OTP value was used again!")
+            else:
+                log.warning("VASCO token failed to authenticate, result: {!r}".format(result))
             return -1

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -45,6 +45,18 @@ class VascoTokenClass(TokenClass):
     Token class for VASCO Digipass tokens. Relies on vendor-specific
     shared library, whose location needs to be set in the VASCO_LIBRARY
     config option.
+
+    VASCO Tokens can be read from a CSV file which is structured as follows::
+
+        <serial1>,<hexlify(blob1)>,vasco
+        <serial2>,<hexlify(blob2)>,vasco
+        ...
+
+    whereas blobX is the 248-byte blob holding the token information.
+    Consequently, hexlify(blobX) is a 496-character hex string.
+
+    The CSV file can be imported by using the "Import Tokens" feature of the Web UI,
+    where "OATH CSV" needs to be chosen as the file type.
     """
 
     def __init__(self, db_token):
@@ -116,6 +128,10 @@ class VascoTokenClass(TokenClass):
         # encodes a 248-byte blob. As we want to set a 248-byte OTPKey (= Blob),
         # we unhexlify the OTP key
         if 'otpkey' in param:
+            if len(param['otpkey']) != 496:
+                raise ParameterError('Expected OTP key as 496-character hex string, but length is {!s}'.format(
+                    len(param['otpkey'])
+                ))
             upd_param['otpkey'] = binascii.unhexlify(upd_param['otpkey'])
 
         TokenClass.update(self, upd_param, reset_failcount)

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)
 class VascoTokenClass(TokenClass):
     """
     Token class for VASCO Digipass tokens. Relies on vendor-specific
-    shared library, whose location needs to be set in the VASCO_LIBRARY
+    shared library, whose location needs to be set in the PI_VASCO_LIBRARY
     config option.
 
     VASCO Tokens can be read from a CSV file which is structured as follows::
@@ -81,6 +81,7 @@ class VascoTokenClass(TokenClass):
         """
         return the token type prefix
         """
+        # TODO: Revisit token type?
         return "VASC"
 
     @staticmethod
@@ -98,7 +99,6 @@ class VascoTokenClass(TokenClass):
                'title': 'VASCO Token',
                'description': _('VASCO Token: Authentication using VASCO tokens'),
                'user': ["enroll"],
-               'ui_enroll': ["admin", "user"],
                'policy': {},
                }
 

--- a/tests/test_lib_tokens_vasco.py
+++ b/tests/test_lib_tokens_vasco.py
@@ -1,0 +1,102 @@
+"""
+This test file tests the lib.tokens.vascotoken
+This depends on lib.tokenclass
+"""
+import functools
+
+import mock
+
+from privacyidea.lib.error import ParameterError
+from privacyidea.lib.tokens.vascotoken import VascoTokenClass
+from privacyidea.models import Token
+from tests.base import MyTestCase
+
+def mock_verification(replacement):
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            with mock.patch('privacyidea.lib.tokens.vasco.vasco_dll') as mock_dll:
+                mock_dll.AAL2VerifyPassword.side_effect = replacement
+                return f(*args, **kwargs)
+        return wrapper
+    return decorator
+
+def mock_success(data, params, password, challenge):
+    # fake a new blob
+    data._obj.Blob = "Y" * 224
+    return 0
+
+def mock_failure(data, params, password, challenge):
+    # fake a new blob
+    data._obj.Blob = "Y"*224
+    return 42
+
+
+class VascoTokenTest(MyTestCase):
+    otppin = "topsecret"
+    serial1 = "ser1"
+    serial2 = "ser2"
+    resolvername1 = "resolver1"
+    resolvername2 = "Resolver2"
+    resolvername3 = "reso3"
+    realm1 = "realm1"
+    realm2 = "realm2"
+
+    def test_01_create_token(self):
+        db_token = Token(self.serial1, tokentype="vasco")
+        db_token.save()
+        token = VascoTokenClass(db_token)
+        token.update({"otpkey": "X" * 248,
+                      "pin": self.otppin})
+        self.assertTrue(token.token.serial == self.serial1, token)
+        self.assertTrue(token.token.tokentype == "vasco", token.token.tokentype)
+        self.assertTrue(token.type == "vasco", token)
+        class_prefix = token.get_class_prefix()
+        self.assertTrue(class_prefix == "VASC", class_prefix)
+        self.assertTrue(token.get_class_type() == "vasco", token)
+
+    def test_02_genkey_fails(self):
+        db_token = Token(self.serial2, tokentype="vasco")
+        db_token.save()
+        token = VascoTokenClass(db_token)
+        self.assertRaises(ParameterError, token.update, {"genkey": "1"})
+        token.delete_token()
+
+    def test_03_no_vasco_library(self):
+        db_token = Token(self.serial2, tokentype="vasco")
+        db_token.save()
+        token = VascoTokenClass(db_token)
+        token.update({"otpkey": "X"*248,
+                      "pin": self.otppin})
+        self.assertRaises(RuntimeError, token.authenticate, "{}123456".format(self.otppin))
+        token.delete_token()
+
+    @mock_verification(mock_failure)
+    def test_04_failure(self):
+        db_token = Token(self.serial2, tokentype="vasco")
+        db_token.save()
+        token = VascoTokenClass(db_token)
+        token.update({"otpkey": "X"*248,
+                      "pin": self.otppin})
+        r = token.authenticate("{}123456".format(self.otppin))
+        self.assertEqual(r[0], True)
+        self.assertEqual(r[1], -1)
+        # failure, but the token secret has been updated nonetheless
+        key = token.token.get_otpkey().getKey()
+        self.assertEqual(key, "X"*24 + "Y"*224)
+        token.delete_token()
+
+    @mock_verification(mock_success)
+    def test_05_success(self):
+        db_token = Token(self.serial2, tokentype="vasco")
+        db_token.save()
+        token = VascoTokenClass(db_token)
+        token.update({"otpkey": "X"*248,
+                      "pin": self.otppin})
+        r = token.authenticate("{}123456".format(self.otppin))
+        self.assertEqual(r[0], True)
+        self.assertEqual(r[1], 0) # TODO: that is success?
+        # failure, but the token secret has been updated nonetheless
+        key = token.token.get_otpkey().getKey()
+        self.assertEqual(key, "X"*24 + "Y"*224)
+        token.delete_token()

--- a/tests/test_lib_tokens_vasco.py
+++ b/tests/test_lib_tokens_vasco.py
@@ -204,3 +204,15 @@ class VascoTokenTest(MyTestCase):
         key = token.token.get_otpkey().getKey()
         self.assertEqual(key, "X"*24 + "Y"*224)
         token.delete_token()
+
+    def test_08_invalid_otpkey(self):
+        db_token = Token(self.serial2, tokentype="vasco")
+        db_token.save()
+        token = VascoTokenClass(db_token)
+        self.assertRaises(ParameterError,
+                          token.update,
+                          {"otpkey": hexlify("X"*250)}) # wrong length
+        self.assertRaises(ParameterError,
+                          token.update,
+                          {"otpkey": "X"*496}) # not a hex-string
+        token.delete_token()


### PR DESCRIPTION
This is a first try at implementing #891.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-357975028%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-357993283%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r161829815%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r161835331%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162324730%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162328255%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/8587d50199328280face1206a73d859cdb628473%23commitcomment-26937906%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162338040%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-358656971%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162395987%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-358703503%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-358710530%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-358711230%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162406513%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-358713751%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/967c445189bd6667cac7e2a2103f7efcc323c72b%23commitcomment-26964712%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-358975079%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-358976283%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-358977362%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162638576%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162651736%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162652047%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/53b6bf86e4566188078cb3a62218b322e2169df4%23commitcomment-26966725%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/53b6bf86e4566188078cb3a62218b322e2169df4%23commitcomment-26976222%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/53b6bf86e4566188078cb3a62218b322e2169df4%23commitcomment-26984021%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/53b6bf86e4566188078cb3a62218b322e2169df4%23commitcomment-26985738%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-359172578%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23issuecomment-357975028%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Still%20missing%3A%20Configurable%20.so%20location%22%2C%20%22created_at%22%3A%20%222018-01-16T14%3A23%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23897%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/98e723f76113df715903a2e732d94a4002b063dd%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.04%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6092.43%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23897%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.38%25%20%20%2095.42%25%20%20%20%2B0.04%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20127%20%20%20%20%20%20129%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015769%20%20%20%2016093%20%20%20%20%20%2B324%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015041%20%20%20%2015357%20%20%20%20%20%2B316%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20728%20%20%20%20%20%20736%20%20%20%20%20%20%20%2B8%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/config.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ%3D%3D%29%20%7C%20%6096.42%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/vasco.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjby5weQ%3D%3D%29%20%7C%20%6089.7%25%20%3C89.7%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/vascotoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjb3Rva2VuLnB5%29%20%7C%20%6096%25%20%3C96%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.82%25%20%3C0%25%3E%20%28%2B0.48%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6096.78%25%20%3C0%25%3E%20%28%2B0.75%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B98e723f...4ce66b3%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/897%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-01-16T15%3A19%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22TODO%3A%5Cr%5Cn%2A%20Implement%20failcounter%20properly.%20Right%20now%2C%20the%20failcounter%20is%20reset%20on%20each%20authentication%20attempt%2C%20which%20makes%20it%20pretty%20much%20useless.%22%2C%20%22created_at%22%3A%20%222018-01-18T14%3A09%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20model%20could%20be%20imported%20as%20tokeninfo.%20When%20the%20blob%20is%20passed%20as%20otpkey%2C%20the%20vasco%20token%20class%20could%20%20extract%20the%20model%20from%20the%20blob%2C%20right%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-01-18T16%3A36%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22about%20the%20failcounter%20is%20this%20the%20failcounter%20of%20the%20token%3F%20If%20so%2C%20this%20failcounter%20is%20also%20in%20the%20digipass%20blob%20of%20the%20token%2C%20and%20returned%20as%20ERROR_COUNT%20by%20AAL2GetTokenInfoEx%20or%20AAL2GetTokenProperty%2C%20maybe%20we%20can%20use%20that%20to%20update%3F%22%2C%20%22created_at%22%3A%20%222018-01-18T16%3A57%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1587083%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/renini%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20problem%20is%3A%20What%20does%20the%20vacman%20do%2C%20when%20the%20failcounter%20is%20reached%20and%20how%20does%20it%20reset%20the%20failcounter%3F%5Cr%5CnI%20like%20to%20have%20the%20failcounter%20in%20privacyIDEA%2C%20so%20that%20we%20have%20a%20consistent%20behavivour%20for%20all%20token%20types.%5Cr%5Cn%5Cr%5Cn%2A%2AYou%20should%20stop%20using%20vasco%20tokens%21%2A%2A%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-01-18T17%3A00%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20you%20are%20right%2C%20we%20should%20definitely%20stop%20using%20it...%20But%20this%20will%20take%20some%20time.%5Cr%5CnFrom%20what%20i%27ve%20seen%20vacman%20does%20nothing%20when%20this%20counter%20is%20reached%2C%20its%20just%20indicative.%20%5Cr%5Cn%5Cr%5CnIt%20can%20be%20reset%20with%3A%20%2A%2AAAL2ResetTokenInfo%2A%2A%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn/%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A/%5Cr%5Cn/%2A%20Reset%20all%20time%20and%20error%20fields%20for%20a%20token%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2A/%5Cr%5Cn/%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A/%5Cr%5Cn%20%20VDS_EXPORT%28aat_int32%29%20%20AAL2ResetTokenInfo%28TDigipassBlob%20%2ADPData%2C%20TKernelParms%20%20%2ACallParms%29%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-01-18T17%3A07%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1587083%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/renini%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40%20extracting%20the%20model%20from%20the%20blob%20and%20storing%20in%20tokeninfo%3A%20I%20guess%20this%20is%20possible%2C%20but%20we%20would%20need%20to%20wrap%20some%20more%20of%20the%20shared%20library%20then%2C%20which%20might%20take%20a%20while.%22%2C%20%22created_at%22%3A%20%222018-01-19T14%3A06%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20want%20to%20open%20an%20extra%20issue%20for%20this%3F%22%2C%20%22created_at%22%3A%20%222018-01-19T14%3A11%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yup%2C%20I%20opened%20%23901.%22%2C%20%22created_at%22%3A%20%222018-01-19T14%3A15%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22closes%20%23891%5Cr%5Cncloses%20%23899%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-01-20T13%3A44%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%20967c445189bd6667cac7e2a2103f7efcc323c72b%20privacyidea/lib/tokens/vascotoken.py%208%20146%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/967c445189bd6667cac7e2a2103f7efcc323c72b%23commitcomment-26964712%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22perfect%21%22%2C%20%22created_at%22%3A%20%222018-01-19T14%3A04%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/vascotoken.py%3AL146%20%28967c445%29%22%7D%2C%20%22Commit%208587d50199328280face1206a73d859cdb628473%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/8587d50199328280face1206a73d859cdb628473%23commitcomment-26937906%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cud83e%5Cudd47%20awesomeness%21%22%2C%20%22created_at%22%3A%20%222018-01-18T12%3A54%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1587083%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/renini%22%7D%7D%5D%2C%20%22title%22%3A%20%22Commit%208587d50%20comments%22%7D%2C%20%22Pull%20967c445189bd6667cac7e2a2103f7efcc323c72b%20privacyidea/lib/tokens/vascotoken.py%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162638576%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20would%20need%20to%20change%20this%20to%20PI_VASCO_LIBRARY%22%2C%20%22created_at%22%3A%20%222018-01-19T14%3A41%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/vascotoken.py%3AL1-163%22%7D%2C%20%22Commit%2053b6bf86e4566188078cb3a62218b322e2169df4%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/53b6bf86e4566188078cb3a62218b322e2169df4%23commitcomment-26966725%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22being%20able%20to%20paste%20the%20digipass%20blob%20in%20the%20ui%20could%20be%20usefull%20for%20admins%20here%20in%20some%20situations%2C%20especially%20while%20migrating%20away%20from%20the%20current%20backend%20and%20in%20some%20testing%20situations.%20%5Cr%5Cnalthough%20i%20would%20prefer%20not%20to%20hexify%20this%20first%20though%20%3A%29%20but%20either%20way%2C%20should%20be%20fine%5Cr%5Cn%5Cr%5Cnis%20hexify%20really%20needed%20now%20we%20know%20the%20blob%20concists%20of%20only%20printable%20chars%3F%22%2C%20%22created_at%22%3A%20%222018-01-19T15%3A37%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1587083%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/renini%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20%5Cr%5Cn%5Cr%5Cn1.%20this%20is%20consistent%20with%20other%20token%20import%20formats%5Cr%5Cn2.%20we%20saw%20that%20a%20blob%20contains%20blanks.%20This%20could%20lead%20to%20problems%5Cr%5Cn3.%20You%20never%20can%20be%20certain...%5Cr%5Cn%5Cr%5CnWe%20removed%20the%20UI%2C%20since%20we%20currently%20have%20no%20template%20for%20enrolling%20the%20token%20in%20the%20UI.%5Cr%5CnBut%20I%20agree%2C%20that%20it%20makes%20sense%2C%20that%20an%20admin%20could%20need%20to%20enroll%20the%20token%20in%20the%20UI%20during%20testing%20phase.%5Cr%5Cn%40fredreichbier%20what%20do%20you%20think%3F%20I%20guess%20we%20should%20add%20an%20easy%20template%20%28after%20all%20it%20is%20only%20the%20%5C%22otpkey%5C%22.%20%5Cr%5CnWe%20should%20do%20a%20%60%60textedit%60%60%20instead%20of%20an%20%60%60input%60%60%20line.%22%2C%20%22created_at%22%3A%20%222018-01-19T23%3A40%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agree%2C%20this%20would%20be%20useful%21%20I%20opened%20%23903%20for%20that.%5Cr%5CnHm%2C%20I%20guess%20we%20could%20then%20merge%20this%20PR%20and%20close%20%23891%20and%20%23899%3F%22%2C%20%22created_at%22%3A%20%222018-01-20T11%3A03%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK.%20I%20think%20I%20might%20do%20this%20later%20today...%22%2C%20%22created_at%22%3A%20%222018-01-20T13%3A36%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22Commit%2053b6bf8%20comments%22%7D%2C%20%22Pull%20683223971e0b65cc7d3286cb72d3499bea3da3f2%20privacyidea/lib/tokens/vascotoken.py%20132%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162338040%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40cornelinux%20Is%20a%20return%20value%20of%20%60%600%60%60%20ok%20here%3F%20%28I%20think%20HOTP%20tokens%20return%20the%20correct%20OTP%20value%3F%29%22%2C%20%22created_at%22%3A%20%222018-01-18T13%3A17%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22our%20privacyIDEA%20%60%60check_otp%60%60%20would%20return%200%20in%20a%20succesfull%20authentication%20with%20the%20counter%200.%5Cr%5CnIn%20case%20of%20an%20unsuccessful%20authentication%20I%20think%20we%20need%20to%20return%20a%20negative%20value.%22%2C%20%22created_at%22%3A%20%222018-01-18T16%3A28%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22another%20thing%20i%20noticed%20while%20reading%20the%20header%20available%20%40%20https%3A//github.com/mlankenau/vacman_controller/blob/master/ext/vacman_controller/aal2sdk.h%20%2C%20is%20the%20following%3A%5Cr%5Cn%5Cr%5Cn/%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A/%5Cr%5Cn/%2A%20Convert%20a%20numeric%20error%20code%20to%20readable%20text%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2A/%5Cr%5Cn/%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A/%5Cr%5Cn%20%20VDS_EXPORT%28aat_ascii%20%2A%29%20%20AAL2GetErrorMsg%28aat_int32%20errorNum%2C%20aat_ascii%20%2AszBuffer%29%3B%5Cr%5Cn%5Cr%5CnShould/could%20that%20be%20used%20the%20error%20codes%20returned%3F%20I%20will%20try%20to%20find%20more%20error%20codes%20that%20might%20be%20usefull.%22%2C%20%22created_at%22%3A%20%222018-01-18T17%3A00%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1587083%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/renini%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/vascotoken.py%3AL1-142%22%7D%2C%20%22Pull%204ce66b34e56d56cf5d7c6094c04466f10cc660b7%20privacyidea/lib/tokens/vascotoken.py%20132%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r161835331%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22i%20think%20there%20is%20a%20return%20value%20also%20for%20a%20replay%20attempt%20%28try%20with%20the%20same%20OTP%20value%20within%20the%20time%20window%29%22%2C%20%22created_at%22%3A%20%222018-01-16T17%3A51%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1587083%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/renini%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20right%21%20I%20added%20a%20log%20message%20for%20that%20case.%22%2C%20%22created_at%22%3A%20%222018-01-18T12%3A32%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/vascotoken.py%3AL1-135%22%7D%2C%20%22Pull%20967c445189bd6667cac7e2a2103f7efcc323c72b%20privacyidea/lib/tokens/vascotoken.py%2084%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162651736%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27ve%20added%20a%20TODO%20note%20in%2053b6bf8%20in%20order%20to%20keep%20this%20in%20mind.%20%22%2C%20%22created_at%22%3A%20%222018-01-19T15%3A29%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/vascotoken.py%3AL1-163%22%7D%2C%20%22Pull%204ce66b34e56d56cf5d7c6094c04466f10cc660b7%20privacyidea/lib/tokens/vascotoken.py%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r161829815%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3F%20Do%20it%20or%20leave%20it%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-01-16T17%3A30%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-01-18T12%3A16%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/vascotoken.py%3AL1-135%22%7D%2C%20%22Pull%20967c445189bd6667cac7e2a2103f7efcc323c72b%20privacyidea/lib/tokens/vascotoken.py%20101%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/897%23discussion_r162652047%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20noticed%20that%20because%20we%20defined%20no%20template%2C%20VASCO%20tokens%20cannot%20be%20enrolled%20at%20all%20%28because%20we%20cannot%20paste%20a%20blob%20as%20the%20OTP%20key%29.%20So%20in%2053b6bf8%2C%20I%20removed%20the%20%60%60ui_enroll%60%60%20line%20--%20what%20do%20you%20think%3F%20%22%2C%20%22created_at%22%3A%20%222018-01-19T15%3A30%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/vascotoken.py%3AL1-163%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/897#issuecomment-357975028'>General Comment</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Still missing: Configurable .so location
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/897?src=pr&el=h1) Report
> Merging [#897](https://codecov.io/gh/privacyidea/privacyidea/pull/897?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/98e723f76113df715903a2e732d94a4002b063dd?src=pr&el=desc) will **increase** coverage by `0.04%`.
> The diff coverage is `92.43%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/897/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/897?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #897      +/-   ##
==========================================
+ Coverage   95.38%   95.42%   +0.04%
==========================================
Files         127      129       +2
Lines       15769    16093     +324
==========================================
+ Hits        15041    15357     +316
- Misses        728      736       +8
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/897?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/config.py](https://codecov.io/gh/privacyidea/privacyidea/pull/897/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ==) | `96.42% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/vasco.py](https://codecov.io/gh/privacyidea/privacyidea/pull/897/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjby5weQ==) | `89.7% <89.7%> (ø)` | |
| [privacyidea/lib/tokens/vascotoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/897/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjb3Rva2VuLnB5) | `96% <96%> (ø)` | |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/897/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.82% <0%> (+0.48%)` | :arrow_up: |
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/897/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `96.78% <0%> (+0.75%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/897?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/897?src=pr&el=footer). Last update [98e723f...4ce66b3](https://codecov.io/gh/privacyidea/privacyidea/pull/897?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> TODO:
* Implement failcounter properly. Right now, the failcounter is reset on each authentication attempt, which makes it pretty much useless.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The model could be imported as tokeninfo. When the blob is passed as otpkey, the vasco token class could  extract the model from the blob, right?
- <a href='https://github.com/renini'><img border=0 src='https://avatars3.githubusercontent.com/u/1587083?v=4' height=16 width=16></a> about the failcounter is this the failcounter of the token? If so, this failcounter is also in the digipass blob of the token, and returned as ERROR_COUNT by AAL2GetTokenInfoEx or AAL2GetTokenProperty, maybe we can use that to update?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The problem is: What does the vacman do, when the failcounter is reached and how does it reset the failcounter?
I like to have the failcounter in privacyIDEA, so that we have a consistent behavivour for all token types.
**You should stop using vasco tokens!** ;-)
- <a href='https://github.com/renini'><img border=0 src='https://avatars3.githubusercontent.com/u/1587083?v=4' height=16 width=16></a> Yes you are right, we should definitely stop using it... But this will take some time.
From what i've seen vacman does nothing when this counter is reached, its just indicative.
It can be reset with: **AAL2ResetTokenInfo**
/*********************************************************************/
/* Reset all time and error fields for a token                       */
/*********************************************************************/
VDS_EXPORT(aat_int32)  AAL2ResetTokenInfo(TDigipassBlob *DPData, TKernelParms  *CallParms);
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> @ extracting the model from the blob and storing in tokeninfo: I guess this is possible, but we would need to wrap some more of the shared library then, which might take a while.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Do you want to open an extra issue for this?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Yup, I opened #901.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> closes #891
closes #899
- [x] <a href='#crh-comment-Pull 4ce66b34e56d56cf5d7c6094c04466f10cc660b7 privacyidea/lib/tokens/vascotoken.py 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/897#discussion_r161829815'>File: privacyidea/lib/tokens/vascotoken.py:L1-135</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> ? Do it or leave it :-)
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> fixed :)
- [x] <a href='#crh-comment-Pull 4ce66b34e56d56cf5d7c6094c04466f10cc660b7 privacyidea/lib/tokens/vascotoken.py 132'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/897#discussion_r161835331'>File: privacyidea/lib/tokens/vascotoken.py:L1-135</a></b>
- <a href='https://github.com/renini'><img border=0 src='https://avatars3.githubusercontent.com/u/1587083?v=4' height=16 width=16></a> i think there is a return value also for a replay attempt (try with the same OTP value within the time window)
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Oh right! I added a log message for that case.
- [x] <a href='#crh-comment-Commit 8587d50199328280face1206a73d859cdb628473'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/8587d50199328280face1206a73d859cdb628473#commitcomment-26937906'>Commit 8587d50 comments</a></b>
- <a href='https://github.com/renini'><img border=0 src='https://avatars3.githubusercontent.com/u/1587083?v=4' height=16 width=16></a> 🥇 awesomeness!
- [x] <a href='#crh-comment-Pull 683223971e0b65cc7d3286cb72d3499bea3da3f2 privacyidea/lib/tokens/vascotoken.py 132'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/897#discussion_r162338040'>File: privacyidea/lib/tokens/vascotoken.py:L1-142</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> @cornelinux Is a return value of ``0`` ok here? (I think HOTP tokens return the correct OTP value?)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> our privacyIDEA ``check_otp`` would return 0 in a succesfull authentication with the counter 0.
In case of an unsuccessful authentication I think we need to return a negative value.
- <a href='https://github.com/renini'><img border=0 src='https://avatars3.githubusercontent.com/u/1587083?v=4' height=16 width=16></a> another thing i noticed while reading the header available @ https://github.com/mlankenau/vacman_controller/blob/master/ext/vacman_controller/aal2sdk.h , is the following:
/*********************************************************************/
/* Convert a numeric error code to readable text                     */
/*********************************************************************/
VDS_EXPORT(aat_ascii *)  AAL2GetErrorMsg(aat_int32 errorNum, aat_ascii *szBuffer);
Should/could that be used the error codes returned? I will try to find more error codes that might be usefull.
- [x] <a href='#crh-comment-Commit 967c445189bd6667cac7e2a2103f7efcc323c72b privacyidea/lib/tokens/vascotoken.py 8 146'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/967c445189bd6667cac7e2a2103f7efcc323c72b#commitcomment-26964712'>File: privacyidea/lib/tokens/vascotoken.py:L146 (967c445)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> perfect!
- [ ] <a href='#crh-comment-Pull 967c445189bd6667cac7e2a2103f7efcc323c72b privacyidea/lib/tokens/vascotoken.py 46'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/897#discussion_r162638576'>File: privacyidea/lib/tokens/vascotoken.py:L1-163</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We would need to change this to PI_VASCO_LIBRARY
- [ ] <a href='#crh-comment-Pull 967c445189bd6667cac7e2a2103f7efcc323c72b privacyidea/lib/tokens/vascotoken.py 84'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/897#discussion_r162651736'>File: privacyidea/lib/tokens/vascotoken.py:L1-163</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I've added a TODO note in 53b6bf8 in order to keep this in mind.
- [ ] <a href='#crh-comment-Pull 967c445189bd6667cac7e2a2103f7efcc323c72b privacyidea/lib/tokens/vascotoken.py 101'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/897#discussion_r162652047'>File: privacyidea/lib/tokens/vascotoken.py:L1-163</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I noticed that because we defined no template, VASCO tokens cannot be enrolled at all (because we cannot paste a blob as the OTP key). So in 53b6bf8, I removed the ``ui_enroll`` line -- what do you think?
- [ ] <a href='#crh-comment-Commit 53b6bf86e4566188078cb3a62218b322e2169df4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/53b6bf86e4566188078cb3a62218b322e2169df4#commitcomment-26966725'>Commit 53b6bf8 comments</a></b>
- <a href='https://github.com/renini'><img border=0 src='https://avatars3.githubusercontent.com/u/1587083?v=4' height=16 width=16></a> being able to paste the digipass blob in the ui could be usefull for admins here in some situations, especially while migrating away from the current backend and in some testing situations.
although i would prefer not to hexify this first though :) but either way, should be fine
is hexify really needed now we know the blob concists of only printable chars?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Yes,
1. this is consistent with other token import formats
2. we saw that a blob contains blanks. This could lead to problems
3. You never can be certain...
We removed the UI, since we currently have no template for enrolling the token in the UI.
But I agree, that it makes sense, that an admin could need to enroll the token in the UI during testing phase.
@fredreichbier what do you think? I guess we should add an easy template (after all it is only the "otpkey".
We should do a ``textedit`` instead of an ``input`` line.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I agree, this would be useful! I opened #903 for that.
Hm, I guess we could then merge this PR and close #891 and #899?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK. I think I might do this later today...


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/897?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/897?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/897'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>