### PR TITLE
Add retry and HSM re-initialization to generatRandom

### DIFF
--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -104,6 +104,15 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         self.initialize_hsm()
 
     def initialize_hsm(self):
+        """
+        Initialize the HSM:
+        * initialize PKCS11 library
+        * login to HSM
+        * get session
+        :return:
+        """
+        # Reset the is_ready state, so that we login again.
+        self.is_ready = False
         self.pkcs11.lib.C_Initialize()
         if self.password:
             self._login()

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -166,7 +166,18 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         :param length: length of the random bytestring
         :return:
         """
-        r_integers = self.session.generateRandom(length)
+        retries = 0
+        while True:
+            try:
+                r_integers = self.session.generateRandom(length)
+                break
+            except PyKCS11.PyKCS11Error as exx:
+                log.warning(u"Generate Random failed: {0!s}".format(exx))
+                self.initialize_hsm()
+                retries += 1
+                if retries > MAX_RETRIES:
+                    raise HSMException("Failed to generate random number after multiple retries.")
+
         # convert the array of the random integers to a string
         return int_list_to_bytestring(r_integers)
 


### PR DESCRIPTION
Working on #1003

This will mitigate the problem with failing HSMs. However, currently we are not sure if it will completely solve the problem.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1015%23discussion_r181385584%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1015%23issuecomment-381137740%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1015%23discussion_r181479045%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1015%23issuecomment-381728228%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1015%23issuecomment-381137740%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231015%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.22%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/b187ce353a235086c46c2eb44ce88c984ca3bb3a%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015/graphs/tree.svg%3Fwidth%3D650%26src%3Dpr%26token%3D7nHLZki60B%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.22%20%20%20%20%231015%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%20%20%20%20%2095.38%25%20%20%2095.41%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2016192%20%20%20%2016232%20%20%20%20%20%20%2B40%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2015445%20%20%20%2015487%20%20%20%20%20%20%2B42%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20747%20%20%20%20%20%20745%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/security/aeshsm.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2Flc2hzbS5weQ%3D%3D%29%20%7C%20%600%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ%3D%3D%29%20%7C%20%6094.36%25%20%3C0%25%3E%20%28%2B2.2%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bb187ce3...b6354c5%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1015%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-13T13%3A37%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40fredreichbier%20please%20check%20again.%22%2C%20%22created_at%22%3A%20%222018-04-16T19%3A53%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b6354c5ac8318a599f1c84f132b6dcce9c3bbeca%20privacyidea/lib/security/aeshsm.py%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1015%23discussion_r181385584%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hm%2C%20a%20question%20because%20I%20have%20no%20idea%20how%20the%20HSM%20stuff%20works%20%3A%29%20Consider%20the%20case%20that%20%60%60_login%28%29%60%60%20was%20successful%20once%2C%20but%20we%20somehow%20lose%20the%20session%20and%20need%20to%20re-initialize%3A%20Then%2C%20just%20calling%20%60%60initialize_hsm%28%29%60%60%20again%20won%27t%20help%2C%20because%20%60%60self.is_ready%60%60%20is%20still%20%60%60True%60%60%2C%20and%20%60%60_login%28%29%60%60%20will%20just%20do%20nothing.%20Is%20that%20intended%3F%22%2C%20%22created_at%22%3A%20%222018-04-13T13%3A22%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20it%20would%20only%20call%5Cr%5Cn%5Cr%5Cn%7E%7E%7Epython%5Cr%5Cnself.pkcs11.lib.C_Initialize%28%29%5Cr%5Cn%7E%7E%7E%5Cr%5Cn%5Cr%5Cnwhich%20might%20be%20enough%20in%20some%20cases.%20But%20you%20are%20right%20-%20we%20probably%20would%20need%20to%20re-login.%5Cr%5Cn%5Cr%5CnBut%20you%20are%20right%2C%20we%20might%20need%20to%20change%5Cr%5Cn%5Cr%5Cn%7E%7E%7Epython%5Cr%5Cndef%20initialize_hsm%28self%29%3A%5Cr%5Cn%20%20%20%20self.is_ready%20%3D%20False%5Cr%5Cn%20%20%20%20self.pkcs11.lib.C_Initialize%28%29%5Cr%5Cn%20%20%20%20if%20self.password%3A%5Cr%5Cn%20%20%20%20%20%20%20%20self._login%28%29%5Cr%5Cn%7E%7E%7E%5Cr%5Cn%5Cr%5CnThe%20thing%20is%2C%20that%20in%20case%20of%20a%20password%2C%20that%20is%20NOT%20provided%20in%20the%20config%20file%2C%20we%20need%20to%20run%20%60%60C_Initialize%60%60%20and%20later%20%28after%20the%20python%20class%20is%20created%29%20we%20need%20to%20add%20the%20password%20%28and%20thus%20%60%60self._login%60%60%20via%20the%20%60%60setup_module%60%60%20function.%22%2C%20%22created_at%22%3A%20%222018-04-13T18%3A49%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/security/aeshsm.py%3AL166-184%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull b6354c5ac8318a599f1c84f132b6dcce9c3bbeca privacyidea/lib/security/aeshsm.py 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1015#discussion_r181385584'>File: privacyidea/lib/security/aeshsm.py:L166-184</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, a question because I have no idea how the HSM stuff works :) Consider the case that ``_login()`` was successful once, but we somehow lose the session and need to re-initialize: Then, just calling ``initialize_hsm()`` again won't help, because ``self.is_ready`` is still ``True``, and ``_login()`` will just do nothing. Is that intended?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Hm, it would only call
~~~python
self.pkcs11.lib.C_Initialize()
~~~
which might be enough in some cases. But you are right - we probably would need to re-login.
But you are right, we might need to change
~~~python
def initialize_hsm(self):
self.is_ready = False
self.pkcs11.lib.C_Initialize()
if self.password:
self._login()
~~~
The thing is, that in case of a password, that is NOT provided in the config file, we need to run ``C_Initialize`` and later (after the python class is created) we need to add the password (and thus ``self._login`` via the ``setup_module`` function.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1015#issuecomment-381137740'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1015?src=pr&el=h1) Report
> Merging [#1015](https://codecov.io/gh/privacyidea/privacyidea/pull/1015?src=pr&el=desc) into [branch-2.22](https://codecov.io/gh/privacyidea/privacyidea/commit/b187ce353a235086c46c2eb44ce88c984ca3bb3a?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1015/graphs/tree.svg?width=650&src=pr&token=7nHLZki60B&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1015?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.22    #1015      +/-   ##
===============================================
+ Coverage        95.38%   95.41%   +0.02%
===============================================
Files              131      131
Lines            16192    16232      +40
===============================================
+ Hits             15445    15487      +42
+ Misses             747      745       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1015?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/security/aeshsm.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1015/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2Flc2hzbS5weQ==) | `0% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1015/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
| [privacyidea/api/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1015/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ==) | `94.36% <0%> (+2.2%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1015?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1015?src=pr&el=footer). Last update [b187ce3...b6354c5](https://codecov.io/gh/privacyidea/privacyidea/pull/1015?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier please check again.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1015?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1015?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1015'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>