### PR TITLE
Speed up linotp database migration

### DIFF
--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -48,10 +48,14 @@ The "realm" key puts tokens in the privacyIDEA-Resolver into this privacyIDEA re
 
 In this example the resolvername "lokal" from LinOTP gets imported to
 privacyIDEA with the resolver "PIResolver" in realm "pirealm".
+
+Tokens, that were not assigned to a user will be assigned to the realms "realm1" and "realm2"
+in privacyIDEA.
 """
 ASSIGNMENTS = {
     "resolver": {"lokal": "PIResolver"},
-    "realm": {"PIResolver": "pirealm"}
+    "realm": {"PIResolver": "pirealm"},
+    "unassigned_tokens": ["realm1", "realm2"]
 }
 
 """
@@ -61,319 +65,338 @@ statement.
 """
 INSERT_CHUNK_SIZE = 10000
 
-CONFIGURED = False
-
-if not CONFIGURED:
-    raise Exception("You need to configure some data in the script itself!")
-
 # Do not change anything after this line
 # ============================================================================
 #
-
-# THis maps the resolver types. You must not change this!
-resolver_map = {"LDAPIdResolver": "ldapresolver",
-                "SQLIdResolver": "sqlresolver",
-                "PasswdIdResolver": "passwdresolver"}
-
-token_serial_id_map = {}
-realm_id_map = {}
-resolver_id_map = {}
-
 from sqlalchemy import Table, MetaData, Column
 from sqlalchemy import Integer, Unicode, Boolean, UnicodeText
-metadata = MetaData()
+import sys
+import getopt
 
-token_table = Table("token", metadata,
-                    Column("id", Integer, primary_key=True, nullable=False),
-                    Column("description", Unicode(80), default=u''),
-                    Column("serial", Unicode(40), default=u'', unique=True,
-                           nullable=False, index=True),
-                    Column("tokentype", Unicode(30), default=u'HOTP',
-                           index=True),
-                    Column("user_pin", Unicode(512), default=u''),
-                    Column("user_pin_iv", Unicode(32), default=u''),
-                    Column("so_pin", Unicode(512), default=u''),
-                    Column("so_pin_iv", Unicode(32), default=u''),
-                    Column("resolver", Unicode(120), default=u'', index=True),
-                    Column("resolver_type",  Unicode(120), default=u''),
-                    Column("user_id", Unicode(320), default=u'', index=True),
-                    Column("pin_seed", Unicode(32), default=u''),
-                    Column("otplen", Integer(), default=6),
-                    Column("pin_hash", Unicode(512), default=u''),
-                    Column("key_enc", Unicode(1024), default=u''),
-                    Column("key_iv", Unicode(32), default=u''),
-                    Column("maxfail", Integer(), default=10),
-                    Column("active", Boolean(), nullable=False, default=True),
-                    Column("revoked", Boolean(), default=False),
-                    Column("locked", Boolean(), default=False),
-                    Column("failcount", Integer(), default=0),
-                    Column("count", Integer(), default=0),
-                    Column("count_window", Integer(), default=10),
-                    Column("sync_window", Integer(), default=1000),
-                    Column("rollout_state", Unicode(10), default=u''))
 
-tokeninfo_table = Table("tokeninfo", metadata,
-                  Column("id", Integer, primary_key=True),
-                  Column("Key", Unicode(255), nullable=False),
-                  Column("Value", UnicodeText(), default=u''),
-                  Column("Type", Unicode(100), default=u''),
-                  Column("Description", Unicode(2000), default=u''),
-                  Column("token_id", Integer()))
+def migrate():
 
-tokenrealm_table = Table("tokenrealm", metadata,
-                         Column("id", Integer(), primary_key=True),
-                         Column("token_id", Integer()),
-                         Column("realm_id", Integer()))
+    # This maps the resolver types. You must not change this!
+    resolver_map = {"LDAPIdResolver": "ldapresolver",
+                    "SQLIdResolver": "sqlresolver",
+                    "PasswdIdResolver": "passwdresolver"}
 
-realm_table = Table("realm", metadata,
-                    Column("id", Integer, primary_key=True),
-                    Column("name", Unicode(255), default=u''),
-                    Column("default",  Boolean(), default=False),
-                    Column("option", Unicode(40), default=u''))
+    token_serial_id_map = {}
+    realm_id_map = {}
+    resolver_id_map = {}
 
-resolver_table = Table("resolver", metadata,
-                       Column("id", Integer, primary_key=True),
-                       Column("name", Unicode(255), default=u""),
-                       Column("rtype", Unicode(255), default=u""))
+    metadata = MetaData()
 
-resolver_config_table = Table("resolverconfig", metadata,
-                              Column("id", Integer, primary_key=True),
-                              Column("resolver_id", Integer),
-                              Column("Key", Unicode(255), default=u""),
-                              Column("Value", Unicode(2000), default=u""),
-                              Column("Type", Unicode(2000), default=u""),
-                              Column("Description", Unicode(2000), default=u""),
-                              )
-
-resolverrealm_table = Table("resolverrealm", metadata,
-                            Column("id", Integer, primary_key=True),
-                            Column("resolver_id", Integer),
-                            Column("realm_id", Integer),
-                            Column("priority", Integer))
-
-#
-# LinOTP table definitions
-#
-
-linotp_token_table = Table('Token',metadata,
-                           Column('LinOtpTokenId', Integer(),
-                                  primary_key=True, nullable=False),
-                           Column(
-                               'LinOtpTokenDesc', Unicode(80), default=u''),
-                           Column('LinOtpTokenSerialnumber', Unicode(
-                               40), default=u'', unique=True, nullable=False,
-                                  index=True),
-                           Column(
-                               'LinOtpTokenType', Unicode(30), default=u'HMAC',
+    token_table = Table("token", metadata,
+                        Column("id", Integer, primary_key=True, nullable=False),
+                        Column("description", Unicode(80), default=u''),
+                        Column("serial", Unicode(40), default=u'', unique=True,
+                               nullable=False, index=True),
+                        Column("tokentype", Unicode(30), default=u'HOTP',
                                index=True),
-                           Column(
-                               'LinOtpTokenInfo', Unicode(2000), default=u''),
-                           Column(
-                               'LinOtpTokenPinUser', Unicode(512), default=u''),
-                           Column(
-                               'LinOtpTokenPinUserIV', Unicode(32),
-                               default=u''),
-                           Column(
-                               'LinOtpTokenPinSO', Unicode(512), default=u''),
-                           Column(
-                               'LinOtpTokenPinSOIV', Unicode(32), default=u''),
-                           Column(
-                               'LinOtpIdResolver', Unicode(120), default=u'',
-                               index=True),
-                           Column(
-                               'LinOtpIdResClass', Unicode(120), default=u''),
-                           Column(
-                               'LinOtpUserid', Unicode(320), default=u'',
-                               index=True),
-                           Column(
-                               'LinOtpSeed', Unicode(32), default=u''),
-                           Column(
-                               'LinOtpOtpLen', Integer(), default=6),
-                           Column(
-                               'LinOtpPinHash', Unicode(512), default=u''),
-                           Column(
-                               'LinOtpKeyEnc', Unicode(1024), default=u''),
-                           Column(
-                               'LinOtpKeyIV', Unicode(32), default=u''),
-                           Column(
-                               'LinOtpMaxFail', Integer(), default=10),
-                           Column(
-                               'LinOtpIsactive', Boolean(), default=True),
-                           Column(
-                               'LinOtpFailCount', Integer(), default=0),
-                           Column('LinOtpCount', Integer(), default=0),
-                           Column(
-                               'LinOtpCountWindow', Integer(), default=10),
-                           Column(
-                               'LinOtpSyncWindow', Integer(), default=1000)
-                           )
+                        Column("user_pin", Unicode(512), default=u''),
+                        Column("user_pin_iv", Unicode(32), default=u''),
+                        Column("so_pin", Unicode(512), default=u''),
+                        Column("so_pin_iv", Unicode(32), default=u''),
+                        Column("resolver", Unicode(120), default=u'', index=True),
+                        Column("resolver_type",  Unicode(120), default=u''),
+                        Column("user_id", Unicode(320), default=u'', index=True),
+                        Column("pin_seed", Unicode(32), default=u''),
+                        Column("otplen", Integer(), default=6),
+                        Column("pin_hash", Unicode(512), default=u''),
+                        Column("key_enc", Unicode(1024), default=u''),
+                        Column("key_iv", Unicode(32), default=u''),
+                        Column("maxfail", Integer(), default=10),
+                        Column("active", Boolean(), nullable=False, default=True),
+                        Column("revoked", Boolean(), default=False),
+                        Column("locked", Boolean(), default=False),
+                        Column("failcount", Integer(), default=0),
+                        Column("count", Integer(), default=0),
+                        Column("count_window", Integer(), default=10),
+                        Column("sync_window", Integer(), default=1000),
+                        Column("rollout_state", Unicode(10), default=u''))
+
+    tokeninfo_table = Table("tokeninfo", metadata,
+                      Column("id", Integer, primary_key=True),
+                      Column("Key", Unicode(255), nullable=False),
+                      Column("Value", UnicodeText(), default=u''),
+                      Column("Type", Unicode(100), default=u''),
+                      Column("Description", Unicode(2000), default=u''),
+                      Column("token_id", Integer()))
+
+    tokenrealm_table = Table("tokenrealm", metadata,
+                             Column("id", Integer(), primary_key=True),
+                             Column("token_id", Integer()),
+                             Column("realm_id", Integer()))
+
+    realm_table = Table("realm", metadata,
+                        Column("id", Integer, primary_key=True),
+                        Column("name", Unicode(255), default=u''),
+                        Column("default",  Boolean(), default=False),
+                        Column("option", Unicode(40), default=u''))
+
+    resolver_table = Table("resolver", metadata,
+                           Column("id", Integer, primary_key=True),
+                           Column("name", Unicode(255), default=u""),
+                           Column("rtype", Unicode(255), default=u""))
+
+    resolver_config_table = Table("resolverconfig", metadata,
+                                  Column("id", Integer, primary_key=True),
+                                  Column("resolver_id", Integer),
+                                  Column("Key", Unicode(255), default=u""),
+                                  Column("Value", Unicode(2000), default=u""),
+                                  Column("Type", Unicode(2000), default=u""),
+                                  Column("Description", Unicode(2000), default=u""),
+                                  )
+
+    resolverrealm_table = Table("resolverrealm", metadata,
+                                Column("id", Integer, primary_key=True),
+                                Column("resolver_id", Integer),
+                                Column("realm_id", Integer),
+                                Column("priority", Integer))
+
+    #
+    # LinOTP table definitions
+    #
+
+    linotp_token_table = Table('Token',metadata,
+                               Column('LinOtpTokenId', Integer(),
+                                      primary_key=True, nullable=False),
+                               Column(
+                                   'LinOtpTokenDesc', Unicode(80), default=u''),
+                               Column('LinOtpTokenSerialnumber', Unicode(
+                                   40), default=u'', unique=True, nullable=False,
+                                      index=True),
+                               Column(
+                                   'LinOtpTokenType', Unicode(30), default=u'HMAC',
+                                   index=True),
+                               Column(
+                                   'LinOtpTokenInfo', Unicode(2000), default=u''),
+                               Column(
+                                   'LinOtpTokenPinUser', Unicode(512), default=u''),
+                               Column(
+                                   'LinOtpTokenPinUserIV', Unicode(32),
+                                   default=u''),
+                               Column(
+                                   'LinOtpTokenPinSO', Unicode(512), default=u''),
+                               Column(
+                                   'LinOtpTokenPinSOIV', Unicode(32), default=u''),
+                               Column(
+                                   'LinOtpIdResolver', Unicode(120), default=u'',
+                                   index=True),
+                               Column(
+                                   'LinOtpIdResClass', Unicode(120), default=u''),
+                               Column(
+                                   'LinOtpUserid', Unicode(320), default=u'',
+                                   index=True),
+                               Column(
+                                   'LinOtpSeed', Unicode(32), default=u''),
+                               Column(
+                                   'LinOtpOtpLen', Integer(), default=6),
+                               Column(
+                                   'LinOtpPinHash', Unicode(512), default=u''),
+                               Column(
+                                   'LinOtpKeyEnc', Unicode(1024), default=u''),
+                               Column(
+                                   'LinOtpKeyIV', Unicode(32), default=u''),
+                               Column(
+                                   'LinOtpMaxFail', Integer(), default=10),
+                               Column(
+                                   'LinOtpIsactive', Boolean(), default=True),
+                               Column(
+                                   'LinOtpFailCount', Integer(), default=0),
+                               Column('LinOtpCount', Integer(), default=0),
+                               Column(
+                                   'LinOtpCountWindow', Integer(), default=10),
+                               Column(
+                                   'LinOtpSyncWindow', Integer(), default=1000)
+                               )
 
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql import select
-import json
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.sql import select
+    import json
 
-linotp_engine = create_engine(LINOTP_URI)
-privacyidea_engine = create_engine(PRIVACYIDEA_URI)
+    linotp_engine = create_engine(LINOTP_URI)
+    privacyidea_engine = create_engine(PRIVACYIDEA_URI)
 
-linotp_session = sessionmaker(bind=linotp_engine)()
-privacyidea_session = sessionmaker(bind=privacyidea_engine)()
+    linotp_session = sessionmaker(bind=linotp_engine)()
+    privacyidea_session = sessionmaker(bind=privacyidea_engine)()
 
-conn_linotp = linotp_engine.connect()
-conn_pi = privacyidea_engine.connect()
+    conn_linotp = linotp_engine.connect()
+    conn_pi = privacyidea_engine.connect()
 
-def insert_chunks(conn, table, values, chunk_size=INSERT_CHUNK_SIZE):
-    """
-    Split **values** into chunks of size **chunk_size** and insert them sequentially.
-    """
-    values_length = len(values)
-    for i in xrange(0, values_length, chunk_size):
-        print 'Insert records {} to {} ...'.format(i, min(i + chunk_size, values_length) - 1)
-        conn.execute(table.insert(), values[i:i+chunk_size])
+    def insert_chunks(conn, table, values, chunk_size=INSERT_CHUNK_SIZE):
+        """
+        Split **values** into chunks of size **chunk_size** and insert them sequentially.
+        """
+        values_length = len(values)
+        for i in xrange(0, values_length, chunk_size):
+            print 'Insert records {} to {} ...'.format(i, min(i + chunk_size, values_length) - 1)
+            conn.execute(table.insert(), values[i:i+chunk_size])
 
 
-# Values to be imported
-token_values = []
-tokeninfo_values = []
-tokenrealm_values = []
+    # Values to be imported
+    token_values = []
+    tokeninfo_values = []
+    tokenrealm_values = []
 
-warnings = []
+    warnings = []
 
-# Process Assignments in table "tokenrealm"
-if MIGRATE.get("assignments"):
-    s = select([realm_table])
-    result = conn_pi.execute(s)
-    for r in result:
-        realm_id_map[r["name"]] = r["id"]
+    # Process Assignments in table "tokenrealm"
+    if MIGRATE.get("assignments"):
+        s = select([realm_table])
+        result = conn_pi.execute(s)
+        for r in result:
+            realm_id_map[r["name"]] = r["id"]
 
-    s = select([resolver_table])
-    result = conn_pi.execute(s)
-    for r in result:
-        resolver_id_map[r["name"]] = r["id"]
+        s = select([resolver_table])
+        result = conn_pi.execute(s)
+        for r in result:
+            resolver_id_map[r["name"]] = r["id"]
 
-    print("Realm-Map: {}".format(realm_id_map))
-    print("Resolver-Map: {}".format(resolver_id_map))
+        print("Realm-Map: {}".format(realm_id_map))
+        print("Resolver-Map: {}".format(resolver_id_map))
 
-# Process Tokens
+    # Process Tokens
 
-if MIGRATE.get("tokens"):
-    s = select([linotp_token_table])
-    result = conn_linotp.execute(s)
+    if MIGRATE.get("tokens"):
+        s = select([linotp_token_table])
+        result = conn_linotp.execute(s)
 
-    i = 0
-    for r in result:
-        i = i + 1
-        print("processing token #{1!s}: {0!s}".format(r["LinOtpTokenSerialnumber"], i))
-        # Adapt type
-        type = r["LinOtpTokenType"]
-        if type.lower() == "hmac":
-            type = "HOTP"
-        # Adapt resolver
-        linotp_resolver = r["LinOtpIdResClass"].split(".")[-1]
+        i = 0
+        for r in result:
+            i = i + 1
+            print("processing token #{1!s}: {0!s}".format(r["LinOtpTokenSerialnumber"], i))
+            # Adapt type
+            type = r["LinOtpTokenType"]
+            if type.lower() == "hmac":
+                type = "HOTP"
+            # Adapt resolver
+            linotp_resolver = r["LinOtpIdResClass"].split(".")[-1]
 
-        # Adapt resolver type
-        resolver_type = ""
-        if r["LinOtpIdResClass"]:
-            resolver_type = r['LinOtpIdResClass'].split(".")[1]
-            resolver_type = resolver_map.get(resolver_type)
+            # Adapt resolver type
+            resolver_type = ""
+            if r["LinOtpIdResClass"]:
+                resolver_type = r['LinOtpIdResClass'].split(".")[1]
+                resolver_type = resolver_map.get(resolver_type)
 
-        # Adapt tokeninfo
-        ti = {}
-        if r["LinOtpTokenInfo"]:
-            ti = json.loads(r["LinOtpTokenInfo"])
+            # Adapt tokeninfo
+            ti = {}
+            if r["LinOtpTokenInfo"]:
+                ti = json.loads(r["LinOtpTokenInfo"])
 
-        if MIGRATE.get("assignments"):
-            user_pin = r['LinOtpTokenPinUser']
-            user_pin_iv = r['LinOtpTokenPinUserIV']
-            # Map the LinOTP-Resolver to the PI-Resolver
-            resolver = ASSIGNMENTS.get("resolver").get(linotp_resolver)
-            if not resolver and linotp_resolver:
-                warnings.append(u"No mapping defined for the LinOTP resolver: {0!s}".format(linotp_resolver))
-            resolver_type = resolver_type
-            user_id = r['LinOtpUserid']
-        else:
-            user_pin = None
-            user_pin_iv = None
-            resolver = None
-            resolver_type = None
-            user_id = None
+            if MIGRATE.get("assignments"):
+                user_pin = r['LinOtpTokenPinUser']
+                user_pin_iv = r['LinOtpTokenPinUserIV']
+                # Map the LinOTP-Resolver to the PI-Resolver
+                resolver = ASSIGNMENTS.get("resolver").get(linotp_resolver)
+                if not resolver and linotp_resolver:
+                    warnings.append(u"No mapping defined for the LinOTP resolver: {0!s}".format(linotp_resolver))
+                resolver_type = resolver_type
+                user_id = r['LinOtpUserid']
+            else:
+                user_pin = None
+                user_pin_iv = None
+                resolver = None
+                resolver_type = None
+                user_id = None
 
-        token_values.append(dict(
-            description=r["LinOtpTokenDesc"],
-            serial=r["LinOtpTokenSerialnumber"],
-            tokentype=type,
-            user_pin=user_pin,
-            user_pin_iv=user_pin_iv,
-            so_pin=r['LinOtpTokenPinSO'],
-            so_pin_iv=r['LinOtpTokenPinSOIV'],
-            resolver=resolver,
-            resolver_type=resolver_type,
-            user_id=user_id,
-            pin_seed=r['LinOtpSeed'],
-            pin_hash=r['LinOtpPinHash'],
-            key_enc=r['LinOtpKeyEnc'],
-            key_iv=r['LinOtpKeyIV'],
-            maxfail=r['LinOtpMaxFail'],
-            active=r['LinOtpIsactive'],
-            failcount=r['LinOtpFailCount'],
-            count=r['LinOtpCount'],
-            count_window=r['LinOtpCountWindow'],
-            sync_window=r['LinOtpSyncWindow']))
+            token_values.append(dict(
+                description=r["LinOtpTokenDesc"],
+                serial=r["LinOtpTokenSerialnumber"],
+                tokentype=type,
+                user_pin=user_pin,
+                user_pin_iv=user_pin_iv,
+                so_pin=r['LinOtpTokenPinSO'],
+                so_pin_iv=r['LinOtpTokenPinSOIV'],
+                resolver=resolver,
+                resolver_type=resolver_type,
+                user_id=user_id,
+                pin_seed=r['LinOtpSeed'],
+                pin_hash=r['LinOtpPinHash'],
+                key_enc=r['LinOtpKeyEnc'],
+                key_iv=r['LinOtpKeyIV'],
+                maxfail=r['LinOtpMaxFail'],
+                active=r['LinOtpIsactive'],
+                failcount=r['LinOtpFailCount'],
+                count=r['LinOtpCount'],
+                count_window=r['LinOtpCountWindow'],
+                sync_window=r['LinOtpSyncWindow']))
 
-        if MIGRATE.get("tokeninfo") and ti:
-            # Add tokeninfo for this token
-            for k, v in ti.iteritems():
-                tokeninfo_values.append(dict(
-                    serial=r["LinOtpTokenSerialnumber"],
-                    Key=k, Value=v,
-                    token_id=r["LinOtpTokenId"]))
-                print(" +--- processing tokeninfo {0!s}".format(k))
+            if MIGRATE.get("tokeninfo") and ti:
+                # Add tokeninfo for this token
+                for k, v in ti.iteritems():
+                    tokeninfo_values.append(dict(
+                        serial=r["LinOtpTokenSerialnumber"],
+                        Key=k, Value=v,
+                        token_id=r["LinOtpTokenId"]))
+                    print(" +--- processing tokeninfo {0!s}".format(k))
 
-    print
-    print("Adding {} tokens...".format(len(token_values)))
-    insert_chunks(conn_pi, token_table, token_values)
+        print
+        print("Adding {} tokens...".format(len(token_values)))
+        insert_chunks(conn_pi, token_table, token_values)
 
-    # fetch the new token_id's in privacyIDEA and write them to the
-    # token serial id map.
-    s = select([token_table])
-    result = conn_pi.execute(s)
-    for r in result:
-        token_serial_id_map[r["serial"]] = r["id"]
+        # fetch the new token_id's in privacyIDEA and write them to the
+        # token serial id map.
+        s = select([token_table])
+        result = conn_pi.execute(s)
+        for r in result:
+            token_serial_id_map[r["serial"]] = r["id"]
 
-    # rewrite the id's in the token_values list
-    for i in range(0, len(token_values)):
-        token_values[i]["id"] = token_serial_id_map[token_values[i]["serial"]]
+        # rewrite the id's in the token_values list
+        for i in range(0, len(token_values)):
+            token_values[i]["id"] = token_serial_id_map[token_values[i]["serial"]]
 
-    if MIGRATE.get("tokeninfo"):
-        # Now we have to rewrite the token_id in the tokeninfo_values
-        for ti in tokeninfo_values:
-            ti["token_id"] = token_serial_id_map[ti["serial"]]
-            del ti["serial"]
+        if MIGRATE.get("tokeninfo"):
+            # Now we have to rewrite the token_id in the tokeninfo_values
+            for ti in tokeninfo_values:
+                ti["token_id"] = token_serial_id_map[ti["serial"]]
+                del ti["serial"]
 
-        print("Adding {} token infos...".format(len(tokeninfo_values)))
-        insert_chunks(conn_pi, tokeninfo_table, tokeninfo_values)
+            print("Adding {} token infos...".format(len(tokeninfo_values)))
+            insert_chunks(conn_pi, tokeninfo_table, tokeninfo_values)
 
-if MIGRATE.get("assignments") and resolver:
-    # If the token is assigned, we also need to create an entry for tokenrealm
-    # We need to determine the realm_id for this resolver!
-    for token in token_values:
-        token_id = token.get("id")
-        resolver = token.get("resolver")
-        if resolver:
-            realm = ASSIGNMENTS.get("realm").get(resolver)
-            realm_id = realm_id_map.get(realm)
-            print("Assigning token {} for resolver {} to realm_id {} (realm {})").format(token_id,
-                                                                                         resolver,
-                                                                                         realm_id,
-                                                                                         realm)
-            tokenrealm_values.append(dict(token_id=token_id,
-                                          realm_id=realm_id))
+    if MIGRATE.get("assignments") and resolver:
+        # If the token is assigned, we also need to create an entry for tokenrealm
+        # We need to determine the realm_id for this resolver!
+        for token in token_values:
+            token_id = token.get("id")
+            resolver = token.get("resolver")
+            if resolver:
+                realm = ASSIGNMENTS.get("realm").get(resolver)
+                realm_id = realm_id_map.get(realm)
+                print("Assigning token {} for resolver {} to realm_id {} (realm {})").format(token_id,
+                                                                                             resolver,
+                                                                                             realm_id,
+                                                                                             realm)
+                tokenrealm_values.append(dict(token_id=token_id,
+                                              realm_id=realm_id))
 
-    print("Adding {} tokenrealms...".format(len(tokenrealm_values)))
-    insert_chunks(conn_pi, tokenrealm_table, tokenrealm_values)
+        print("Adding {} tokenrealms...".format(len(tokenrealm_values)))
+        insert_chunks(conn_pi, tokenrealm_table, tokenrealm_values)
 
-if warnings:
-    print("We need to inform you about the following WARNGINGS:")
-    for warning in warnings:
-        print(warning)
+    if warnings:
+        print("We need to inform you about the following WARNGINGS:")
+        for warning in warnings:
+            print(warning)
+
+
+def usage():
+    print("You need to configure some mapping within the script and then pass the parameter '-c'.")
+
+
+try:
+    opts, args = getopt.getopt(sys.argv[1:], "c", ["configured"])
+except getopt.GetoptError as e:
+    print(str(e))
+    sys.exit(1)
+
+for o, a in opts:
+    if o in ("-c", "--configured"):
+        migrate()
+        sys.exit(0)
+
+usage()
+sys.exit(1)

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -373,7 +373,7 @@ def migrate():
                                               realm_id=realm_id))
             else:
                 # The token has no resolver and thus is not assigned
-                for tokenrealm in ASSIGNMENTS.get("unassigned_tokens"):
+                for tokenrealm in ASSIGNMENTS.get("unassigned_tokens", []):
                     realm_id = realm_id_map.get(tokenrealm)
                     if realm_id:
                         tokenrealm_values.append(dict(token_id=token_id,

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -356,7 +356,7 @@ def migrate():
             print("Adding {} token infos...".format(len(tokeninfo_values)))
             insert_chunks(conn_pi, tokeninfo_table, tokeninfo_values)
 
-    if MIGRATE.get("assignments") and resolver:
+    if MIGRATE.get("assignments"):
         # If the token is assigned, we also need to create an entry for tokenrealm
         # We need to determine the realm_id for this resolver!
         for token in token_values:

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -288,7 +288,7 @@ if MIGRATE.get("tokens"):
             user_pin_iv = r['LinOtpTokenPinUserIV']
             # Map the LinOTP-Resolver to the PI-Resolver
             resolver = ASSIGNMENTS.get("resolver").get(linotp_resolver)
-            if not resolver:
+            if not resolver and linotp_resolver:
                 warnings.append(u"No mapping defined for the LinOTP resolver: {0!s}".format(linotp_resolver))
             resolver_type = resolver_type
             user_id = r['LinOtpUserid']
@@ -311,6 +311,7 @@ if MIGRATE.get("tokens"):
             resolver_type=resolver_type,
             user_id=user_id,
             pin_seed=r['LinOtpSeed'],
+            pin_hash=r['LinOtpPinHash'],
             key_enc=r['LinOtpKeyEnc'],
             key_iv=r['LinOtpKeyIV'],
             maxfail=r['LinOtpMaxFail'],
@@ -359,14 +360,15 @@ if MIGRATE.get("assignments") and resolver:
     for token in token_values:
         token_id = token.get("id")
         resolver = token.get("resolver")
-        realm = ASSIGNMENTS.get("realm").get(resolver)
-        realm_id = realm_id_map.get(realm)
-        print("Assigning token {} for resolver {} to realm_id {} (realm {})").format(token_id,
-                                                                                     resolver,
-                                                                                     realm_id,
-                                                                                     realm)
-        tokenrealm_values.append(dict(token_id=token_id,
-                                      realm_id=realm_id))
+        if resolver:
+            realm = ASSIGNMENTS.get("realm").get(resolver)
+            realm_id = realm_id_map.get(realm)
+            print("Assigning token {} for resolver {} to realm_id {} (realm {})").format(token_id,
+                                                                                         resolver,
+                                                                                         realm_id,
+                                                                                         realm)
+            tokenrealm_values.append(dict(token_id=token_id,
+                                          realm_id=realm_id))
 
     print("Adding {} tokenrealms...".format(len(tokenrealm_values)))
     insert_chunks(conn_pi, tokenrealm_table, tokenrealm_values)

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -1,16 +1,63 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
+#  2018-02-09 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Speedup thanks to Friedrich Weber.
+#             Add flexible resolver mapping
 #  2016-09-14 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #
 """
 You can use this script to migrate a LinOTP database to privacyIDEA.
 All tokens and token assignments are transferred to privacyIDEA.
 
+You only need an export of the LinOTP "Token" table.
+Please configure below, how your database URIs look like,
+what should be migrated and what should be mapped.
 """
 # You need to change this!
-LINOTP_URI = "mysql://linotp2:testtest@localhost/LinOTP2"
-PRIVACYIDEA_URI = "mysql://pi:pi@localhost/pi"
+LINOTP_URI = "mysql://linotp2:linotp2@localhost/linotp2"
+PRIVACYIDEA_URI = "mysql://pitest:pitest@localhost/pitest"
+
+
+"""
+Define, what should be migrated:
+
+"tokens" should always be True.
+If "assignments" is False, the imported tokens will be unassigned!
+
+"""
+MIGRATE = {"tokens": True,
+           "tokeninfo": True,
+           "assignments": True}
+
+"""
+This assigns the token to the new resolver
+
+The "resolver" key maps LinOTP-resolvers to privacyIDEA-Resolvers. This value is
+rewritten in the token tabel.
+
+The "realm" key puts tokens in the privacyIDEA-Resolver into this privacyIDEA realm.
+
+In this example the resolvername "lokal" from LinOTP gets imported to
+privacyIDEA with the resolver "PIResolver" in realm "pirealm".
+"""
+ASSIGNMENTS = {
+    "resolver": {"lokal": "PIResolver"},
+    "realm": {"PIResolver": "pirealm"}
+}
+
+# Do not change anything after this line
+# ============================================================================
+#
+
+# THis maps the resolver types. You must not change this!
+resolver_map = {"LDAPIdResolver": "ldapresolver",
+                "SQLIdResolver": "sqlresolver",
+                "PasswdIdResolver": "passwdresolver"}
+
+token_serial_id_map = {}
+realm_id_map = {}
+resolver_id_map = {}
 
 from sqlalchemy import Table, MetaData, Column
 from sqlalchemy import Integer, Unicode, Boolean, UnicodeText
@@ -173,182 +220,135 @@ privacyidea_session = sessionmaker(bind=privacyidea_engine)()
 conn_linotp = linotp_engine.connect()
 conn_pi = privacyidea_engine.connect()
 
-resolver_map = {"LDAPIdResolver": "ldapresolver",
-                "SQLIdResolver": "sqlresolver",
-                "PasswdIdResolver": "passwdresolver"}
+
+# Values to be imported
+token_values = []
+tokeninfo_values = []
+tokenrealm_values = []
+
+# Process Assignments in table "tokenrealm"
+if MIGRATE.get("assignments"):
+    s = select([realm_table])
+    result = conn_pi.execute(s)
+    for r in result:
+        realm_id_map[r["name"]] = r["id"]
+
+    s = select([resolver_table])
+    result = conn_pi.execute(s)
+    for r in result:
+        resolver_id_map[r["name"]] = r["id"]
+
+    print("Realm-Map: {}".format(realm_id_map))
+    print("Resolver-Map: {}".format(resolver_id_map))
 
 # Process Tokens
 
-s = select([linotp_token_table])
-result = conn_linotp.execute(s)
-for r in result:
-    print("migrating token {0!s}".format(r["LinOtpTokenSerialnumber"]))
-    # Adapt type
-    type = r["LinOtpTokenType"]
-    if type.lower() == "hmac":
-        type = "HOTP"
-    # Adapt resolver
-    resolver = r["LinOtpIdResolver"].split(".")[-1]
+if MIGRATE.get("tokens"):
+    s = select([linotp_token_table])
+    result = conn_linotp.execute(s)
 
-    # Adapt resolver type
-    resolver_type = ""
-    if r["LinOtpIdResClass"]:
-        resolver_type = r['LinOtpIdResClass'].split(".")[1]
-        resolver_type = resolver_map.get(resolver_type)
-
-    # Adapt tokeninfo
-    ti = {}
-    if r["LinOtpTokenInfo"]:
-        ti = json.loads(r["LinOtpTokenInfo"])
-
-    ins = token_table.insert().values(
-        id=r["LinOtpTokenId"],
-        description=r["LinOtpTokenDesc"],
-        serial=r["LinOtpTokenSerialnumber"],
-        tokentype=type,
-        user_pin=r['LinOtpTokenPinUser'],
-        user_pin_iv=r['LinOtpTokenPinUserIV'],
-        so_pin=r['LinOtpTokenPinSO'],
-        so_pin_iv=r['LinOtpTokenPinSOIV'],
-        resolver=resolver,
-        resolver_type=resolver_type,
-        user_id=r['LinOtpUserid'],
-        pin_seed=r['LinOtpSeed'],
-        key_enc=r['LinOtpKeyEnc'],
-        key_iv=r['LinOtpKeyIV'],
-        maxfail=r['LinOtpMaxFail'],
-        active=r['LinOtpIsactive'],
-        failcount=r['LinOtpFailCount'],
-        count=r['LinOtpCount'],
-        count_window=r['LinOtpCountWindow'],
-        sync_window=r['LinOtpSyncWindow'])
-    conn_pi.execute(ins)
-
-    if ti:
-        # Add tokeninfo for this token
-        for k, v in ti.iteritems():
-            ins = tokeninfo_table.insert().values(
-                Key=k, Value=v, token_id=r["LinOtpTokenId"])
-            conn_pi.execute(ins)
-            print(" +--- adding tokeninfo {0!s}".format(k))
-
-# Process Realms
-
-s = select([linotp_realm_table])
-result = conn_linotp.execute(s)
-for r in result:
-    print("migrating realm {0!s}".format(r["name"]))
-    ins = realm_table.insert().values(
-        id=r["id"],
-        name=r["name"],
-        default=r["default"],
-        option=r["option"]
-    )
-    conn_pi.execute(ins)
-
-# Process Tokenrealms
-
-s = select([linotp_tokenrealm_table])
-result = conn_linotp.execute(s)
-for r in result:
-    print("migrating tokenrealm {0!s}".format(r["id"]))
-    ins = tokenrealm_table.insert().values(
-        id=r["id"],
-        token_id=r["token_id"],
-        realm_id=r["realm_id"]
-    )
-    conn_pi.execute(ins)
-
-# Process Resolvers
-
-s = select([linotp_config_table])
-result = conn_linotp.execute(s)
-resolvers = {}
-for r in result:
-    config_key = r["Key"]
-    # TODO: We need to supprt the other resolvers!
-    entry = config_key.split(".")
-    if entry[1] == "ldapresolver":
-        name = entry[3]
-        resolver_key = entry[2]
-        value = r["Value"]
-        desc = r["Description"]
-        type = r["Type"]
-
-        if name not in resolvers:
-            resolvers[name] = {"type": "ldapresolver",
-                               "config": [{"Key": "CACHE_TIMEOUT",
-                                           "Value": "120"},
-                                          {"Key": "SCOPE",
-                                           "Value": "SUBTREE",
-                                           "Type": "string"},
-                                          {"Key": "EDITABLE",
-                                           "Value": "0",
-                                           "Type": "bool"}]}
-        resolvers[name]["config"].append({
-            "Key": resolver_key,
-            "Value": value,
-            "Description": desc,
-            "Type": type
-        })
-
-if resolvers:
-    # Write the resolvers
-    for name, config in resolvers.iteritems():
-        print("Migrating Resolver {0!s}".format(name))
-
-        ins = resolver_table.insert().values(
-                name=name,
-                rtype=config.get("type")
-        )
-        res_id = conn_pi.execute(ins)
-        resolver_id = res_id.inserted_primary_key[0]
-        for resolver_entry in config.get("config"):
-            # save the list of resolver configuration
-            ins = resolver_config_table.insert().values(
-                resolver_id=resolver_id,
-                Key=resolver_entry.get("Key") or "",
-                Value=resolver_entry.get("Value") or "",
-                Type=resolver_entry.get("Type") or "",
-                Description=resolver_entry.get("Description") or ""
-            )
-            conn_pi.execute(ins)
-
-
-# Put resolvers into realms
-s = select([linotp_config_table])
-result = conn_linotp.execute(s)
-realms = {}
-for r in result:
-    config_key = r["Key"]
-    entry = config_key.split(".")
-    if entry[1] == "useridresolver" and entry[2] == "group":
-        resolvers = r["Value"].split()
-        realms[entry[3]] = [x.split(".")[3] for x in resolvers]
-
-print("Migrating realm definitions {0}".format(realms))
-
-# Save the resolvers in the realms
-"""For this we need to get the IDs of the realmname and the resolvernames"""
-for realmname, resolvers in realms.iteritems():
-    print("Migrating realm {0!s}".format(realmname))
-    s = select([realm_table]).where(realm_table.c.name == realmname)
-    result = conn_pi.execute(s)
+    i = 0
     for r in result:
-        realm_id = r["id"]
+        i = i + 1
+        print("processing token #{1!s}: {0!s}".format(r["LinOtpTokenSerialnumber"], i))
+        # Adapt type
+        type = r["LinOtpTokenType"]
+        if type.lower() == "hmac":
+            type = "HOTP"
+        # Adapt resolver
+        linotp_resolver = r["LinOtpIdResClass"].split(".")[-1]
 
-    for resolvername in resolvers:
-        s = select([resolver_table]).where(resolver_table.c.name ==
-                                           resolvername)
+        # Adapt resolver type
+        resolver_type = ""
+        if r["LinOtpIdResClass"]:
+            resolver_type = r['LinOtpIdResClass'].split(".")[1]
+            resolver_type = resolver_map.get(resolver_type)
+
+        # Adapt tokeninfo
+        ti = {}
+        if r["LinOtpTokenInfo"]:
+            ti = json.loads(r["LinOtpTokenInfo"])
+
+        if MIGRATE.get("assignments"):
+            user_pin = r['LinOtpTokenPinUser']
+            user_pin_iv = r['LinOtpTokenPinUserIV']
+            # Map the LinOTP-Resolver to the PI-Resolver
+            resolver = ASSIGNMENTS.get("resolver").get(linotp_resolver)
+            resolver_type = resolver_type
+            user_id = r['LinOtpUserid']
+        else:
+            user_pin = None
+            user_pin_iv = None
+            resolver = None
+            resolver_type = None
+            user_id = None
+
+        token_values.append(dict(
+            id=r["LinOtpTokenId"],
+            description=r["LinOtpTokenDesc"],
+            serial=r["LinOtpTokenSerialnumber"],
+            tokentype=type,
+            user_pin=user_pin,
+            user_pin_iv=user_pin_iv,
+            so_pin=r['LinOtpTokenPinSO'],
+            so_pin_iv=r['LinOtpTokenPinSOIV'],
+            resolver=resolver,
+            resolver_type=resolver_type,
+            user_id=user_id,
+            pin_seed=r['LinOtpSeed'],
+            key_enc=r['LinOtpKeyEnc'],
+            key_iv=r['LinOtpKeyIV'],
+            maxfail=r['LinOtpMaxFail'],
+            active=r['LinOtpIsactive'],
+            failcount=r['LinOtpFailCount'],
+            count=r['LinOtpCount'],
+            count_window=r['LinOtpCountWindow'],
+            sync_window=r['LinOtpSyncWindow']))
+
+        if MIGRATE.get("tokeninfo") and ti:
+            # Add tokeninfo for this token
+            for k, v in ti.iteritems():
+                tokeninfo_values.append(dict(
+                    serial=r["LinOtpTokenSerialnumber"],
+                    Key=k, Value=v,
+                    token_id=r["LinOtpTokenId"]))
+                print(" +--- processing tokeninfo {0!s}".format(k))
+
+    print
+    print("Adding {} tokens...".format(len(token_values)))
+    conn_pi.execute(token_table.insert(), token_values)
+
+    if MIGRATE.get("tokeninfo"):
+        # fet the new token_id's in privacyIDEA
+        s = select([token_table])
         result = conn_pi.execute(s)
         for r in result:
-            resolver_id = r["id"]
-        # insert each resolver_id for the realm_id
-        ins = resolverrealm_table.insert().values(
-            realm_id=realm_id,
-            resolver_id=resolver_id
-        )
-        print(" +--- Adding resolver {0!s} to realm {1!s}".format(
-            resolvername, realmname))
-        conn_pi.execute(ins)
+            token_serial_id_map[r["serial"]] = r["id"]
+
+        # Now we have to rewrite the token_id in the tokeninfo_values
+        for ti in tokeninfo_values:
+            ti["token_id"] = token_serial_id_map[ti["serial"]]
+            del ti["serial"]
+
+        print("Adding {} token infos...".format(len(tokeninfo_values)))
+        conn_pi.execute(tokeninfo_table.insert(), tokeninfo_values)
+
+if MIGRATE.get("assignments") and resolver:
+    # If the token is assigned, we also need to create an entry for tokenrealm
+    # We need to determine the realm_id for this resolver!
+    for token in token_values:
+        token_id = token.get("id")
+        resolver = token.get("resolver")
+        realm = ASSIGNMENTS.get("realm").get(resolver)
+        realm_id = realm_id_map.get(realm)
+        print("Assigning token {} for resolver {} to realm_id {} (realm {})").format(token_id,
+                                                                                     resolver,
+                                                                                     realm_id,
+                                                                                     realm)
+        tokenrealm_values.append(dict(token_id=token_id,
+                                      realm_id=realm_id))
+
+    print("Adding {} tokenrealms...".format(len(tokenrealm_values)))
+    conn_pi.execute(tokenrealm_table.insert(), tokenrealm_values)
+
 

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -222,6 +222,8 @@ token_values = []
 tokeninfo_values = []
 tokenrealm_values = []
 
+warnings = []
+
 # Process Assignments in table "tokenrealm"
 if MIGRATE.get("assignments"):
     s = select([realm_table])
@@ -270,6 +272,8 @@ if MIGRATE.get("tokens"):
             user_pin_iv = r['LinOtpTokenPinUserIV']
             # Map the LinOTP-Resolver to the PI-Resolver
             resolver = ASSIGNMENTS.get("resolver").get(linotp_resolver)
+            if not resolver:
+                warnings.append(u"No mapping defined for the LinOTP resolver: {0!s}".format(linotp_resolver))
             resolver_type = resolver_type
             user_id = r['LinOtpUserid']
         else:
@@ -346,4 +350,7 @@ if MIGRATE.get("assignments") and resolver:
     print("Adding {} tokenrealms...".format(len(tokenrealm_values)))
     conn_pi.execute(tokenrealm_table.insert(), tokenrealm_values)
 
-
+if warnings:
+    print("We need to inform you about the following WARNGINGS:")
+    for warning in warnings:
+        print(warning)

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -317,13 +317,18 @@ if MIGRATE.get("tokens"):
     print("Adding {} tokens...".format(len(token_values)))
     conn_pi.execute(token_table.insert(), token_values)
 
-    if MIGRATE.get("tokeninfo"):
-        # fetch the new token_id's in privacyIDEA
-        s = select([token_table])
-        result = conn_pi.execute(s)
-        for r in result:
-            token_serial_id_map[r["serial"]] = r["id"]
+    # fetch the new token_id's in privacyIDEA and write them to the
+    # token serial id map.
+    s = select([token_table])
+    result = conn_pi.execute(s)
+    for r in result:
+        token_serial_id_map[r["serial"]] = r["id"]
 
+    # rewrite the id's in the token_values list
+    for i in range(0, len(token_values)):
+        token_values[i]["id"] = token_serial_id_map[token_values[i]["serial"]]
+
+    if MIGRATE.get("tokeninfo"):
         # Now we have to rewrite the token_id in the tokeninfo_values
         for ti in tokeninfo_values:
             ti["token_id"] = token_serial_id_map[ti["serial"]]

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -367,18 +367,25 @@ def migrate():
             if resolver:
                 realm = ASSIGNMENTS.get("realm").get(resolver)
                 realm_id = realm_id_map.get(realm)
-                print("Assigning token {} for resolver {} to realm_id {} (realm {})").format(token_id,
-                                                                                             resolver,
-                                                                                             realm_id,
-                                                                                             realm)
+                print("Assigning token {} for resolver {} to realm_id {} (realm {})".format(token_id,
+                                                                                            resolver,
+                                                                                            realm_id,
+                                                                                            realm))
                 tokenrealm_values.append(dict(token_id=token_id,
                                               realm_id=realm_id))
+            else:
+                # The token has no resolver and thus is not assigned
+                for tokenrealm in ASSIGNMENTS.get("unassigned_tokens"):
+                    realm_id = realm_id_map.get(tokenrealm)
+                    if realm_id:
+                        tokenrealm_values.append(dict(token_id=token_id,
+                                                      realm_id=realm_id))
 
         print("Adding {} tokenrealms...".format(len(tokenrealm_values)))
         insert_chunks(conn_pi, tokenrealm_table, tokenrealm_values)
 
     if warnings:
-        print("We need to inform you about the following WARNGINGS:")
+        print("We need to inform you about the following WARNINGS:")
         for warning in warnings:
             print(warning)
 

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -284,7 +284,6 @@ if MIGRATE.get("tokens"):
             user_id = None
 
         token_values.append(dict(
-            id=r["LinOtpTokenId"],
             description=r["LinOtpTokenDesc"],
             serial=r["LinOtpTokenSerialnumber"],
             tokentype=type,
@@ -319,7 +318,7 @@ if MIGRATE.get("tokens"):
     conn_pi.execute(token_table.insert(), token_values)
 
     if MIGRATE.get("tokeninfo"):
-        # fet the new token_id's in privacyIDEA
+        # fetch the new token_id's in privacyIDEA
         s = select([token_table])
         result = conn_pi.execute(s)
         for r in result:

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -14,10 +14,18 @@ You only need an export of the LinOTP "Token" table.
 Please configure below, how your database URIs look like,
 what should be migrated and what should be mapped.
 """
-# You need to change this!
+# ========================================================
+# You need to change the following values:
+#  1. set the database URIs for LinOTP and privacyIDEA
+#  2. configure, what you want to migrate in the
+#     MIGRATE dictionary
+#  3. Set the ASSIGNMENTS dictionary, to define, which
+#     realms you want to have the tokens in.
+#
+#  4. Finally set the value CONFIGURED=True
+# =========================================================
 LINOTP_URI = "mysql://linotp2:linotp2@localhost/linotp2"
 PRIVACYIDEA_URI = "mysql://pitest:pitest@localhost/pitest"
-
 
 """
 Define, what should be migrated:
@@ -45,6 +53,11 @@ ASSIGNMENTS = {
     "resolver": {"lokal": "PIResolver"},
     "realm": {"PIResolver": "pirealm"}
 }
+
+CONFIGURED = False
+
+if not CONFIGURED:
+    raise Exception("You need to configure some data in the script itself!")
 
 # Do not change anything after this line
 # ============================================================================
@@ -134,23 +147,6 @@ resolverrealm_table = Table("resolverrealm", metadata,
 #
 # LinOTP table definitions
 #
-linotp_config_table = Table("Config", metadata,
-                            Column("Key", Unicode(255)),
-                            Column("Value", Unicode(2000)),
-                            Column("Type", Unicode(2000)),
-                            Column("Description", Unicode(2000))
-                            )
-
-linotp_tokenrealm_table = Table("TokenRealm", metadata,
-                         Column("id", Integer(), primary_key=True),
-                         Column("token_id", Integer()),
-                         Column("realm_id", Integer()))
-
-linotp_realm_table = Table("Realm", metadata,
-                    Column("id", Integer, primary_key=True),
-                    Column("name", Unicode(255), default=u''),
-                    Column("default",  Boolean(), default=False),
-                    Column("option", Unicode(40), default=u''))
 
 linotp_token_table = Table('Token',metadata,
                            Column('LinOtpTokenId', Integer(),


### PR DESCRIPTION
Values are now read into lists and disctionaries.

Resolver and Realm definitions are not read from LinOTP, but you can configure a mapping.

Tokens can be migrated without deleting existing tokens in privacyIDEA.

Closes #914
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/925%23issuecomment-364459590%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167837405%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167851388%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167851419%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167851637%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167851674%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167857290%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167859083%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167859102%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167876508%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167877470%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167896074%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23issuecomment-365297919%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23issuecomment-365304777%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23issuecomment-365327355%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/9d3581beb56a2ed3ed64aa7d7c2e8154d1124807%23commitcomment-27677322%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/9d3581beb56a2ed3ed64aa7d7c2e8154d1124807%23commitcomment-27684443%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23issuecomment-364459590%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23925%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/157b42067d8cbabb5da672790c471079ff635ead%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925/graphs/tree.svg%3Fsrc%3Dpr%26token%3D7nHLZki60B%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23925%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.41%25%20%20%2095.42%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20129%20%20%20%20%20%20129%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016002%20%20%20%2016010%20%20%20%20%20%20%20%2B8%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015269%20%20%20%2015277%20%20%20%20%20%20%20%2B8%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20733%20%20%20%20%20%20733%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/smsprovider/SmppSMSProvider.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Ntc3Byb3ZpZGVyL1NtcHBTTVNQcm92aWRlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B157b420...b41fd31%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/925%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-09T15%3A08%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22TODO%3A%20With%20a%20lot%20of%20tokens%2C%20we%20may%20hit%20the%20limit%20defined%20by%20MySQL%27s%20%60%60max_allowed_packet%60%60%20setting%3A%5Cr%5Cn%60%60%60%5Cr%5Cn2018-02-13T14%3A41%3A15.864147Z%207%20%5BNote%5D%20Aborted%20connection%207%20to%20db%3A%20%27pi%27%20user%3A%20%27pi%27%20host%3A%20%27192.168.33.1%27%20%28Got%20a%20packet%20bigger%20than%20%27max_allowed_packet%27%20bytes%29%5Cr%5Cn%60%60%60%5Cr%5CnThus%2C%20we%20should%20probably%20split%20the%20INSERT%20values%20into%20smaller%20lists.%20This%20is%20probably%20necessary%20for%20both%20tokens%20and%20token%20infos.%20Maybe%20we%20could%20even%20make%20the%20size%20of%20the%20%5C%22INSERT%20batches%5C%22%20configurable.%22%2C%20%22created_at%22%3A%20%222018-02-13T15%3A19%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Another%20TODO%3A%5Cr%5CnCurrently%2C%20the%20assignment%20of%20tokens%20to%20realm%20does%20not%20work%3A%5Cr%5Cn%60%60%60%5Cr%5CnAssigning%20token%20None%20for%20resolver%20deflocal%20to%20realm_id%201%20%28realm%20defrealm%29%5Cr%5Cn%60%60%60%5Cr%5CnThis%20is%20because%20the%20dictionaries%20in%20%60%60token_values%60%60%20do%20not%20contain%20the%20%60%60id%60%60%20field%20anymore%2C%20so%20%5Bthis%20line%5D%28https%3A//github.com/privacyidea/privacyidea/pull/925/files%23diff-e1842ba06215a72933f7a4c84c31cb1eR335%29%20sets%20%60%60token_id%60%60%20to%20None.%20We%20can%20probably%20use%20%60%60token_serial_id_map%60%60%20again%20to%20get%20hold%20of%20the%20token%20ID.%22%2C%20%22created_at%22%3A%20%222018-02-13T15%3A40%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20the%20problem%20with%20the%20missing%20tokenream%20assignment.%22%2C%20%22created_at%22%3A%20%222018-02-13T16%3A46%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%209d3581beb56a2ed3ed64aa7d7c2e8154d1124807%20tools/privacyidea-migrate-linotp.py%2016%20378%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/9d3581beb56a2ed3ed64aa7d7c2e8154d1124807%23commitcomment-27677322%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20we%20should%20use%20%60%60ASSIGNMENTS.get%28%5C%22unassigned_tokens%5C%22%2C%20%5B%5D%29%60%60%20instead%20--%20otherwise%2C%20the%20script%20will%20break%20if%20the%20user%20deletes%20the%20%60%60unassigned_tokens%60%60%20key%20from%20%60%60ASSIGNMENTS%60%60.%22%2C%20%22created_at%22%3A%20%222018-02-20T16%3A58%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%22%2C%20%22created_at%22%3A%20%222018-02-20T23%3A10%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/privacyidea-migrate-linotp.py%3AL378%20%289d3581b%29%22%7D%2C%20%22Pull%20b41fd31c23832f65b1f8bdffd5d486e553503fd7%20tools/privacyidea-migrate-linotp.py%20360%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167851419%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22s.a.%22%2C%20%22created_at%22%3A%20%222018-02-13T12%3A40%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/privacyidea-migrate-linotp.py%3AL220-355%22%7D%2C%20%22Pull%20b41fd31c23832f65b1f8bdffd5d486e553503fd7%20tools/privacyidea-migrate-linotp.py%20296%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167837405%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22IIRC%2C%20one%20advantage%20of%20the%20migration%20script%20should%20be%20that%20we%20can%20import%20tokens%20even%20if%20we%20have%20already%20rolled%20out%20other%20tokens.%20But%20I%20think%20this%20is%20not%20the%20case%20right%20now%2C%20as%20we%20just%20copy%20the%20%60%60LinOtpTokenId%60%60%20values%20which%20may%20conflict%20with%20privacyIDEA%20token%20IDs.%22%2C%20%22created_at%22%3A%20%222018-02-13T11%3A35%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20totally%20right.%20I%20thought%20I%20would%20have%20dumped%20this.%5Cr%5Cn%5Cr%5CnThis%20is%20why%20I%20also%20create%20the%20%60%60token_serial_id_map%60%60%20later%2C%20to%20rewrite%20the%20tokeninfo%20data.%5Cr%5Cn%5Cr%5CnWill%20fix%20and%20test%20this.%22%2C%20%22created_at%22%3A%20%222018-02-13T12%3A41%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Removed%20LinOtpTokenId%22%2C%20%22created_at%22%3A%20%222018-02-13T13%3A11%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/privacyidea-migrate-linotp.py%3AL220-355%22%7D%2C%20%22Pull%20b41fd31c23832f65b1f8bdffd5d486e553503fd7%20tools/privacyidea-migrate-linotp.py%20260%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167857290%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20do%20not%20understand%20this%20%3A-/%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-13T13%3A04%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Instead%20of%20using%20an%20explicit%20counter%20variable%20%60%60i%60%60%2C%20one%20can%20use%20%60%60enumerate%60%60%3A%5Cr%5Cn%60%60%60python%5Cr%5Cn%3E%3E%3E%20for%20i%2C%20letter%20in%20enumerate%28%5B%27a%27%2C%20%27b%27%2C%20%27c%27%2C%20%27d%27%5D%2C%201%29%3A%20print%20i%2C%20letter%5Cr%5Cn...%20%5Cr%5Cn1%20a%5Cr%5Cn2%20b%5Cr%5Cn3%20c%5Cr%5Cn4%20d%5Cr%5Cn%60%60%60%5Cr%5Cn...%20but%20this%20does%20not%20seem%20that%20important%20to%20me%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-02-13T14%3A20%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/privacyidea-migrate-linotp.py%3AL220-355%22%7D%2C%20%22Pull%20b41fd31c23832f65b1f8bdffd5d486e553503fd7%20tools/privacyidea-migrate-linotp.py%20285%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167851388%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20also%20thought%20we%20should%20add%20something%20like%3A%5Cr%5Cn%5Cr%5Cn%20%20%20CONFIGURES%20%3D%20False%5Cr%5Cn%5Cr%5Cnand%20bail%20out%2C%20if%20it%20was%20not%20set%20to%20True%2C%20so%20that%20the%20admin%20is%20aware%2C%20that%20he%20needs%20to%20change%20data%20in%20the%20script.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-13T12%3A39%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sounds%20good%20to%20me%21%5Cr%5CnBut%20maybe%20it%20would%20still%20be%20useful%20to%20add%20a%20warning%20or%20even%20bail%20out%20in%20case%20the%20LinOTP%20resolver%20cannot%20be%20found%20in%20the%20mapping%3F%22%2C%20%22created_at%22%3A%20%222018-02-13T14%3A17%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20currently%20not%20sure.%20I%20probably%20would%20prefer%20to%20only%20dump%20a%20warning.%5Cr%5CnIt%20could%20be%20that%20there%20were%20a%20lot%20of%20resolver%20definitions%2C%20that%20you%20actually%20do%20not%20want%20to%20migrate.%5Cr%5Cn%5Cr%5CnSo%20this%20would%20be%20a%20way%20to%20migrate%20the%20assignments%20to%20%2Aresolver/realm1%2A%2C%20but%20not%20to%20%2Aresolver/realm2%2A.%20Bailing%20out%20would%20be%20a%20bit...%20...drastic.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-13T15%3A18%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/privacyidea-migrate-linotp.py%3AL220-355%22%7D%2C%20%22Pull%20b41fd31c23832f65b1f8bdffd5d486e553503fd7%20tools/privacyidea-migrate-linotp.py%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/925%23discussion_r167851674%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%22%2C%20%22created_at%22%3A%20%222018-02-13T12%3A41%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Removed%20tables%22%2C%20%22created_at%22%3A%20%222018-02-13T13%3A11%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/privacyidea-migrate-linotp.py%3AL220-355%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/925#issuecomment-364459590'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/925?src=pr&el=h1) Report
> Merging [#925](https://codecov.io/gh/privacyidea/privacyidea/pull/925?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/157b42067d8cbabb5da672790c471079ff635ead?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/925/graphs/tree.svg?src=pr&token=7nHLZki60B&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/925?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #925      +/-   ##
==========================================
+ Coverage   95.41%   95.42%   +<.01%
==========================================
Files         129      129
Lines       16002    16010       +8
==========================================
+ Hits        15269    15277       +8
Misses        733      733
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/925?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/smsprovider/SmppSMSProvider.py](https://codecov.io/gh/privacyidea/privacyidea/pull/925/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Ntc3Byb3ZpZGVyL1NtcHBTTVNQcm92aWRlci5weQ==) | `100% <0%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/925?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/925?src=pr&el=footer). Last update [157b420...b41fd31](https://codecov.io/gh/privacyidea/privacyidea/pull/925?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> TODO: With a lot of tokens, we may hit the limit defined by MySQL's ``max_allowed_packet`` setting:
```
2018-02-13T14:41:15.864147Z 7 [Note] Aborted connection 7 to db: 'pi' user: 'pi' host: '192.168.33.1' (Got a packet bigger than 'max_allowed_packet' bytes)
```
Thus, we should probably split the INSERT values into smaller lists. This is probably necessary for both tokens and token infos. Maybe we could even make the size of the "INSERT batches" configurable.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Another TODO:
Currently, the assignment of tokens to realm does not work:
```
Assigning token None for resolver deflocal to realm_id 1 (realm defrealm)
```
This is because the dictionaries in ``token_values`` do not contain the ``id`` field anymore, so [this line](https://github.com/privacyidea/privacyidea/pull/925/files#diff-e1842ba06215a72933f7a4c84c31cb1eR335) sets ``token_id`` to None. We can probably use ``token_serial_id_map`` again to get hold of the token ID.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Fixed the problem with the missing tokenream assignment.
- [ ] <a href='#crh-comment-Pull b41fd31c23832f65b1f8bdffd5d486e553503fd7 tools/privacyidea-migrate-linotp.py 296'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/925#discussion_r167837405'>File: tools/privacyidea-migrate-linotp.py:L220-355</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> IIRC, one advantage of the migration script should be that we can import tokens even if we have already rolled out other tokens. But I think this is not the case right now, as we just copy the ``LinOtpTokenId`` values which may conflict with privacyIDEA token IDs.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are totally right. I thought I would have dumped this.
This is why I also create the ``token_serial_id_map`` later, to rewrite the tokeninfo data.
Will fix and test this.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Removed LinOtpTokenId
- [ ] <a href='#crh-comment-Pull b41fd31c23832f65b1f8bdffd5d486e553503fd7 tools/privacyidea-migrate-linotp.py 285'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/925#discussion_r167851388'>File: tools/privacyidea-migrate-linotp.py:L220-355</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I also thought we should add something like:
CONFIGURES = False
and bail out, if it was not set to True, so that the admin is aware, that he needs to change data in the script.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Sounds good to me!
But maybe it would still be useful to add a warning or even bail out in case the LinOTP resolver cannot be found in the mapping?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I am currently not sure. I probably would prefer to only dump a warning.
It could be that there were a lot of resolver definitions, that you actually do not want to migrate.
So this would be a way to migrate the assignments to *resolver/realm1*, but not to *resolver/realm2*. Bailing out would be a bit... ...drastic.
- [ ] <a href='#crh-comment-Pull b41fd31c23832f65b1f8bdffd5d486e553503fd7 tools/privacyidea-migrate-linotp.py 360'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/925#discussion_r167851419'>File: tools/privacyidea-migrate-linotp.py:L220-355</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> s.a.
- [ ] <a href='#crh-comment-Pull b41fd31c23832f65b1f8bdffd5d486e553503fd7 tools/privacyidea-migrate-linotp.py 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/925#discussion_r167851674'>File: tools/privacyidea-migrate-linotp.py:L220-355</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Removed tables
- [ ] <a href='#crh-comment-Pull b41fd31c23832f65b1f8bdffd5d486e553503fd7 tools/privacyidea-migrate-linotp.py 260'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/925#discussion_r167857290'>File: tools/privacyidea-migrate-linotp.py:L220-355</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I do not understand this :-/
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Instead of using an explicit counter variable ``i``, one can use ``enumerate``:
```python
>>> for i, letter in enumerate(['a', 'b', 'c', 'd'], 1): print i, letter
...
1 a
2 b
3 c
4 d
```
... but this does not seem that important to me :)
- [ ] <a href='#crh-comment-Commit 9d3581beb56a2ed3ed64aa7d7c2e8154d1124807 tools/privacyidea-migrate-linotp.py 16 378'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/9d3581beb56a2ed3ed64aa7d7c2e8154d1124807#commitcomment-27677322'>File: tools/privacyidea-migrate-linotp.py:L378 (9d3581b)</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Maybe we should use ``ASSIGNMENTS.get("unassigned_tokens", [])`` instead -- otherwise, the script will break if the user deletes the ``unassigned_tokens`` key from ``ASSIGNMENTS``.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> ok


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/925?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/925?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/925'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>