### PR TITLE
Pass SMTP Server Password to Web UI

### DIFF
--- a/privacyidea/api/smtpserver.py
+++ b/privacyidea/api/smtpserver.py
@@ -34,6 +34,7 @@ from .lib.utils import (getParam,
                         required,
                         send_result)
 from ..lib.log import log_with
+from ..lib.crypto import decryptPassword, FAILED_TO_DECRYPT_PASSWORD
 from ..lib.policy import ACTION
 from ..api.lib.prepolicy import prepolicy, check_base_action
 from flask import g
@@ -91,9 +92,14 @@ def list_smtpservers():
     res = {}
     server_list = get_smtpservers()
     for server in server_list:
+        decrypted_password = decryptPassword(server.config.password)
+        # If the database contains garbage, use the empty password as fallback
+        if decrypted_password == FAILED_TO_DECRYPT_PASSWORD:
+            decrypted_password = ""
         res[server.config.identifier] = {"server": server.config.server,
                                          "tls": server.config.tls,
                                          "username": server.config.username,
+                                         "password": decrypted_password,
                                          "port": server.config.port,
                                          "description":
                                              server.config.description,

--- a/tests/test_api_smtpserver.py
+++ b/tests/test_api_smtpserver.py
@@ -50,7 +50,7 @@ class SMTPServerTestCase(MyTestCase):
             self.assertEqual(server1.get("server"), "1.2.3.4")
             self.assertEqual(server1.get("sender"), "privacyidea@local")
             self.assertEqual(server1.get("username"), "cornelius")
-            self.assertTrue("password" not in server1)
+            self.assertEqual(server1.get("password"), "secret")
 
         # delete server
         with self.app.test_request_context('/smtpserver/server1',


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/924%23issuecomment-364444638%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/924%23issuecomment-364449943%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/924%23issuecomment-364444638%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22looks%20good%20to%20me.%22%2C%20%22created_at%22%3A%20%222018-02-09T14%3A14%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23924%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/157b42067d8cbabb5da672790c471079ff635ead%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6075%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23924%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.41%25%20%20%2095.41%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20129%20%20%20%20%20%20129%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016002%20%20%20%2016006%20%20%20%20%20%20%20%2B4%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015269%20%20%20%2015272%20%20%20%20%20%20%20%2B3%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20733%20%20%20%20%20%20734%20%20%20%20%20%20%20%2B1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/smtpserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3NtdHBzZXJ2ZXIucHk%3D%29%20%7C%20%6098.46%25%20%3C75%25%3E%20%28-1.54%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B157b420...5cd607a%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/924%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-09T14%3A33%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/924#issuecomment-364444638'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> looks good to me.
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/924?src=pr&el=h1) Report
> Merging [#924](https://codecov.io/gh/privacyidea/privacyidea/pull/924?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/157b42067d8cbabb5da672790c471079ff635ead?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `75%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/924/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/924?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #924      +/-   ##
==========================================
- Coverage   95.41%   95.41%   -0.01%
==========================================
Files         129      129
Lines       16002    16006       +4
==========================================
+ Hits        15269    15272       +3
- Misses        733      734       +1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/924?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/smtpserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/924/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3NtdHBzZXJ2ZXIucHk=) | `98.46% <75%> (-1.54%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/924?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/924?src=pr&el=footer). Last update [157b420...5cd607a](https://codecov.io/gh/privacyidea/privacyidea/pull/924?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/924?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/924?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/924'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>