### PR TITLE
Allow event to check for result->status

### DIFF
--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -67,6 +67,8 @@ class CONDITION(object):
     TOKENINFO = "tokeninfo"
     DETAIL_ERROR_MESSAGE = "detail_error_message"
     DETAIL_MESSAGE = "detail_message"
+    RESULT_VALUE = "result_value"
+    RESULT_STATUS = "result_status"
 
 
 class BaseEventHandler(object):
@@ -129,9 +131,15 @@ class BaseEventHandler(object):
                 "desc": _("The logged in user is of the following type."),
                 "value": (ROLE.ADMIN, ROLE.USER)
             },
-            "result_value": {
+            CONDITION.RESULT_VALUE: {
                 "type": "str",
                 "desc": _("The result.value within the response is "
+                          "True or False."),
+                "value": ("True", "False")
+            },
+            CONDITION.RESULT_STATUS: {
+                "type": "str",
+                "desc": _("The result.status within the response is "
                           "True or False."),
                 "value": ("True", "False")
             },
@@ -308,10 +316,16 @@ class BaseEventHandler(object):
             if user_role != conditions.get("logged_in_user"):
                 return False
 
-        if "result_value" in conditions:
-            condition_value = conditions.get("result_value")
+        if CONDITION.RESULT_VALUE in conditions:
+            condition_value = conditions.get(CONDITION.RESULT_VALUE)
             result_value = content.get("result", {}).get("value")
             if condition_value != str(result_value):
+                return False
+
+        if CONDITION.RESULT_STATUS in conditions:
+            condition_value = conditions.get(CONDITION.RESULT_STATUS)
+            result_status = content.get("result", {}).get("status")
+            if condition_value != str(result_status):
                 return False
 
         # checking of max-failcounter state of the token

--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -39,7 +39,7 @@ from privacyidea.lib.policy import ACTION
 from privacyidea.lib.token import get_token_owner, get_tokens
 from privacyidea.lib.user import User, UserError
 from privacyidea.lib.utils import (compare_condition, compare_value_value,
-                                   parse_time_offset_from_now)
+                                   parse_time_offset_from_now, is_true)
 import datetime
 from dateutil.tz import tzlocal
 import re
@@ -319,13 +319,13 @@ class BaseEventHandler(object):
         if CONDITION.RESULT_VALUE in conditions:
             condition_value = conditions.get(CONDITION.RESULT_VALUE)
             result_value = content.get("result", {}).get("value")
-            if condition_value != str(result_value):
+            if is_true(condition_value) != is_true(result_value):
                 return False
 
         if CONDITION.RESULT_STATUS in conditions:
             condition_value = conditions.get(CONDITION.RESULT_STATUS)
             result_status = content.get("result", {}).get("status")
-            if condition_value != str(result_status):
+            if is_true(condition_value) != is_true(result_status):
                 return False
 
         # checking of max-failcounter state of the token

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -1447,7 +1447,7 @@ class UserNotificationTestCase(MyTestCase):
 
         uhandler = UserNotificationEventHandler()
         resp = Response()
-        resp.data = """{"result": {"value": false}}"""
+        resp.data = """{"result": {"value": false, "status": false}}"""
         builder = EnvironBuilder(method='POST')
         env = builder.get_environ()
         req = Request(env)
@@ -1463,6 +1463,13 @@ class UserNotificationTestCase(MyTestCase):
         r = uhandler.check_condition(
             {"g": {},
              "handler_def": {"conditions": {"result_value": True}},
+             "response": resp,
+             "request": req})
+        self.assertEqual(r, False)
+
+        r = uhandler.check_condition(
+            {"g": {},
+             "handler_def": {"conditions": {"result_status": True}},
              "response": resp,
              "request": req})
         self.assertEqual(r, False)

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -1447,6 +1447,7 @@ class UserNotificationTestCase(MyTestCase):
 
         uhandler = UserNotificationEventHandler()
         resp = Response()
+        # The actual result_status is false and the result_value is false.
         resp.data = """{"result": {"value": false, "status": false}}"""
         builder = EnvironBuilder(method='POST')
         env = builder.get_environ()
@@ -1460,19 +1461,37 @@ class UserNotificationTestCase(MyTestCase):
              "request": req})
         self.assertEqual(r, False)
 
+        # We expect the result_value to be True, but it is not.
         r = uhandler.check_condition(
             {"g": {},
-             "handler_def": {"conditions": {"result_value": True}},
+             "handler_def": {"conditions": {"result_value": "True"}},
              "response": resp,
              "request": req})
         self.assertEqual(r, False)
 
+        # We expect the result_value to be False, and it is.
         r = uhandler.check_condition(
             {"g": {},
-             "handler_def": {"conditions": {"result_status": True}},
+             "handler_def": {"conditions": {"result_value": "False"}},
+             "response": resp,
+             "request": req})
+        self.assertEqual(r, True)
+
+        # We expect the result_status to be True, but it is not!
+        r = uhandler.check_condition(
+            {"g": {},
+             "handler_def": {"conditions": {"result_status": "True"}},
              "response": resp,
              "request": req})
         self.assertEqual(r, False)
+
+        # We expect the result_status to be False, and it is!
+        r = uhandler.check_condition(
+            {"g": {},
+             "handler_def": {"conditions": {"result_status": "False"}},
+             "response": resp,
+             "request": req})
+        self.assertEqual(r, True)
 
         # check a locked token with maxfail = failcount
         builder = EnvironBuilder(method='POST',


### PR DESCRIPTION
Closes #971
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/972%23issuecomment-371577946%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/972%23discussion_r174151643%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/972%23discussion_r174203436%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/972%23discussion_r174442003%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/972%23discussion_r174482713%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/972%23issuecomment-371577946%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23972%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/899e0b8c78aeb65217a5d1bed377e5067bde6c28%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972/graphs/tree.svg%3Fheight%3D150%26width%3D650%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23972%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.37%25%20%20%2095.39%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016162%20%20%20%2016169%20%20%20%20%20%20%20%2B7%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015415%20%20%20%2015424%20%20%20%20%20%20%20%2B9%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20747%20%20%20%20%20%20745%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/base.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9iYXNlLnB5%29%20%7C%20%6093.02%25%20%3C100%25%3E%20%28%2B0.23%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B899e0b8...4a92daa%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/972%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-03-08T18%3A26%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204a92daa97a17ebe74011d0ad02b3eb6d66191f20%20tests/test_lib_events.py%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/972%23discussion_r174151643%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20this%20be%20%60%60%7B%5C%22result_status%5C%22%3A%20%5C%22True%5C%22%7D%60%60%3F%20i.e.%20the%20event%20condition%20should%20contain%20strings%2C%20not%20booleans%20%28same%20with%20the%20%60%60result_value%60%60%20test%20above%29.%22%2C%20%22created_at%22%3A%20%222018-03-13T14%3A30%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20code%20will%20receive%20a%20boolean%20%60%60True%60%60%20since%20this%20is%20the%20data%20privacyIDEA%20generates%20and%20not%20that%20the%20API%20returns.%5Cr%5CnSee%20line%20https%3A//github.com/privacyidea/privacyidea/pull/972/files%23diff-bf9bddc6356fca28b236be606b262187L1465%22%2C%20%22created_at%22%3A%20%222018-03-13T16%3A44%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20but%20if%20I%20read%20the%20code%20correctly%2C%20privacyIDEA%20does%20not%20actually%20generate%20a%20boolean%20%60%60True%60%60%2C%20but%20a%20string%20%60%60%5C%22True%5C%22%60%60%2C%20because%20the%20%60%60CONDITION.RESULT_STATUS%60%60%20and%20%60%60CONDITION.RESULT_VALUE%60%60%20conditions%20are%20defined%20as%20a%20choice%20between%20%60%60%5C%22True%5C%22%60%60%20and%20%60%60%5C%22False%60%60%5C%22%2C%20of%20type%20%60%60str%60%60%3F%5Cr%5Cn%60%60%60python%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20CONDITION.RESULT_STATUS%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22type%5C%22%3A%20%5C%22str%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22desc%5C%22%3A%20_%28%5C%22The%20result.status%20within%20the%20response%20is%20%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22True%20or%20False.%5C%22%29%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22value%5C%22%3A%20%28%5C%22True%5C%22%2C%20%5C%22False%5C%22%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222018-03-14T12%3A29%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right.%20The%20%5C%22conditions-value%5C%22%20is%20read%20from%20the%20database%20table%20%60%60eventhandlercondition%60%60%20and%20is%20always%20a%20string%20representation.%22%2C%20%22created_at%22%3A%20%222018-03-14T14%3A41%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_events.py%3AL1467-1480%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/972#issuecomment-371577946'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/972?src=pr&el=h1) Report
> Merging [#972](https://codecov.io/gh/privacyidea/privacyidea/pull/972?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/899e0b8c78aeb65217a5d1bed377e5067bde6c28?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/972/graphs/tree.svg?height=150&width=650&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/972?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #972      +/-   ##
==========================================
+ Coverage   95.37%   95.39%   +0.01%
==========================================
Files         131      131
Lines       16162    16169       +7
==========================================
+ Hits        15415    15424       +9
+ Misses        747      745       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/972?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/eventhandler/base.py](https://codecov.io/gh/privacyidea/privacyidea/pull/972/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9iYXNlLnB5) | `93.02% <100%> (+0.23%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/972/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/972?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/972?src=pr&el=footer). Last update [899e0b8...4a92daa](https://codecov.io/gh/privacyidea/privacyidea/pull/972?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 4a92daa97a17ebe74011d0ad02b3eb6d66191f20 tests/test_lib_events.py 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/972#discussion_r174151643'>File: tests/test_lib_events.py:L1467-1480</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Shouldn't this be ``{"result_status": "True"}``? i.e. the event condition should contain strings, not booleans (same with the ``result_value`` test above).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The code will receive a boolean ``True`` since this is the data privacyIDEA generates and not that the API returns.
See line https://github.com/privacyidea/privacyidea/pull/972/files#diff-bf9bddc6356fca28b236be606b262187L1465
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, but if I read the code correctly, privacyIDEA does not actually generate a boolean ``True``, but a string ``"True"``, because the ``CONDITION.RESULT_STATUS`` and ``CONDITION.RESULT_VALUE`` conditions are defined as a choice between ``"True"`` and ``"False``", of type ``str``?
```python
CONDITION.RESULT_STATUS: {
"type": "str",
"desc": _("The result.status within the response is "
"True or False."),
"value": ("True", "False")
},
```
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are right. The "conditions-value" is read from the database table ``eventhandlercondition`` and is always a string representation.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/972?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/972?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/972'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>