### PR TITLE
Auto fill vasco serial from digipass blob in admin-ui

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -242,6 +242,23 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
         }
         if ($scope.form.type === "vasco") {
             $scope.form.genkey = false;
+
+            // auto fill serialnumber with serial from digipass blob
+            $scope.$watch('form.otpkey', function(newValue){
+               if(newValue.length === 496){
+                 //console.log('DEBUG: got 496 hexlify otpkey, check vasco serialnumber!');
+
+                 // convert hexlified input blob to ascii and use the serialnumber (first 10 chars)
+                 var vasco_hex = newValue.toString();//force conversion
+                 var vasco_otpstr = '';
+                 for (var i = 0; i < vasco_hex.length; i += 2)
+                     vasco_otpstr += String.fromCharCode(parseInt(vasco_hex.substr(i, 2), 16));
+                 var vasco_serial = vasco_otpstr.slice(0, 10);
+                 //console.log(vasco_serial);
+                 $scope.form.serial = vasco_serial;
+               }
+            });
+            
         } else {
             $scope.form.genkey = true;
         }

--- a/privacyidea/static/components/token/views/token.enroll.vasco.html
+++ b/privacyidea/static/components/token/views/token.enroll.vasco.html
@@ -15,3 +15,8 @@ The VASCO token is a proprietary OTP token. You can paste the VASCO token blob
               ng-model="form.otpkey" name="otpkey" id="otpkey">
     </textarea>
 </div>
+
+<div class="form-group">
+    <label for="vascoSerial" translate>VASCO Serial</label>
+    <input class="form-control" type="text" ng-model="form.serial" name="serial" id="serial" ng-disabled="true">
+</div>


### PR DESCRIPTION
@cornelinux i made this for #909 
Do you think this is an acceptable solution?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/910%23issuecomment-359809860%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/910%23issuecomment-359826120%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/910%23issuecomment-360057825%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/910%23issuecomment-360174567%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/910%23issuecomment-359809860%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23910%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/a62fd9b3d0555b43cf31be3c4092a549fd73f724%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23910%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.38%25%20%20%2095.4%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20129%20%20%20%20%20129%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2015933%20%20%2015933%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015198%20%20%2015201%20%20%20%20%20%20%20%2B3%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20735%20%20%20%20%20732%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.79%25%20%3C0%25%3E%20%28%2B2.52%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Ba62fd9b...0771a96%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/910%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-01-23T14%3A37%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20a%20lot%20for%20the%20pull%20request.%5Cr%5Cn%5Cr%5CnI%20thought%20i%20would%20push%20this%20into%20the%20server%2C%20so%20that%20the%20basic%20configuration%20can%20decide%2C%20if%20the%20%2Anew%2A%20token%20should%20have%20the%20vasco%20serial%20number%20or%20a%20generated%20serial%20number.%5Cr%5Cn%5Cr%5CnBut%20presenting%20the%20vasco%20serial%20number%20to%20the%20admin%20is%20nice%20anyways%21%5Cr%5Cn%5Cr%5CnAs%20mentioned%2C%20I%20am%20a%20bit%20hesitant%20to%20have%20the%20client/webui%20decide%20for%20the%20serial%20number.%22%2C%20%22created_at%22%3A%20%222018-01-23T15%3A28%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20was%20thinking%20about%20it%20this%20way%2C%20if%20another%20client%20other%20then%20the%20webui%20doesn%27t%20supply%20the%20serial%20number%20it%20would%20still%20get%20generated%20as%20VASC%24RANDOM%24.%20%5Cr%5Cn%5Cr%5CnBut%20a%20server%20generation%20of%20serialnumbers%20for%20vasco%20might%20be%20a%20better%20approach.%20I%20will%20leave%20that%20up%20to%20you.%5Cr%5Cn%5Cr%5CnCould%20there%20in%20theory%20be%20a%20serialno%20clashing%20with%20other%20type%20of%20tokens%20then%20vasco%3F%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-01-24T08%3A34%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1587083%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/renini%22%7D%7D%2C%20%7B%22body%22%3A%20%22privacyIDEA%20generates%20serial%20numbers%20that%20do%20not%20clash%20-%20unless%20you%20may%20have%20over%20100.000%20tokens%20and%20create%20tokens%20in%20a%20very%20fast%20manner%20%28I%20think%20there%20is%20an%20issue%20somewhere%20-%20but%20imho%20even%20this%20should%20not%20happen%29.%5Cr%5Cn%5Cr%5CnThe%20serial%20numbers%20that%20are%20generated%20by%20privacyIDEA%20are%20prefixed%20with%20a%20token%20type.%5Cr%5Cn%5Cr%5CnHowever%2C%20if%20you%20import%20tokens%20and%20the%20serial%20number%20of%20the%20imported%20tokens%20is%20simply%202120934980192%20%28a%20number%29%2C%20then%20one%20imported%20token%20would%20overwrite%20another%20imported%20token.%20But%20this%20also%20usually%20does%20not%20happen%2C%20since%20in%20setups%20mostly%20one%20token%20vendor%20is%20used%20and%20also%20the%20tokenvendors%20I%20know%2C%20use%20different%20number%20ranges.%5Cr%5Cn%5Cr%5CnSo%20short%3A%20No.%22%2C%20%22created_at%22%3A%20%222018-01-24T15%3A39%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/910#issuecomment-359809860'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/910?src=pr&el=h1) Report
> Merging [#910](https://codecov.io/gh/privacyidea/privacyidea/pull/910?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/a62fd9b3d0555b43cf31be3c4092a549fd73f724?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/910/graphs/tree.svg?width=650&height=150&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/910?src=pr&el=tree)
```diff
@@            Coverage Diff            @@
##           master    #910      +/-   ##
=========================================
+ Coverage   95.38%   95.4%   +0.01%
=========================================
Files         129     129
Lines       15933   15933
=========================================
+ Hits        15198   15201       +3
+ Misses        735     732       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/910?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/910/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.79% <0%> (+2.52%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/910?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/910?src=pr&el=footer). Last update [a62fd9b...0771a96](https://codecov.io/gh/privacyidea/privacyidea/pull/910?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Thanks a lot for the pull request.
I thought i would push this into the server, so that the basic configuration can decide, if the *new* token should have the vasco serial number or a generated serial number.
But presenting the vasco serial number to the admin is nice anyways!
As mentioned, I am a bit hesitant to have the client/webui decide for the serial number.
- <a href='https://github.com/renini'><img border=0 src='https://avatars3.githubusercontent.com/u/1587083?v=4' height=16 width=16></a> I was thinking about it this way, if another client other then the webui doesn't supply the serial number it would still get generated as VASC$RANDOM$.
But a server generation of serialnumbers for vasco might be a better approach. I will leave that up to you.
Could there in theory be a serialno clashing with other type of tokens then vasco?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> privacyIDEA generates serial numbers that do not clash - unless you may have over 100.000 tokens and create tokens in a very fast manner (I think there is an issue somewhere - but imho even this should not happen).
The serial numbers that are generated by privacyIDEA are prefixed with a token type.
However, if you import tokens and the serial number of the imported tokens is simply 2120934980192 (a number), then one imported token would overwrite another imported token. But this also usually does not happen, since in setups mostly one token vendor is used and also the tokenvendors I know, use different number ranges.
So short: No.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/910?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/910?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/910'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>