### PR TITLE
Allow to set SMS or Email token dynamically

### DIFF
--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -106,6 +106,9 @@ class EmailTokenClass(HotpTokenClass):
     def _email_address(self):
         if is_true(self.get_tokeninfo("dynamic_email")):
             email = self.user.info.get(self.EMAIL_ADDRESS_KEY)
+            if type(email) == list and email:
+                # If there is a non-empty list, we use the first entry
+                email = email[0]
         else:
             email = self.get_tokeninfo(self.EMAIL_ADDRESS_KEY)
         if not email:  # pragma: no cover

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -108,6 +108,8 @@ class EmailTokenClass(HotpTokenClass):
             email = self.user.info.get(self.EMAIL_ADDRESS_KEY)
         else:
             email = self.get_tokeninfo(self.EMAIL_ADDRESS_KEY)
+        if not email:  # pragma: no cover
+            log.warning("Token {0!s} does not have an email address!".format(self.token.serial))
         return email
 
     @_email_address.setter

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -346,6 +346,9 @@ class SmsTokenClass(HotpTokenClass):
         """
         if is_true(self.get_tokeninfo("dynamic_phone")):
             phone = self.user.get_user_phone("mobile")
+            if type(phone) == list and phone:
+                # if there is a non-empty list, we use the first entry
+                phone = phone[0]
         else:
             phone = self.get_tokeninfo("phone")
         if not phone:  # pragma: no cover

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -348,6 +348,8 @@ class SmsTokenClass(HotpTokenClass):
             phone = self.user.get_user_phone("mobile")
         else:
             phone = self.get_tokeninfo("phone")
+        if not phone:  # pragma: no cover
+            log.warning("Token {0!s} does not have a phone number!".format(self.token.serial))
         otp = self.get_otp()[2]
         serial = self.get_serial()
 

--- a/privacyidea/static/components/token/views/token.enroll.email.html
+++ b/privacyidea/static/components/token/views/token.enroll.email.html
@@ -8,7 +8,13 @@
     <a ui-sref="config.tokens({tokentype:'email'})">Email Token Config</a>!
 </div>
 
+
 <div class="form-group">
+    <input type="checkbox" ng-model="form.dynamic_email"
+           name="dynamic_email" id="dynamic_email">
+    <label for="dynamic_email" translate>Read email address dynamically from user source on each request.</label>
+</div>
+<div class="form-group" ng-hide="form.dynamic_email">
     <label for="phone" translate>Email Address</label>
     <input type="email"
            autofocus

--- a/privacyidea/static/components/token/views/token.enroll.sms.html
+++ b/privacyidea/static/components/token/views/token.enroll.sms.html
@@ -9,7 +9,13 @@
     <a ui-sref="config.tokens({tokentype:'sms'})">SMS Token Config</a>!
 </div>
 
+
 <div class="form-group">
+    <input type="checkbox" ng-model="form.dynamic_phone"
+           name="dynamic_phone" id="dynamic_phone">
+    <label for="dynamic_phone" translate>Read number dynamically from user source on each request.</label>
+</div>
+<div ng-hide="form.dynamic_phone" class="form-group">
     <label for="phone" translate>Phone number</label>
     <input type="text"
            autofocus
@@ -22,9 +28,12 @@
             {{ phone }}
         </button>
     </div>
+</div>
+<div class="form-group">
     <label for="description" translate>Description</label>
     <input type="text" class="form-control"
             placeholder="{{ 'Some nice words...'|translate }}"
             ng-model="form.description" />
 </div>
+
 

--- a/tests/test_lib_tokens_email.py
+++ b/tests/test_lib_tokens_email.py
@@ -32,6 +32,7 @@ class EmailTokenTestCase(MyTestCase):
     realm1 = "realm1"
     realm2 = "realm2"
     serial1 = "SE123456"
+    serial2 = "SE000000"
     otpkey = "3132333435363738393031323334353637383930"
 
     success_body = "ID 12345"
@@ -73,6 +74,22 @@ class EmailTokenTestCase(MyTestCase):
         class_prefix = token.get_class_prefix()
         self.assertTrue(class_prefix == "PIEM", class_prefix)
         self.assertTrue(token.get_class_type() == "email", token)
+
+        # create token with dynamic email
+        db_token = Token(self.serial2, tokentype="email")
+        db_token.save()
+        token = EmailTokenClass(db_token)
+        token.update({"dynamic_email": True})
+        token.save()
+        self.assertEqual(token.get_tokeninfo("dynamic_email"), "1")
+        self.assertTrue(token.token.serial == self.serial2, token)
+        self.assertTrue(token.token.tokentype == "email", token.token)
+        self.assertTrue(token.type == "email", token.type)
+        class_prefix = token.get_class_prefix()
+        self.assertTrue(class_prefix == "PIEM", class_prefix)
+        self.assertTrue(token.get_class_type() == "email", token)
+        token.set_user(User(login="cornelius",
+                            realm=self.realm1))
 
     def test_02_set_user(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()
@@ -325,6 +342,27 @@ class EmailTokenTestCase(MyTestCase):
         set_privacyidea_config("email.username", "password")
         set_privacyidea_config("email.tls", True)
         db_token = Token.query.filter_by(serial=self.serial1).first()
+        token = EmailTokenClass(db_token)
+        self.assertTrue(token.check_otp("123456", 1, 10) == -1)
+        c = token.create_challenge(transactionid)
+        self.assertTrue(c[0], c)
+        otp = c[1]
+        self.assertTrue(c[3].get("state"), transactionid)
+
+        # check for the challenges response
+        r = token.check_challenge_response(passw=otp)
+        self.assertTrue(r, r)
+
+    @smtpmock.activate
+    def test_18a_challenge_request_dynamic(self):
+        smtpmock.setdata(response={"pi_tester@privacyidea.org": (200, 'OK')})
+        transactionid = "123456098712"
+        # send the email with the old configuration
+        set_privacyidea_config("email.mailserver", "localhost")
+        set_privacyidea_config("email.username", "user")
+        set_privacyidea_config("email.username", "password")
+        set_privacyidea_config("email.tls", True)
+        db_token = Token.query.filter_by(serial=self.serial2).first()
         token = EmailTokenClass(db_token)
         self.assertTrue(token.check_otp("123456", 1, 10) == -1)
         c = token.create_challenge(transactionid)


### PR DESCRIPTION
You can choose to read the phone number or email
address of the challenge response token on each auth
request dynamically from the user source.

Closes #932
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/936%23issuecomment-366462769%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169375629%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169378503%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169381036%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169388304%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169389807%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169390831%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169392116%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169392194%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169393098%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23issuecomment-367053808%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23issuecomment-367477496%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r170048456%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23issuecomment-367772974%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23issuecomment-366462769%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23936%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/4d440ae11eab605ecc43dbe05745cd191e81cbcd%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26width%3D650%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23936%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.41%25%20%20%2095.42%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20129%20%20%20%20%20%20129%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016019%20%20%20%2016029%20%20%20%20%20%20%2B10%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015285%20%20%20%2015295%20%20%20%20%20%20%2B10%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20734%20%20%20%20%20%20734%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/smstoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9zbXN0b2tlbi5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/emailtoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9lbWFpbHRva2VuLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B4d440ae...e5dbd01%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/936%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-17T18%3A49%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22One%20remaining%20thing%3A%20In%20case%20of%20the%20SMS%20token%20and%20the%20LDAP%20resolver%2C%20we%20explicitly%20need%20to%20specify%20a%20list%20of%20Multivalue%20attributes%20that%20%2Adoes%20not%20contain%2A%20%5C%22mobile%5C%22%20%28which%20the%20default%20value%20does%29%20for%20this%20to%20work%20--%20otherwise%2C%20the%20SMS%20recipient%20number%20is%20taken%20to%20be%20e.g.%20%60%60%5Bu%2712345671337%27%5D%60%60%20instead%20of%20%60%6012345671337%60%60.%5Cr%5CnI%27m%20not%20sure%20if%20we%20should%20change%20anything%20here.%20In%20a%20way%2C%20it%20works%20as%20designed.%22%2C%20%22created_at%22%3A%20%222018-02-20T17%3A28%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20we%20could%20check%20if%20it%20is%20a%20list%20type%20and%20in%20this%20case%20use%20the%20first%20element.%5Cr%5CnSounds%20sensible%20to%20me.%20Would%20save%20us%20a%20lot%20of%20support%20requests%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-02-21T21%3A25%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22To%20me%2C%20your%20changes%20look%20mergable.%5Cr%5CnDo%20my%20changes%20look%20this%20way%20to%20you%3F%22%2C%20%22created_at%22%3A%20%222018-02-22T18%3A20%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e5dbd0178faa63c60d0a588c05b80ff2910bb288%20privacyidea/lib/tokens/smstoken.py%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169375629%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Likewise%2C%20should%20we%20check%20for%20an%20empty%20phone%20number%3F%22%2C%20%22created_at%22%3A%20%222018-02-20T16%3A23%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20pushed%20it...%22%2C%20%22created_at%22%3A%20%222018-02-20T17%3A13%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/smstoken.py%3AL344-354%22%7D%2C%20%22Pull%20e5dbd0178faa63c60d0a588c05b80ff2910bb288%20privacyidea/lib/tokens/emailtoken.py%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r169378503%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Honestly%20I%20am%20not%20sure.%5Cr%5Cn%5Cr%5CnI%20am%20even%20not%20sure%20if%20we%20should%20check%20for%20both%20cases%20or%20only%20in%20the%20dynamic%20case.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-02-20T16%3A31%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see.%20Then%2C%20we%20should%20maybe%20only%20add%20a%20log%20warning%3F%20%5C%22Warning%3A%20The%20email%20is%20sent%20to%20an%20empty%20recipient%5C%22%2C%20%5C%22Warning%3A%20The%20SMS%20is%20sent%20to%20an%20empty%20phone%20number%5C%22%20or%20so.%22%2C%20%22created_at%22%3A%20%222018-02-20T16%3A39%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Doesn%27t%20%20the%20lower%20level%20raise%20an%20exception%3F%5Cr%5Cn%5Cr%5CnWell%2C%20if%20we%20add%20code%2C%20then%20I%20think%20I%20would%20like%20to%20raise%20an%20exception%20myself.%20But%20the%20exception%20would%20be%20displayed%20to%20the%20user.%20%3A-/%5Cr%5Cn%5Cr%5CnSo%2C%20a%20log%20warning%20might%20be%20better.%20Because%20this%20nags%20the%20admin%20with%20his%20log%20monitoring...%22%2C%20%22created_at%22%3A%20%222018-02-20T17%3A00%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20I%20added%20a%20log%20warning.%20Bummer.%20THis%20adds%20two%20lines%20without%20code%20coverage.%5Cr%5CnWorking%20on%20the%20test%20case...%22%2C%20%22created_at%22%3A%20%222018-02-20T17%3A05%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20checked%3A%20In%20case%20of%20the%20LDAP%20resolver%2C%20if%20the%20LDAP%20user%20entry%20has%20no%20%60%60mail%60%60%20attribute%2C%20but%20the%20mapping%20contains%20a%20mapping%20to%20the%20%60%60email%60%60%20userinfo%20key%2C%20then%20no%20exception%20is%20thrown%2C%20the%20email%20recipient%20is%20just%20empty.%5Cr%5CnIn%20case%20the%20mapping%20does%20not%20contain%20a%20mapping%20to%20the%20%60%60email%60%60%20userinfo%20key%2C%20the%20above%20exception%20is%20thrown.%22%2C%20%22created_at%22%3A%20%222018-02-20T17%3A08%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20everything%20is%20fine%20-%20isn%27t%20it%3F%5Cr%5Cn%5Cr%5CnIf%20the%20administrator%20enrolls%20dynamic%20email%20tokens%20without%20an%20email%20mapping%20in%20his%20resolver%20config%2C%20he%20can%20come%20to%20me%20in%20person%20and%20I%20am%20happy%20to%20argue%2C%20if%20this%20is%20a%20wise%20idea%20or%20not%21%20%3B%29%5Cr%5Cn%5Cr%5CnShit%20in%20-%20shit%20out.%20Or%20do%20I%20fail%20to%20get%20the%20point%3F%22%2C%20%22created_at%22%3A%20%222018-02-20T17%3A12%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20looks%20good%20now%20%3A%29%20Guess%20I%20didn%27t%20see%20your%20new%20commit%20in%20time.%22%2C%20%22created_at%22%3A%20%222018-02-20T17%3A16%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/emailtoken.py%3AL104-115%22%7D%2C%20%22Pull%2007d16226ed7127d9619a2f9392785e1eda24d190%20tests/test_lib_tokens_email.py%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/936%23discussion_r170048456%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Interesting%2C%20you%20need%20to%20tell%20me%20more%20about%20mocking.%22%2C%20%22created_at%22%3A%20%222018-02-22T18%3A20%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_tokens_email.py%3AL375-392%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/936#issuecomment-366462769'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/936?src=pr&el=h1) Report
> Merging [#936](https://codecov.io/gh/privacyidea/privacyidea/pull/936?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/4d440ae11eab605ecc43dbe05745cd191e81cbcd?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/936/graphs/tree.svg?token=7nHLZki60B&width=650&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/936?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #936      +/-   ##
==========================================
+ Coverage   95.41%   95.42%   +<.01%
==========================================
Files         129      129
Lines       16019    16029      +10
==========================================
+ Hits        15285    15295      +10
Misses        734      734
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/936?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/smstoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/936/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9zbXN0b2tlbi5weQ==) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/emailtoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/936/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9lbWFpbHRva2VuLnB5) | `100% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/936?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/936?src=pr&el=footer). Last update [4d440ae...e5dbd01](https://codecov.io/gh/privacyidea/privacyidea/pull/936?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> One remaining thing: In case of the SMS token and the LDAP resolver, we explicitly need to specify a list of Multivalue attributes that *does not contain* "mobile" (which the default value does) for this to work -- otherwise, the SMS recipient number is taken to be e.g. ``[u'12345671337']`` instead of ``12345671337``.
I'm not sure if we should change anything here. In a way, it works as designed.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Yes, we could check if it is a list type and in this case use the first element.
Sounds sensible to me. Would save us a lot of support requests ;-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> To me, your changes look mergable.
Do my changes look this way to you?
- [ ] <a href='#crh-comment-Pull e5dbd0178faa63c60d0a588c05b80ff2910bb288 privacyidea/lib/tokens/smstoken.py 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/936#discussion_r169375629'>File: privacyidea/lib/tokens/smstoken.py:L344-354</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Likewise, should we check for an empty phone number?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I just pushed it...
- [ ] <a href='#crh-comment-Pull e5dbd0178faa63c60d0a588c05b80ff2910bb288 privacyidea/lib/tokens/emailtoken.py 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/936#discussion_r169378503'>File: privacyidea/lib/tokens/emailtoken.py:L104-115</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Honestly I am not sure.
I am even not sure if we should check for both cases or only in the dynamic case.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I see. Then, we should maybe only add a log warning? "Warning: The email is sent to an empty recipient", "Warning: The SMS is sent to an empty phone number" or so.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Doesn't  the lower level raise an exception?
Well, if we add code, then I think I would like to raise an exception myself. But the exception would be displayed to the user. :-/
So, a log warning might be better. Because this nags the admin with his log monitoring...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Oh, I added a log warning. Bummer. THis adds two lines without code coverage.
Working on the test case...
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I just checked: In case of the LDAP resolver, if the LDAP user entry has no ``mail`` attribute, but the mapping contains a mapping to the ``email`` userinfo key, then no exception is thrown, the email recipient is just empty.
In case the mapping does not contain a mapping to the ``email`` userinfo key, the above exception is thrown.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> So everything is fine - isn't it?
If the administrator enrolls dynamic email tokens without an email mapping in his resolver config, he can come to me in person and I am happy to argue, if this is a wise idea or not! ;)
Shit in - shit out. Or do I fail to get the point?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Yep, looks good now :) Guess I didn't see your new commit in time.
- [ ] <a href='#crh-comment-Pull 07d16226ed7127d9619a2f9392785e1eda24d190 tests/test_lib_tokens_email.py 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/936#discussion_r170048456'>File: tests/test_lib_tokens_email.py:L375-392</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Interesting, you need to tell me more about mocking.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/936?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/936?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/936'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>