### PR TITLE
Fix TiQR and OCRA token challenge response

### DIFF
--- a/privacyidea/lib/tokens/ocratoken.py
+++ b/privacyidea/lib/tokens/ocratoken.py
@@ -252,12 +252,8 @@ class OcraTokenClass(TokenClass):
     @check_token_locked
     def check_challenge_response(self, user=None, passw=None, options=None):
         """
-        This function checks, if the challenge for the given transaction_id
-        was marked as answered correctly.
-        For this we check the otp_status of the challenge with the
-        transaction_id in the database.
-
-        We do not care about the password
+        This function checks if the given password matches the expected response
+        for the challenge identified by the given transaction_id.
 
         :param user: the requesting user
         :type user: User object
@@ -285,7 +281,7 @@ class OcraTokenClass(TokenClass):
             for challengeobject in challengeobject_list:
                 # check if we are still in time.
                 if challengeobject.is_valid():
-                    if self.verify_response(passw, challengeobject.challenge):
+                    if self.verify_response(passw, challengeobject.challenge) > 0:
                         # create a positive response
                         otp_counter = 1
                         # delete the challenge

--- a/privacyidea/lib/tokens/ocratoken.py
+++ b/privacyidea/lib/tokens/ocratoken.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 #  http://www.privacyidea.org
+#  2018-04-16 Friedrich Weber <friedrich.weber@netknights.it>
+#             Fix validation of challenge responses
 #  2017-08-29 Cornelis Kölbel <cornelius.koelbel@netknights.it>
 #             Initial implementation of OCRA base token
 #

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 #  http://www.privacyidea.org
+#  2018-04-16 Friedrich Weber <friedrich.weber@netknights.it>
+#             Fix validation of challenge responses
 #  2015-09-01 Initial writeup.
 #             Cornelius Kölbel <cornelius@privacyidea.org>
 #

--- a/tests/test_lib_tokens_tiqr.py
+++ b/tests/test_lib_tokens_tiqr.py
@@ -4,6 +4,7 @@ This test file tests the lib.tokens.tiqrtoken and lib.tokens.ocra
 This depends on lib.tokenclass
 """
 from .base import MyTestCase
+from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib.tokens.tiqrtoken import TiqrTokenClass
 from privacyidea.lib.tokens.ocratoken import OcraTokenClass
 from privacyidea.lib.tokens.ocra import OCRASuite, OCRA
@@ -349,9 +350,40 @@ class OcraTokenTestCase(MyTestCase):
         self.assertEqual(r[0], True)
         self.assertEqual(r[1], "Please answer the challenge")
 
+        # answer the challenge wrongly
+        r = token.verify_response(passw="00065298", challenge=challengeQH40)
+        self.assertTrue(r < 0, r)
+
         # answer the challenge
         r = token.verify_response(passw="90065298", challenge=challengeQH40)
         self.assertTrue(r > 0, r)
+
+        # create another challenge
+        displayTAN_challenge = "83507112  ~320,00~1399458665_G6HNVF"
+        challengeQH40 = binascii.hexlify(hashlib.sha1(
+            displayTAN_challenge).digest())
+        r = token.create_challenge(options={"challenge": challengeQH40})
+        self.assertEqual(r[0], True)
+        self.assertEqual(r[1], "Please answer the challenge")
+        transaction_id = r[2]
+
+        # answer the challenge wrongly using check_challenge_response
+        r = token.check_challenge_response(passw="00065298", options={
+            "transaction_id": transaction_id
+        })
+        self.assertEqual(r, -1)
+
+        # assert there is still one challenge
+        self.assertEqual(len(get_challenges(serial="OCRA1", transaction_id=transaction_id)), 1)
+
+        # answer the challenge correctly using check_challenge_response
+        r = token.check_challenge_response(passw="90065298", options={
+            "transaction_id": transaction_id
+        })
+        self.assertTrue(r > 0, r)
+
+        # assert there is no challenge anymore
+        self.assertEqual(len(get_challenges(serial="OCRA1", transaction_id=transaction_id)), 0)
 
 
 class TiQRTokenTestCase(MyTestCase):
@@ -501,6 +533,11 @@ class TiQRTokenTestCase(MyTestCase):
         r = TiqrTokenClass.api_endpoint(req, g)
         self.assertEqual(r[0], "plain")
         self.assertEqual(r[1], "INVALID_RESPONSE")
+
+        # Check that the OTP status is still incorrect
+        r = token.check_challenge_response(options={"transaction_id":
+                                                    transaction_id})
+        self.assertEqual(r, -1)
 
         # Send the correct response
         req.all_data = {"response": response,


### PR DESCRIPTION
This fixes #1008.

5cee78f fixes the relevant portions of ``check_challenge_response`` in ``OcraTokenClass``/``TiqrTokenClass`` and adds respective unit tests.

As we have a lot of code duplication between ``TokenClass.check_challenge_response``, ``OcraTokenClass.check_challenge_response`` and ``TiqrTokenClass.check_challenge_response``, 036cf1a attempts a small refactoring. I think it should be correct, but I'm of course open to suggestions :)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1009%23issuecomment-380470742%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1009%23issuecomment-380497670%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1009%23issuecomment-380470742%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231009%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/8307090f7f6dd6b56a9cc8f024d64bdf78998000%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6094.73%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009/graphs/tree.svg%3Fsrc%3Dpr%26token%3D7nHLZki60B%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231009%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.37%25%20%20%2095.39%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016190%20%20%20%2016194%20%20%20%20%20%20%20%2B4%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015442%20%20%20%2015449%20%20%20%20%20%20%20%2B7%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20748%20%20%20%20%20%20745%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/ocratoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9vY3JhdG9rZW4ucHk%3D%29%20%7C%20%6095.69%25%20%3C100%25%3E%20%28%2B0.41%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/tiqrtoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90aXFydG9rZW4ucHk%3D%29%20%7C%20%6099.35%25%20%3C94.11%25%3E%20%28-0.65%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B2.5%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B8307090...036cf1a%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1009%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-11T14%3A23%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20this%20looks%20all%20right%20-%20but%20I%20would%20like%20to%20finally%20discuss%20this.%22%2C%20%22created_at%22%3A%20%222018-04-11T15%3A38%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1009#issuecomment-380470742'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1009?src=pr&el=h1) Report
> Merging [#1009](https://codecov.io/gh/privacyidea/privacyidea/pull/1009?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/8307090f7f6dd6b56a9cc8f024d64bdf78998000?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `94.73%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1009/graphs/tree.svg?src=pr&token=7nHLZki60B&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1009?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1009      +/-   ##
==========================================
+ Coverage   95.37%   95.39%   +0.01%
==========================================
Files         131      131
Lines       16190    16194       +4
==========================================
+ Hits        15442    15449       +7
+ Misses        748      745       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1009?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/ocratoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1009/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9vY3JhdG9rZW4ucHk=) | `95.69% <100%> (+0.41%)` | :arrow_up: |
| [privacyidea/lib/tokens/tiqrtoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1009/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90aXFydG9rZW4ucHk=) | `99.35% <94.11%> (-0.65%)` | :arrow_down: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1009/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+2.5%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1009?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1009?src=pr&el=footer). Last update [8307090...036cf1a](https://codecov.io/gh/privacyidea/privacyidea/pull/1009?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think this looks all right - but I would like to finally discuss this.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1009?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1009?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1009'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>