### PR TITLE
We only set the username and realmname after loading the realms

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -59,7 +59,7 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
         }
     };
 
-    if ($scope.loggedInUser.role == "admin") {
+    if ($scope.loggedInUser.role === "admin") {
         /*
         * Functions to check and to create a default realm. At the moment this is
         * in the tokenview, as the token view is the first view. This could be
@@ -69,7 +69,7 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
             // Check if there is a realm defined, or if we should display the
             // Auto Create Dialog
             var number_of_realms = Object.keys(data.result.value).length;
-            if (number_of_realms == 0) {
+            if (number_of_realms === 0) {
                 $('#dialogAutoCreateRealm').modal();
             }
         });
@@ -105,12 +105,12 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
     };
 
 
-    if ($location.path() == "/token/list") {
+    if ($location.path() === "/token/list") {
         $scope.get();
     }
 
     // go to the list view by default
-    if ($location.path() == "/token") {
+    if ($location.path() === "/token") {
         $location.path("/token/list");
     }
     // go to token.wizard, if the wizard is defined
@@ -281,7 +281,7 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
     // Set the default value of the "2stepinit" field if twostep enrollment should be forced
     $scope.setTwostepEnrollmentDefault = function () {
         $scope.form["2stepinit"] = $scope.checkRight($scope.form.type + "_2step=force");
-    }
+    };
 
     // Initially set the default value
     $scope.setTwostepEnrollmentDefault();
@@ -297,7 +297,7 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
         });
 
     // Get the realms and fill the realm dropdown box
-    if (AuthFactory.getRole() == 'admin') {
+    if (AuthFactory.getRole() === 'admin') {
         ConfigFactory.getRealms(function (data) {
             $scope.realms = data.result.value;
             // Set the default realm
@@ -314,30 +314,30 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
                     //debug: console.log($scope.newUser);
                 }
             });
-        });
-        // init the user, if token.enroll was called from the user.details
-        if ($stateParams.realmname) {
-            $scope.newUser.realm = $stateParams.realmname;
-        }
-        if ($stateParams.username) {
-            $scope.newUser.user = $stateParams.username;
-            // preset the mobile and email for SMS or EMAIL token
-            UserFactory.getUsers({realm: $scope.newUser.realm,
-                username: $scope.newUser.user},
-                function(data) {
-                    var userObject = data.result.value[0];
-                    $scope.form.email = userObject.email;
-                    if (typeof userObject.mobile === "string") {
-                        $scope.form.phone = userObject.mobile;
-                    } else {
-                        $scope.phone_list = userObject.mobile;
-                        if ($scope.phone_list.length === 1) {
-                            $scope.form.phone = $scope.phone_list[0];
+            // init the user, if token.enroll was called from the user.details
+            if ($stateParams.realmname) {
+                $scope.newUser.realm = $stateParams.realmname;
+            }
+            if ($stateParams.username) {
+                $scope.newUser.user = $stateParams.username;
+                // preset the mobile and email for SMS or EMAIL token
+                UserFactory.getUsers({realm: $scope.newUser.realm,
+                    username: $scope.newUser.user},
+                    function(data) {
+                        var userObject = data.result.value[0];
+                        $scope.form.email = userObject.email;
+                        if (typeof userObject.mobile === "string") {
+                            $scope.form.phone = userObject.mobile;
+                        } else {
+                            $scope.phone_list = userObject.mobile;
+                            if ($scope.phone_list.length === 1) {
+                                $scope.form.phone = $scope.phone_list[0];
+                            }
                         }
-                    }
-            });
-        }
-    } else if (AuthFactory.getRole() == 'user') {
+                });
+            }
+        });
+    } else if (AuthFactory.getRole() === 'user') {
         // init the user, if token.enroll was called as a normal user
         $scope.newUser.user = AuthFactory.getUser().username;
         $scope.newUser.realm = AuthFactory.getUser().realm;


### PR DESCRIPTION
The username and realmname is set within the callback function of the ``getRealms`` to assure, that the user information from ``stateParams`` is not overwritten.

Fixes #918
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1018%23issuecomment-381596622%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1018%23issuecomment-381596622%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231018%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.22%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/b187ce353a235086c46c2eb44ce88c984ca3bb3a%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018/graphs/tree.svg%3Fheight%3D150%26token%3D7nHLZki60B%26src%3Dpr%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.22%20%20%20%20%231018%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%20%20%20%20%2095.38%25%20%20%2095.41%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2016192%20%20%20%2016232%20%20%20%20%20%20%2B40%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2015445%20%20%20%2015487%20%20%20%20%20%20%2B42%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20747%20%20%20%20%20%20745%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ%3D%3D%29%20%7C%20%6094.36%25%20%3C0%25%3E%20%28%2B2.2%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bb187ce3...b1c852b%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1018%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-16T13%3A20%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1018#issuecomment-381596622'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1018?src=pr&el=h1) Report
> Merging [#1018](https://codecov.io/gh/privacyidea/privacyidea/pull/1018?src=pr&el=desc) into [branch-2.22](https://codecov.io/gh/privacyidea/privacyidea/commit/b187ce353a235086c46c2eb44ce88c984ca3bb3a?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1018/graphs/tree.svg?height=150&token=7nHLZki60B&src=pr&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/1018?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.22    #1018      +/-   ##
===============================================
+ Coverage        95.38%   95.41%   +0.02%
===============================================
Files              131      131
Lines            16192    16232      +40
===============================================
+ Hits             15445    15487      +42
+ Misses             747      745       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1018?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1018/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
| [privacyidea/api/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1018/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ==) | `94.36% <0%> (+2.2%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1018?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1018?src=pr&el=footer). Last update [b187ce3...b1c852b](https://codecov.io/gh/privacyidea/privacyidea/pull/1018?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1018?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1018?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1018'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>