### PR TITLE
#995 Fixing challenge response input visibility

### DIFF
--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -272,7 +272,7 @@ class SmsTokenClass(HotpTokenClass):
         sms = ""
         options = options or {}
         return_message = "Enter the OTP from the SMS:"
-        attributes = {'state': transactionid}
+        attributes = {'state': transactionid, 'hideResponseInput': False}
         validity = self._get_sms_timeout()
 
         if self.is_active() is True:
@@ -442,8 +442,8 @@ class SmsTokenClass(HotpTokenClass):
     def _get_sms_text(options):
         """
         This returns the SMSTEXT from the policy "smstext"
-        
-        options contains data like clientip, g, user and also the Request 
+
+        options contains data like clientip, g, user and also the Request
         parameters like "challenge" or "pass".
 
         :param options: contains user and g object.

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -216,7 +216,7 @@ angular.module("privacyideaApp")
 
                 // Challenge Response always containes mult_challenge!
                 var multi_challenge = error.detail.multi_challenge;
-                if (multi_challenge.length > 1) {
+                if (multi_challenge.length >= 1) {
                     $scope.challenge_message = gettextCatalog.getString('Please confirm with one of these tokens:');
                     $scope.challenge_multiple_tokens = true;
                 } else {
@@ -224,7 +224,7 @@ angular.module("privacyideaApp")
                     $scope.challenge_multiple_tokens = false;
                 }
                 for (var i = 0; i < multi_challenge.length; i++) {
-                    if (multi_challenge.length > 1) {
+                    if (multi_challenge.length >= 1) {
                         $scope.challenge_message = $scope.challenge_message + ' ' + multi_challenge[i].serial;
                     }
                     var attributes = multi_challenge[i].attributes;


### PR DESCRIPTION
#995
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/996%23issuecomment-378561794%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/996%23discussion_r179173718%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/996%23discussion_r179255694%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/996%23issuecomment-378733772%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/996%23issuecomment-378561794%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23996%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/d4633f1a53b79ab31e27ceafc4ccd68e972ff2de%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26height%3D150%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23996%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.37%25%20%20%2095.37%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016190%20%20%20%2016190%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2015442%20%20%20%2015442%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20748%20%20%20%20%20%20748%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/smstoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9zbXN0b2tlbi5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bd4633f1...e590635%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/996%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-04T11%3A00%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20text%20above%20the%20%2A%2AAnswer%2A%2A%20is%20supposed%20to%20only%20be%20displayed%2C%20if%20there%20are%20more%20than%20ONE%20chall-resp%20tokens.%20Otherwise%20the%20challenge%20text%20is%20only%20displayed%20%2Ain%2A%20the%20input%20dialog.%20%28Feature%29%5Cr%5Cn%5Cr%5CnThe%20problem%20with%20the%20missing%20input%20field%20will%20be%20fixed%20by%20reverting%20the%20logic%20in%20line%20231%20as%20mentioned%20earlier.%5Cr%5Cn%5Cr%5Cn%20%20%20%20if%20%28attributes%20%3D%3D%3D%20null%20%7C%7C%20attributes.hideResponseInput%20%21%3D%3D%20true%20%29%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-04T20%3A26%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e59063504410213b2e1ebdbab28423265b3c6022%20privacyidea/static/components/login/controllers/loginControllers.js%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/996%23discussion_r179255694%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Problem%20is%20that%20your%20dont%20get%20first%20message%22%2C%20%22created_at%22%3A%20%222018-04-04T19%3A24%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5985348%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/p53%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/login/controllers/loginControllers.js%3AL216-231%22%7D%2C%20%22Pull%20e59063504410213b2e1ebdbab28423265b3c6022%20privacyidea/static/components/login/controllers/loginControllers.js%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/996%23discussion_r179173718%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20error%20seems%20to%20be%20in%20the%20line%20below%20%28line%20231%29.%5Cr%5CnIt%20probably%20should%20be%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20if%20%28attributes%20%3D%3D%3D%20null%20%7C%7C%20attributes.hideResponseInput%20%21%3D%3D%20true%20%29%5Cr%5Cn%5Cr%5Cnbecause%3A%20if%20we%20have%20attributes%2C%20but%20the%20attributes%20do%20not%20contain%20%5C%22hideRespsoneInput%5C%22%20explicitly%2C%20then%20we%20need%20to%20display%20the%20input%20field.%20attributes.hideResponseInput%20is%20null%2C%20if%20it%20is%20not%20set.%22%2C%20%22created_at%22%3A%20%222018-04-04T15%3A02%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/login/controllers/loginControllers.js%3AL216-231%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/996#issuecomment-378561794'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/996?src=pr&el=h1) Report
> Merging [#996](https://codecov.io/gh/privacyidea/privacyidea/pull/996?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/d4633f1a53b79ab31e27ceafc4ccd68e972ff2de?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/996/graphs/tree.svg?token=7nHLZki60B&src=pr&height=150&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/996?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master     #996   +/-   ##
=======================================
Coverage   95.37%   95.37%
=======================================
Files         131      131
Lines       16190    16190
=======================================
Hits        15442    15442
Misses        748      748
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/996?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/smstoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/996/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9zbXN0b2tlbi5weQ==) | `100% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/996?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/996?src=pr&el=footer). Last update [d4633f1...e590635](https://codecov.io/gh/privacyidea/privacyidea/pull/996?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The text above the **Answer** is supposed to only be displayed, if there are more than ONE chall-resp tokens. Otherwise the challenge text is only displayed *in* the input dialog. (Feature)
The problem with the missing input field will be fixed by reverting the logic in line 231 as mentioned earlier.
if (attributes === null || attributes.hideResponseInput !== true )
- [ ] <a href='#crh-comment-Pull e59063504410213b2e1ebdbab28423265b3c6022 privacyidea/static/components/login/controllers/loginControllers.js 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/996#discussion_r179173718'>File: privacyidea/static/components/login/controllers/loginControllers.js:L216-231</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The error seems to be in the line below (line 231).
It probably should be:
if (attributes === null || attributes.hideResponseInput !== true )
because: if we have attributes, but the attributes do not contain "hideRespsoneInput" explicitly, then we need to display the input field. attributes.hideResponseInput is null, if it is not set.
- [ ] <a href='#crh-comment-Pull e59063504410213b2e1ebdbab28423265b3c6022 privacyidea/static/components/login/controllers/loginControllers.js 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/996#discussion_r179255694'>File: privacyidea/static/components/login/controllers/loginControllers.js:L216-231</a></b>
- <a href='https://github.com/p53'><img border=0 src='https://avatars1.githubusercontent.com/u/5985348?v=4' height=16 width=16></a> Problem is that your dont get first message


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/996?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/996?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/996'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>