### PR TITLE
839/offline refill

### DIFF
--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -189,7 +189,7 @@ def offlinerefill():
             tokenobj = get_tokens(serial=serial)[0]
             if tokenobj.get_tokeninfo("refilltoken") == refilltoken:
                 # refill
-                otps = MachineApplication.get_appropriate_refill(tokenobj, password, mdef.get("options"))
+                otps = MachineApplication.get_refill(tokenobj, password, mdef.get("options"))
                 refilltoken = MachineApplication.generate_new_refilltoken(tokenobj)
                 result = True
 

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -189,7 +189,8 @@ def offlinerefill():
             tokenobj = get_tokens(serial=serial)[0]
             if tokenobj.get_tokeninfo("refilltoken") == refilltoken:
                 # refill
-                refilltoken, otps = MachineApplication.get_refill(serial, password, mdef.get("options"))
+                otps = MachineApplication.get_appropriate_refill(serial, password, mdef.get("options"))
+                refilltoken = MachineApplication.generate_new_refilltoken(tokenobj)
                 result = True
 
     response = send_result(result)

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -176,7 +176,7 @@ def offlinerefill():
     :param pass: the last password (maybe password+OTP) entered by the user
     :return:
     """
-    refilltoken = None
+    result = False
     otps = {}
     serial = getParam(request.all_data, "serial", required)
     refilltoken = getParam(request.all_data, "refilltoken", required)
@@ -190,8 +190,9 @@ def offlinerefill():
             if tokenobj.get_tokeninfo("refilltoken") == refilltoken:
                 # refill
                 refilltoken, otps = MachineApplication.get_refill(serial, password, mdef.get("options"))
+                result = True
 
-    response = send_result(True)
+    response = send_result(result)
     content = json.loads(response.data)
     content["auth_items"] = {"offline": [{"refilltoken": refilltoken,
                                           "response": otps}]}

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -189,7 +189,7 @@ def offlinerefill():
             tokenobj = get_tokens(serial=serial)[0]
             if tokenobj.get_tokeninfo("refilltoken") == refilltoken:
                 # refill
-                otps = MachineApplication.get_appropriate_refill(serial, password, mdef.get("options"))
+                otps = MachineApplication.get_appropriate_refill(tokenobj, password, mdef.get("options"))
                 refilltoken = MachineApplication.generate_new_refilltoken(tokenobj)
                 result = True
 

--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -106,8 +106,7 @@ class MachineApplication(MachineApplicationBase):
         :param options: dict that might contain "count" and "rounds"
         :return: a dictionary of auth items
         """
-        if options is None:
-            options = {}
+        options = options or {}
         count = int(options.get("count", 100))
         rounds = int(options.get("rounds", ROUNDS))
         _r, otppin, otpval = token_obj.split_pin_pass(password)

--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -25,6 +25,7 @@
 #
 from privacyidea.lib.applications import MachineApplicationBase
 from privacyidea.lib.crypto import geturandom
+from privacyidea.lib.error import ValidateError
 import logging
 import passlib.hash
 from privacyidea.lib.token import get_tokens
@@ -84,6 +85,9 @@ class MachineApplication(MachineApplicationBase):
                 # find the value in the old OTP values! This resets the token.count!
                 matching_count = token_obj.check_otp(otpval, first_old_counter, count)
             token_obj.set_otp_count(current_token_counter)
+            # Raise an exception *after* we reset the token counter
+            if matching_count < 0:
+                raise ValidateError("You provided a wrong OTP value.")
             if first_fill:
                 counter_diff = count
             else:

--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -24,62 +24,13 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from privacyidea.lib.applications import MachineApplicationBase
+from privacyidea.lib.crypto import geturandom
 import logging
 import passlib.hash
 from privacyidea.lib.token import get_tokens
 log = logging.getLogger(__name__)
 ROUNDS = 6549
-
-"""
-TOOD: Add a mechanism for resynching offline
-
-Resynching the offline state means that the backend is online again _before_
-the cached OTP values are used up.
-Then we need to be able to contact the privacyIDEA server again, to either
-authenticate online or to fetch new OTP values.
-
-Requirements for resynching offline state.
-
-1. When going offline the client receives a list of hashed
-   OTP PIN / OTP values pairs. These are marked as not usable, since the server
-   would not know, if the values were used offline.
-
-2. The privacyIDEA server can not simply verify on off the offline OTP values.
-   We need an additional proof, that not a shoulder surfer is using a offline
-   OTP value, that he akquired from shoulder surfing.
-
-3. Two consecutive OTP values could be aquired by shoulder surfing a longer
-   time.
-
-4. For synching we need to add information, that can not be aquired from
-   shoulder surfing.
-
-5. This could be the remaining hashed OTP values. These hashed OTP values are
-   only known to the system.
-
-Resynching the offline state requires:
-a) a OTP value entered by the user
-b) the list of (or parts of the list) remaining hashed OTP values.
-
-This way the attacker would have to:
-
-1. should surf to receive an OTP value
-2. get grasp of the client machine, to get the remaining hashed OTP values.
-
-So if the client has cached OTP values the client may:
-1. authenticate against these hashed values
-2. if successfull try to contact the privacyIDEA server and try to resync
-   using
-   a) the entered OTP PIN / OTP value
-   b) the remaining hashed OTP values.
-
-privacyIDEA knows that this is an offline token and try to find the OTP value in
-the past OTP values and ask for the hashed OTP values.
-It then can reissue another 100 hashed OTP values.
-
-This way the issued offline OTP values become some kind of offline cache.
-
-"""
+REFILLTOKEN_LENGTH = 40
 
 
 class MachineApplication(MachineApplicationBase):
@@ -154,6 +105,9 @@ class MachineApplication(MachineApplicationBase):
                     uInfo = user_object.info
                     if "username" in uInfo:
                         ret["username"] = uInfo.get("username")
+                ret["refilltoken"] = geturandom(REFILLTOKEN_LENGTH, hex=True)
+                token_obj.add_tokeninfo("refilltoken", ret["refilltoken"],
+                                        value_type="password")
 
         else:
             log.info("Token %r, type %r is not supported by"

--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -160,8 +160,8 @@ class MachineApplication(MachineApplicationBase):
                     otppin = ""
                 otps = MachineApplication.get_offline_otps(token_obj,
                                                            otppin,
-                                                           options.get("count", 100),
-                                                           options.get("rounds", ROUNDS))
+                                                           int(options.get("count", 100)),
+                                                           int(options.get("rounds", ROUNDS)))
                 refilltoken = MachineApplication.generate_new_refilltoken(token_obj)
                 ret["response"] = otps
                 ret["refilltoken"] = refilltoken

--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -65,22 +65,27 @@ class MachineApplication(MachineApplicationBase):
         :return: tuple of refilltoken and auth_items
         """
         otps = []
+        otppin = ""
+        otpval = ""
+        matching_count = 0
         count = int(options.get("count", 100))
         rounds = int(options.get("rounds", ROUNDS))
         new_refilltoken = geturandom(REFILLTOKEN_LENGTH, hex=True)
         toks = get_tokens(serial=serial)
         if len(toks) == 1:
             token_obj = toks[0]
-            _r, otppin, otpval = token_obj.split_pin_pass(password)
+            if password:
+                _r, otppin, otpval = token_obj.split_pin_pass(password)
             current_token_counter = token_obj.token.count
             first_old_counter = current_token_counter - count
             if first_old_counter < 0:
                 first_old_counter = 0
-            # find the value in the old OTP values! This resets the token.count!
-            matching_count = token_obj.check_otp(otpval, first_old_counter, count)
+            if otpval:
+                # find the value in the old OTP values! This resets the token.count!
+                matching_count = token_obj.check_otp(otpval, first_old_counter, count)
             token_obj.set_otp_count(current_token_counter)
             if first_fill:
-                counter_diff = 100
+                counter_diff = count
             else:
                 counter_diff = matching_count - first_old_counter
             (res, err, otp_dict) = token_obj.get_multi_otp(count=counter_diff, counter_index=True)

--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -95,7 +95,7 @@ class MachineApplication(MachineApplicationBase):
         return otps
 
     @staticmethod
-    def get_appropriate_refill(token_obj, password, options=None):
+    def get_refill(token_obj, password, options=None):
         """
         Returns new authentication OTPs to refill the client
 
@@ -106,6 +106,8 @@ class MachineApplication(MachineApplicationBase):
         :param options: dict that might contain "count" and "rounds"
         :return: a dictionary of auth items
         """
+        if options is None:
+            options = {}
         count = int(options.get("count", 100))
         rounds = int(options.get("rounds", ROUNDS))
         _r, otppin, otpval = token_obj.split_pin_pass(password)

--- a/privacyidea/lib/machine.py
+++ b/privacyidea/lib/machine.py
@@ -156,7 +156,7 @@ def attach_token(serial, application, hostname=None, machine_id=None,
     :param resolver_name: The resolver_name of the machine you want attach
     the token to.
     :type resolver_name: basestring
-    :param options: addtional options
+    :param options: additional options
     :return: the new MachineToken Object
     """
     machine_id, resolver_name = _get_host_identifier(hostname, machine_id,

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -595,7 +595,8 @@ class HotpTokenClass(TokenClass):
 
     @log_with(log)
     def get_multi_otp(self, count=0, epoch_start=0, epoch_end=0,
-                        curTime=None, timestamp=None):
+                      curTime=None, timestamp=None,
+                      counter_index=False):
         """
         return a dictionary of multiple future OTP values of the
         HOTP/HMAC token
@@ -605,10 +606,11 @@ class HotpTokenClass(TokenClass):
 
         :param count: how many otp values should be returned
         :type count: int
-        :epoch_start: Not used in HOTP
-        :epoch_end: Not used in HOTP
-        :curTime: Not used in HOTP
-        :timestamp: not used in HOTP
+        :param epoch_start: Not used in HOTP
+        :param epoch_end: Not used in HOTP
+        :param curTime: Not used in HOTP
+        :param timestamp: not used in HOTP
+        :param counter_index: whether the counter should be used as index
         :return: tuple of status: boolean, error: text and the OTP dictionary
         """
         otp_dict = {"type": "hotp", "otp": {}}
@@ -626,7 +628,10 @@ class HotpTokenClass(TokenClass):
             for i in range(count):
                 otpval = hmac2Otp.generate(self.token.count + i,
                                            inc_counter=False)
-                otp_dict["otp"][i] = otpval
+                if counter_index:
+                    otp_dict["otp"][self.token.count + i] = otpval
+                else:
+                    otp_dict["otp"][i] = otpval
             ret = True
 
         return ret, error, otp_dict

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -380,9 +380,9 @@ class APIMachinesTestCase(MyTestCase):
             self.assertEqual(token_obj.token.count, 35) # 17 + 17 + 1, because we consumed 447589
             self.assertTrue(passlib.hash. \
                             pbkdf2_sha512.verify("test903435", # count = 18
-                                                 response.get('0')))
+                                                 response.get('18')))
             self.assertTrue(passlib.hash. \
                             pbkdf2_sha512.verify("test749439", # count = 34
-                                                 response.get('16')))
+                                                 response.get('34')))
         self.assertEqual(token_obj.check_otp('747439'), -1) # count = 34
         self.assertEqual(token_obj.check_otp('037211'), 35) # count = 35

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -393,14 +393,15 @@ class AAValidateOfflineTestCase(MyTestCase):
             auth_items = json.loads(res.data).get("auth_items")
             offline = auth_items.get("offline")[0]
             # Check the number of OTP values
-            self.assertEqual(len(offline.get("response")), 2)
+            self.assertEqual(len(offline.get("response")), 3)
             self.assertTrue("102" in offline.get("response"))
             self.assertTrue("103" in offline.get("response"))
+            self.assertTrue("104" in offline.get("response"))
             refilltoken_2 = offline.get("refilltoken")
             self.assertEqual(len(refilltoken_2), 2 * REFILLTOKEN_LENGTH)
             # check the token counter
             tok = get_tokens(serial=self.serials[0])[0]
-            self.assertEqual(tok.token.count, 104)
+            self.assertEqual(tok.token.count, 105)
             # The refilltoken changes each time
             self.assertNotEqual(refilltoken_1, refilltoken_2)
 
@@ -414,7 +415,6 @@ class AAValidateOfflineTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
             data = json.loads(res.data)
-            self.assertTrue(res.status_code == 400, res)
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR905: Token is not an offline token or refill token is incorrect")
 
@@ -435,16 +435,16 @@ class AAValidateOfflineTestCase(MyTestCase):
             offline = auth_items.get("offline")[0]
             # Check the number of OTP values
             self.assertEqual(len(offline.get("response")), 5)
-            self.assertTrue("104" in offline.get("response"))
             self.assertTrue("105" in offline.get("response"))
             self.assertTrue("106" in offline.get("response"))
             self.assertTrue("107" in offline.get("response"))
             self.assertTrue("108" in offline.get("response"))
+            self.assertTrue("109" in offline.get("response"))
             refilltoken_3 = offline.get("refilltoken")
             self.assertEqual(len(refilltoken_3), 2 * REFILLTOKEN_LENGTH)
             # check the token counter
             tok = get_tokens(serial=self.serials[0])[0]
-            self.assertEqual(tok.token.count, 109)
+            self.assertEqual(tok.token.count, 110)
             # The refilltoken changes each time
             self.assertNotEqual(refilltoken_2, refilltoken_3)
             self.assertNotEqual(refilltoken_1, refilltoken_3)

--- a/tests/test_lib_applications.py
+++ b/tests/test_lib_applications.py
@@ -2,7 +2,7 @@
 This test file tests the applications definitions standalone
 lib/applications/*
 """
-
+from privacyidea.lib.error import ParameterError
 from .base import MyTestCase
 from privacyidea.lib.applications import MachineApplicationBase
 from privacyidea.lib.applications.ssh import (MachineApplication as
@@ -145,6 +145,10 @@ class OfflineApplicationTestCase(MyTestCase):
         self.assertEqual(res, -1)
         res = tok.check_otp("378717")  # count = 103
         self.assertEqual(res, 103)
+        # check illegal API usage
+        self.assertRaises(ParameterError,
+                          OfflineApplication.get_offline_otps, tok, 'foo', -1)
+        self.assertEqual(OfflineApplication.get_offline_otps(tok, 'foo', 0), {})
 
     def test_03_get_auth_item_unsupported(self):
         # unsupported token type

--- a/tests/test_lib_applications.py
+++ b/tests/test_lib_applications.py
@@ -125,10 +125,10 @@ class OfflineApplicationTestCase(MyTestCase):
         self.assertEqual(len(refilltoken), REFILLTOKEN_LENGTH * 2)
         self.assertTrue(passlib.hash.\
                         pbkdf2_sha512.verify("969429", # count = 3
-                                             auth_item.get("response").get(0)))
+                                             auth_item.get("response").get(3)))
         self.assertTrue(passlib.hash.\
                         pbkdf2_sha512.verify("399871", # count = 8
-                                             auth_item.get("response").get(5)))
+                                             auth_item.get("response").get(8)))
         # The token now contains the refill token information:
         self.assertEqual(refilltoken, tok.get_tokeninfo("refilltoken"))
 
@@ -140,7 +140,7 @@ class OfflineApplicationTestCase(MyTestCase):
         self.assertEqual(len(auth_item.get("response")), 100)
         self.assertTrue(passlib.hash.\
                         pbkdf2_sha512.verify("629694", # count = 102
-                                             auth_item.get("response").get(99)))
+                                             auth_item.get("response").get(102)))
         res = tok.check_otp("629694") # count = 102
         self.assertEqual(res, -1)
         res = tok.check_otp("378717")  # count = 103


### PR DESCRIPTION
Closes #839
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/908%23issuecomment-359469224%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r162970333%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r162968866%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r162996458%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r163012138%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23issuecomment-360135456%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23issuecomment-360187425%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/f122e407070f17cf5cba298ea4cd3687ef343a6a%23commitcomment-27367865%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/f122e407070f17cf5cba298ea4cd3687ef343a6a%23commitcomment-27370482%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166328707%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166334084%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166455222%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166455650%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166570453%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166579622%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166579804%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23issuecomment-363777278%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23issuecomment-364089536%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23issuecomment-359469224%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23908%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/32f69064f0ca4de731f76256467573069ed60e39%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23908%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.38%25%20%20%2095.42%25%20%20%20%2B0.03%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20129%20%20%20%20%20%20129%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015913%20%20%20%2015978%20%20%20%20%20%20%2B65%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015179%20%20%20%2015247%20%20%20%20%20%20%2B68%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20734%20%20%20%20%20%20731%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/machine.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmUucHk%3D%29%20%7C%20%6095.34%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/hotptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/validate.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3ZhbGlkYXRlLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/applications/offline.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2FwcGxpY2F0aW9ucy9vZmZsaW5lLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.79%25%20%3C0%25%3E%20%28%2B1.68%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/vascotoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjb3Rva2VuLnB5%29%20%7C%20%6098.66%25%20%3C0%25%3E%20%28%2B2.11%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B32f6906...7621cb3%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/908%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-01-22T15%3A58%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tried%20to%20make%20the%20code%20a%20bit%20clearer%20in%202c6bfad3ed3d13854cf4a479252a5c27e0d3056a.%5Cr%5CnThere%2C%20we%20have%20two%20methods%20for%20the%20two%20cases%3A%5Cr%5Cn%2A%20%60%60get_offline_otps%60%60%3A%20just%20retrieve%20a%20number%20of%20offline%20OTPs%20%28%3D%20hash%28PIN%20%2B%20OTP%29%29%5Cr%5Cn%2A%20%60%60get_appropriate_refill%60%60%3A%20given%20a%20PIN%2BOTP%2C%20calculate%20the%20size%20of%20the%20refill%20and%20call%20%60%60get_offline_otps%60%60%20to%20get%20the%20right%20amount%20of%20new%20offline%20OTPs%22%2C%20%22created_at%22%3A%20%222018-01-24T13%3A36%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20looks%20good%20to%20me.%5Cr%5CnBut%20I%20have%20two%20comments%3A%5Cr%5Cn%5Cr%5Cn1.%20I%20would%20rename%20the%20%20%60%60get_appropriate_refill%60%60%20%20to%20%60%60get_refill%60%60.%20I%20always%20hope%20that%20the%20return%20value%20of%20a%20function%20is%20in%20fact%20appropriate%20%3B-%29%5Cr%5Cn2.%20In%20the%20method%20%60%60get_authentication_item%60%60%20I%20think%20the%20%60%60password%60%60%20will%20never%20be%20empty.%20Because%20in%20get%20its%20value%20from%20the%20%60%60pass%60%60%20parameter%20from%20validate/check.%20%28see%20https%3A//github.com/privacyidea/privacyidea/blob/master/privacyidea/api/lib/postpolicy.py%23L480%29%20The%20API%20call%20will%20always%20have%20a%20pass%20-%20or%20not%3F%20Do%20we%20have%20a%20test%20case%20for%20the%20empty%20password%3F%22%2C%20%22created_at%22%3A%20%222018-01-24T16%3A17%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20might%20have%20had%20an%20off-by-one%20error%20in%20%60%60get_refill%60%60%20until%20now%3A%5Cr%5CnAssume%20a%20user%20rolls%20out%20a%20new%20token%20and%20attaches%20it%20to%20a%20machine.%20Then%2C%20the%20user%20uses%20the%20OTP%20value%20with%20%60%60count%20%3D%200%60%60%20to%20get%20100%20offline%20OTPs.%20Then%2C%20the%20user%20presses%20the%20button%20%2Aonce%2A%20%28%3D%20OTP%20with%20%60%60count%20%3D%201%60%60%29%20and%20uses%20the%20OTP%20to%20get%20a%20refill.%20Up%20until%20now%2C%20the%20refill%20response%20had%200%20elements.%20But%20shouldn%27t%20it%20have%201%20element%2C%20as%20the%20user%20has%20consumed%20one%20OTP%20value%20already%3F%20%5Cr%5CnI%27ve%20attempted%20to%20fix%20the%20code%20and%20tests%20accordingly%20and%20pushed%20243533d.%20But%20we%20should%20probably%20double-check%20that%20this%20is%20now%20the%20intended%20behavior%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-02-07T14%3A00%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40fredreichbier%3A%20I%20am%20merging%20this%20now%21%5Cr%5Cn%5Cr%5CnThen%20we%20adapt%20the%20pam%20module%20and%20check%20it%20in%20real%20live.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-08T11%3A54%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207f40cff3b08dd3577af42cf25f111b0ecf68aa57%20privacyidea/lib/applications/offline.py%20131%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166328707%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40cornelinux%20I%27m%20wondering%20if%20this%20is%20even%20a%20legal%20case%3F%20In%20case%20of%20a%20refill%2C%20shouldn%27t%20the%20current%20token%20counter%20value%20always%20be%20higher%20than%20the%20refill%20amount%3F%22%2C%20%22created_at%22%3A%20%222018-02-06T14%3A58%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20you%20are%20right.%20But%20I%20am%20not%20sure%20here.%20Because%20in%20some%20tests%20I%20ran%20into%20this%20problem.%5Cr%5Cn%5Cr%5Cn%20%20%20%20if%20first_old_counter%20%3C%200%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20log.error%28%5C%22This%20should%20not%20happen%5C%22%29%20%20%5Cr%5Cn%5Cr%5Cn%3B-%29%5Cr%5Cn%5Cr%5CnAnd%20I%20think%20you%20said%3A%20If%20we%20have%20a%20negative%20value%2C%20the%20counter%20on%20the%20server%20would%20be%20decreased.%20So%20this%20might%20be%20the%20safe%20net%20for%20states%2C%20that%20should%20not%20occur%21%22%2C%20%22created_at%22%3A%20%222018-02-06T15%3A14%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20I%20guess%20this%20could%20happen%20if%20a%20token%20gets%20100%20offline%20OTPs%20%28i.e.%20the%20online%20token%20counter%20is%20101%29%2C%20then%20the%20administrator%20increases%20the%20offline%20OTP%20count%20to%20200%20and%20the%20client%20attempts%20a%20refill%20%28i.e.%20%60%60101%20-%20200%20%3D%20-99%60%60%29.%5Cr%5Cn%5Cr%5CnBut%20apart%20from%20that%2C%20we%20ensure%20that%20we%20never%20decrease%20the%20counter%20on%20the%20server%20by%20checking%20for%20%60%60amount%20%3C%200%60%60%20in%20%60%60get_offline_otps%60%60.%22%2C%20%22created_at%22%3A%20%222018-02-07T10%3A07%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/applications/offline.py%3AL53-134%22%7D%2C%20%22Commit%20f122e407070f17cf5cba298ea4cd3687ef343a6a%20privacyidea/lib/applications/offline.py%2014%20110%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/f122e407070f17cf5cba298ea4cd3687ef343a6a%23commitcomment-27367865%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Usually%20I%20do%20this%20like%5Cr%5Cn%5Cr%5Cn%20%20%20%20options%20%3D%20options%20or%20%7B%7D%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-06T10%3A38%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20usually%20use%20the%20%60%60if%20options%20is%20None%3A%20options%20%3D%20%7B%7D%60%60%20approach%20because%20%60%60options%20%3D%20options%20or%20%7B%7D%60%60%20allocates%20a%20new%20dictionary%20in%20case%20%60%60options%60%60%20is%20the%20empty%20dictionary.%20But%20I%20guess%20this%20is%20just%20a%20matter%20of%20style%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-02-06T13%3A08%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/applications/offline.py%3AL110%20%28f122e40%29%22%7D%2C%20%22Pull%207621cb3e053a8761be670f099e431ab85b042faa%20privacyidea/lib/applications/offline.py%2099%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r162996458%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20think%20in%20case%20the%20passed%20OTP%20value%20is%20not%20found%2C%20%60%60matching_count%60%60%20is%20set%20to%20-1%2C%20which%20results%20in%20a%20negative%20%60%60counter_diff%60%60%20later%20on%2C%20which%20results%20in%20a%20decreasing%20OTP%20counter%3F%22%2C%20%22created_at%22%3A%20%222018-01-22T16%3A46%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/applications/offline.py%3AL52-114%22%7D%2C%20%22Pull%207621cb3e053a8761be670f099e431ab85b042faa%20privacyidea/api/validate.py%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r166455650%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20still%20a%20problem%20or%20is%20this%20outdated%20due%20to%20your%20rewrite%3F%22%2C%20%22created_at%22%3A%20%222018-02-06T21%3A57%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20forgot%20about%20this%20%3A%29%20ce085ac%20now%20deals%20with%20error%20cases.%22%2C%20%22created_at%22%3A%20%222018-02-07T10%3A44%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/validate.py%3AL162-205%22%7D%2C%20%22Pull%207621cb3e053a8761be670f099e431ab85b042faa%20privacyidea/api/validate.py%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r162968866%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20this%20line%20can%20be%20deleted%2C%20as%20%60%60refilltoken%60%60%20is%20defined%20later%20on.%22%2C%20%22created_at%22%3A%20%222018-01-22T15%3A25%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22correct.%22%2C%20%22created_at%22%3A%20%222018-01-22T17%3A39%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/validate.py%3AL162-205%22%7D%2C%20%22Pull%207621cb3e053a8761be670f099e431ab85b042faa%20privacyidea/lib/applications/offline.py%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/908%23discussion_r162970333%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20we%20should%20add%20a%20log%20message%20in%20case%20the%20serial%20has%20no%20matching%20token%3F%20Because%20currently%2C%20in%20this%20case%2C%20a%20new%20refilltoken%20and%20an%20empty%20list%20are%20returned.%22%2C%20%22created_at%22%3A%20%222018-01-22T15%3A29%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20mean%20something%20in%20case%20%60%60len%28toks%29%20%21%3D%201%60%60%3F%5Cr%5Cn%5Cr%5CnSounds%20sensible%20to%20me.%22%2C%20%22created_at%22%3A%20%222018-02-06T21%3A56%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%20yeah%2C%20looking%20at%20it%20again%2C%20the%20current%20behavior%20seems%20okay%20at%20this%20point%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-02-07T10%3A44%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/applications/offline.py%3AL52-114%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 7621cb3e053a8761be670f099e431ab85b042faa privacyidea/api/validate.py 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/908#discussion_r162968866'>File: privacyidea/api/validate.py:L162-205</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think this line can be deleted, as ``refilltoken`` is defined later on.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> correct.
- [ ] <a href='#crh-comment-Pull 7621cb3e053a8761be670f099e431ab85b042faa privacyidea/lib/applications/offline.py 89'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/908#discussion_r162970333'>File: privacyidea/lib/applications/offline.py:L52-114</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Maybe we should add a log message in case the serial has no matching token? Because currently, in this case, a new refilltoken and an empty list are returned.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You mean something in case ``len(toks) != 1``?
Sounds sensible to me.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm yeah, looking at it again, the current behavior seems okay at this point :)
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/908#issuecomment-359469224'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/908?src=pr&el=h1) Report
> Merging [#908](https://codecov.io/gh/privacyidea/privacyidea/pull/908?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/32f69064f0ca4de731f76256467573069ed60e39?src=pr&el=desc) will **increase** coverage by `0.03%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/908/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/908?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #908      +/-   ##
==========================================
+ Coverage   95.38%   95.42%   +0.03%
==========================================
Files         129      129
Lines       15913    15978      +65
==========================================
+ Hits        15179    15247      +68
+ Misses        734      731       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/908?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/machine.py](https://codecov.io/gh/privacyidea/privacyidea/pull/908/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmUucHk=) | `95.34% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/hotptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/908/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/validate.py](https://codecov.io/gh/privacyidea/privacyidea/pull/908/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3ZhbGlkYXRlLnB5) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/applications/offline.py](https://codecov.io/gh/privacyidea/privacyidea/pull/908/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2FwcGxpY2F0aW9ucy9vZmZsaW5lLnB5) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/908/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.79% <0%> (+1.68%)` | :arrow_up: |
| [privacyidea/lib/tokens/vascotoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/908/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjb3Rva2VuLnB5) | `98.66% <0%> (+2.11%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/908?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/908?src=pr&el=footer). Last update [32f6906...7621cb3](https://codecov.io/gh/privacyidea/privacyidea/pull/908?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I tried to make the code a bit clearer in 2c6bfad3ed3d13854cf4a479252a5c27e0d3056a.
There, we have two methods for the two cases:
* ``get_offline_otps``: just retrieve a number of offline OTPs (= hash(PIN + OTP))
* ``get_appropriate_refill``: given a PIN+OTP, calculate the size of the refill and call ``get_offline_otps`` to get the right amount of new offline OTPs
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This looks good to me.
But I have two comments:
1. I would rename the  ``get_appropriate_refill``  to ``get_refill``. I always hope that the return value of a function is in fact appropriate ;-)
2. In the method ``get_authentication_item`` I think the ``password`` will never be empty. Because in get its value from the ``pass`` parameter from validate/check. (see https://github.com/privacyidea/privacyidea/blob/master/privacyidea/api/lib/postpolicy.py#L480) The API call will always have a pass - or not? Do we have a test case for the empty password?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> We might have had an off-by-one error in ``get_refill`` until now:
Assume a user rolls out a new token and attaches it to a machine. Then, the user uses the OTP value with ``count = 0`` to get 100 offline OTPs. Then, the user presses the button *once* (= OTP with ``count = 1``) and uses the OTP to get a refill. Up until now, the refill response had 0 elements. But shouldn't it have 1 element, as the user has consumed one OTP value already?
I've attempted to fix the code and tests accordingly and pushed 243533d. But we should probably double-check that this is now the intended behavior :)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier: I am merging this now!
Then we adapt the pam module and check it in real live.
- [ ] <a href='#crh-comment-Pull 7621cb3e053a8761be670f099e431ab85b042faa privacyidea/lib/applications/offline.py 99'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/908#discussion_r162996458'>File: privacyidea/lib/applications/offline.py:L52-114</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, I think in case the passed OTP value is not found, ``matching_count`` is set to -1, which results in a negative ``counter_diff`` later on, which results in a decreasing OTP counter?
- [ ] <a href='#crh-comment-Commit f122e407070f17cf5cba298ea4cd3687ef343a6a privacyidea/lib/applications/offline.py 14 110'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/f122e407070f17cf5cba298ea4cd3687ef343a6a#commitcomment-27367865'>File: privacyidea/lib/applications/offline.py:L110 (f122e40)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Usually I do this like
options = options or {}
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I usually use the ``if options is None: options = {}`` approach because ``options = options or {}`` allocates a new dictionary in case ``options`` is the empty dictionary. But I guess this is just a matter of style :)
- [ ] <a href='#crh-comment-Pull 7f40cff3b08dd3577af42cf25f111b0ecf68aa57 privacyidea/lib/applications/offline.py 131'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/908#discussion_r166328707'>File: privacyidea/lib/applications/offline.py:L53-134</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> @cornelinux I'm wondering if this is even a legal case? In case of a refill, shouldn't the current token counter value always be higher than the refill amount?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think you are right. But I am not sure here. Because in some tests I ran into this problem.
if first_old_counter < 0:
log.error("This should not happen")
;-)
And I think you said: If we have a negative value, the counter on the server would be decreased. So this might be the safe net for states, that should not occur!
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, I guess this could happen if a token gets 100 offline OTPs (i.e. the online token counter is 101), then the administrator increases the offline OTP count to 200 and the client attempts a refill (i.e. ``101 - 200 = -99``).
But apart from that, we ensure that we never decrease the counter on the server by checking for ``amount < 0`` in ``get_offline_otps``.
- [ ] <a href='#crh-comment-Pull 7621cb3e053a8761be670f099e431ab85b042faa privacyidea/api/validate.py 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/908#discussion_r166455650'>File: privacyidea/api/validate.py:L162-205</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Is this still a problem or is this outdated due to your rewrite?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I forgot about this :) ce085ac now deals with error cases.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/908?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/908?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/908'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>