### PR TITLE
Describe the customization in more detail

### DIFF
--- a/doc/workflows_and_tools/enrollment_wizard/index.rst
+++ b/doc/workflows_and_tools/enrollment_wizard/index.rst
@@ -49,7 +49,7 @@ Example
 ~~~~~~~
 
 Your privacyIDEA system is running in the URL sub path ``/pi``.
-The files could be addressed via a path componente ``mydesign`` (in this case ``pi/mydesign``).
+The files could be addressed via a path component ``mydesign`` (in this case ``pi/mydesign``).
 Thus the WebUI will look for the files in the URL path ``/pi/mydesign/views/includes/``.
 
 So you set in ``pi.cfg``:

--- a/doc/workflows_and_tools/enrollment_wizard/index.rst
+++ b/doc/workflows_and_tools/enrollment_wizard/index.rst
@@ -49,7 +49,7 @@ Example
 ~~~~~~~
 
 Your privacyIDEA system is running in the URL sub path ``/pi``.
-You want the files to be addressed via the URL path ``/mydesign``.
+The files could be addressed via a path componente ``mydesign`` (in this case ``pi/mydesign``).
 Thus the WebUI will look for the files in the URL path ``/pi/mydesign/views/includes/``.
 
 So you set in ``pi.cfg``:

--- a/doc/workflows_and_tools/enrollment_wizard/index.rst
+++ b/doc/workflows_and_tools/enrollment_wizard/index.rst
@@ -44,3 +44,19 @@ wizard in your html templates defined in these files:
    your needs the best by defining a variable PI_CUSTOMIZATION in the file
    pi.cfg. This way you can put all modifications in one place apart from the
    original code.
+
+Example
+~~~~~~~
+
+Your privacyIDEA system is running in the URL sub path ``/pi``.
+You want the files to be addressed via the URL path ``/mydesign``.
+Thus the WebUI will look for the files in the URL path ``/pi/mydesign/views/includes/``.
+
+So you set in ``pi.cfg``:
+
+    PI_CUSTOMIZATION = "/mydesign"
+
+Your customized files are located in ``/etc/privacyidea/customize/views/includes/``.
+In the Apache webserver you need to map ``/pi/mydesign`` to ``/etc/privacyidea/customize``:
+
+    Alias /pi/mydesign /etc/privacyidea/customize

--- a/privacyidea/static/customize/README.rst
+++ b/privacyidea/static/customize/README.rst
@@ -3,7 +3,7 @@ privacyIDEA Web UI.
 
 This directory translates to the URL `/static/customize/`.
 
-If you want to use another directory, you can set the URL 
+If you want to use another directory, you can set the URL path
 in `pi.cfg` like:
 
    PI_CUSTOMIZATION = "/mydirectory"
@@ -23,6 +23,23 @@ sub directory `views/includes`:
 * token.enroll.pre.bottom.html
 * token.enroll.post.top.html
 * token.enroll.post.bottom.html
+
+Example
+-------
+
+Your privacyIDEA system is running in the URL sub path ``/pi``.
+You want the files to be addressed via the URL path ``/mydesign``.
+Thus the WebUI will look for the files in the URL path ``/pi/mydesign/views/includes/``.
+
+So you set in ``pi.cfg``:
+
+    PI_CUSTOMIZATION = "/mydesign"
+
+Your customized files are located in ``/etc/privacyidea/customize/views/includes/``.
+In the Apache webserver you need to map ``/pi/mydesign`` to ``/etc/privacyidea/customize``:
+
+    Alias /pi/mydesign /etc/privacyidea/customize
+
 
 Paper Token
 ===========

--- a/privacyidea/static/customize/README.rst
+++ b/privacyidea/static/customize/README.rst
@@ -28,7 +28,7 @@ Example
 -------
 
 Your privacyIDEA system is running in the URL sub path ``/pi``.
-You want the files to be addressed via the URL path ``/mydesign``.
+The files could be addressed via a path componente ``mydesign`` (in this case ``pi/mydesign``).
 Thus the WebUI will look for the files in the URL path ``/pi/mydesign/views/includes/``.
 
 So you set in ``pi.cfg``:

--- a/privacyidea/static/customize/README.rst
+++ b/privacyidea/static/customize/README.rst
@@ -28,7 +28,7 @@ Example
 -------
 
 Your privacyIDEA system is running in the URL sub path ``/pi``.
-The files could be addressed via a path componente ``mydesign`` (in this case ``pi/mydesign``).
+The files could be addressed via a path component ``mydesign`` (in this case ``pi/mydesign``).
 Thus the WebUI will look for the files in the URL path ``/pi/mydesign/views/includes/``.
 
 So you set in ``pi.cfg``:


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/985%23issuecomment-374651744%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/985%23issuecomment-374666160%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/985%23discussion_r176030208%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/985%23discussion_r176036424%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/985%23discussion_r176037756%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/985%23discussion_r176039683%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/985%23issuecomment-374651744%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20check%20if%20this%20is%20better%20understandable.%22%2C%20%22created_at%22%3A%20%222018-03-20T15%3A56%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23985%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/953e0db31729a87961f3a23e291861ed704e1150%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.1%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23985%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.39%25%20%20%2095.49%25%20%20%20%2B0.1%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016190%20%20%20%2016440%20%20%20%20%2B250%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015445%20%20%20%2015700%20%20%20%20%2B255%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20745%20%20%20%20%20%20740%20%20%20%20%20%20-5%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6096.66%25%20%3C0%25%3E%20%28%2B2.84%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B953e0db...dfafad3%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/985%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-03-20T16%3A34%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20dfafad3c51ac5c8d74b5adbe69be3d6f876c50bb%20doc/workflows_and_tools/enrollment_wizard/index.rst%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/985%23discussion_r176030208%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20don%27t%20really%20understand%20this%20sentence.%20Don%27t%20we%20want%20the%20files%20to%20be%20addressed%20via%20the%20URL%20path%20%60%60/pi/mydesign%60%60%3F%22%2C%20%22created_at%22%3A%20%222018-03-21T10%3A05%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20actually%20the%20files%20are%20available%20on%20the%20webserver%20via%20%5C%22/pi/mydesign%5C%22.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-03-21T10%3A32%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20okay.%20Then%2C%20I%20find%20the%20sentence%20you%20suggested%20better%20understandable%2C%20because%20%60%60/mydesign%60%60%20reads%20like%20an%20absolute%20path%20to%20me.%22%2C%20%22created_at%22%3A%20%222018-03-21T10%3A37%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22updated.%22%2C%20%22created_at%22%3A%20%222018-03-21T10%3A44%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/workflows_and_tools/enrollment_wizard/index.rst%3AL44-63%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/985#issuecomment-374651744'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Please check if this is better understandable.
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/985?src=pr&el=h1) Report
> Merging [#985](https://codecov.io/gh/privacyidea/privacyidea/pull/985?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/953e0db31729a87961f3a23e291861ed704e1150?src=pr&el=desc) will **increase** coverage by `0.1%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/985/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/985?src=pr&el=tree)
```diff
@@            Coverage Diff            @@
##           master     #985     +/-   ##
=========================================
+ Coverage   95.39%   95.49%   +0.1%
=========================================
Files         131      131
Lines       16190    16440    +250
=========================================
+ Hits        15445    15700    +255
+ Misses        745      740      -5
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/985?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/985/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `96.66% <0%> (+2.84%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/985?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/985?src=pr&el=footer). Last update [953e0db...dfafad3](https://codecov.io/gh/privacyidea/privacyidea/pull/985?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull dfafad3c51ac5c8d74b5adbe69be3d6f876c50bb doc/workflows_and_tools/enrollment_wizard/index.rst 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/985#discussion_r176030208'>File: doc/workflows_and_tools/enrollment_wizard/index.rst:L44-63</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, I don't really understand this sentence. Don't we want the files to be addressed via the URL path ``/pi/mydesign``?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Yes, actually the files are available on the webserver via "/pi/mydesign".
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah okay. Then, I find the sentence you suggested better understandable, because ``/mydesign`` reads like an absolute path to me.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> updated.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/985?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/985?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/985'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>