### PR TITLE
Fix WebUI login with multiple CR tokens

### DIFF
--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -232,17 +232,17 @@ angular.module("privacyideaApp")
                         $scope.hideResponseInput = false;
                     }
                     if (attributes !== null) {
-                        if (attributes.u2fSignRequest !== null) {
+                        if (attributes.u2fSignRequest) {
                            $scope.u2fSignRequests.push(attributes.u2fSignRequest);
                         }
-                        if (attributes.img !== null) {
+                        if (attributes.img) {
                             $scope.image = attributes.img;
                             if ($scope.image.indexOf("data:image") === -1) {
                                 // In case of an Image link, we prepend the instanceUrl
                                 $scope.image = $scope.instanceUrl + "/" + $scope.image;
                             }
                         }
-                        if (attributes.poll !== null) {
+                        if (attributes.poll) {
                             $scope.polling = attributes.poll;
                         }
                     }

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -255,7 +255,7 @@ angular.module("privacyideaApp")
                     PollingAuthFactory.start($scope.check_authentication);
                 }
                 // In case of u2f we do:
-                if ($scope.u2fSignRequests) {
+                if ($scope.u2fSignRequests.length > 0) {
                     $scope.u2f_first_error = error;
                     U2fFactory.sign_request(error, $scope.u2fSignRequests,
                         $scope.login.username,


### PR DESCRIPTION
This fixes #1004.

The reason for the error is that ``attributes.img !== null`` evaluates to true if ``attributes.img`` is ``undefined``. Hence, the body is entered and fails at ``$scope.image.indexOf("data:image")``.

I also fixed a minor bug where U2F routines are invoked even if no U2F token is present. This is because ``$scope.u2fSignRequests`` is an empty list, but empty lists are truthy in JavaScript (but falsy in Python).

I'm actually not sure if this should go into ``branch-2.22`` or ``master``. I chose master for now :)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1005%23issuecomment-380152395%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1005%23issuecomment-380344455%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1005%23discussion_r180494338%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1005%23discussion_r180648232%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1005%23discussion_r180648521%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1005%23discussion_r180648542%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1005%23issuecomment-380152395%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1005%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231005%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1005%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/d4633f1a53b79ab31e27ceafc4ccd68e972ff2de%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1005/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1005%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231005%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.39%25%20%20%2095.39%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016190%20%20%20%2016190%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2015445%20%20%20%2015445%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20745%20%20%20%20%20%20745%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1005%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1005%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bd4633f1...938de3c%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1005%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-10T15%3A54%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-04-11T06%3A41%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20938de3cd69b1aa86587fe281e69d601eedd3b20f%20privacyidea/static/components/login/controllers/loginControllers.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1005%23discussion_r180494338%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20happens%20if%20%60%60%24scope.u2fSignRequests%60%60%20would%20be%20undefined%3F%20%28it%20probably%20will%20not%20be%29%2C%20but%20then%20we%20would%20have%20a%20script%20error.%22%2C%20%22created_at%22%3A%20%222018-04-10T16%3A55%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20it%20shouldn%27t%20be%20%28because%20we%20set%20it%20to%20%60%60Array%28%29%60%60%29%20in%20Line%20214.%20But%20I%20guess%20you%27re%20right%2C%20we%20could%20go%20the%20safe%20route%20here%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-04-11T06%3A39%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20no.%20THis%20is%20fine.%20You%20are%20right.%20We%20set%20this%20to%20%60%60Array%28%29%60%60%20%20and%20later%20only%20push%20to%20this%20array.%20So%20this%20is%20ok.%22%2C%20%22created_at%22%3A%20%222018-04-11T06%3A41%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-04-11T06%3A41%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/login/controllers/loginControllers.js%3AL255-262%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cornelinux%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cornelinux'><img src='https://avatars1.githubusercontent.com/u/1908620?v=4' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1005#issuecomment-380152395'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1005?src=pr&el=h1) Report
> Merging [#1005](https://codecov.io/gh/privacyidea/privacyidea/pull/1005?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/d4633f1a53b79ab31e27ceafc4ccd68e972ff2de?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1005/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1005?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master    #1005   +/-   ##
=======================================
Coverage   95.39%   95.39%
=======================================
Files         131      131
Lines       16190    16190
=======================================
Hits        15445    15445
Misses        745      745
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1005?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1005?src=pr&el=footer). Last update [d4633f1...938de3c](https://codecov.io/gh/privacyidea/privacyidea/pull/1005?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull 938de3cd69b1aa86587fe281e69d601eedd3b20f privacyidea/static/components/login/controllers/loginControllers.js 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1005#discussion_r180494338'>File: privacyidea/static/components/login/controllers/loginControllers.js:L255-262</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What happens if ``$scope.u2fSignRequests`` would be undefined? (it probably will not be), but then we would have a script error.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, it shouldn't be (because we set it to ``Array()``) in Line 214. But I guess you're right, we could go the safe route here :)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK, no. THis is fine. You are right. We set this to ``Array()``  and later only push to this array. So this is ok.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1005?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1005?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1005?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1005'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>