### PR TITLE
Store boolean values as strings "True"/"False"

### DIFF
--- a/privacyidea/api/privacyideaserver.py
+++ b/privacyidea/api/privacyideaserver.py
@@ -32,6 +32,7 @@ from .lib.utils import (getParam,
 from ..lib.log import log_with
 from ..lib.policy import ACTION
 from ..api.lib.prepolicy import prepolicy, check_base_action
+from ..lib.utils import is_true
 from flask import g
 import logging
 from privacyidea.lib.privacyideaserver import (add_privacyideaserver,
@@ -63,7 +64,7 @@ def create(identifier=None):
     param = request.all_data
     identifier = identifier.replace(" ", "_")
     url = getParam(param, "url", required)
-    tls = bool(int(getParam(param, "tls", default="1")))
+    tls = is_true(getParam(param, "tls", default="1"))
     description = getParam(param, "description", default="")
 
     r = add_privacyideaserver(identifier, url=url, tls=tls,
@@ -127,7 +128,7 @@ def test():
     param = request.all_data
     identifier = getParam(param, "identifier", required)
     url = getParam(param, "url", required)
-    tls = bool(int(getParam(param, "tls", default="1")))
+    tls = is_true(getParam(param, "tls", default="1"))
     user = getParam(param, "username", required)
     password = getParam(param, "password", required)
 

--- a/privacyidea/api/smtpserver.py
+++ b/privacyidea/api/smtpserver.py
@@ -36,6 +36,7 @@ from .lib.utils import (getParam,
 from ..lib.log import log_with
 from ..lib.crypto import decryptPassword, FAILED_TO_DECRYPT_PASSWORD
 from ..lib.policy import ACTION
+from ..lib.utils import is_true
 from ..api.lib.prepolicy import prepolicy, check_base_action
 from flask import g
 from flask_babel import gettext as _
@@ -70,8 +71,7 @@ def create(identifier=None):
     username = getParam(param, "username", default="")
     password = getParam(param, "password", default="")
     sender = getParam(param, "sender", default="")
-    tls = getParam(param, "tls", default=False)
-    tls = tls in ["True", True, "true", "1"]
+    tls = is_true(getParam(param, "tls", default=False))
     description = getParam(param, "description", default="")
     timeout = int(getParam(param, "timeout") or 10)
 
@@ -141,8 +141,7 @@ def test():
     username = getParam(param, "username", default="")
     password = getParam(param, "password", default="")
     sender = getParam(param, "sender", default="")
-    tls = getParam(param, "tls", default=False)
-    tls = tls in [True, "True", "true", "1"]
+    tls = is_true(getParam(param, "tls", default=False))
     recipient = getParam(param, "recipient", required)
     timeout = int(getParam(param, "timeout") or 10)
 

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -46,7 +46,7 @@ from .crypto import decryptPassword
 from .resolvers.UserIdResolver import UserIdResolver
 from .machines.base import BaseMachineResolver
 from .caconnectors.localca import BaseCAConnector
-from .utils import reload_db
+from .utils import reload_db, is_true
 import importlib
 import datetime
 
@@ -193,7 +193,7 @@ class ConfigClass(object):
             if isinstance(r_config, int):
                 r_config = r_config > 0
             if isinstance(r_config, basestring):
-                r_config = r_config.lower() in ["true", "1"]
+                r_config = is_true(r_config.lower())
 
         return r_config
 

--- a/privacyidea/lib/tokens/radiustoken.py
+++ b/privacyidea/lib/tokens/radiustoken.py
@@ -149,7 +149,7 @@ class RadiusTokenClass(RemoteTokenClass):
 
         :return: bool
         """
-        local_check = 1 == int(self.get_tokeninfo("radius.local_checkpin"))
+        local_check = is_true(self.get_tokeninfo("radius.local_checkpin"))
         log.debug("local checking pin? {0!r}".format(local_check))
 
         return local_check

--- a/privacyidea/lib/tokens/radiustoken.py
+++ b/privacyidea/lib/tokens/radiustoken.py
@@ -45,6 +45,7 @@ import logging
 
 import traceback
 import binascii
+from privacyidea.lib.utils import is_true
 from privacyidea.lib.tokenclass import TokenClass, TOKENKIND
 from privacyidea.lib.tokens.remotetoken import RemoteTokenClass
 from privacyidea.api.lib.utils import getParam, ParameterError

--- a/privacyidea/lib/tokens/remotetoken.py
+++ b/privacyidea/lib/tokens/remotetoken.py
@@ -44,6 +44,7 @@ The code is tested in tests/test_lib_tokens_remote
 import logging
 import traceback
 import requests
+from privacyidea.lib.utils import is_true
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.config import get_from_config
 from privacyidea.api.lib.utils import getParam
@@ -243,10 +244,7 @@ class RemoteTokenClass(TokenClass):
                                      False, return_bool=True) or False
 
         if type(ssl_verify) in [str, unicode]:
-            if ssl_verify.lower() in ["true", "1"]:
-                ssl_verify = True
-            else:
-                ssl_verify = False
+            ssl_verify = is_true(ssl_verify.lower())
 
         # here we also need to check for remote.user and so on....
         log.debug("checking OTP len:%r remotely on server: %r,"

--- a/privacyidea/lib/tokens/remotetoken.py
+++ b/privacyidea/lib/tokens/remotetoken.py
@@ -157,7 +157,7 @@ class RemoteTokenClass(TokenClass):
 
         :return: bool
         """
-        local_check = 1 == int(self.get_tokeninfo("remote.local_checkpin"))
+        local_check = is_true(self.get_tokeninfo("remote.local_checkpin"))
         log.debug(" local checking pin? {0!r}".format(local_check))
 
         return local_check

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -636,7 +636,9 @@ class TokenInfo(MethodsMixin, db.Model):
         """
         self.token_id = token_id
         self.Key = Key
-        self.Value = unicode(Value)
+        if Value is not None:
+            Value = unicode(Value)
+        self.Value = Value
         self.Type = Type
         self.Description = Description
 
@@ -727,7 +729,9 @@ class Config(TimestampMethodsMixin, db.Model):
     @log_with(log)
     def __init__(self, Key, Value, Type=u'', Description=u''):
         self.Key = Key
-        self.Value = unicode(Value)
+        if Value is not None:
+            Value = unicode(Value)
+        self.Value = Value
         self.Type = Type
         self.Description = Description
 
@@ -853,7 +857,9 @@ class CAConnectorConfig(db.Model):
                                        .first()\
                                        .id
         self.Key = Key
-        self.Value = unicode(Value)
+        if Value is not None:
+            Value = unicode(Value)
+        self.Value = Value
         self.Type = Type
         self.Description = Description
 
@@ -948,7 +954,9 @@ class ResolverConfig(TimestampMethodsMixin, db.Model):
                                        .first()\
                                        .id
         self.Key = Key
-        self.Value = unicode(Value)
+        if Value is not None:
+            Value = unicode(Value)
+        self.Value = Value
         self.Type = Type
         self.Description = Description
 
@@ -1671,7 +1679,9 @@ class EventHandlerCondition(db.Model):
     def __init__(self, eventhandler_id, Key, Value, comparator="equal"):
         self.eventhandler_id = eventhandler_id
         self.Key = Key
-        self.Value = unicode(Value)
+        if Value is not None:
+            Value = unicode(Value)
+        self.Value = Value
         self.comparator = comparator
         self.save()
 
@@ -1718,7 +1728,9 @@ class EventHandlerOption(db.Model):
     def __init__(self, eventhandler_id, Key, Value, Type="", Description=""):
         self.eventhandler_id = eventhandler_id
         self.Key = Key
-        self.Value = unicode(Value)
+        if Value is not None:
+            Value = unicode(Value)
+        self.Value = Value
         self.Type = Type
         self.Description = Description
         self.save()
@@ -1809,7 +1821,9 @@ class MachineResolverConfig(db.Model):
                                 .first()\
                                 .id
         self.Key = Key
-        self.Value = unicode(Value)
+        if Value is not None:
+            Value = unicode(Value)
+        self.Value = Value
         self.Type = Type
         self.Description = Description
 
@@ -2013,7 +2027,9 @@ class SMSGatewayOption(MethodsMixin, db.Model):
         """
         self.gateway_id = gateway_id
         self.Key = Key
-        self.Value = unicode(Value)
+        if Value is not None:
+            Value = unicode(Value)
+        self.Value = Value
         self.Type = Type
         self.save()
 

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -728,12 +728,12 @@ class Config(TimestampMethodsMixin, db.Model):
 
     @log_with(log)
     def __init__(self, Key, Value, Type=u'', Description=u''):
-        self.Key = Key
+        self.Key = unicode(Key)
         if Value is not None:
             Value = unicode(Value)
         self.Value = Value
-        self.Type = Type
-        self.Description = Description
+        self.Type = unicode(Type)
+        self.Description = unicode(Description)
 
     def __unicode__(self):
         return "<{0!s} ({1!s})>".format(self.Key, self.Type)
@@ -953,12 +953,12 @@ class ResolverConfig(TimestampMethodsMixin, db.Model):
                                        .filter_by(name=resolver)\
                                        .first()\
                                        .id
-        self.Key = Key
+        self.Key = unicode(Key)
         if Value is not None:
             Value = unicode(Value)
         self.Value = Value
-        self.Type = Type
-        self.Description = Description
+        self.Type = unicode(Type)
+        self.Description = unicode(Description)
 
     def save(self):
         c = ResolverConfig.query.filter_by(resolver_id=self.resolver_id,

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -636,7 +636,7 @@ class TokenInfo(MethodsMixin, db.Model):
         """
         self.token_id = token_id
         self.Key = Key
-        self.Value = Value
+        self.Value = unicode(Value)
         self.Type = Type
         self.Description = Description
 
@@ -726,10 +726,10 @@ class Config(TimestampMethodsMixin, db.Model):
 
     @log_with(log)
     def __init__(self, Key, Value, Type=u'', Description=u''):
-        self.Key = unicode(Key)
+        self.Key = Key
         self.Value = unicode(Value)
-        self.Type = unicode(Type)
-        self.Description = unicode(Description)
+        self.Type = Type
+        self.Description = Description
 
     def __unicode__(self):
         return "<{0!s} ({1!s})>".format(self.Key, self.Type)
@@ -853,7 +853,7 @@ class CAConnectorConfig(db.Model):
                                        .first()\
                                        .id
         self.Key = Key
-        self.Value = Value
+        self.Value = unicode(Value)
         self.Type = Type
         self.Description = Description
 
@@ -947,10 +947,10 @@ class ResolverConfig(TimestampMethodsMixin, db.Model):
                                        .filter_by(name=resolver)\
                                        .first()\
                                        .id
-        self.Key = unicode(Key)
+        self.Key = Key
         self.Value = unicode(Value)
-        self.Type = unicode(Type)
-        self.Description = unicode(Description)
+        self.Type = Type
+        self.Description = Description
 
     def save(self):
         c = ResolverConfig.query.filter_by(resolver_id=self.resolver_id,
@@ -1487,7 +1487,7 @@ class MachineTokenOptions(db.Model):
                                                             machinetoken_id))
         self.machinetoken_id = machinetoken_id
         self.mt_key = key
-        self.mt_value = value
+        self.mt_value = unicode(value)
 
         # if the combination machinetoken_id / mt_key already exist,
         # we need to update
@@ -1671,7 +1671,7 @@ class EventHandlerCondition(db.Model):
     def __init__(self, eventhandler_id, Key, Value, comparator="equal"):
         self.eventhandler_id = eventhandler_id
         self.Key = Key
-        self.Value = Value
+        self.Value = unicode(Value)
         self.comparator = comparator
         self.save()
 
@@ -1718,7 +1718,7 @@ class EventHandlerOption(db.Model):
     def __init__(self, eventhandler_id, Key, Value, Type="", Description=""):
         self.eventhandler_id = eventhandler_id
         self.Key = Key
-        self.Value = Value
+        self.Value = unicode(Value)
         self.Type = Type
         self.Description = Description
         self.save()
@@ -1809,7 +1809,7 @@ class MachineResolverConfig(db.Model):
                                 .first()\
                                 .id
         self.Key = Key
-        self.Value = Value
+        self.Value = unicode(Value)
         self.Type = Type
         self.Description = Description
 
@@ -2013,7 +2013,7 @@ class SMSGatewayOption(MethodsMixin, db.Model):
         """
         self.gateway_id = gateway_id
         self.Key = Key
-        self.Value = Value
+        self.Value = unicode(Value)
         self.Type = Type
         self.save()
 

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -47,6 +47,7 @@ from .lib.crypto import (encrypt,
 from sqlalchemy import and_
 from sqlalchemy.schema import Sequence
 from .lib.log import log_with
+from .lib.utils import is_true
 log = logging.getLogger(__name__)
 
 #
@@ -1288,10 +1289,7 @@ class Policy(TimestampMethodsMixin, db.Model):
                  resolver="", user="", client="", time="", condition=0,
                  check_all_resolvers=False):
         if type(active) in [str, unicode]:
-            if active.lower() in ["true", "1"]:
-                active = True
-            else:
-                active = False
+            active = is_true(active.lower())
         self.name = name
         self.action = action
         self.scope = scope

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -33,6 +33,7 @@ from privacyidea.lib.tokenclass import DATE_FORMAT
 from privacyidea.lib.user import create_user, User
 from privacyidea.lib.policy import ACTION
 from privacyidea.lib.error import ParameterError
+from privacyidea.lib.utils import is_true
 from datetime import datetime, timedelta
 from dateutil.parser import parse as parse_date_string
 from dateutil.tz import tzlocal
@@ -1058,7 +1059,7 @@ class TokenEventTestCase(MyTestCase):
         t = get_tokens(tokentype="sms")[0]
         self.assertTrue(t)
         self.assertEqual(t.user, user_obj)
-        self.assertEqual(t.get_tokeninfo("dynamic_phone"), "1")
+        self.assertEqual(is_true(t.get_tokeninfo("dynamic_phone")))
         remove_token(t.token.serial)
 
     def test_06_set_description(self):

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -1059,7 +1059,7 @@ class TokenEventTestCase(MyTestCase):
         t = get_tokens(tokentype="sms")[0]
         self.assertTrue(t)
         self.assertEqual(t.user, user_obj)
-        self.assertEqual(is_true(t.get_tokeninfo("dynamic_phone")))
+        self.assertTrue(is_true(t.get_tokeninfo("dynamic_phone")))
         remove_token(t.token.serial)
 
     def test_06_set_description(self):

--- a/tests/test_lib_tokens_email.py
+++ b/tests/test_lib_tokens_email.py
@@ -83,7 +83,7 @@ class EmailTokenTestCase(MyTestCase):
         token = EmailTokenClass(db_token)
         token.update({"dynamic_email": True})
         token.save()
-        self.assertEqual(is_true(token.get_tokeninfo("dynamic_email")))
+        self.assertTrue(is_true(token.get_tokeninfo("dynamic_email")))
         self.assertTrue(token.token.serial == self.serial2, token)
         self.assertTrue(token.token.tokentype == "email", token.token)
         self.assertTrue(token.type == "email", token.type)

--- a/tests/test_lib_tokens_email.py
+++ b/tests/test_lib_tokens_email.py
@@ -8,6 +8,7 @@ from .base import MyTestCase, FakeFlaskG
 from privacyidea.lib.resolver import (save_resolver)
 from privacyidea.lib.realm import (set_realm)
 from privacyidea.lib.user import (User)
+from privacyidea.lib.utils import is_true
 from privacyidea.lib.tokenclass import DATE_FORMAT
 from privacyidea.lib.tokens.emailtoken import EmailTokenClass, EMAILACTION
 from privacyidea.models import (Token, Config, Challenge)
@@ -82,7 +83,7 @@ class EmailTokenTestCase(MyTestCase):
         token = EmailTokenClass(db_token)
         token.update({"dynamic_email": True})
         token.save()
-        self.assertEqual(token.get_tokeninfo("dynamic_email"), "1")
+        self.assertEqual(is_true(token.get_tokeninfo("dynamic_email")))
         self.assertTrue(token.token.serial == self.serial2, token)
         self.assertTrue(token.token.tokentype == "email", token.token)
         self.assertTrue(token.type == "email", token.type)

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -7,6 +7,7 @@ from .base import MyTestCase, FakeFlaskG
 from privacyidea.lib.resolver import (save_resolver)
 from privacyidea.lib.realm import (set_realm)
 from privacyidea.lib.user import (User)
+from privacyidea.lib.utils import is_true
 from privacyidea.lib.tokenclass import DATE_FORMAT
 from privacyidea.lib.tokens.smstoken import SmsTokenClass, SMSACTION
 from privacyidea.models import (Token, Config, Challenge)
@@ -94,7 +95,7 @@ class SMSTokenTestCase(MyTestCase):
         token.save()
         self.assertTrue(token.token.serial == self.serial2, token)
         self.assertTrue(token.token.tokentype == "sms", token.token)
-        self.assertEqual(token.get_tokeninfo("dynamic_phone"), "1")
+        self.assertEqual(is_true(token.get_tokeninfo("dynamic_phone")))
         self.assertTrue(token.type == "sms", token.type)
         class_prefix = token.get_class_prefix()
         self.assertTrue(class_prefix == "PISM", class_prefix)

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -95,7 +95,7 @@ class SMSTokenTestCase(MyTestCase):
         token.save()
         self.assertTrue(token.token.serial == self.serial2, token)
         self.assertTrue(token.token.tokentype == "sms", token.token)
-        self.assertEqual(is_true(token.get_tokeninfo("dynamic_phone")))
+        self.assertTrue(is_true(token.get_tokeninfo("dynamic_phone")))
         self.assertTrue(token.type == "sms", token.type)
         class_prefix = token.get_class_prefix()
         self.assertTrue(class_prefix == "PISM", class_prefix)


### PR DESCRIPTION
Should fix #1000.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181383410%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181382591%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23issuecomment-381140370%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181752584%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181752773%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23issuecomment-381618356%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181760817%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181760863%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23issuecomment-381725715%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23issuecomment-381140370%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231016%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/8307090f7f6dd6b56a9cc8f024d64bdf78998000%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6097.5%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26height%3D150%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231016%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.37%25%20%20%2095.41%25%20%20%20%2B0.03%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016190%20%20%20%2016205%20%20%20%20%20%20%2B15%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015442%20%20%20%2015462%20%20%20%20%20%20%2B20%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20748%20%20%20%20%20%20743%20%20%20%20%20%20%20-5%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/radiustoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9yYWRpdXN0b2tlbi5weQ%3D%3D%29%20%7C%20%6098.26%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/smtpserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3NtdHBzZXJ2ZXIucHk%3D%29%20%7C%20%6098.48%25%20%3C100%25%3E%20%28-0.03%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/privacyideaserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3ByaXZhY3lpZGVhc2VydmVyLnB5%29%20%7C%20%6098.3%25%20%3C100%25%3E%20%28%2B0.02%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.77%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/config.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ%3D%3D%29%20%7C%20%6096.42%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/remotetoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9yZW1vdGV0b2tlbi5weQ%3D%3D%29%20%7C%20%6098.26%25%20%3C66.66%25%3E%20%28%2B1.7%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B2.5%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B8307090...3c25a1e%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1016%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-13T13%3A46%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20would%20probably%20be%20a%20part%20of%20%231000.%22%2C%20%22created_at%22%3A%20%222018-04-16T14%3A27%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%27s%20up%20with.%20Travis.%20I%20ran%20the%20tests%20locally%20and%20passed%20fine.%20Merging%20it%20to%20master%21%22%2C%20%22created_at%22%3A%20%222018-04-16T19%3A44%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e%20privacyidea/api/privacyideaserver.py%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181382591%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20replaces%20a%20custom%20conversion%20%60%60bool%28int%28%3Csome%20string%20parameter%3E%29%29%60%60%20with%20%60%60is_true%60%60.%20Initially%20I%20thought%20this%20is%20a%20good%20idea%20%3A%29%20But%20I%27m%20not%20so%20sure%20if%20we%20should%20really%20do%20this%2C%20because%20it%20changes%20behavior%3A%20e.g.%20%60%60bool%28int%28%5C%222%5C%22%29%29%60%60%20evaluates%20to%20True%2C%20but%20%60%60is_true%28%5C%222%5C%22%29%60%60%20evaluates%20to%20False.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-04-13T13%3A11%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/privacyideaserver.py%3AL64-71%22%7D%2C%20%22Pull%203c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e%20privacyidea/models.py%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181752773%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20leave%20the%20unicode%20in%20there.%22%2C%20%22created_at%22%3A%20%222018-04-16T14%3A26%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL953-965%22%7D%2C%20%22Pull%203c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e%20privacyidea/models.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181760863%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22s.o.%22%2C%20%22created_at%22%3A%20%222018-04-16T14%3A49%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL953-965%22%7D%2C%20%22Pull%203c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e%20privacyidea/models.py%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181383410%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20removed%20the%20conversions%20of%20%60%60Key%60%60%2C%20%60%60Type%60%60%20and%20%60%60Descriptions%60%60%20to%20unicode%20here%3A%20My%20reasoning%20was%20that%20they%20should%20always%20be%20strings%20anyway.%20However%2C%20then%20I%20realized%20they%20can%20be%20ASCII%20bytestrings%2C%20and%20converting%20them%20to%20%60%60unicode%60%60%20could%20help%20us%20get%20rid%20of%20the%20SQLAlchemy%20warnings%20like%5Cr%5Cn%60%60%60%5Cr%5CnSAWarning%3A%20Unicode%20type%20received%20non-unicode%20bind%20param%20value%20%27...%27.%5Cr%5Cn%60%60%60%5Cr%5CnSo%20I%27m%20not%20really%20sure%20what%20to%20do%20here%20%3A%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-13T13%3A14%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20discussed%20I%20think%20we%20should%20keep%20the%20unicode%21%22%2C%20%22created_at%22%3A%20%222018-04-16T14%3A49%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL728-740%22%7D%2C%20%22Pull%203c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e%20privacyidea/models.py%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1016%23discussion_r181752584%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20like%20to%20keep%20these%20unicode%20conversions.%22%2C%20%22created_at%22%3A%20%222018-04-16T14%3A26%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL728-740%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 3c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e privacyidea/api/privacyideaserver.py 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1016#discussion_r181382591'>File: privacyidea/api/privacyideaserver.py:L64-71</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> This replaces a custom conversion ``bool(int(<some string parameter>))`` with ``is_true``. Initially I thought this is a good idea :) But I'm not so sure if we should really do this, because it changes behavior: e.g. ``bool(int("2"))`` evaluates to True, but ``is_true("2")`` evaluates to False. What do you think?
- [ ] <a href='#crh-comment-Pull 3c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e privacyidea/models.py 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1016#discussion_r181383410'>File: privacyidea/models.py:L728-740</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I removed the conversions of ``Key``, ``Type`` and ``Descriptions`` to unicode here: My reasoning was that they should always be strings anyway. However, then I realized they can be ASCII bytestrings, and converting them to ``unicode`` could help us get rid of the SQLAlchemy warnings like
```
SAWarning: Unicode type received non-unicode bind param value '...'.
```
So I'm not really sure what to do here :)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> As discussed I think we should keep the unicode!
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1016#issuecomment-381140370'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1016?src=pr&el=h1) Report
> Merging [#1016](https://codecov.io/gh/privacyidea/privacyidea/pull/1016?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/8307090f7f6dd6b56a9cc8f024d64bdf78998000?src=pr&el=desc) will **increase** coverage by `0.03%`.
> The diff coverage is `97.5%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1016/graphs/tree.svg?token=7nHLZki60B&src=pr&height=150&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/1016?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1016      +/-   ##
==========================================
+ Coverage   95.37%   95.41%   +0.03%
==========================================
Files         131      131
Lines       16190    16205      +15
==========================================
+ Hits        15442    15462      +20
+ Misses        748      743       -5
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1016?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/radiustoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1016/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9yYWRpdXN0b2tlbi5weQ==) | `98.26% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/api/smtpserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1016/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3NtdHBzZXJ2ZXIucHk=) | `98.48% <100%> (-0.03%)` | :arrow_down: |
| [privacyidea/api/privacyideaserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1016/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3ByaXZhY3lpZGVhc2VydmVyLnB5) | `98.3% <100%> (+0.02%)` | :arrow_up: |
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1016/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.77% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/lib/config.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1016/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ==) | `96.42% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/remotetoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1016/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9yZW1vdGV0b2tlbi5weQ==) | `98.26% <66.66%> (+1.7%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1016/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+2.5%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1016?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1016?src=pr&el=footer). Last update [8307090...3c25a1e](https://codecov.io/gh/privacyidea/privacyidea/pull/1016?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This would probably be a part of #1000.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What's up with. Travis. I ran the tests locally and passed fine. Merging it to master!
- [ ] <a href='#crh-comment-Pull 3c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e privacyidea/models.py 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1016#discussion_r181752584'>File: privacyidea/models.py:L728-740</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I would like to keep these unicode conversions.
- [ ] <a href='#crh-comment-Pull 3c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e privacyidea/models.py 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1016#discussion_r181752773'>File: privacyidea/models.py:L953-965</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Please leave the unicode in there.
- [ ] <a href='#crh-comment-Pull 3c25a1eb26b8ee98bbb4152bbd050fe3fbe45d6e privacyidea/models.py 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1016#discussion_r181760863'>File: privacyidea/models.py:L953-965</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> s.o.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1016?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1016?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1016'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>