### PR TITLE
Catch LDAPSizeLimitExceededResult exception, work around ldap3 behavior

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -319,6 +319,14 @@ class IdResolver (UserIdResolver):
                 uid = attributes.get(uidtype)[0]
             else:
                 uid = attributes.get(uidtype)
+            if uidtype.lower() == "objectguid":
+                # For ldap3 versions <= 2.4.1, objectGUID attribute values are returned as UUID strings.
+                # For versions greater than 2.4.1, they are returned in the curly-braced string
+                # representation, i.e. objectGUID := "{" UUID "}"
+                # In order to ensure backwards compatibility for user mappings,
+                # we strip the curly braces from objectGUID values.
+                # If we are using ldap3 <= 2.4.1, there are no curly braces and we leave the value unchanged.
+                uid = uid.strip("{").strip("}")
         return uid
 
     def _trim_user_id(self, userId):

--- a/tests/ldap3mock.py
+++ b/tests/ldap3mock.py
@@ -135,7 +135,11 @@ class Connection(object):
                                        paged_size=kwargs.get("page_size"),
                                        size_limit=kwargs.get("size_limit"),
                                        paged_cookie=None)
-                return self.connection.response
+                result = self.connection.response
+                if kwargs.get("generator", False):
+                    # If ``generator=True`` is passed, ``paged_search`` should return an iterator.
+                    result = iter(result)
+                return result
 
         def __init__(self, connection):
             self.standard = self.Standard(connection)

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -14,7 +14,6 @@ import ldap3mock
 from ldap3.core.exceptions import LDAPOperationResult
 from ldap3.core.results import RESULT_SIZE_LIMIT_EXCEEDED
 import mock
-from itertools import islice
 import responses
 import uuid
 from privacyidea.lib.resolvers.LDAPIdResolver import IdResolver as LDAPResolver
@@ -1576,9 +1575,8 @@ class LDAPResolverTestCase(MyTestCase):
                                        paged_cookie=None)
                 result = self.connection.response
                 assert kwargs['generator']
-                # Only return two results
-                for result in islice(result, 1):
-                    yield result
+                # Only return one result
+                yield next(result)
                 raise LDAPOperationResult(result=RESULT_SIZE_LIMIT_EXCEEDED)
 
             mock_search.side_effect = _search_with_exception

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -1519,7 +1519,7 @@ class LDAPResolverTestCase(MyTestCase):
         self.assertTrue("value2" in info.get("piAttr"))
 
     @ldap3mock.activate
-    def test_01_sizelimit(self):
+    def test_29_sizelimit(self):
         # This tests usernames are entered in the LDAPresolver as unicode.
         ldap3mock.setLDAPDirectory(LDAPDirectory)
         y = LDAPResolver()
@@ -1576,7 +1576,7 @@ class LDAPResolverTestCase(MyTestCase):
                 result = self.connection.response
                 assert kwargs['generator']
                 # Only return one result
-                yield next(result)
+                yield result[0]
                 raise LDAPOperationResult(result=RESULT_SIZE_LIMIT_EXCEEDED)
 
             mock_search.side_effect = _search_with_exception


### PR DESCRIPTION
This fixes #887.

Since ldap3 2.3, ldap3 throws a LDAPSizeLimitExceededResult exception to signal that the client-side size limit of a search request has been reached. This PR catches the exception and carries on.

Addtionally, this also works around the issue I described in cannatag/ldap3#508, in which some entries might get lost. However, assuming a future ldap3 version in which this issue is fixed, the workaround would result in duplicate entries. Thus, this PR also (hopefully) handles the case of a future ldap3 package in which the problem shown in cannatag/ldap3#508 is fixed.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/982%23issuecomment-373427783%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/982%23issuecomment-373431505%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/982%23issuecomment-373461231%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/982%23issuecomment-373463471%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/982%23issuecomment-374014157%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/982%23issuecomment-373427783%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23982%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/204a562318594fbcb8343f3c969cc102ec029b24%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6095.23%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23982%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.39%25%20%20%2095.42%25%20%20%20%2B0.03%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016173%20%20%20%2016251%20%20%20%20%20%20%2B78%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015428%20%20%20%2015508%20%20%20%20%20%20%2B80%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20745%20%20%20%20%20%20743%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6093.81%25%20%3C95.23%25%3E%20%28%2B0.23%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.33%25%20%3C0%25%3E%20%28-2.5%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/base.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9iYXNlLnB5%29%20%7C%20%6096.37%25%20%3C0%25%3E%20%28%2B3.35%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B204a562...44c2bca%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/982%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-03-15T15%3A58%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Does%20the%20sizelimit%20problem%20also%20occure%20with%20version%202.4%20and%202.4.1%3F%22%2C%20%22created_at%22%3A%20%222018-03-15T16%3A09%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20this%20is%20the%20case%20for%20ldap3%202.3%2C%202.4%2C%202.4.1%20and%20the%20current%20dev%20branch.%22%2C%20%22created_at%22%3A%20%222018-03-15T17%3A35%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20so%20the%20patch%20makes%20sense%20since%20we%20also%20need%20it%20for%20ldap3%202.4.1.%20OK.%22%2C%20%22created_at%22%3A%20%222018-03-15T17%3A42%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20this%20patch%20pretty%20much%20consists%20of%20two%20parts%3A%5Cr%5Cn%2A%20the%20%60%60ignore_sizelimit_exception%60%60%20wrapper%20function.%20We%20need%20this%20to%20fix%20%23887%20for%20all%20ldap3%20versions%20starting%20with%202.3%2C%20and%20also%20the%20next%20ldap3%20release.%5Cr%5Cn%2A%20inside%20%60%60ignore_sizelimit_exception%60%60%2C%20we%20work%20around%20the%20issue%20in%20cannatag/ldap3%23508%20in%20lines%20175-177.%20We%20need%20this%20to%20ensure%20that%20the%20correct%20number%20of%20entries%20is%20returned%20for%20ldap3%202.3%2C%202.4%20and%202.4.1.%20I%20also%20tried%20to%20ensure%20that%20the%20same%20code%20will%20work%20with%20the%20next%20release%20of%20ldap3%2C%20which%20will%20contain%20the%20fix%20in%20cannatag/ldap3%23508.%20Another%20possibility%20would%20be%20to%20decide%20that%20we%20don%27t%20support%20ldap3%202.3%2C%202.4%20and%202.4.1%20%28which%20would%20be%20valid%2C%20as%20these%20versions%20cause%20a%20lot%20of%20other%20bugs%29%20and%20get%20rid%20of%20the%20workaround%2C%20resulting%20in%20a%20less%20confusing%20%60%60ignore_sizelimit_exception%60%60%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-03-18T16%3A37%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/982#issuecomment-373427783'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/982?src=pr&el=h1) Report
> Merging [#982](https://codecov.io/gh/privacyidea/privacyidea/pull/982?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/204a562318594fbcb8343f3c969cc102ec029b24?src=pr&el=desc) will **increase** coverage by `0.03%`.
> The diff coverage is `95.23%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/982/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/982?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #982      +/-   ##
==========================================
+ Coverage   95.39%   95.42%   +0.03%
==========================================
Files         131      131
Lines       16173    16251      +78
==========================================
+ Hits        15428    15508      +80
+ Misses        745      743       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/982?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/982/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `93.81% <95.23%> (+0.23%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/982/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.33% <0%> (-2.5%)` | :arrow_down: |
| [privacyidea/lib/eventhandler/base.py](https://codecov.io/gh/privacyidea/privacyidea/pull/982/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9iYXNlLnB5) | `96.37% <0%> (+3.35%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/982?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/982?src=pr&el=footer). Last update [204a562...44c2bca](https://codecov.io/gh/privacyidea/privacyidea/pull/982?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Does the sizelimit problem also occure with version 2.4 and 2.4.1?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Yep, this is the case for ldap3 2.3, 2.4, 2.4.1 and the current dev branch.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK, so the patch makes sense since we also need it for ldap3 2.4.1. OK.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Well, this patch pretty much consists of two parts:
* the ``ignore_sizelimit_exception`` wrapper function. We need this to fix #887 for all ldap3 versions starting with 2.3, and also the next ldap3 release.
* inside ``ignore_sizelimit_exception``, we work around the issue in cannatag/ldap3#508 in lines 175-177. We need this to ensure that the correct number of entries is returned for ldap3 2.3, 2.4 and 2.4.1. I also tried to ensure that the same code will work with the next release of ldap3, which will contain the fix in cannatag/ldap3#508. Another possibility would be to decide that we don't support ldap3 2.3, 2.4 and 2.4.1 (which would be valid, as these versions cause a lot of other bugs) and get rid of the workaround, resulting in a less confusing ``ignore_sizelimit_exception`` :-)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/982?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/982?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/982'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>