### PR TITLE
tokenkind can be hardware, software, virtual

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -900,6 +900,7 @@ def loadtokens_api(filename=None):
         #    self.Policy.checkPolicyPre('admin', 'loadtokens',
         #                   {'tokenrealm': tokenrealm })
 
+        # Imported tokens are usually hardware tokens
         token = init_token(init_param, tokenrealms=tokenrealms,
                            tokenkind=TOKENKIND.HARDWARE)
         if TOKENS[serial].get("counter"):

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -90,6 +90,7 @@ from privacyidea.api.lib.postpolicy import (save_pin_change,
 from privacyidea.lib.event import event
 from privacyidea.api.auth import admin_required
 from privacyidea.lib.subscriptions import CheckSubscription
+from privacyidea.lib.tokenclass import TOKENKIND
 
 
 token_blueprint = Blueprint('token_blueprint', __name__)
@@ -899,7 +900,8 @@ def loadtokens_api(filename=None):
         #    self.Policy.checkPolicyPre('admin', 'loadtokens',
         #                   {'tokenrealm': tokenrealm })
 
-        token = init_token(init_param, tokenrealms=tokenrealms)
+        token = init_token(init_param, tokenrealms=tokenrealms,
+                           tokenkind=TOKENKIND.HARDWARE)
         if TOKENS[serial].get("counter"):
             token.set_otp_count(TOKENS[serial].get("counter"))
 

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #  privacyIDEA is a fork of LinOTP
 #
+#  2018-01-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Add tokenkind
 #  2017-08-11 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add auth_cache
 #  2017-04-19 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -92,6 +94,7 @@ from privacyidea.lib.policydecorators import (libpolicy,
                                               auth_cache,
                                               config_lost_token)
 from privacyidea.lib.tokenclass import DATE_FORMAT
+from privacyidea.lib.tokenclass import TOKENKIND
 from dateutil.tz import tzlocal
 
 log = logging.getLogger(__name__)
@@ -844,7 +847,8 @@ def gen_serial(tokentype=None, prefix=None):
 
 
 @log_with(log)
-def init_token(param, user=None, tokenrealms=None):
+def init_token(param, user=None, tokenrealms=None,
+               tokenkind=None):
     """
     create a new token or update an existing token
 
@@ -857,6 +861,8 @@ def init_token(param, user=None, tokenrealms=None):
     :type user: User Object
     :param tokenrealms: the realms, to which the token should belong
     :type tokenrealms: list
+    :param tokenkind: The kind of the token, can be "software",
+        "hardware" or "virtual"
 
     :return: token object or None
     :rtype: TokenClass object
@@ -934,6 +940,10 @@ def init_token(param, user=None, tokenrealms=None):
         log.error('token create failed!')
         log.debug("{0!s}".format(traceback.format_exc()))
         raise TokenAdminError("token create failed {0!r}".format(e), id=1112)
+
+    # Set the tokenkind
+    if tokenkind:
+        tokenobject.add_tokeninfo("tokenkind", tokenkind)
 
     # Set the validity period
     validity_period_start = param.get("validity_period_start")

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -941,7 +941,9 @@ def init_token(param, user=None, tokenrealms=None,
         log.debug("{0!s}".format(traceback.format_exc()))
         raise TokenAdminError("token create failed {0!r}".format(e), id=1112)
 
-    # Set the tokenkind
+    # We only set the tokenkind here, if it was explicitly set in the
+    # init_token call.
+    # In all other cases it is set in the update method of the tokenclass.
     if tokenkind:
         tokenobject.add_tokeninfo("tokenkind", tokenkind)
 

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-#  privacyIDEA is a fork of LinOTP
 #
+#  2018-01-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Implement tokenkind. Token can be hardware, software or virtual
 #  2017-07-08 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Failcount unlock
 #  2017-04-27 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -115,6 +116,12 @@ TWOSTEP_DEFAULT_CLIENTSIZE = 8
 TWOSTEP_DEFAULT_DIFFICULTY = 10000
 
 log = logging.getLogger(__name__)
+
+
+class TOKENKIND(object):
+    SOFTWARE = "software"
+    HARDWARE = "hardware"
+    VIRTUAL = "virtual"
 
 
 class TokenClass(object):
@@ -571,6 +578,9 @@ class TokenClass(object):
         for p in param.keys():
             if p.startswith(self.type + "."):
                 self.add_tokeninfo(p, getParam(param, p))
+
+        # The base class will be a software tokenkind
+        self.add_tokeninfo("tokenkind", TOKENKIND.SOFTWARE)
 
         return
 

--- a/privacyidea/lib/tokens/foureyestoken.py
+++ b/privacyidea/lib/tokens/foureyestoken.py
@@ -3,6 +3,8 @@
 #  License:  AGPLv3
 #  contact:  http://www.privacyidea.org
 #
+#  2018-01-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Add tokenkind
 #  2015-08-28 Initial writeup of the 4eyes token
 #             according to
 #             https://github.com/privacyidea/privacyidea/issues/167
@@ -34,7 +36,7 @@ The code is tested in tests/test_lib_tokens_4eyes.
 import logging
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.log import log_with
-from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.tokenclass import TokenClass, TOKENKIND
 from privacyidea.lib.error import ParameterError
 from privacyidea.lib.token import check_realm_pass
 from privacyidea.lib.decorators import check_token_locked
@@ -212,6 +214,7 @@ class FourEyesTokenClass(TokenClass):
         self.convert_realms(realms)
         self.add_tokeninfo("separator", separator)
         self.add_tokeninfo("4eyes", realms)
+        self.add_tokeninfo("tokenkind", TOKENKIND.VIRTUAL)
 
     @log_with(log)
     @check_token_locked

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -5,6 +5,8 @@
 #  License: AGPLv3
 #  contact: http://www.privacyidea.org
 #
+#  2018-01-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Set Yubikeys to be hardware tokenkind
 #  2017-07-13 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add period to key uri for TOTP token
 #
@@ -45,7 +47,10 @@ import binascii
 from .HMAC import HmacOtp
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.config import get_from_config
-from privacyidea.lib.tokenclass import TokenClass, TWOSTEP_DEFAULT_DIFFICULTY, TWOSTEP_DEFAULT_CLIENTSIZE
+from privacyidea.lib.tokenclass import (TokenClass,
+                                        TWOSTEP_DEFAULT_DIFFICULTY,
+                                        TWOSTEP_DEFAULT_CLIENTSIZE,
+                                        TOKENKIND)
 from privacyidea.lib.log import log_with
 from privacyidea.lib.apps import create_google_authenticator_url as cr_google
 from privacyidea.lib.error import ParameterError
@@ -316,6 +321,10 @@ class HotpTokenClass(TokenClass):
         TokenClass.update(self, upd_param, reset_failcount)
 
         self.add_tokeninfo("hashlib", hashlibStr)
+
+        # check the tokenkind
+        if self.token.serial.startswith("UB"):
+            self.add_tokeninfo("tokenkind", TOKENKIND.HARDWARE)
 
     @property
     def hashlib(self):

--- a/privacyidea/lib/tokens/radiustoken.py
+++ b/privacyidea/lib/tokens/radiustoken.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2018-01-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Add tokenkind
 #  2016-02-22 Cornelius Kölbel <cornelius@privacyidea.org>
 #             Add the RADIUS identifier, which points to the system wide list
 #             of RADIUS servers.
@@ -43,7 +45,7 @@ import logging
 
 import traceback
 import binascii
-from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.tokenclass import TokenClass, TOKENKIND
 from privacyidea.lib.tokens.remotetoken import RemoteTokenClass
 from privacyidea.api.lib.utils import getParam, ParameterError
 from privacyidea.lib.log import log_with
@@ -138,6 +140,7 @@ class RadiusTokenClass(RemoteTokenClass):
 
         val = getParam(param, "radius.user", required)
         self.add_tokeninfo("radius.user", val)
+        self.add_tokeninfo("tokenkind", TOKENKIND.VIRTUAL)
 
     @property
     def check_pin_local(self):

--- a/privacyidea/lib/tokens/remotetoken.py
+++ b/privacyidea/lib/tokens/remotetoken.py
@@ -5,6 +5,8 @@
 #  License:  AGPLv3
 #  contact:  http://www.privacyidea.org
 #
+#  2018-01-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Add tokenkind
 #  2015-01-28 Rewrite for migration to flask
 #             Cornelius Kölbel <cornelius@privacyidea.org>
 #
@@ -47,7 +49,7 @@ from privacyidea.lib.config import get_from_config
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.log import log_with
 from privacyidea.lib.policydecorators import challenge_response_allowed
-from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.tokenclass import TokenClass, TOKENKIND
 from privacyidea.lib import _
 
 optional = True
@@ -144,6 +146,8 @@ class RemoteTokenClass(TokenClass):
             val = getParam(param, key, optional)
             if val is not None:
                 self.add_tokeninfo(key, val)
+
+        self.add_tokeninfo("tokenkind", TOKENKIND.VIRTUAL)
 
     @property
     def check_pin_local(self):

--- a/privacyidea/lib/tokens/yubicotoken.py
+++ b/privacyidea/lib/tokens/yubicotoken.py
@@ -47,7 +47,7 @@ from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.crypto import geturandom
 from privacyidea.lib.config import get_from_config
 from privacyidea.lib.log import log_with
-from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.tokenclass import TokenClass, TOKENKIND
 from privacyidea.lib.tokens.yubikeytoken import (yubico_check_api_signature,
                                                  yubico_api_signature)
 import os
@@ -122,6 +122,7 @@ class YubicoTokenClass(TokenClass):
         param['otplen'] = 44
         TokenClass.update(self, param)
         self.add_tokeninfo("yubico.tokenid", self.tokenid)
+        self.add_tokeninfo("tokenkind", TOKENKIND.HARDWARE)
 
     @log_with(log)
     @check_token_locked

--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -66,6 +66,7 @@ import base64
 import hmac
 from hashlib import sha1
 from privacyidea.lib.config import get_from_config
+from privacyidea.lib.tokenclass import TOKENKIND
 from privacyidea.lib import _
 
 optional = True
@@ -452,3 +453,7 @@ h={h}
         (res, opt) = check_token_list(token_list, passw)
         return res, opt
 
+    @log_with(log)
+    def update(self, param, reset_failcount=True):
+        TokenClass.update(self, param, reset_failcount)
+        self.add_tokeninfo("tokenkind", TOKENKIND.HARDWARE)

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -860,5 +860,3 @@ class TokenBaseTestCase(MyTestCase):
         self.assertEqual(token_obj.get_failcount(), 0)
 
         token_obj.delete_token()
-
-


### PR DESCRIPTION
Each token gets a tokenkind during the enrollment.
The tokenkind is stored in the tokeninfo and can
be used in policies and in event handlers.

Closes #828
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/905%23discussion_r162803505%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/905%23discussion_r162803538%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/905%23issuecomment-359230521%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/905%23issuecomment-359231769%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/905%23issuecomment-359493583%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/905%23issuecomment-359230521%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40fredreichbier%20%20What%20do%20you%20think%3F%5Cr%5Cn%5Cr%5CnAvoiding%20extending%20the%20data%20schema%20with%20a%20tokenkind%2C%20we%20can%20use%20the%20tokeninfo%20methods%20with%20the%20policies%20and%20event%20handlers.%5Cr%5Cn%5Cr%5CnShould%20I%20add%20my%20comments%20in%20the%20PR%20as%20comments%20in%20the%20code%3F%22%2C%20%22created_at%22%3A%20%222018-01-21T07%3A53%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23905%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/32f69064f0ca4de731f76256467573069ed60e39%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/graphs/tree.svg%3Fheight%3D150%26width%3D650%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23905%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.38%25%20%20%2095.38%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20129%20%20%20%20%20%20129%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015913%20%20%20%2015933%20%20%20%20%20%20%2B20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015179%20%20%20%2015198%20%20%20%20%20%20%2B19%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20734%20%20%20%20%20%20735%20%20%20%20%20%20%20%2B1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6094.54%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/remotetoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9yZW1vdGV0b2tlbi5weQ%3D%3D%29%20%7C%20%6096.55%25%20%3C100%25%3E%20%28%2B0.02%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/hotptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/foureyestoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9mb3VyZXllc3Rva2VuLnB5%29%20%7C%20%6090.8%25%20%3C100%25%3E%20%28%2B0.1%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/yubicotoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy95dWJpY290b2tlbi5weQ%3D%3D%29%20%7C%20%6095.87%25%20%3C100%25%3E%20%28%2B0.04%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokenclass.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk%3D%29%20%7C%20%6098.95%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/radiustoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9yYWRpdXN0b2tlbi5weQ%3D%3D%29%20%7C%20%6098.24%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5%29%20%7C%20%6098.14%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/yubikeytoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy95dWJpa2V5dG9rZW4ucHk%3D%29%20%7C%20%6097.61%25%20%3C100%25%3E%20%28%2B0.07%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.27%25%20%3C0%25%3E%20%28-0.85%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B32f6906...86d040f%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/905%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-01-21T08%3A20%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20had%20a%20quick%20look%2C%20the%20PR%20looks%20good%20to%20me%20so%20far%21%20I%20also%20agree%20that%20using%20the%20tokeninfo%20to%20store%20the%20information%20is%20a%20good%20idea.%20I%20think%20adding%20the%20PR%20comments%20as%20comments%20would%20be%20nice%20as%20well.%5Cr%5CnWhat%20about%20the%20other%20tokenclasses%3F%20I%20guess%20they%20would%20implicitly%20be%20software%20tokens%2C%20which%20seems%20okay%20to%20me.%5Cr%5CnI%27ll%20have%20another%20look%20at%20the%20PR%20tomorrow%20and%20merge%20then.%22%2C%20%22created_at%22%3A%20%222018-01-22T17%3A04%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2086d040f389317a66cdb891aa56553911fe81acfc%20privacyidea/api/token.py%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/905%23discussion_r162803505%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20import%20is%20marked%20as%20a%20hardware%20token%22%2C%20%22created_at%22%3A%20%222018-01-21T07%3A51%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/token.py%3AL900-908%22%7D%2C%20%22Pull%2086d040f389317a66cdb891aa56553911fe81acfc%20privacyidea/lib/token.py%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/905%23discussion_r162803538%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20only%20set%20the%20tokenkind%20here%2C%20if%20it%20was%20explicitly%20set%20in%20the%20%60%60init_token%60%60%20call.%5Cr%5CnIn%20all%20other%20cases%20it%20is%20set%20in%20the%20%60%60update%60%60%20method%20of%20the%20tokenclass.%22%2C%20%22created_at%22%3A%20%222018-01-21T07%3A52%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL941-951%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 86d040f389317a66cdb891aa56553911fe81acfc privacyidea/api/token.py 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/905#discussion_r162803505'>File: privacyidea/api/token.py:L900-908</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The import is marked as a hardware token
- [ ] <a href='#crh-comment-Pull 86d040f389317a66cdb891aa56553911fe81acfc privacyidea/lib/token.py 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/905#discussion_r162803538'>File: privacyidea/lib/token.py:L941-951</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We only set the tokenkind here, if it was explicitly set in the ``init_token`` call.
In all other cases it is set in the ``update`` method of the tokenclass.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/905#issuecomment-359230521'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier  What do you think?
Avoiding extending the data schema with a tokenkind, we can use the tokeninfo methods with the policies and event handlers.
Should I add my comments in the PR as comments in the code?
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/905?src=pr&el=h1) Report
> Merging [#905](https://codecov.io/gh/privacyidea/privacyidea/pull/905?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/32f69064f0ca4de731f76256467573069ed60e39?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/905/graphs/tree.svg?height=150&width=650&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/905?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #905      +/-   ##
==========================================
- Coverage   95.38%   95.38%   -0.01%
==========================================
Files         129      129
Lines       15913    15933      +20
==========================================
+ Hits        15179    15198      +19
- Misses        734      735       +1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/905?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `94.54% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/lib/tokens/remotetoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9yZW1vdGV0b2tlbi5weQ==) | `96.55% <100%> (+0.02%)` | :arrow_up: |
| [privacyidea/lib/tokens/hotptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/foureyestoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9mb3VyZXllc3Rva2VuLnB5) | `90.8% <100%> (+0.1%)` | :arrow_up: |
| [privacyidea/lib/tokens/yubicotoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy95dWJpY290b2tlbi5weQ==) | `95.87% <100%> (+0.04%)` | :arrow_up: |
| [privacyidea/lib/tokenclass.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuY2xhc3MucHk=) | `98.95% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/radiustoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9yYWRpdXN0b2tlbi5weQ==) | `98.24% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/api/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5) | `98.14% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/yubikeytoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy95dWJpa2V5dG9rZW4ucHk=) | `97.61% <100%> (+0.07%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/905/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.27% <0%> (-0.85%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/905?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/905?src=pr&el=footer). Last update [32f6906...86d040f](https://codecov.io/gh/privacyidea/privacyidea/pull/905?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I had a quick look, the PR looks good to me so far! I also agree that using the tokeninfo to store the information is a good idea. I think adding the PR comments as comments would be nice as well.
What about the other tokenclasses? I guess they would implicitly be software tokens, which seems okay to me.
I'll have another look at the PR tomorrow and merge then.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/905?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/905?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/905'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>