### PR TITLE
Added Description field to TOTP and HOTP enrollment templates

### DIFF
--- a/privacyidea/static/components/token/views/token.enroll.hotp.html
+++ b/privacyidea/static/components/token/views/token.enroll.hotp.html
@@ -64,3 +64,9 @@ The HOTP token is an event based token. You can paste a secret key or
         The Google Authenticator only supports the SHA1 algorithm.
     </p>
 </div>
+<div class="form-group">
+    <label for="description" translate>Description</label>
+    <input type="text" class="form-control"
+            placeholder="{{ 'Some nice words...'|translate }}"
+            ng-model="form.description" />
+</div>

--- a/privacyidea/static/components/token/views/token.enroll.totp.html
+++ b/privacyidea/static/components/token/views/token.enroll.totp.html
@@ -72,3 +72,9 @@ The TOTP token is a time based token. You can paste a secret key or
         The Google Authenticator only supports the SHA1 algorithm.
     </p>
 </div>
+<div class="form-group">
+    <label for="description" translate>Description</label>
+    <input type="text" class="form-control"
+            placeholder="{{ 'Some nice words...'|translate }}"
+            ng-model="form.description" />
+</div>


### PR DESCRIPTION
The TOTP and HOTP enrollment templates now allow specifying a Description, currently also allowed by EMail, SMS, and SSH Public Key token types.

This would resolve #928
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/934?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/934'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>