### PR TITLE
Allow the tokenhandler to enroll dynamic SMS token

### DIFF
--- a/privacyidea/lib/eventhandler/tokenhandler.py
+++ b/privacyidea/lib/eventhandler/tokenhandler.py
@@ -137,6 +137,13 @@ class TokenEventHandler(BaseEventHandler):
                              "description": _("Set the realm of the newly "
                                               "created token."),
                              "value": realm_list},
+                        "dynamic_phone": {
+                            "type": "bool",
+                            "visibleIf": "tokentype",
+                            "visibleValue": "sms",
+                            "description": _("Dynamically read the mobile number "
+                                             "from the user store.")
+                        },
                         "motppin": {
                             "type": "str",
                             "visibleIf": "tokentype",
@@ -327,11 +334,14 @@ class TokenEventHandler(BaseEventHandler):
                 # will fail to enroll.
                 # TODO: Other tokentypes will require additional parameters
                 if tokentype == "sms":
-                    init_param['phone'] = user.get_user_phone(
-                        phone_type='mobile')
-                    if not init_param['phone']:
-                        log.warning("Enrolling SMS token. But the user "
-                                    "{0!r} has no mobile number!".format(user))
+                    if handler_options.get("dynamic_phone"):
+                        init_param["dynamic_phone"] = 1
+                    else:
+                        init_param['phone'] = user.get_user_phone(
+                            phone_type='mobile')
+                        if not init_param['phone']:
+                            log.warning("Enrolling SMS token. But the user "
+                                        "{0!r} has no mobile number!".format(user))
                 elif tokentype == "email":
                     init_param['email'] = user.info.get("email", "")
                     if not init_param['email']:

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -746,7 +746,6 @@ class FederationEventTestCase(MyTestCase):
                          "https://remote/token/init")
 
 
-
 class TokenEventTestCase(MyTestCase):
 
     def test_01_set_tokenrealm(self):
@@ -1040,6 +1039,26 @@ class TokenEventTestCase(MyTestCase):
         t = get_tokens(tokentype="motp")[0]
         self.assertTrue(t)
         self.assertEqual(t.user, user_obj)
+        remove_token(t.token.serial)
+
+        # Enroll an SMS token
+        options = {"g": g,
+                   "request": req,
+                   "response": resp,
+                   "handler_def": {"options":
+                                       {"tokentype": "sms",
+                                        "user": "1",
+                                        "dynamic_phone": "1"}}
+                   }
+
+        t_handler = TokenEventHandler()
+        res = t_handler.do(ACTION_TYPE.INIT, options=options)
+        self.assertTrue(res)
+        # Check if the token was created and assigned
+        t = get_tokens(tokentype="sms")[0]
+        self.assertTrue(t)
+        self.assertEqual(t.user, user_obj)
+        self.assertEqual(t.get_tokeninfo("dynamic_phone"), "1")
         remove_token(t.token.serial)
 
     def test_06_set_description(self):


### PR DESCRIPTION
We add an option to allow the token handler to
run init as action and use dynamic_phone for SMS.
This does not close the issue #970 completely
but solves the enrollment of dynamic sms token.

Working on #970
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/973%23issuecomment-372703127%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/973%23issuecomment-372703127%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23973%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/899e0b8c78aeb65217a5d1bed377e5067bde6c28%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6080%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973/graphs/tree.svg%3Fheight%3D150%26width%3D650%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23973%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.37%25%20%20%2095.39%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016162%20%20%20%2016164%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015415%20%20%20%2015419%20%20%20%20%20%20%20%2B4%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20747%20%20%20%20%20%20745%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/tokenhandler.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci90b2tlbmhhbmRsZXIucHk%3D%29%20%7C%20%6092.24%25%20%3C80%25%3E%20%28%2B0.13%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B899e0b8...d8ea18b%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/973%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-03-13T15%3A20%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/973#issuecomment-372703127'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/973?src=pr&el=h1) Report
> Merging [#973](https://codecov.io/gh/privacyidea/privacyidea/pull/973?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/899e0b8c78aeb65217a5d1bed377e5067bde6c28?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `80%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/973/graphs/tree.svg?height=150&width=650&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/973?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #973      +/-   ##
==========================================
+ Coverage   95.37%   95.39%   +0.01%
==========================================
Files         131      131
Lines       16162    16164       +2
==========================================
+ Hits        15415    15419       +4
+ Misses        747      745       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/973?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/eventhandler/tokenhandler.py](https://codecov.io/gh/privacyidea/privacyidea/pull/973/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci90b2tlbmhhbmRsZXIucHk=) | `92.24% <80%> (+0.13%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/973/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/973?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/973?src=pr&el=footer). Last update [899e0b8...d8ea18b](https://codecov.io/gh/privacyidea/privacyidea/pull/973?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/973?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/973?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/973'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>