### PR TITLE
Avoid some requests resulting in 404 errors

### DIFF
--- a/privacyidea/static/components/audit/views/audit.stats.html
+++ b/privacyidea/static/components/audit/views/audit.stats.html
@@ -78,7 +78,7 @@
                 users.
                 The successful and the failed requests are listed.
             </p>
-            <img width="700" src="{{ stats.validate_user_plot }}"
+            <img width="700" ng-src="{{ stats.validate_user_plot }}"
                  alt="{{ stats.validate_user_plot }}"/>
         </accordion-group>
 
@@ -91,7 +91,7 @@
                 serial number of the token.
                 The successful and the failed requests are listed.
             </p>
-            <img width="700" src="{{ stats.validate_serial_plot }}"
+            <img width="700" ng-src="{{ stats.validate_serial_plot }}"
                  alt="{{ stats.validate_serial_plot }}"/>
         </accordion-group>
 
@@ -102,7 +102,7 @@
             <p class="help-block" translate>
                 Failed authentication requests per token
             </p>
-            <img width="700" src="{{ stats.validate_failed_serial_plot }}"
+            <img width="700" ng-src="{{ stats.validate_failed_serial_plot }}"
                  alt="{{ stats.validate_failed_serial_plot }}"/>
 
 
@@ -126,7 +126,7 @@
             <p class="help-block" translate>
                 Failed authentication requests per user
             </p>
-            <img width="700" src="{{ stats.validate_failed_user_plot }}"
+            <img width="700" ng-src="{{ stats.validate_failed_user_plot }}"
                  alt="{{ stats.validate_failed_user_plot }}"/>
 
             <table class="table table-hover">
@@ -149,7 +149,7 @@
             <p class="help-block" translate>
                 Which administrative request where the most popular.
             </p>
-            <img width="700" src="{{ stats.admin_plot }}"
+            <img width="700" ng-src="{{ stats.admin_plot }}"
                  alt="{{ stats.admin_plot }}"/>
 
             <table class="table table-hover">
@@ -171,7 +171,7 @@
             <p class="help-block" translate>This is the overall token usage with
                 any
                 kind of action in regards to the serial number.</p>
-            <img width="700" src="{{ stats.serial_plot }}"
+            <img width="700" ng-src="{{ stats.serial_plot }}"
                  alt="{{ stats.serial_plot }}"/>
 
             <table class="table table-hover">

--- a/privacyidea/static/components/config/views/config.system.html
+++ b/privacyidea/static/components/config/views/config.system.html
@@ -1,6 +1,3 @@
-<div ng-include="instanceUrl+'/static/components/config/views/config.system.addons.html'">
-</div>
-
 <div class="row">
     <div class="col-lg-3">
         <div class="pa-sidebar panel">

--- a/privacyidea/static/components/login/views/enter-response.html
+++ b/privacyidea/static/components/login/views/enter-response.html
@@ -5,7 +5,7 @@
         </div>
         <div class="center"
             ng-show="image">
-            <img width="250" src="{{ image }}"/>
+            <img width="250" ng-src="{{ image }}" />
         </div>
 
         <div ng-hide="hideResponseInput">

--- a/privacyidea/static/components/login/views/enter-response.html
+++ b/privacyidea/static/components/login/views/enter-response.html
@@ -4,7 +4,7 @@
             <p>{{ challenge_message }}</p>
         </div>
         <div class="center"
-            ng-show="image">
+            ng-if="image">
             <img width="250" ng-src="{{ image }}" />
         </div>
 

--- a/privacyidea/static/components/login/views/login.html
+++ b/privacyidea/static/components/login/views/login.html
@@ -3,7 +3,7 @@
     <div class="container" ng-show="!loginWithCredentials">
         <form name="formRemoteUserLogin" class="form-signin" role="form">
             <div class="text-center">
-                <img src="{{ instanceUrl }}/static/css/{{ piLogo }}"
+                <img ng-src="{{ instanceUrl }}/static/css/{{ piLogo }}"
                      width="90px">
             </div>
             <h2 class="form-signin-heading" translate>Login as
@@ -42,7 +42,7 @@
         <div class="container">
             <form name="formSignin" class="form-signin" role="form" novalidate>
                 <div class="text-center">
-                    <img src="{{ instanceUrl }}/static/css/{{ piLogo }}"
+                    <img ng-src="{{ instanceUrl }}/static/css/{{ piLogo }}"
                          width="90px">
                 </div>
                 <h2 class="form-signin-heading" translate>Please sign in</h2>

--- a/privacyidea/static/components/token/views/token.enrolled.hotp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.hotp.html
@@ -1,7 +1,7 @@
 <div class="row">
     <div class="col-sm-6" ng-hide="form['2stepinit'] && enrolledToken.rollout_state !== 'clientwait'">
         <img width="{{ qrCodeWidth }}"
-             src="{{ enrolledToken.googleurl.img }}"/>
+             ng-src="{{ enrolledToken.googleurl.img }}"/>
     </div>
     <div class="col-sm-6" ng-hide="$state.includes('token.wizard') || form['2stepinit']">
         <accordion close-others="oneAtATime">

--- a/privacyidea/static/components/token/views/token.enrolled.motp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.motp.html
@@ -1,7 +1,7 @@
 
 <div class="row">
     <div class="col-sm-6">
-        <img width="250" src="{{ enrolledToken.motpurl.img }}"/>
+        <img width="250" ng-src="{{ enrolledToken.motpurl.img }}"/>
     </div>
     <div class="col-sm-6">
         <accordion close-others="oneAtATime">

--- a/privacyidea/static/components/token/views/token.enrolled.tiqr.html
+++ b/privacyidea/static/components/token/views/token.enrolled.tiqr.html
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col-sm-6">
-        <img width="250" src="{{ enrolledToken.tiqrenroll.img }}"/>
+        <img width="250" ng-src="{{ enrolledToken.tiqrenroll.img }}"/>
     </div>
     <div class="col-sm-6">
         <accordion close-others="oneAtATime">

--- a/privacyidea/static/components/token/views/token.enrolled.totp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.totp.html
@@ -1,7 +1,7 @@
 <div class="row">
     <div class="col-sm-6" ng-hide="form['2stepinit'] && enrolledToken.rollout_state !== 'clientwait'">
         <img width="{{ qrCodeWidth }}"
-             src="{{ enrolledToken.googleurl.img }}"/>
+             ng-src="{{ enrolledToken.googleurl.img }}"/>
     </div>
     <div class="col-sm-6" ng-hide="$state.includes('token.wizard') || form['2stepinit']">
         <accordion close-others="oneAtATime">

--- a/privacyidea/static/templates/footer.html
+++ b/privacyidea/static/templates/footer.html
@@ -59,7 +59,6 @@
 <script src="{{ instance }}/static/components/config/controllers/radiusServerController.js"></script>
 <script src="{{ instance }}/static/components/config/controllers/privacyideaServerController.js"></script>
 <script src="{{ instance }}/static/components/config/controllers/smsgatewayController.js"></script>
-<script src="{{ instance }}/static/components/config/controllers/system.addons.js"></script>
 <script src="{{ instance }}/static/components/machine/factories/machine.js"></script>
 <script src="{{ instance }}/static/components/machine/states/states.js"></script>
 <script src="{{ instance }}/static/components/machine/controllers/machineController.js"></script>

--- a/privacyidea/static/templates/menu.html
+++ b/privacyidea/static/templates/menu.html
@@ -12,7 +12,7 @@
 <div class="navbar navbar-default navbar-fixed-top">
     <div class="container">
         <a class="navbar-brand" ui-sref="token.list">
-            <img src="{{ instanceUrl }}/static/css/{{ piLogo }}"
+            <img ng-src="{{ instanceUrl }}/static/css/{{ piLogo }}"
                          width="28px">
         </a>
         <button type="button" class="navbar-toggle"


### PR DESCRIPTION
This avoids some HTTP 404s that would clutter logfiles otherwise and fixes #963.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1006%23issuecomment-380161358%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1006%23discussion_r180495357%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1006%23discussion_r180647377%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1006%23discussion_r180647758%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1006%23issuecomment-380161358%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1006%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231006%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1006%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/d4633f1a53b79ab31e27ceafc4ccd68e972ff2de%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1006/graphs/tree.svg%3Fheight%3D150%26width%3D650%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1006%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231006%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.39%25%20%20%2095.39%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016190%20%20%20%2016190%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2015445%20%20%20%2015445%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20745%20%20%20%20%20%20745%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1006%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1006%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bd4633f1...a6fdfb9%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1006%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-10T16%3A20%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a6fdfb917d9f122ec17a005b7d306ff00cd32407%20privacyidea/static/components/login/views/enter-response.html%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1006%23discussion_r180495357%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20change%20this%20to%20ng-if%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-10T16%3A58%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60%60ng-show%60%60%20has%20the%20following%20disadvantage%3A%20If%20%60%60image%60%60%20is%20false%2C%20the%20%60%60%3Cimg%3E%60%60%20below%20actually%20gets%20added%20to%20the%20page%20%28but%20is%20subsequently%20hidden%29.%20And%20this%20results%20in%20a%20request%20for%20%60%60/false%60%60%2C%20because%20of%20%60%60src%3D%5C%22%7B%7B%20image%20%7D%7D%5C%22%60%60%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-04-11T06%3A34%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20ok.%20This%20is%20false.%20And%20we%20do%20not%20change%20the%20image%20later%2C%20so%20this%20is%20ok...%22%2C%20%22created_at%22%3A%20%222018-04-11T06%3A36%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/login/views/enter-response.html%3AL4-12%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1006#issuecomment-380161358'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1006?src=pr&el=h1) Report
> Merging [#1006](https://codecov.io/gh/privacyidea/privacyidea/pull/1006?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/d4633f1a53b79ab31e27ceafc4ccd68e972ff2de?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1006/graphs/tree.svg?height=150&width=650&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1006?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master    #1006   +/-   ##
=======================================
Coverage   95.39%   95.39%
=======================================
Files         131      131
Lines       16190    16190
=======================================
Hits        15445    15445
Misses        745      745
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1006?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1006?src=pr&el=footer). Last update [d4633f1...a6fdfb9](https://codecov.io/gh/privacyidea/privacyidea/pull/1006?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull a6fdfb917d9f122ec17a005b7d306ff00cd32407 privacyidea/static/components/login/views/enter-response.html 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1006#discussion_r180495357'>File: privacyidea/static/components/login/views/enter-response.html:L4-12</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Why change this to ng-if?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> ``ng-show`` has the following disadvantage: If ``image`` is false, the ``<img>`` below actually gets added to the page (but is subsequently hidden). And this results in a request for ``/false``, because of ``src="{{ image }}"`` :-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Ah, ok. This is false. And we do not change the image later, so this is ok...


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1006?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1006?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1006'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>