### PR TITLE
Add Update Notes on ldap3+pyasn1

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -2,5 +2,15 @@
 
 ## Update from 2.21 to 2.22
 
+* Some combinations of installed packages may cause problems with the LDAP resolver:
+  * ldap3 2.1.1, pyasn1 0.4.2: Attempts to use STARTTLS fail with an exception (Issue #885)
+  * ldap3 >= 2.3: The user list appears to be empty, the log shows LDAPSizeLimitExceededResult exceptions. (Issue #887)
+                  This can be mitigated by setting a size limit greater than the number of users in the LDAP directory.
+  * ldap3 >= 2.4: User attributes are not retrieved properly (Issue #911)
+  * ldap3 >= 2.4.1: UnicodeError on authentication, token view displays resolver errors (Issue #911)
+  * ldap3 >= 2.4.1: Cannot search for non-ASCII characters in user view (#980)
+* Depending on your requirements, you may consider using ldap3 2.1.1 and pyasn1 0.1.9.
+  While this combination does not exhibit any of the problems listed above, both software
+  releases are quite old and several security fixes have been incorporated since then!
 * The size of the ``serial`` column in the ``pidea_audit`` database table was increased from 20 to 40 characters.
   Please verify that your database can handle this increasing of the table size!

--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -12,5 +12,7 @@
 * Depending on your requirements, you may consider using ldap3 2.1.1 and pyasn1 0.1.9.
   While this combination does not exhibit any of the problems listed above, both software
   releases are quite old and several security fixes have been incorporated since then!
+* By default, Ubuntu installations will have ldap3 2.1.1 and pyasn1 0.1.9 installed,
+  whereas pip/virtualenv installations will have ldap3 2.1.1 and pyasn1 0.4.2.
 * The size of the ``serial`` column in the ``pidea_audit`` database table was increased from 20 to 40 characters.
   Please verify that your database can handle this increasing of the table size!


### PR DESCRIPTION
I added some notes on ldap3 and pyasn1 combinations -- pretty much a summary of #912.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/981%23discussion_r174806429%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/981%23issuecomment-373402239%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/981%23discussion_r174818195%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/981%23issuecomment-373402239%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23981%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/204a562318594fbcb8343f3c969cc102ec029b24%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.08%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981/graphs/tree.svg%3Fsrc%3Dpr%26token%3D7nHLZki60B%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23981%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.39%25%20%20%2095.47%25%20%20%20%2B0.08%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016173%20%20%20%2016420%20%20%20%20%20%2B247%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015428%20%20%20%2015677%20%20%20%20%20%2B249%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20745%20%20%20%20%20%20743%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6094.98%25%20%3C0%25%3E%20%28%2B1.4%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/base.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9iYXNlLnB5%29%20%7C%20%6096.37%25%20%3C0%25%3E%20%28%2B3.35%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B204a562...228fb3c%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/981%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-03-15T14%3A49%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20228fb3c61a527d3974b4782d81261d245081abec%20READ_BEFORE_UPDATE.md%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/981%23discussion_r174806429%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20is%20the%20difference%20between%20%5C%22ldap3%20%3E%3D%202.4%5C%22%20and%20%5C%22ldap3%20%3E%3D%202.4.1%5C%22.%5Cr%5Cn%5Cr%5CnShould%20we%20point%20out%2C%20that%20the%20pip%20installation%20will%20install%20the%20combination%20of%202.1.1/0.4.2%20and%20the%20ubuntu%20installation%20will%20install%202.1.1/0.1.9%3F%22%2C%20%22created_at%22%3A%20%222018-03-15T14%3A40%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20the%20UnicodeError%20only%20occurs%20in%202.4.1%2C%20not%202.4%20%3A-%29%20Maybe%20this%20is%20a%20confusing%20way%20to%20write%20that.%5Cr%5Cn%5Cr%5CnGood%20idea%2C%20I%27ll%20add%20a%20note%21%22%2C%20%22created_at%22%3A%20%222018-03-15T15%3A10%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20READ_BEFORE_UPDATE.md%3AL2-17%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 228fb3c61a527d3974b4782d81261d245081abec READ_BEFORE_UPDATE.md 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/981#discussion_r174806429'>File: READ_BEFORE_UPDATE.md:L2-17</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What is the difference between "ldap3 >= 2.4" and "ldap3 >= 2.4.1".
Should we point out, that the pip installation will install the combination of 2.1.1/0.4.2 and the ubuntu installation will install 2.1.1/0.1.9?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Well, the UnicodeError only occurs in 2.4.1, not 2.4 :-) Maybe this is a confusing way to write that.
Good idea, I'll add a note!
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/981#issuecomment-373402239'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/981?src=pr&el=h1) Report
> Merging [#981](https://codecov.io/gh/privacyidea/privacyidea/pull/981?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/204a562318594fbcb8343f3c969cc102ec029b24?src=pr&el=desc) will **increase** coverage by `0.08%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/981/graphs/tree.svg?src=pr&token=7nHLZki60B&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/981?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #981      +/-   ##
==========================================
+ Coverage   95.39%   95.47%   +0.08%
==========================================
Files         131      131
Lines       16173    16420     +247
==========================================
+ Hits        15428    15677     +249
+ Misses        745      743       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/981?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/981/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `94.98% <0%> (+1.4%)` | :arrow_up: |
| [privacyidea/lib/eventhandler/base.py](https://codecov.io/gh/privacyidea/privacyidea/pull/981/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9iYXNlLnB5) | `96.37% <0%> (+3.35%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/981?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/981?src=pr&el=footer). Last update [204a562...228fb3c](https://codecov.io/gh/privacyidea/privacyidea/pull/981?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/981?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/981?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/981'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>