### PR TITLE
Add smtpserver timeout

### DIFF
--- a/migrations/versions/2118e566df16_.py
+++ b/migrations/versions/2118e566df16_.py
@@ -1,0 +1,26 @@
+"""Add timeout to SMTP server definition
+
+Revision ID: 2118e566df16
+Revises: 14a1bcb10018
+Create Date: 2018-02-09 08:48:03.308744
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2118e566df16'
+down_revision = '14a1bcb10018'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    try:
+        op.add_column('smtpserver', sa.Column('timeout', sa.Integer(), nullable=True))
+    except Exception as exx:
+        print("Could not add column 'smtpserver.timeout'")
+        print (exx)
+
+
+def downgrade():
+    op.drop_column('smtpserver', 'timeout')

--- a/privacyidea/api/smtpserver.py
+++ b/privacyidea/api/smtpserver.py
@@ -138,7 +138,7 @@ def test():
     tls = getParam(param, "tls", default=False)
     tls = tls in [True, "True", "true", "1"]
     recipient = getParam(param, "recipient", required)
-    timeout = int(getParam(param, "timeout", default=10))
+    timeout = int(getParam(param, "timeout") or 10)
 
     s = SMTPServerDB(identifier=identifier, server=server, port=port,
                      username=username, password=password, sender=sender,

--- a/privacyidea/api/smtpserver.py
+++ b/privacyidea/api/smtpserver.py
@@ -72,10 +72,11 @@ def create(identifier=None):
     tls = getParam(param, "tls", default=False)
     tls = tls in ["True", True, "true", "1"]
     description = getParam(param, "description", default="")
+    timeout = int(getParam(param, "timeout", default=10))
 
     r = add_smtpserver(identifier, server, port=port, username=username,
                        password=password, tls=tls, description=description,
-                       sender=sender)
+                       sender=sender, timeout=timeout)
 
     g.audit_object.log({'success': r > 0,
                         'info':  r})
@@ -97,7 +98,8 @@ def list_smtpservers():
                                          "port": server.config.port,
                                          "description":
                                              server.config.description,
-                                         "sender": server.config.sender}
+                                         "sender": server.config.sender,
+                                         "timeout": server.config.timeout}
     g.audit_object.log({'success': True})
     return send_result(res)
 
@@ -136,10 +138,11 @@ def test():
     tls = getParam(param, "tls", default=False)
     tls = tls in [True, "True", "true", "1"]
     recipient = getParam(param, "recipient", required)
+    timeout = int(getParam(param, "timeout", default=10))
 
     s = SMTPServerDB(identifier=identifier, server=server, port=port,
                      username=username, password=password, sender=sender,
-                     tls=tls)
+                     tls=tls, timeout=timeout)
     r = SMTPServer.test_email(s, recipient,
                               "Test Email from privacyIDEA",
                               "This is a test email from privacyIDEA. "

--- a/privacyidea/api/smtpserver.py
+++ b/privacyidea/api/smtpserver.py
@@ -72,7 +72,7 @@ def create(identifier=None):
     tls = getParam(param, "tls", default=False)
     tls = tls in ["True", True, "true", "1"]
     description = getParam(param, "description", default="")
-    timeout = int(getParam(param, "timeout", default=10))
+    timeout = int(getParam(param, "timeout") or 10)
 
     r = add_smtpserver(identifier, server, port=port, username=username,
                        password=password, tls=tls, description=description,

--- a/privacyidea/lib/smtpserver.py
+++ b/privacyidea/lib/smtpserver.py
@@ -93,7 +93,8 @@ class SMTPServer(object):
         msg['Reply-To'] = reply_to
 
         mail = smtplib.SMTP(config.server, port=int(config.port),
-                            timeout=TIMEOUT)
+                            timeout=config.timeout)
+        log.debug("Saying EHLO to mailserver {0!s}".format(config.server))
         mail.ehlo()
         # Start TLS if required
         if config.tls:
@@ -119,6 +120,7 @@ class SMTPServer(object):
                                                                   res_id,
                                                                   res_text))
         mail.quit()
+        log.debug("I am done sending your email.")
         return success
 
 
@@ -146,7 +148,7 @@ def send_email_identifier(identifier, recipient, subject, body, sender=None,
 @log_with(log)
 def send_email_data(mailserver, subject, message, mail_from,
                     recipient, username=None,
-                    password=None, port=25, email_tls=False):
+                    password=None, port=25, email_tls=False, timeout=TIMEOUT):
     """
     Send an email via the given email configuration data.
 
@@ -164,7 +166,7 @@ def send_email_data(mailserver, subject, message, mail_from,
     """
     dbserver = SMTPServerDB(identifier="emailtoken", server=mailserver,
                             sender=mail_from, username=username,
-                            password=password, port=port, tls=email_tls)
+                            password=password, port=port, tls=email_tls, timeout=timeout)
     smtpserver = SMTPServer(dbserver)
     return smtpserver.send_email(recipient, subject, message)
 
@@ -216,7 +218,7 @@ def get_smtpservers(identifier=None, server=None):
 
 @log_with(log)
 def add_smtpserver(identifier, server, port=25, username="", password="",
-                   sender="", description="", tls=False):
+                   sender="", description="", tls=False, timeout=TIMEOUT):
     """
     This adds an smtp server to the smtp server database table.
 
@@ -233,8 +235,9 @@ def add_smtpserver(identifier, server, port=25, username="", password="",
     cryptedPassword = encryptPassword(password)
     r = SMTPServerDB(identifier=identifier, server=server, port=port,
                      username=username, password=cryptedPassword, sender=sender,
-                     description=description, tls=tls).save()
+                     description=description, tls=tls, timeout=timeout).save()
     return r
+
 
 @log_with(log)
 def delete_smtpserver(identifier):

--- a/privacyidea/lib/smtpserver.py
+++ b/privacyidea/lib/smtpserver.py
@@ -93,9 +93,10 @@ class SMTPServer(object):
         msg['Reply-To'] = reply_to
 
         mail = smtplib.SMTP(config.server, port=int(config.port),
-                            timeout=config.timeout)
+                            timeout=config.timeout or TIMEOUT)
         log.debug("Saying EHLO to mailserver {0!s}".format(config.server))
-        mail.ehlo()
+        r = mail.ehlo()
+        log.debug("mailserver responded with {0!s}".format(r))
         # Start TLS if required
         if config.tls:
             log.debug("Trying to STARTTLS: {0!s}".format(config.tls))

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2161,6 +2161,7 @@ class SMTPServer(MethodsMixin, db.Model):
     sender = db.Column(db.Unicode(255), default=u"")
     tls = db.Column(db.Boolean, default=False)
     description = db.Column(db.Unicode(2000), default=u'')
+    timeout = db.Column(db.Integer, default=10)
 
     def save(self):
         smtp = SMTPServer.query.filter(SMTPServer.identifier ==
@@ -2185,6 +2186,8 @@ class SMTPServer(MethodsMixin, db.Model):
                 values["tls"] = self.tls
             if self.description is not None:
                 values["description"] = self.description
+            if self.timeout is not None:
+                values["timeout"] = self.timeout
             SMTPServer.query.filter(SMTPServer.identifier ==
                                     self.identifier).update(values)
             ret = smtp.id

--- a/privacyidea/static/components/config/views/config.smtp.edit.html
+++ b/privacyidea/static/components/config/views/config.smtp.edit.html
@@ -42,6 +42,16 @@
         </div>
     </div>
     <div class="form-group">
+        <label for="port" class="col-sm-3 control-label" translate>
+            Timeout</label>
+
+        <div class="col-sm-9">
+            <input name="timeout" class="form-control"
+                   ng-model="params.timeout"
+                   placeholder="10"/>
+        </div>
+    </div>
+    <div class="form-group">
         <label for="sender" class="col-sm-3 control-label"
                translate>Sender Email</label>
 


### PR DESCRIPTION
Closes #919
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/920%23issuecomment-364381387%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23discussion_r167190812%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23discussion_r167194077%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23discussion_r167198965%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23discussion_r167214655%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23discussion_r167264505%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23discussion_r167264509%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23issuecomment-364473470%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23issuecomment-364381387%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23920%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/157b42067d8cbabb5da672790c471079ff635ead%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26height%3D150%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23920%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.41%25%20%20%2095.42%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20129%20%20%20%20%20%20129%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016002%20%20%20%2016018%20%20%20%20%20%20%2B16%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015269%20%20%20%2015285%20%20%20%20%20%20%2B16%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20733%20%20%20%20%20%20733%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.74%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/smtpserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NtdHBzZXJ2ZXIucHk%3D%29%20%7C%20%6098.87%25%20%3C100%25%3E%20%28%2B0.03%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/smtpserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3NtdHBzZXJ2ZXIucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/smsprovider/SmppSMSProvider.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Ntc3Byb3ZpZGVyL1NtcHBTTVNQcm92aWRlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B157b420...1d626c3%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/920%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-09T09%3A28%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20not%20sure%2C%20how%20to%20change%20the%20review%20state.%5Cr%5CnAll%20problems%20in%20api/smtpserver.py%20have%20been%20fixed.%22%2C%20%22created_at%22%3A%20%222018-02-09T15%3A54%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20cc868560e79f3e989c87b1132ede7f4d8add8aa0%20privacyidea/api/smtpserver.py%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23discussion_r167190812%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20I%20do%20not%20enter%20a%20timeout%20value%20and%20use%20the%20%5C%22Send%20Test%20Email%5C%22%20button%2C%20I%20get%20the%20following%20error%3A%5Cr%5Cn%60%60%60Traceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201817%2C%20in%20wsgi_app%5Cr%5Cn%20%20%20%20response%20%3D%20self.full_dispatch_request%28%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201477%2C%20in%20full_dispatch_request%5Cr%5Cn%20%20%20%20rv%20%3D%20self.handle_user_exception%28e%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201381%2C%20in%20handle_user_exception%5Cr%5Cn%20%20%20%20reraise%28exc_type%2C%20exc_value%2C%20tb%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201475%2C%20in%20full_dispatch_request%5Cr%5Cn%20%20%20%20rv%20%3D%20self.dispatch_request%28%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201461%2C%20in%20dispatch_request%5Cr%5Cn%20%20%20%20return%20self.view_functions%5Brule.endpoint%5D%28%2A%2Areq.view_args%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/api/lib/prepolicy.py%5C%22%2C%20line%20117%2C%20in%20policy_wrapper%5Cr%5Cn%20%20%20%20return%20wrapped_function%28%2Aargs%2C%20%2A%2Akwds%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/lib/log.py%5C%22%2C%20line%20154%2C%20in%20log_wrapper%5Cr%5Cn%20%20%20%20return%20func%28%2Aargs%2C%20%2A%2Akwds%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/api/smtpserver.py%5C%22%2C%20line%20141%2C%20in%20test%5Cr%5Cn%20%20%20%20timeout%20%3D%20int%28getParam%28param%2C%20%5C%22timeout%5C%22%2C%20default%3D10%29%29%5Cr%5CnTypeError%3A%20int%28%29%20argument%20must%20be%20a%20string%20or%20a%20number%2C%20not%20%27NoneType%27%5Cr%5Cn%60%60%60%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-09T10%3A26%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20and%20the%20following%20error%20if%20I%20enter%20the%20empty%20string%3A%5Cr%5Cn%60%60%60%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201817%2C%20in%20wsgi_app%5Cr%5Cn%20%20%20%20response%20%3D%20self.full_dispatch_request%28%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201477%2C%20in%20full_dispatch_request%5Cr%5Cn%20%20%20%20rv%20%3D%20self.handle_user_exception%28e%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201381%2C%20in%20handle_user_exception%5Cr%5Cn%20%20%20%20reraise%28exc_type%2C%20exc_value%2C%20tb%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201475%2C%20in%20full_dispatch_request%5Cr%5Cn%20%20%20%20rv%20%3D%20self.dispatch_request%28%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201461%2C%20in%20dispatch_request%5Cr%5Cn%20%20%20%20return%20self.view_functions%5Brule.endpoint%5D%28%2A%2Areq.view_args%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/api/lib/prepolicy.py%5C%22%2C%20line%20117%2C%20in%20policy_wrapper%5Cr%5Cn%20%20%20%20return%20wrapped_function%28%2Aargs%2C%20%2A%2Akwds%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/lib/log.py%5C%22%2C%20line%20154%2C%20in%20log_wrapper%5Cr%5Cn%20%20%20%20return%20func%28%2Aargs%2C%20%2A%2Akwds%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/api/smtpserver.py%5C%22%2C%20line%20141%2C%20in%20test%5Cr%5Cn%20%20%20%20timeout%20%3D%20int%28getParam%28param%2C%20%5C%22timeout%5C%22%2C%20default%3D10%29%29%5Cr%5CnValueError%3A%20invalid%20literal%20for%20int%28%29%20with%20base%2010%3A%20%27%27%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222018-02-09T10%3A40%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20it%20is%20ok%2C%20to%20get%20an%20exception%2C%20if%20someone%20enters%20crap.%5Cr%5CnWe%20should%20however%20allow%20an%20empty%20string%20to%20be%20set%20to%20%5C%2210%5C%22.%5Cr%5Cn%5Cr%5CnI%20will%20add%20it%20accordingly.%22%2C%20%22created_at%22%3A%20%222018-02-09T11%3A01%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-02-09T15%3A48%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/smtpserver.py%3AL138-149%22%7D%2C%20%22Pull%20ee4f170626d7a7266f8405cfa98e90416b79731f%20privacyidea/api/smtpserver.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/920%23discussion_r167214655%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20still%20have%20a%20similar%20problem%20%3A/%5Cr%5CnSteps%3A%20Have%20SMTP%20Server%20without%20timeout%20defined%20in%20master%2C%20migrate%20database%2C%20edit%20the%20SMTP%20server%2C%20do%20not%20touch%20the%20timeout%20field%2C%20save%3A%5Cr%5Cn%60%60%60%5B2018-02-09%2013%3A22%3A45%2C949%5D%5B4072%5D%5B140416845743296%5D%5BERROR%5D%5Bprivacyidea.app%3A1423%5D%20Exception%20on%20/smtpserver/local%20%5BPOST%5D%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201817%2C%20in%20wsgi_app%5Cr%5Cn%20%20%20%20response%20%3D%20self.full_dispatch_request%28%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201477%2C%20in%20full_dispatch_request%5Cr%5Cn%20%20%20%20rv%20%3D%20self.handle_user_exception%28e%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201381%2C%20in%20handle_user_exception%5Cr%5Cn%20%20%20%20reraise%28exc_type%2C%20exc_value%2C%20tb%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201475%2C%20in%20full_dispatch_request%5Cr%5Cn%20%20%20%20rv%20%3D%20self.dispatch_request%28%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py%5C%22%2C%20line%201461%2C%20in%20dispatch_request%5Cr%5Cn%20%20%20%20return%20self.view_functions%5Brule.endpoint%5D%28%2A%2Areq.view_args%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/api/lib/prepolicy.py%5C%22%2C%20line%20117%2C%20in%20policy_wrapper%5Cr%5Cn%20%20%20%20return%20wrapped_function%28%2Aargs%2C%20%2A%2Akwds%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/lib/log.py%5C%22%2C%20line%20154%2C%20in%20log_wrapper%5Cr%5Cn%20%20%20%20return%20func%28%2Aargs%2C%20%2A%2Akwds%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/privacyidea/api/smtpserver.py%5C%22%2C%20line%2075%2C%20in%20create%5Cr%5Cn%20%20%20%20timeout%20%3D%20int%28getParam%28param%2C%20%5C%22timeout%5C%22%2C%20default%3D10%29%29%5Cr%5CnTypeError%3A%20int%28%29%20argument%20must%20be%20a%20string%20or%20a%20number%2C%20not%20%27NoneType%27%5Cr%5Cn%60%60%60%5Cr%5CnMaybe%20we%20should%20also%20use%20%60%60or%2010%60%60%20here%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-09T12%3A25%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-02-09T15%3A48%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/smtpserver.py%3AL72-83%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/920#issuecomment-364381387'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/920?src=pr&el=h1) Report
> Merging [#920](https://codecov.io/gh/privacyidea/privacyidea/pull/920?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/157b42067d8cbabb5da672790c471079ff635ead?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/920/graphs/tree.svg?token=7nHLZki60B&src=pr&height=150&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/920?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #920      +/-   ##
==========================================
+ Coverage   95.41%   95.42%   +<.01%
==========================================
Files         129      129
Lines       16002    16018      +16
==========================================
+ Hits        15269    15285      +16
Misses        733      733
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/920?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/920/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.74% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/smtpserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/920/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NtdHBzZXJ2ZXIucHk=) | `98.87% <100%> (+0.03%)` | :arrow_up: |
| [privacyidea/api/smtpserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/920/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3NtdHBzZXJ2ZXIucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/smsprovider/SmppSMSProvider.py](https://codecov.io/gh/privacyidea/privacyidea/pull/920/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Ntc3Byb3ZpZGVyL1NtcHBTTVNQcm92aWRlci5weQ==) | `100% <0%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/920?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/920?src=pr&el=footer). Last update [157b420...1d626c3](https://codecov.io/gh/privacyidea/privacyidea/pull/920?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I am not sure, how to change the review state.
All problems in api/smtpserver.py have been fixed.
- [x] <a href='#crh-comment-Pull cc868560e79f3e989c87b1132ede7f4d8add8aa0 privacyidea/api/smtpserver.py 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/920#discussion_r167190812'>File: privacyidea/api/smtpserver.py:L138-149</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> If I do not enter a timeout value and use the "Send Test Email" button, I get the following error:
```Traceback (most recent call last):
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
response = self.full_dispatch_request()
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
rv = self.dispatch_request()
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/home/fred/privacyidea/privacyidea/privacyidea/api/lib/prepolicy.py", line 117, in policy_wrapper
return wrapped_function(*args, **kwds)
File "/home/fred/privacyidea/privacyidea/privacyidea/lib/log.py", line 154, in log_wrapper
return func(*args, **kwds)
File "/home/fred/privacyidea/privacyidea/privacyidea/api/smtpserver.py", line 141, in test
timeout = int(getParam(param, "timeout", default=10))
TypeError: int() argument must be a string or a number, not 'NoneType'
```
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, and the following error if I enter the empty string:
```
Traceback (most recent call last):
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
response = self.full_dispatch_request()
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
rv = self.dispatch_request()
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/home/fred/privacyidea/privacyidea/privacyidea/api/lib/prepolicy.py", line 117, in policy_wrapper
return wrapped_function(*args, **kwds)
File "/home/fred/privacyidea/privacyidea/privacyidea/lib/log.py", line 154, in log_wrapper
return func(*args, **kwds)
File "/home/fred/privacyidea/privacyidea/privacyidea/api/smtpserver.py", line 141, in test
timeout = int(getParam(param, "timeout", default=10))
ValueError: invalid literal for int() with base 10: ''
```
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think it is ok, to get an exception, if someone enters crap.
We should however allow an empty string to be set to "10".
I will add it accordingly.
- [x] <a href='#crh-comment-Pull ee4f170626d7a7266f8405cfa98e90416b79731f privacyidea/api/smtpserver.py 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/920#discussion_r167214655'>File: privacyidea/api/smtpserver.py:L72-83</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> We still have a similar problem :/
Steps: Have SMTP Server without timeout defined in master, migrate database, edit the SMTP server, do not touch the timeout field, save:
```[2018-02-09 13:22:45,949][4072][140416845743296][ERROR][privacyidea.app:1423] Exception on /smtpserver/local [POST]
Traceback (most recent call last):
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
response = self.full_dispatch_request()
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
rv = self.dispatch_request()
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/home/fred/privacyidea/privacyidea/privacyidea/api/lib/prepolicy.py", line 117, in policy_wrapper
return wrapped_function(*args, **kwds)
File "/home/fred/privacyidea/privacyidea/privacyidea/lib/log.py", line 154, in log_wrapper
return func(*args, **kwds)
File "/home/fred/privacyidea/privacyidea/privacyidea/api/smtpserver.py", line 75, in create
timeout = int(getParam(param, "timeout", default=10))
TypeError: int() argument must be a string or a number, not 'NoneType'
```
Maybe we should also use ``or 10`` here?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/920?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/920?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/920'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>