### PR TITLE
Fix the validity-equals

### DIFF
--- a/privacyidea/lib/tokens/ocratoken.py
+++ b/privacyidea/lib/tokens/ocratoken.py
@@ -252,12 +252,8 @@ class OcraTokenClass(TokenClass):
     @check_token_locked
     def check_challenge_response(self, user=None, passw=None, options=None):
         """
-        This function checks, if the challenge for the given transaction_id
-        was marked as answered correctly.
-        For this we check the otp_status of the challenge with the
-        transaction_id in the database.
-
-        We do not care about the password
+        This function checks if the given password matches the expected response
+        for the challenge identified by the given transaction_id.
 
         :param user: the requesting user
         :type user: User object
@@ -285,7 +281,7 @@ class OcraTokenClass(TokenClass):
             for challengeobject in challengeobject_list:
                 # check if we are still in time.
                 if challengeobject.is_valid():
-                    if self.verify_response(passw, challengeobject.challenge):
+                    if self.verify_response(passw, challengeobject.challenge) > 0:
                         # create a positive response
                         otp_counter = 1
                         # delete the challenge

--- a/privacyidea/lib/tokens/ocratoken.py
+++ b/privacyidea/lib/tokens/ocratoken.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 #  http://www.privacyidea.org
+#  2018-04-16 Friedrich Weber <friedrich.weber@netknights.it>
+#             Fix validation of challenge responses
 #  2017-08-29 Cornelis Kölbel <cornelius.koelbel@netknights.it>
 #             Initial implementation of OCRA base token
 #

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 #  http://www.privacyidea.org
+#  2018-04-16 Friedrich Weber <friedrich.weber@netknights.it>
+#             Fix validation of challenge responses
 #  2015-09-01 Initial writeup.
 #             Cornelius Kölbel <cornelius@privacyidea.org>
 #

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -275,11 +275,11 @@ myApp.directive('equals', function() {
 
       var validate = function() {
         // values
-        var val1 = ngModel.$viewValue;
-        var val2 = attrs.equals;
+        var val1 = ngModel.$viewValue || "";
+        var val2 = attrs.equals || "";
 
         // set validity
-        ngModel.$setValidity('equals', ! val1 || ! val2 || val1 === val2);
+        ngModel.$setValidity('equals', val1 === val2);
       };
     }
   };

--- a/privacyidea/static/components/directives/views/directive.assignuser.html
+++ b/privacyidea/static/components/directives/views/directive.assignuser.html
@@ -31,7 +31,7 @@ This is the directive for assigning users.
     <label for="otppin" translate>PIN</label>
     <input name="otppin" ng-model="newUserObject.pin"
             type=password class="form-control"
-            euqals="{{pin2}}"
+            equals="{{pin2}}"
             placeholder="{{ 'Type a password'|translate }}">
     <input name="otppin2" ng-model="pin2"
             type=password class="form-control"

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -24,7 +24,7 @@
         </ng-include>
 
         <!-- User Assignment -->
-        <div ng-show="loggedInUser.role == 'admin'">
+        <div ng-if="loggedInUser.role == 'admin'">
             <h4 translate>Assign token to user</h4>
 
             <div assign-user new-user-object="newUser" realms="realms"
@@ -37,7 +37,7 @@
         </div>
         <!-- Token PIN -->
         <div class="form-group"
-             ng-show="loggedInUser.role == 'user' && !hidePin &&
+             ng-if="loggedInUser.role == 'user' && !hidePin &&
                     !$state.includes('token.wizard') &&
                     checkRight('enrollpin')">
             <label for="otppin" translate>PIN</label>

--- a/privacyidea/static/components/token/views/token.enroll.motp.html
+++ b/privacyidea/static/components/token/views/token.enroll.motp.html
@@ -35,7 +35,7 @@ The mOTP token is a time based OTP token for mobile devices.
     </p>
     <input name="motppin" ng-model="form.motppin"
            type=password class="form-control"
-           euqals="{{ motppin2 }}"
+           equals="{{ motppin2 }}"
            placeholder="{{ 'Type a password'|translate }}">
     <input name="motppin2" ng-model="motppin2"
            type=password class="form-control"

--- a/tests/test_lib_tokens_tiqr.py
+++ b/tests/test_lib_tokens_tiqr.py
@@ -4,6 +4,7 @@ This test file tests the lib.tokens.tiqrtoken and lib.tokens.ocra
 This depends on lib.tokenclass
 """
 from .base import MyTestCase
+from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib.tokens.tiqrtoken import TiqrTokenClass
 from privacyidea.lib.tokens.ocratoken import OcraTokenClass
 from privacyidea.lib.tokens.ocra import OCRASuite, OCRA
@@ -349,9 +350,40 @@ class OcraTokenTestCase(MyTestCase):
         self.assertEqual(r[0], True)
         self.assertEqual(r[1], "Please answer the challenge")
 
+        # answer the challenge wrongly
+        r = token.verify_response(passw="00065298", challenge=challengeQH40)
+        self.assertTrue(r < 0, r)
+
         # answer the challenge
         r = token.verify_response(passw="90065298", challenge=challengeQH40)
         self.assertTrue(r > 0, r)
+
+        # create another challenge
+        displayTAN_challenge = "83507112  ~320,00~1399458665_G6HNVF"
+        challengeQH40 = binascii.hexlify(hashlib.sha1(
+            displayTAN_challenge).digest())
+        r = token.create_challenge(options={"challenge": challengeQH40})
+        self.assertEqual(r[0], True)
+        self.assertEqual(r[1], "Please answer the challenge")
+        transaction_id = r[2]
+
+        # answer the challenge wrongly using check_challenge_response
+        r = token.check_challenge_response(passw="00065298", options={
+            "transaction_id": transaction_id
+        })
+        self.assertEqual(r, -1)
+
+        # assert there is still one challenge
+        self.assertEqual(len(get_challenges(serial="OCRA1", transaction_id=transaction_id)), 1)
+
+        # answer the challenge correctly using check_challenge_response
+        r = token.check_challenge_response(passw="90065298", options={
+            "transaction_id": transaction_id
+        })
+        self.assertTrue(r > 0, r)
+
+        # assert there is no challenge anymore
+        self.assertEqual(len(get_challenges(serial="OCRA1", transaction_id=transaction_id)), 0)
 
 
 class TiQRTokenTestCase(MyTestCase):
@@ -501,6 +533,11 @@ class TiQRTokenTestCase(MyTestCase):
         r = TiqrTokenClass.api_endpoint(req, g)
         self.assertEqual(r[0], "plain")
         self.assertEqual(r[1], "INVALID_RESPONSE")
+
+        # Check that the OTP status is still incorrect
+        r = token.check_challenge_response(options={"transaction_id":
+                                                    transaction_id})
+        self.assertEqual(r, -1)
 
         # Send the correct response
         req.all_data = {"response": response,


### PR DESCRIPTION
Closes #1010
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1017%23issuecomment-381246523%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1017%23issuecomment-381612828%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1017%23issuecomment-381625502%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1017%23issuecomment-381638411%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1017%23issuecomment-381246523%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231017%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.22%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/b187ce353a235086c46c2eb44ce88c984ca3bb3a%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017/graphs/tree.svg%3Fheight%3D150%26width%3D650%26token%3D7nHLZki60B%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.22%20%20%20%20%231017%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%20%20%20%20%2095.38%25%20%20%2095.41%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2016192%20%20%20%2016232%20%20%20%20%20%20%2B40%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2015445%20%20%20%2015487%20%20%20%20%20%20%2B42%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20747%20%20%20%20%20%20745%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ%3D%3D%29%20%7C%20%6094.36%25%20%3C0%25%3E%20%28%2B2.2%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bb187ce3...4dcf5e6%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1017%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-13T20%3A03%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20there%20is%20one%20problem%20with%20this%20in%20the%20%5C%22Enroll%20Token%5C%22%20form%3A%5Cr%5Cn%2A%20Type%20%5C%22a%5C%22%20in%20the%20first%20OTP%20PIN%20field.%20Everything%20as%20expected%3A%20The%20second%20PIN%20field%20is%20red%2C%20the%20%5C%22Enroll%5C%22%20button%20is%20grayed%20out%5Cr%5Cn%2A%20Type%20%5C%22a%5C%22%20in%20the%20second%20OTP%20PIN%20field.%20The%20%5C%22Enroll%5C%22%20button%20is%20still%20grayed%20out%2C%20even%20though%20it%20should%20be%20enabled%20again%21%5Cr%5Cn%5Cr%5CnInterestingly%2C%20everything%20works%20fine%20for%20the%20%5C%22assign%20token%5C%22%20form.%22%2C%20%22created_at%22%3A%20%222018-04-16T14%3A11%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20works%20for%20me%20-%20for%20assign%20and%20for%20enroll%21%5Cr%5CnPlease%20assure%2C%20that%20you%20really%20use%20the%20new%20templates%20and%20javascripts.%20In%20both%20cases%20load%20the%20pages%20anew%20with%20%60%60Ctrl-Shift-R%60%60.%22%2C%20%22created_at%22%3A%20%222018-04-16T14%3A48%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20no%2C%20I%20still%20have%20the%20problem%20with%20a%20fresh%20privacyIDEA%20instance%2C%20in%20Firefox%20and%20Chrome%20with%20disabled%20cache%20%3A-/%5Cr%5Cni.e.%20I%20can%20only%20enroll%20a%20token%20if%20I%20set%20an%20empty%20PIN.%22%2C%20%22created_at%22%3A%20%222018-04-16T15%3A08%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1017#issuecomment-381246523'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1017?src=pr&el=h1) Report
> Merging [#1017](https://codecov.io/gh/privacyidea/privacyidea/pull/1017?src=pr&el=desc) into [branch-2.22](https://codecov.io/gh/privacyidea/privacyidea/commit/b187ce353a235086c46c2eb44ce88c984ca3bb3a?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1017/graphs/tree.svg?height=150&width=650&token=7nHLZki60B&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1017?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.22    #1017      +/-   ##
===============================================
+ Coverage        95.38%   95.41%   +0.02%
===============================================
Files              131      131
Lines            16192    16232      +40
===============================================
+ Hits             15445    15487      +42
+ Misses             747      745       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1017?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1017/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
| [privacyidea/api/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1017/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ==) | `94.36% <0%> (+2.2%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1017?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1017?src=pr&el=footer). Last update [b187ce3...4dcf5e6](https://codecov.io/gh/privacyidea/privacyidea/pull/1017?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, there is one problem with this in the "Enroll Token" form:
* Type "a" in the first OTP PIN field. Everything as expected: The second PIN field is red, the "Enroll" button is grayed out
* Type "a" in the second OTP PIN field. The "Enroll" button is still grayed out, even though it should be enabled again!
Interestingly, everything works fine for the "assign token" form.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> It works for me - for assign and for enroll!
Please assure, that you really use the new templates and javascripts. In both cases load the pages anew with ``Ctrl-Shift-R``.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm no, I still have the problem with a fresh privacyIDEA instance, in Firefox and Chrome with disabled cache :-/
i.e. I can only enroll a token if I set an empty PIN.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1017?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1017?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1017'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>