### PR TITLE
Allow to create API keys with longer validity

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -949,7 +949,13 @@ def create(name, scope, action, filename=None):
         return r
 
 
-@api_manager.command
+@api_manager.option('-r', '--role', help="The role of the API key can either be"
+                                         "'admin' or 'validate' to access the admin"
+                                         "API or the validate API.")
+@api_manager.option('-d', '--days', help='The number of days the access token should be valid.'
+                                         ' Defaults to 365.')
+@api_manager.option('-R', '--realm', help='The realm of the admin. Defaults to "API"')
+@api_manager.option('-u', '--username', help='The username of the admin.')
 def createtoken(role=ROLE.ADMIN, days=365, Realm="API", Username=None):
     """
     Create an API authentication token

--- a/pi-manage
+++ b/pi-manage
@@ -950,27 +950,32 @@ def create(name, scope, action, filename=None):
 
 
 @api_manager.command
-def createtoken(role=ROLE.ADMIN):
+def createtoken(role=ROLE.ADMIN, days=365, Realm="API", Username=None):
     """
     Create an API authentication token
     for administrative or validate use.
     Possible roles are "admin" or "validate".
     """
-    username = geturandom(hex=True)
+    if role not in ["admin", "validate"]:
+        print("ERROR: The role must be 'admin' or 'validate'!")
+        sys.exit(1)
+    username = Username or geturandom(hex=True)
     secret = app.config.get("SECRET_KEY")
     authtype = "API"
-    validity = timedelta(days=365)
+    validity = timedelta(days=int(days))
     token = jwt.encode({"username": username,
-                        "realm": "API",
+                        "realm": Realm,
                         "nonce": geturandom(hex=True),
                         "role": role,
                         "authtype": authtype,
                         "exp": datetime.datetime.utcnow() + validity,
                         "rights": "TODO"},
                        secret)
-    print("Username:   %s" % username)
-    print("Role:       %s" % role)
-    print("Auth-Token: %s" % token)
+    print("Username:   {0!s}".format(username))
+    print("Realm:      {0!s}".format(Realm))
+    print("Role:       {0!s}".format(role))
+    print("Validity:   {0!s} days".format(days))
+    print("Auth-Token: {0!s}".format(token))
 
 
 if __name__ == '__main__':

--- a/pi-manage
+++ b/pi-manage
@@ -949,14 +949,21 @@ def create(name, scope, action, filename=None):
         return r
 
 
-@api_manager.option('-r', '--role', help="The role of the API key can either be"
-                                         "'admin' or 'validate' to access the admin"
-                                         "API or the validate API.")
-@api_manager.option('-d', '--days', help='The number of days the access token should be valid.'
-                                         ' Defaults to 365.')
-@api_manager.option('-R', '--realm', help='The realm of the admin. Defaults to "API"')
-@api_manager.option('-u', '--username', help='The username of the admin.')
-def createtoken(role=ROLE.ADMIN, days=365, realm="API", username=None):
+@api_manager.option('-r', '--role',
+                    help="The role of the API key can either be "
+                         "'admin' or 'validate' to access the admin "
+                         "API or the validate API.",
+                    default=ROLE.ADMIN)
+@api_manager.option('-d', '--days',
+                    help='The number of days the access token should be valid.'
+                         ' Defaults to 365.',
+                    default=365)
+@api_manager.option('-R', '--realm',
+                    help='The realm of the admin. Defaults to "API"',
+                    default="API")
+@api_manager.option('-u', '--username',
+                    help='The username of the admin.')
+def createtoken(role, days, realm, username):
     """
     Create an API authentication token
     for administrative or validate use.

--- a/pi-manage
+++ b/pi-manage
@@ -956,7 +956,7 @@ def create(name, scope, action, filename=None):
                                          ' Defaults to 365.')
 @api_manager.option('-R', '--realm', help='The realm of the admin. Defaults to "API"')
 @api_manager.option('-u', '--username', help='The username of the admin.')
-def createtoken(role=ROLE.ADMIN, days=365, Realm="API", Username=None):
+def createtoken(role=ROLE.ADMIN, days=365, realm="API", username=None):
     """
     Create an API authentication token
     for administrative or validate use.
@@ -965,12 +965,12 @@ def createtoken(role=ROLE.ADMIN, days=365, Realm="API", Username=None):
     if role not in ["admin", "validate"]:
         print("ERROR: The role must be 'admin' or 'validate'!")
         sys.exit(1)
-    username = Username or geturandom(hex=True)
+    username = username or geturandom(hex=True)
     secret = app.config.get("SECRET_KEY")
     authtype = "API"
     validity = timedelta(days=int(days))
     token = jwt.encode({"username": username,
-                        "realm": Realm,
+                        "realm": realm,
                         "nonce": geturandom(hex=True),
                         "role": role,
                         "authtype": authtype,
@@ -978,7 +978,7 @@ def createtoken(role=ROLE.ADMIN, days=365, Realm="API", Username=None):
                         "rights": "TODO"},
                        secret)
     print("Username:   {0!s}".format(username))
-    print("Realm:      {0!s}".format(Realm))
+    print("Realm:      {0!s}".format(realm))
     print("Role:       {0!s}".format(role))
     print("Validity:   {0!s} days".format(days))
     print("Auth-Token: {0!s}".format(token))


### PR DESCRIPTION
closes #931
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/935%23issuecomment-366159709%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169340312%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169341986%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169342953%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169344429%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169346303%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169348205%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169348461%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169356399%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23issuecomment-366159709%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/935%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23935%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/935%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/e27cf02223992069739b1dbe7a225c9197f24a83%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/935/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26height%3D150%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/935%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23935%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.41%25%20%20%2095.41%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20129%20%20%20%20%20%20129%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016019%20%20%20%2016019%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2015285%20%20%20%2015285%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20734%20%20%20%20%20%20734%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/935%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/935%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Be27cf02...9d23923%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/935%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-16T07%3A07%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%209c5133c64bc5be11650a6988b6a4d9acc457032a%20pi-manage%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169356399%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Oh%20no%2C%20seems%20like%20manager.option%20loses%20the%20default%20arguments.%20We%20need%20to%20specify%20them%20in%20the%20.option%20decorators%2C%20because%20right%20now%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cu2570%5Cu2500%24%20./pi-manage%20api%20createtoken%20-r%20admin%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%201%20%5Cu21b5%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20_%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_______%20%20_______%5Cr%5Cn%20%20%20___%20%20____%28_%29%20%20_____%20_______%20__/%20%20_/%20_%20%5C%5C/%20__/%20_%20%7C%5Cr%5Cn%20%20/%20_%20%5C%5C/%20__/%20/%20%7C/%20/%20_%20%60/%20__/%20//%20//%20//%20//%20/%20_//%20__%20%7C%5Cr%5Cn%20/%20.__/_/%20/_/%7C___/%5C%5C_%2C_/%5C%5C__/%5C%5C_%2C%20/___/____/___/_/%20%7C_%7C%5Cr%5Cn/_/%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20/___/%5Cr%5Cn%20%20%20%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22./pi-manage%5C%22%2C%20line%20996%2C%20in%20%3Cmodule%3E%5Cr%5Cn%20%20%20%20manager.run%28%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/__init__.py%5C%22%2C%20line%20412%2C%20in%20run%5Cr%5Cn%20%20%20%20result%20%3D%20self.handle%28sys.argv%5B0%5D%2C%20sys.argv%5B1%3A%5D%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/__init__.py%5C%22%2C%20line%20383%2C%20in%20handle%5Cr%5Cn%20%20%20%20res%20%3D%20handle%28%2Aargs%2C%20%2A%2Aconfig%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/commands.py%5C%22%2C%20line%20216%2C%20in%20__call__%5Cr%5Cn%20%20%20%20return%20self.run%28%2Aargs%2C%20%2A%2Akwargs%29%5Cr%5Cn%20%20File%20%5C%22./pi-manage%5C%22%2C%20line%20971%2C%20in%20createtoken%5Cr%5Cn%20%20%20%20validity%20%3D%20timedelta%28days%3Dint%28days%29%29%5Cr%5CnTypeError%3A%20%3Cflask_script.commands.Command%20object%20at%200x7f323b564350%3E%3A%20int%28%29%20argument%20must%20be%20a%20string%20or%20a%20number%2C%20not%20%27NoneType%27%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222018-02-20T15%3A33%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL949-988%22%7D%2C%20%22Pull%209d239239acace496d30e37a1a6312ab3a906bd7d%20pi-manage%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169340312%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20it%20would%20be%20nicer%20if%20we%20could%20use%20%60%60realm%60%60%20and%20%60%60username%60%60%20as%20variables%20here.%20Also%20because%20the%20capitalized%20%60%60--Username%60%60%20flag%20looks%20a%20bit%20un-linuxy%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20-%3F%2C%20--help%20%20%20%20%20%20%20%20%20%20%20%20show%20this%20help%20message%20and%20exit%5Cr%5Cn...%5Cr%5Cn%20%20-U%20USERNAME%2C%20--Username%20USERNAME%5Cr%5Cn%60%60%60%5Cr%5Cn...%20and%20I%20think%20it%27s%20a%20bit%20inconsistent%20because%20%60%60pi-manage%60%60%20accepts%20usernames%20as%20%60%60-u%60%60%20everywhere%20else.%5Cr%5Cn%20%5Cr%5CnMaybe%20we%20could%20do%20that%20by%20resorting%20to%20%5B%40api_manager.option%5D%28https%3A//flask-script.readthedocs.io/en/latest/%23adding-options-to-the-manager%29%20here%3F%22%2C%20%22created_at%22%3A%20%222018-02-20T14%3A47%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20can%20not%20use%20%60%60realm%60%60.%20The%20lower%20case%20%5C%22r%5C%22%20conflicts%20with%20the%20%5C%22r%5C%22%20from%20%60%60role%60%60.%5Cr%5CnSo%20I%20had%20to%20do%20%5C%22Realm%5C%22%20%28with%20a%20capital%20%5C%22R%5C%22%29%20and%20so%20I%20decided%20to%20use%20a%20captial%20%5C%22U%5C%22.%20%3A-/%22%2C%20%22created_at%22%3A%20%222018-02-20T14%3A52%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20yeah%2C%20I%20think%20using%20%60%60-r%60%60/%60%60--role%60%60%20and%20%60%60-R%60%60/%60%60--realm%60%60%20would%20be%20fine.%20But%20I%20guess%20if%20we%20use%20%60%60%40api_manager.option%60%60%20to%20explicitly%20define%20the%20command-line%20arguments%20%28like%20e.g.%20for%20%60%60rotate_audit%60%60%29%2C%20we%20end%20up%20with%20a%20little%20bit%20of%20boilerplate%2C%20but%20a%20nicer%20command-line%20interface%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-02-20T14%3A54%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20totally%20right...%22%2C%20%22created_at%22%3A%20%222018-02-20T14%3A59%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20hope%20you%20like%20it%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-02-20T15%3A04%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL950-982%22%7D%2C%20%22Pull%202f6eade80a037ab5da5b9fce5cde7e440307ea35%20pi-manage%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/935%23discussion_r169348205%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20CLI%20looks%20lovely%20now%21%20%3A-%29%20Unfortunately%20we%20need%20to%20rename%20the%20arguments%20%60%60Realm%60%60%20and%20%60%60Username%60%60%20to%20%60%60realm%60%60%20and%20%60%60username%60%60%2C%20cause%20otherwise%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cu2570%5Cu2500%24%20./pi-manage%20api%20createtoken%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20130%20%5Cu21b5%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20_%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_______%20%20_______%5Cr%5Cn%20%20%20___%20%20____%28_%29%20%20_____%20_______%20__/%20%20_/%20_%20%5C%5C/%20__/%20_%20%7C%5Cr%5Cn%20%20/%20_%20%5C%5C/%20__/%20/%20%7C/%20/%20_%20%60/%20__/%20//%20//%20//%20//%20/%20_//%20__%20%7C%5Cr%5Cn%20/%20.__/_/%20/_/%7C___/%5C%5C_%2C_/%5C%5C__/%5C%5C_%2C%20/___/____/___/_/%20%7C_%7C%5Cr%5Cn/_/%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20/___/%5Cr%5Cn%20%20%20%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22./pi-manage%5C%22%2C%20line%20996%2C%20in%20%3Cmodule%3E%5Cr%5Cn%20%20%20%20manager.run%28%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/__init__.py%5C%22%2C%20line%20412%2C%20in%20run%5Cr%5Cn%20%20%20%20result%20%3D%20self.handle%28sys.argv%5B0%5D%2C%20sys.argv%5B1%3A%5D%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/__init__.py%5C%22%2C%20line%20383%2C%20in%20handle%5Cr%5Cn%20%20%20%20res%20%3D%20handle%28%2Aargs%2C%20%2A%2Aconfig%29%5Cr%5Cn%20%20File%20%5C%22/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/commands.py%5C%22%2C%20line%20216%2C%20in%20__call__%5Cr%5Cn%20%20%20%20return%20self.run%28%2Aargs%2C%20%2A%2Akwargs%29%5Cr%5CnTypeError%3A%20%3Cflask_script.commands.Command%20object%20at%200x7fe901ce8350%3E%3A%20createtoken%28%29%20got%20an%20unexpected%20keyword%20argument%20%27username%27%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222018-02-20T15%3A10%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20sounds%20sensible%20to%20me.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-20T15%3A10%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL949-988%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/935#issuecomment-366159709'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/935?src=pr&el=h1) Report
> Merging [#935](https://codecov.io/gh/privacyidea/privacyidea/pull/935?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/e27cf02223992069739b1dbe7a225c9197f24a83?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/935/graphs/tree.svg?token=7nHLZki60B&src=pr&height=150&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/935?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master     #935   +/-   ##
=======================================
Coverage   95.41%   95.41%
=======================================
Files         129      129
Lines       16019    16019
=======================================
Hits        15285    15285
Misses        734      734
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/935?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/935?src=pr&el=footer). Last update [e27cf02...9d23923](https://codecov.io/gh/privacyidea/privacyidea/pull/935?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 9d239239acace496d30e37a1a6312ab3a906bd7d pi-manage 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/935#discussion_r169340312'>File: pi-manage:L950-982</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think it would be nicer if we could use ``realm`` and ``username`` as variables here. Also because the capitalized ``--Username`` flag looks a bit un-linuxy:
```
-?, --help            show this help message and exit
...
-U USERNAME, --Username USERNAME
```
... and I think it's a bit inconsistent because ``pi-manage`` accepts usernames as ``-u`` everywhere else.
Maybe we could do that by resorting to [@api_manager.option](https://flask-script.readthedocs.io/en/latest/#adding-options-to-the-manager) here?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You can not use ``realm``. The lower case "r" conflicts with the "r" from ``role``.
So I had to do "Realm" (with a capital "R") and so I decided to use a captial "U". :-/
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, yeah, I think using ``-r``/``--role`` and ``-R``/``--realm`` would be fine. But I guess if we use ``@api_manager.option`` to explicitly define the command-line arguments (like e.g. for ``rotate_audit``), we end up with a little bit of boilerplate, but a nicer command-line interface :)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are totally right...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I hope you like it :-)
- [ ] <a href='#crh-comment-Pull 2f6eade80a037ab5da5b9fce5cde7e440307ea35 pi-manage 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/935#discussion_r169348205'>File: pi-manage:L949-988</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> The CLI looks lovely now! :-) Unfortunately we need to rename the arguments ``Realm`` and ``Username`` to ``realm`` and ``username``, cause otherwise:
```
╰─$ ./pi-manage api createtoken                                                          130 ↵
_                    _______  _______
___  ____(_)  _____ _______ __/  _/ _ \/ __/ _ |
/ _ \/ __/ / |/ / _ `/ __/ // // // // / _// __ |
/ .__/_/ /_/|___/\_,_/\__/\_, /___/____/___/_/ |_|
/_/                       /___/
Traceback (most recent call last):
File "./pi-manage", line 996, in <module>
manager.run()
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/__init__.py", line 412, in run
result = self.handle(sys.argv[0], sys.argv[1:])
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/__init__.py", line 383, in handle
res = handle(*args, **config)
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/commands.py", line 216, in __call__
return self.run(*args, **kwargs)
TypeError: <flask_script.commands.Command object at 0x7fe901ce8350>: createtoken() got an unexpected keyword argument 'username'
```
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The sounds sensible to me.
- [ ] <a href='#crh-comment-Pull 9c5133c64bc5be11650a6988b6a4d9acc457032a pi-manage 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/935#discussion_r169356399'>File: pi-manage:L949-988</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Oh no, seems like manager.option loses the default arguments. We need to specify them in the .option decorators, because right now:
```
╰─$ ./pi-manage api createtoken -r admin                                                   1 ↵
_                    _______  _______
___  ____(_)  _____ _______ __/  _/ _ \/ __/ _ |
/ _ \/ __/ / |/ / _ `/ __/ // // // // / _// __ |
/ .__/_/ /_/|___/\_,_/\__/\_, /___/____/___/_/ |_|
/_/                       /___/
Traceback (most recent call last):
File "./pi-manage", line 996, in <module>
manager.run()
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/__init__.py", line 412, in run
result = self.handle(sys.argv[0], sys.argv[1:])
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/__init__.py", line 383, in handle
res = handle(*args, **config)
File "/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_script/commands.py", line 216, in __call__
return self.run(*args, **kwargs)
File "./pi-manage", line 971, in createtoken
validity = timedelta(days=int(days))
TypeError: <flask_script.commands.Command object at 0x7f323b564350>: int() argument must be a string or a number, not 'NoneType'
```


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/935?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/935?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/935'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>