### PR TITLE
#817 Add new error for non-existent resource and handle those situations i…

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -216,6 +216,17 @@ def after_request(response):
     response.headers['Cache-Control'] = 'no-cache'
     return response
 
+@realm_blueprint.app_errorhandler(NonExistentResourceError)
+@resolver_blueprint.app_errorhandler(NonExistentResourceError)
+@policy_blueprint.app_errorhandler(NonExistentResourceError)
+@postrequest(sign_response, request=request)
+def nonexistentresource_error(error):
+    if "audit_object" in g:
+        g.audit_object.log({"info": error.description})
+        g.audit_object.finalize_log()
+    return send_error(error.description,
+                      error_code=-404,
+                      details=error.details), error.status_code
 
 @system_blueprint.errorhandler(AuthError)
 @realm_blueprint.app_errorhandler(AuthError)

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -217,6 +217,8 @@ def after_request(response):
     return response
 
 @realm_blueprint.app_errorhandler(NonExistentResourceError)
+@smsgateway_blueprint.app_errorhandler(NonExistentResourceError)
+@eventhandling_blueprint.app_errorhandler(NonExistentResourceError)
 @resolver_blueprint.app_errorhandler(NonExistentResourceError)
 @policy_blueprint.app_errorhandler(NonExistentResourceError)
 @postrequest(sign_response, request=request)

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -61,7 +61,7 @@ from .subscriptions import subscriptions_blueprint
 from privacyidea.api.lib.postpolicy import postrequest, sign_response
 from ..lib.error import (privacyIDEAError,
                          AuthError, UserError,
-                         PolicyError)
+                         PolicyError, NonExistentResourceError)
 from privacyidea.lib.utils import get_client_ip
 from privacyidea.lib.user import User
 

--- a/privacyidea/api/event.py
+++ b/privacyidea/api/event.py
@@ -180,18 +180,18 @@ def disable_event_api(eventid):
 
 
 @eventhandling_blueprint.route('/<eid>', methods=['DELETE'])
+@check_resource_exists('EventHandler', 'id')
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.EVENTHANDLINGWRITE)
-def delete_eventid(eid=None):
+def delete_eventid(identity=None):
     """
     this function deletes an existing event handling configuration
 
     :param eid: The id of the event handling configuration
     :return: json with success or fail
     """
-    res = delete_event(eid)
+    res = delete_event(identity)
     g.audit_object.log({"success": res,
-                        "info": eid})
+                        "info": identity})
 
     return send_result(res)
-

--- a/privacyidea/api/event.py
+++ b/privacyidea/api/event.py
@@ -38,7 +38,7 @@ from ..lib.policy import ACTION
 from privacyidea.lib.event import AVAILABLE_EVENTS, get_handler_object
 from privacyidea.lib.utils import is_true
 import json
-from privacyidea.lib.decorators import check_resource_exists
+from ..lib.decorators import check_resource_exists
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/api/event.py
+++ b/privacyidea/api/event.py
@@ -38,7 +38,7 @@ from ..lib.policy import ACTION
 from privacyidea.lib.event import AVAILABLE_EVENTS, get_handler_object
 from privacyidea.lib.utils import is_true
 import json
-
+from privacyidea.lib.decorators import check_resource_exists
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/api/event.py
+++ b/privacyidea/api/event.py
@@ -179,7 +179,7 @@ def disable_event_api(eventid):
     return send_result(p)
 
 
-@eventhandling_blueprint.route('/<eid>', methods=['DELETE'])
+@eventhandling_blueprint.route('/<identity>', methods=['DELETE'])
 @check_resource_exists('EventHandler', 'id')
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.EVENTHANDLINGWRITE)

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -59,7 +59,7 @@ from cgi import FieldStorage
 
 import logging
 import re
-
+from privacyidea.lib.decorators import check_resource_exists
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -288,10 +288,11 @@ def get_policy(name=None, export=None):
     return ret
 
 
-@policy_blueprint.route('/<name>', methods=['DELETE'])
+@policy_blueprint.route('/<identity>', methods=['DELETE'])
+@check_resource_exists('Policy', 'name')
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.POLICYDELETE)
-def delete_policy_api(name=None):
+def delete_policy_api(identity=None):
     """
     This deletes the policy of the given name.
 
@@ -329,9 +330,9 @@ def delete_policy_api(name=None):
           "version": "privacyIDEA unknown"
        }
     """
-    ret = delete_policy(name)
+    ret = delete_policy(identity)
     g.audit_object.log({'success': ret,
-                        'info': name})
+                        'info': identity})
     return send_result(ret)
 
 

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -59,7 +59,7 @@ from cgi import FieldStorage
 
 import logging
 import re
-from privacyidea.lib.decorators import check_resource_exists
+from ..lib.decorators import check_resource_exists
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/api/realm.py
+++ b/privacyidea/api/realm.py
@@ -60,6 +60,7 @@ from flask import g
 from privacyidea.lib.auth import ROLE
 from flask_babel import gettext as _
 import logging
+from privacyidea.lib.decorators import check_resource_exists
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/api/realm.py
+++ b/privacyidea/api/realm.py
@@ -341,6 +341,7 @@ def get_default_realm_api():
 
 
 @realm_blueprint.route('/<identity>', methods=['DELETE'])
+@check_resource_exists('Realm', 'name')
 @log_with(log)
 #@system_blueprint.route('/delRealm', methods=['POST', 'DELETE'])
 @prepolicy(check_base_action, request, ACTION.RESOLVERDELETE)

--- a/privacyidea/api/realm.py
+++ b/privacyidea/api/realm.py
@@ -339,11 +339,11 @@ def get_default_realm_api():
     return send_result(res)
 
 
-@realm_blueprint.route('/<realm>', methods=['DELETE'])
+@realm_blueprint.route('/<identity>', methods=['DELETE'])
 @log_with(log)
 #@system_blueprint.route('/delRealm', methods=['POST', 'DELETE'])
 @prepolicy(check_base_action, request, ACTION.RESOLVERDELETE)
-def delete_realm_api(realm=None):
+def delete_realm_api(identity=None):
     """
     This call deletes the given realm.
 
@@ -377,9 +377,8 @@ def delete_realm_api(realm=None):
         }
 
     """
-    ret = delete_realm(realm)
+    ret = delete_realm(identity)
     g.audit_object.log({"success": ret,
-                        "info": realm})
+                        "info": identity})
 
     return send_result(ret)
-

--- a/privacyidea/api/realm.py
+++ b/privacyidea/api/realm.py
@@ -60,7 +60,7 @@ from flask import g
 from privacyidea.lib.auth import ROLE
 from flask_babel import gettext as _
 import logging
-from privacyidea.lib.decorators import check_resource_exists
+from ..lib.decorators import check_resource_exists
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/api/resolver.py
+++ b/privacyidea/api/resolver.py
@@ -47,7 +47,7 @@ from flask import g
 import logging
 from ..api.lib.prepolicy import prepolicy, check_base_action
 from ..lib.policy import ACTION
-from privacyidea.lib.decorators import check_resource_exists
+from ..lib.decorators import check_resource_exists
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/api/resolver.py
+++ b/privacyidea/api/resolver.py
@@ -47,7 +47,7 @@ from flask import g
 import logging
 from ..api.lib.prepolicy import prepolicy, check_base_action
 from ..lib.policy import ACTION
-
+from privacyidea.lib.decorators import check_resource_exists
 
 log = logging.getLogger(__name__)
 
@@ -141,10 +141,11 @@ def set_resolver(resolver=None):
     return send_result(res)
 
 
-@resolver_blueprint.route('/<resolver>', methods=['DELETE'])
+@resolver_blueprint.route('/<identity>', methods=['DELETE'])
+@check_resource_exists('Resolver', 'name')
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.RESOLVERDELETE)
-def delete_resolver_api(resolver=None):
+def delete_resolver_api(identity=None):
     """
     This function deletes an existing resolver.
     A resolver can not be deleted, if it is contained in a realm
@@ -152,9 +153,9 @@ def delete_resolver_api(resolver=None):
     :param resolver: the name of the resolver to delete.
     :return: json with success or fail
     """
-    res = delete_resolver(resolver)
+    res = delete_resolver(identity)
     g.audit_object.log({"success": res,
-                        "info": resolver})
+                        "info": identity})
 
     return send_result(res)
 
@@ -186,4 +187,3 @@ def test_resolver():
     rtype = getParam(param, "type", required)
     success, desc = pretestresolver(rtype, param)
     return send_result(success, details={"description": desc})
-

--- a/privacyidea/lib/decorators.py
+++ b/privacyidea/lib/decorators.py
@@ -40,11 +40,11 @@ def check_resource_exists(model, identifier):
     def resource_exists(func):
 
         @functools.wraps(func)
-        def resource_exists_wrapper(identity, *args, **kwds):
+        def resource_exists_wrapper(*args, **kwds):
             my_class = getattr(privacyidea.models, model)
 
             params = {}
-            params[identifier] = identity
+            params[identifier] = kwds['identity']
             models = my_class.query.filter_by(**params).first()
 
             if not models:
@@ -52,7 +52,7 @@ def check_resource_exists(model, identifier):
                                 'You are trying to delete object which does not exists.',
                                  status=404)
 
-            f_result = func(identity, *args, **kwds)
+            f_result = func(*args, **kwds)
             return f_result
 
         return resource_exists_wrapper

--- a/privacyidea/lib/decorators.py
+++ b/privacyidea/lib/decorators.py
@@ -22,9 +22,42 @@ import logging
 import functools
 from privacyidea.lib.error import TokenAdminError
 from privacyidea.lib.error import ParameterError
+from privacyidea.lib.error import NonExistentResourceError
 from privacyidea.lib import _
+import importlib
+from flask import request
+import privacyidea.models
+
 log = logging.getLogger(__name__)
 
+def check_resource_exists(model, identifier):
+    """
+    Decorator to check if resource exists
+
+    If the resource doesn't exists, NonExistentResourceError is raised.
+    """
+
+    def resource_exists(func):
+
+        @functools.wraps(func)
+        def resource_exists_wrapper(identity, *args, **kwds):
+            my_class = getattr(privacyidea.models, model)
+
+            params = {}
+            params[identifier] = identity
+            models = my_class.query.filter_by(**params).first()
+
+            if not models:
+                raise NonExistentResourceError('Non-existent resource!',
+                                'You are trying to delete object which does not exists.',
+                                 status=404)
+
+            f_result = func(identity, *args, **kwds)
+            return f_result
+
+        return resource_exists_wrapper
+
+    return resource_exists
 
 def check_token_locked(func):
     """
@@ -117,4 +150,3 @@ def check_copy_serials(func):
         return f_result
 
     return check_serial_wrapper
-

--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU Affero General Public
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#    
+#
 """
 contains Errors and Exceptions
 """
@@ -94,12 +94,12 @@ class BaseError(Exception):
         self.description = description
         self.status_code = status
         self.headers = headers
-        
+
     def to_dict(self):
         return {"status_code": self.status_code,
                 "error": self.error,
                 "description": self.description}
-        
+
     def __repr__(self):
         ret = '{0!s}(error={1!r}, description={2!r}, id={3:d})'.format(type(self).__name__,
                                                        self.error,
@@ -108,12 +108,18 @@ class BaseError(Exception):
         return ret
 
 
+class NonExistentResourceError(BaseError):
+    def __init__(self, error, description, status=404, headers=None,
+                 details=None):
+        self.details = details
+        BaseError.__init__(self, error, description, status, headers)
+
 class AuthError(BaseError):
     def __init__(self, error, description, status=401, headers=None,
                  details=None):
         self.details = details
         BaseError.__init__(self, error, description, status, headers)
-        
+
 
 class PolicyError(privacyIDEAError):
     def __init__(self, description, id=403):

--- a/privacyidea/lib/event.py
+++ b/privacyidea/lib/event.py
@@ -21,7 +21,7 @@
 #
 #
 from privacyidea.models import EventHandler, EventHandlerOption, db
-from privacyidea.lib.error import ParameterError
+from privacyidea.lib.error import ParameterError, NonExistentResourceError
 from privacyidea.lib.audit import getAudit
 import functools
 import logging
@@ -200,6 +200,11 @@ def delete_event(event_id):
     """
     event_id = int(event_id)
     ev = EventHandler.query.filter_by(id=event_id).first()
+
+    if not ev:
+        raise NonExistentResourceError('Non-existent resource!',
+                        'You are trying to delete object which does not exists.',
+                         status=404)
     r = ev.delete()
     return r
 
@@ -250,4 +255,3 @@ class EventConfiguration(object):
         q = EventHandler.query.order_by(EventHandler.ordering)
         for e in q:
             self.eventlist.append(e.get())
-

--- a/privacyidea/lib/event.py
+++ b/privacyidea/lib/event.py
@@ -21,7 +21,7 @@
 #
 #
 from privacyidea.models import EventHandler, EventHandlerOption, db
-from privacyidea.lib.error import ParameterError, NonExistentResourceError
+from privacyidea.lib.error import ParameterError
 from privacyidea.lib.audit import getAudit
 import functools
 import logging
@@ -200,11 +200,6 @@ def delete_event(event_id):
     """
     event_id = int(event_id)
     ev = EventHandler.query.filter_by(id=event_id).first()
-
-    if not ev:
-        raise NonExistentResourceError('Non-existent resource!',
-                        'You are trying to delete object which does not exists.',
-                         status=404)
     r = ev.delete()
     return r
 

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -161,7 +161,7 @@ from ..models import (Policy, Config, PRIVACYIDEA_TIMESTAMP, db,
 from flask import current_app
 from privacyidea.lib.config import (get_token_classes, get_token_types,
                                     Singleton)
-from privacyidea.lib.error import ParameterError, PolicyError, NonExistentResourceError
+from privacyidea.lib.error import ParameterError, PolicyError
 from privacyidea.lib.realm import get_realms
 from privacyidea.lib.resolver import get_resolver_list
 from privacyidea.lib.smtpserver import get_smtpservers
@@ -907,10 +907,6 @@ def delete_policy(name):
     p = Policy.query.filter_by(name=name).first()
     if p:
         res = p.delete()
-    else:
-        raise NonExistentResourceError('Non-existent resource!',
-                        'You are trying to delete object which does not exists.',
-                         status=404)
     return res
 
 

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -161,7 +161,7 @@ from ..models import (Policy, Config, PRIVACYIDEA_TIMESTAMP, db,
 from flask import current_app
 from privacyidea.lib.config import (get_token_classes, get_token_types,
                                     Singleton)
-from privacyidea.lib.error import ParameterError, PolicyError
+from privacyidea.lib.error import ParameterError, PolicyError, NonExistentResourceError
 from privacyidea.lib.realm import get_realms
 from privacyidea.lib.resolver import get_resolver_list
 from privacyidea.lib.smtpserver import get_smtpservers
@@ -907,6 +907,10 @@ def delete_policy(name):
     p = Policy.query.filter_by(name=name).first()
     if p:
         res = p.delete()
+    else
+        raise NonExistentResourceError('Non-existent resource!',
+                        'You are trying to delete object which does not exists.',
+                         status=404)
     return res
 
 
@@ -921,7 +925,7 @@ def delete_all_policies():
 def export_policies(policies):
     """
     This function takes a policy list and creates an export file from it
-    
+
     :param policies: a policy definition
     :type policies: list of policy dictionaries
     :return: the contents of the file

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -907,7 +907,7 @@ def delete_policy(name):
     p = Policy.query.filter_by(name=name).first()
     if p:
         res = p.delete()
-    else
+    else:
         raise NonExistentResourceError('Non-existent resource!',
                         'You are trying to delete object which does not exists.',
                          status=404)

--- a/privacyidea/lib/realm.py
+++ b/privacyidea/lib/realm.py
@@ -45,7 +45,7 @@ from privacyidea.lib.config import ConfigClass
 import logging
 from privacyidea.lib.utils import sanity_name_check
 log = logging.getLogger(__name__)
-from privacyidea.lib.error import NonExistentResourceError
+
 
 @log_with(log)
 #@cache.memoize(10)
@@ -155,12 +155,6 @@ def delete_realm(realmname):
     hadDefRealmBefore = (defRealm != "")
 
     realm = Realm.query.filter_by(name=realmname).first()
-
-    if not realm:
-        raise NonExistentResourceError('Non-existent resource!',
-                        'You are trying to delete object which does not exists.',
-                         status=404)
-
     ret = realm.delete()
 
     # If there was a default realm before

--- a/privacyidea/lib/realm.py
+++ b/privacyidea/lib/realm.py
@@ -45,14 +45,14 @@ from privacyidea.lib.config import ConfigClass
 import logging
 from privacyidea.lib.utils import sanity_name_check
 log = logging.getLogger(__name__)
-
+from privacyidea.lib.error import NonExistentResourceError
 
 @log_with(log)
 #@cache.memoize(10)
 def get_realms(realmname=""):
     '''
     either return all defined realms or a specific realm
-    
+
     :param realmname: the realm, that is of interestet, if ==""
                       all realms are returned
     :type realmname: string
@@ -86,10 +86,10 @@ def get_realm(realmname):
 def realm_is_defined(realm):
     """
     check, if a realm already exists or not
-    
+
     :param realm: the realm, that should be verified
     :type  realm: string
-    
+
     :return: found or not found
     :rtype: boolean
     """
@@ -105,10 +105,10 @@ def set_default_realm(default_realm=None):
     """
     set the default realm attribute.
     If the realm name is empty, the default realm is cleared.
-        
+
     :param defaultRealm: the default realm name
     :type  defualtRealm: string
-    
+
     :return: success or not
     :rtype: boolean
     """
@@ -132,7 +132,7 @@ def get_default_realm():
     """
     return the default realm
     - lookup in the config for the DefaultRealm key
-    
+
     @return: the realm name
     @rtype : string
     """
@@ -146,7 +146,7 @@ def delete_realm(realmname):
     delete the realm from the Database Table with the given name
     If, after deleting this realm, there is only one realm left,
     the remaining realm is set the default realm.
-    
+
     :param realmname: the to be deleted realm
     :type  realmname: string
     """
@@ -155,6 +155,12 @@ def delete_realm(realmname):
     hadDefRealmBefore = (defRealm != "")
 
     realm = Realm.query.filter_by(name=realmname).first()
+
+    if not realm:
+        raise NonExistentResourceError('Non-existent resource!',
+                        'You are trying to delete object which does not exists.',
+                         status=404)
+
     ret = realm.delete()
 
     # If there was a default realm before
@@ -184,13 +190,13 @@ def set_realm(realm, resolvers=None, priority=None):
     If the realm does not exist, it is created.
     If the realm exists, the old resolvers are removed and the new ones
     are added.
-    
+
     :param realm: an existing or a new realm
     :param resolvers: names of resolvers
     :type resolvers: list
     :param priority: The priority of the resolvers in the realm
     :type priority: dict, with resolver names as keys
-    
+
     :return: tuple of lists of added resolvers and resolvers, that could
              not be added
     """
@@ -211,13 +217,13 @@ def set_realm(realm, resolvers=None, priority=None):
         R = Realm(realm)
         R.save()
         realm_created = True
-        
+
     if not realm_created:
         # delete old resolvers
         oldResos = ResolverRealm.query.filter_by(realm_id=R.id)
         for oldReso in oldResos:
             oldReso.delete()
-        
+
     # assign the resolvers
     for reso_name in resolvers:
         reso_name = reso_name.strip()

--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -241,7 +241,7 @@ def delete_resolver(resolvername):
                                    "realm %r." % (resolvername, realmname))
         reso.delete()
         ret = reso.id
-    else
+    else:
         raise NonExistentResourceError('Non-existent resource!',
                         'You are trying to delete object which does not exists.',
                          status=404)

--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -59,7 +59,6 @@ from flask import g
 from privacyidea.lib.config import ConfigClass
 from privacyidea.lib.utils import is_true
 #from privacyidea.lib.cache import cache
-from privacyidea.lib.error import NonExistentResourceError
 
 log = logging.getLogger(__name__)
 
@@ -241,11 +240,6 @@ def delete_resolver(resolvername):
                                    "realm %r." % (resolvername, realmname))
         reso.delete()
         ret = reso.id
-    else:
-        raise NonExistentResourceError('Non-existent resource!',
-                        'You are trying to delete object which does not exists.',
-                         status=404)
-
     # Delete resolver object from cache
     if 'resolver_objects' in g:
         if g.resolver_objects.get(resolvername):

--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -59,6 +59,7 @@ from flask import g
 from privacyidea.lib.config import ConfigClass
 from privacyidea.lib.utils import is_true
 #from privacyidea.lib.cache import cache
+from privacyidea.lib.error import NonExistentResourceError
 
 log = logging.getLogger(__name__)
 
@@ -129,7 +130,7 @@ def save_resolver(params):
                     log.warn("the passed key %r is not a "
                              "parameter for the resolver %r" % (k,
                                                                 resolvertype))
-                        
+
     # Check that there is no type or desc without the data itself.
     # i.e. if there is a type.BindPW=password, then there must be a
     # BindPW=....
@@ -240,6 +241,11 @@ def delete_resolver(resolvername):
                                    "realm %r." % (resolvername, realmname))
         reso.delete()
         ret = reso.id
+    else
+        raise NonExistentResourceError('Non-existent resource!',
+                        'You are trying to delete object which does not exists.',
+                         status=404)
+
     # Delete resolver object from cache
     if 'resolver_objects' in g:
         if g.resolver_objects.get(resolvername):
@@ -300,7 +306,7 @@ def get_resolver_class(resolver_type):
     :return: resolver object class
     '''
     ret = None
-    
+
     (resolver_clazzes, resolver_types) = get_resolver_class_dict()
 
     if resolver_type in resolver_types.values():
@@ -315,7 +321,7 @@ def get_resolver_class(resolver_type):
 def get_resolver_type(resolvername):
     """
     return the type of a resolvername
-    
+
     :param resolvername: THe name of the resolver
     :return: The type of the resolver
     :rtype: string

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -134,15 +134,15 @@ def get_sms_provider_class(packageName, className):
     """
     helper method to load the SMSProvider class from a given
     package in literal:
-    
+
     example:
-    
+
         get_sms_provider_class("HTTPSMSProvider", "SMSProvider")()
-    
+
     check:
         checks, if the submit_message method exists
         if not an error is thrown
-    
+
     """
     mod = __import__(packageName, globals(), locals(), [className])
     klass = getattr(mod, className)
@@ -188,6 +188,10 @@ def delete_smsgateway(identifier):
     gw = SMSGateway.query.filter_by(identifier=identifier).first()
     if gw:
         r = gw.delete()
+    else
+        raise NonExistentResourceError('Non-existent resource!',
+                        'You are trying to delete object which does not exists.',
+                         status=404)
     return r
 
 

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -188,7 +188,7 @@ def delete_smsgateway(identifier):
     gw = SMSGateway.query.filter_by(identifier=identifier).first()
     if gw:
         r = gw.delete()
-    else
+    else:
         raise NonExistentResourceError('Non-existent resource!',
                         'You are trying to delete object which does not exists.',
                          status=404)

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -404,8 +404,6 @@ class APIConfigTestCase(MyTestCase):
             result = json.loads(res.data).get("result")
             self.assertTrue(res.status_code == 404, res)
             self.assertTrue(result["status"] is False, result)
-            # Trying to delete a non existing resolver returns -1
-            self.assertTrue(result["value"] == -1, result)
 
     def test_09_handle_realms(self):
         resolvername = "reso1_with_realm"

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -247,7 +247,7 @@ class APIConfigTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 404, res)
             result = json.loads(res.data).get("result")
-            self.assertTrue(result["status"] is True, result)
+            self.assertTrue(result["status"] is False, result)
 
         # check policy
         with self.app.test_request_context('/policy/pol_update_del',
@@ -403,7 +403,7 @@ class APIConfigTestCase(MyTestCase):
             print(res.data)
             result = json.loads(res.data).get("result")
             self.assertTrue(res.status_code == 404, res)
-            self.assertTrue(result["status"] is True, result)
+            self.assertTrue(result["status"] is False, result)
             # Trying to delete a non existing resolver returns -1
             self.assertTrue(result["value"] == -1, result)
 

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -21,7 +21,7 @@ class APIConfigTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue('"status": true' in res.data, res.data)
-            
+
     def test_00_failed_auth(self):
         with self.app.test_request_context('/system/',
                                            method='GET'):
@@ -70,7 +70,7 @@ class APIConfigTestCase(MyTestCase):
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"]["DefaultOtpLen"] == "insert",
                             result)
-            
+
         with self.app.test_request_context('/system/DefaultMaxFailCount',
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
@@ -79,7 +79,7 @@ class APIConfigTestCase(MyTestCase):
             result = json.loads(res.data).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1,result)
-        
+
         with self.app.test_request_context('/system/DefaultMaxFailCount',
                                            method='GET',
                                            headers={'Authorization': self.at}):
@@ -181,7 +181,7 @@ class APIConfigTestCase(MyTestCase):
             body = res.data
             self.assertTrue('name = pol1' in body, res.data)
             self.assertTrue("[pol1]" in body, res.data)
-            
+
     def test_07_update_and_delete_policy(self):
         with self.app.test_request_context('/policy/pol_update_del',
                                            data={'action': "enroll",
@@ -200,7 +200,7 @@ class APIConfigTestCase(MyTestCase):
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"]["setPolicy pol_update_del"] > 0,
                             res.data)
-        
+
         # update policy
         with self.app.test_request_context('/policy/pol_update_del',
                                            data={'action': "enroll",
@@ -214,7 +214,7 @@ class APIConfigTestCase(MyTestCase):
             result = json.loads(res.data).get("result")
             self.assertTrue(result["value"]["setPolicy pol_update_del"] > 0,
                             res.data)
-            
+
         # get policy
         with self.app.test_request_context('/policy/pol_update_del',
                                            method='GET',
@@ -230,7 +230,7 @@ class APIConfigTestCase(MyTestCase):
                     break
             self.assertTrue("1.1.1.1" in policy.get("client"),
                             res.data)
-            
+
         # delete policy again does not do anything
         with self.app.test_request_context('/policy/pol_update_del',
                                            method='DELETE',
@@ -245,7 +245,7 @@ class APIConfigTestCase(MyTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertTrue(res.status_code == 404, res)
             result = json.loads(res.data).get("result")
             self.assertTrue(result["status"] is True, result)
 
@@ -262,7 +262,7 @@ class APIConfigTestCase(MyTestCase):
     # Resolvers
     """
     We should move this to LDAP resolver tests and mock this.
-    
+
     def test_08_pretestresolver(self):
         # This test fails, as there is no server at localhost.
         param = {'LDAPURI': 'ldap://localhost',
@@ -402,7 +402,7 @@ class APIConfigTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             print(res.data)
             result = json.loads(res.data).get("result")
-            self.assertTrue(res.status_code == 200, res)
+            self.assertTrue(res.status_code == 404, res)
             self.assertTrue(result["status"] is True, result)
             # Trying to delete a non existing resolver returns -1
             self.assertTrue(result["value"] == -1, result)


### PR DESCRIPTION
#817
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-381961564%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-382306634%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-382345323%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-382698517%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-383060768%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-384181713%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-386605173%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-394315515%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-394331534%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-395436841%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-413973337%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1023%23issuecomment-381961564%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20for%20the%20PR.%20I%20would%20try%20to%20add%20the%20non-existing%20logic%20as%20decorators.%20I%20will%20think%20about%20it%20later.%22%2C%20%22created_at%22%3A%20%222018-04-17T11%3A45%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22my%20opinion%20is%20that%20i%20would%20do%20some%20fix%20in%202.%2A%20versions%20and%20refactoring%20would%20leave%20for%20major%20version%2C%20because%20exceptions%20are%20raised%20all%20over%20the%20code%20and%20it%20can%20produce%20quite%20many%20bugs...%22%2C%20%22created_at%22%3A%20%222018-04-18T08%3A25%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5985348%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/p53%22%7D%7D%2C%20%7B%22body%22%3A%20%22404%20is%20a%20REST%20API%20specific%20error.%20%5Cr%5CnI%20would%20add%20a%20decorator%20to%20the%20REST%20API%20level%20like%20here%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/master/privacyidea/api/event.py%23L77%5Cr%5Cn%5Cr%5CnAnd%20change%20it%20to%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20%40eventhandling_blueprint.route%28%27/actions/%3Chandlermodule%3E%27%2C%20methods%3D%5B%5C%22GET%5C%22%5D%29%5Cr%5Cn%20%20%20%20%40log_with%28log%29%5Cr%5Cn%20%20%20%20%40check_resource_exists%28EventHandler%2C%20handlermodule%29%5Cr%5Cn%20%20%20%20def%20get_module_actions%28handlermodule%3DNone%29%3A%5Cr%5Cn%5Cr%5Cn%60%60check_resource_exists%60%60%20would%20be%20a%20generic%20decorator%2C%20that%20could%20check%20for%20existing%20objects%20in%20the%20models.%5Cr%5Cn%5Cr%5CnThis%20is%20why%20we%20like%20to%20use%20decorators%2C%20since%20we%20can%20add%20such%20things%20without%20poisining%20the%20code%20or%20introducing%20bugs%2C%20but%20keeping%20up%20testability.%22%2C%20%22created_at%22%3A%20%222018-04-18T10%3A45%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22i%20made%20it%20with%20decorator%2C%20take%20a%20look%22%2C%20%22created_at%22%3A%20%222018-04-19T11%3A17%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5985348%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/p53%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231023%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/ccdf320c236c5f50b58df6717006cf4ca22d51f3%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6098.07%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/graphs/tree.svg%3Fsrc%3Dpr%26token%3D7nHLZki60B%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231023%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.41%25%20%20%2095.42%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016211%20%20%20%2016251%20%20%20%20%20%20%2B40%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015468%20%20%20%2015507%20%20%20%20%20%20%2B39%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20743%20%20%20%20%20%20744%20%20%20%20%20%20%20%2B1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.34%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/event.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50LnB5%29%20%7C%20%6098.93%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVyLnB5%29%20%7C%20%6096.64%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/realm.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3JlYWxtLnB5%29%20%7C%20%60100%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/smsprovider/SMSProvider.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Ntc3Byb3ZpZGVyL1NNU1Byb3ZpZGVyLnB5%29%20%7C%20%6092.42%25%20%3C0%25%3E%20%28-1.43%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3BvbGljeS5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/resolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Jlc29sdmVyLnB5%29%20%7C%20%6092.45%25%20%3C100%25%3E%20%28%2B0.29%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/decorators.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2RlY29yYXRvcnMucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/realm.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3JlYWxtLnB5%29%20%7C%20%6098.64%25%20%3C100%25%3E%20%28%2B0.03%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/event.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2V2ZW50LnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20...%20and%20%5B2%20more%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023/diff%3Fsrc%3Dpr%26el%3Dtree-more%29%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bccdf320...eb7778e%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1023%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-20T10%3A54%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thank%20you%20for%20the%20PR%20and%20all%20your%20work%21%20I%20think%20returning%20404s%20if%20a%20resource%20cannot%20be%20found%20is%20a%20good%20idea.%20However%2C%20I%27m%20currently%20not%20sure%20about%20the%20specifics%20of%20the%20implementation.%20Right%20now%2C%20%60%60check_resource_exists%60%60%20queries%20the%20database%20to%20check%20if%20the%20referenced%20object%20exists.%20But%20the%20decorated%20function%20will%20query%20the%20database%20%2Aagain%2A%20with%20the%20same%20SELECT%20statement%20to%20actually%20retrieve%20the%20referenced%20object.%20Maybe%20SQLAlchemy%20does%20some%20caching%20here%20--%20we%20would%20need%20to%20check%20that.%20Otherwise%2C%20this%20seems%20a%20little%20inefficient%20to%20me.%5Cr%5Cn%5Cr%5CnSo%20honestly%2C%20I%20currently%20don%27t%20know%20how%20to%20implement%20this%20while%20keeping%20modularity%20and%20efficiency%20in%20mind%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-04-25T07%3A03%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20%40p53%2C%20just%20a%20quick%20update%3A%20Cornelius%20and%20I%20had%20some%20discussions%20about%20how%20to%20implement%20404s%20for%20nonexistent%20resources%20consistently%20in%20privacyIDEA.%20As%20it%20turns%20out%2C%20similar%20situations%20also%20occur%20at%20the%20library%20level%2C%20where%20we%20couldn%27t%20use%20decorators%20as%20above%20--%20I%20guess%20we%20we%20need%20to%20further%20look%20into%20this%20to%20find%20a%20good%20consistent%20solution.%20Thank%20you%20for%20all%20your%20work%20so%20far%2C%20I%27ll%20keep%20you%20posted%21%22%2C%20%22created_at%22%3A%20%222018-05-04T13%3A42%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20actually%20need%20to%20distinguish%20two%20cases%20here%3A%5Cr%5Cn%2A%20There%20are%20some%20API%20endpoints%20which%20return%20a%20HTTP500%20if%20a%20non-existent%20resource%20is%20referenced%2C%20e.g.%20the%20%60%60DELETE%20/event/%3Aid%60%60%20endpoint%20you%20mentioned%20earlier.%20Modifying%20privacyIDEA%20such%20that%20it%20instead%20raises%20a%20404%20is%20no%20problem%20here.%5Cr%5Cn%2A%20There%20are%20others%20which%20return%20a%20HTTP200%20if%20a%20non-existent%20resource%20is%20referenced%2C%20but%20indicate%20this%20in%20the%20JSON%20response%2C%20e.g.%5Cr%5Cn%60%60%60%5Cr%5Cn%24%20http%20DELETE%20http%3A//localhost%3A5000/policy/doesnotexist%20PI-Authorization%3A%24TOKEN%5Cr%5Cn...%5Cr%5Cn%20%20%20%20%5C%22result%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22status%5C%22%3A%20true%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22value%5C%22%3A%20false%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%60%60%60%5Cr%5CnWhile%20I%20agree%20that%20returning%20a%20HTTP404%20would%20be%20more%20appropriate%2C%20I%20don%27t%20think%20we%20should%20just%20modify%20this%20behavior%20now%2C%20as%20this%20would%20break%20backwards%20compatibility.%20Maybe%20we%20could%20start%20with%20just%20the%20requests%20which%20currently%20result%20in%20a%20HTTP500.%22%2C%20%22created_at%22%3A%20%222018-06-04T10%3A58%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Deleting%20a%20non%20existing%20event%20results%20in%20%2A%2A500%2A%2A%20and%20a%20non-existing%20policy%20in%20%2A%2A200%2A%2A%3F%20This%20is%20indeed%20annoying.%20%3A-/%5Cr%5CnYou%20are%20right.%20the%20500er%20equals%20to%20status%3Dfalse%2C%20so%20this%20is%20not%20a%20big%20difference.%20But%20the%20200%20Resp%20Code%20equals%20to%20status%3Dtrue.%20This%20in%20fact%20is%20a%20rather%20big%20difference.%22%2C%20%22created_at%22%3A%20%222018-06-04T12%3A05%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Based%20on%20your%20PR%20%40p53%20%28thanks%20again%21%29%20and%20our%20discussions%2C%20I%20tried%20something%20in%20834e9cd3e49aedbb77ece8c9b7bca070384f823%3A%5Cr%5CnThis%20adds%20a%20new%20library%20function%20%60%60fetch_one_resource%60%60%20which%20performs%20a%20SQLAlchemy%20query%20and%20returns%20exactly%20one%20result.%20If%20the%20result%20set%20is%20empty%2C%20a%20%60%60ResourceNotFoundError%60%60%20is%20raised.%20Similarly%20to%20the%20PR%2C%20an%20error%20handler%20transforms%20this%20into%20a%20HTTP%20404.%5Cr%5Cn%5Cr%5CnI%20think%20this%20is%20more%20practical%20than%20the%20API%20decorator%20approach%2C%20as%20now%20we%20can%20handle%20non-existent%20resources%20at%20the%20library%20level.%20This%20has%2C%20e.g.%2C%20the%20advantage%20that%20we%20would%20also%20get%20sensible%20error%20messages%20in%20%60%60pi-manage%60%60.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-06-07T14%3A17%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Recently%20we%20were%20working%20on%20performance%20aspects.%5Cr%5CnAnd%20I%20think%20it%20is%20not%20a%20good%20idea%20%28it%20might%20have%20been%20mine%3F%20%3B-%29%20to%20add%20an%20extra%20SQL%20request%20on%20every%20request.%22%2C%20%22created_at%22%3A%20%222018-08-17T19%3A59%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1023#issuecomment-381961564'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Thanks for the PR. I would try to add the non-existing logic as decorators. I will think about it later.
- <a href='https://github.com/p53'><img border=0 src='https://avatars1.githubusercontent.com/u/5985348?v=4' height=16 width=16></a> my opinion is that i would do some fix in 2.* versions and refactoring would leave for major version, because exceptions are raised all over the code and it can produce quite many bugs...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> 404 is a REST API specific error.
I would add a decorator to the REST API level like here:
https://github.com/privacyidea/privacyidea/blob/master/privacyidea/api/event.py#L77
And change it to:
@eventhandling_blueprint.route('/actions/<handlermodule>', methods=["GET"])
@log_with(log)
@check_resource_exists(EventHandler, handlermodule)
def get_module_actions(handlermodule=None):
``check_resource_exists`` would be a generic decorator, that could check for existing objects in the models.
This is why we like to use decorators, since we can add such things without poisining the code or introducing bugs, but keeping up testability.
- <a href='https://github.com/p53'><img border=0 src='https://avatars1.githubusercontent.com/u/5985348?v=4' height=16 width=16></a> i made it with decorator, take a look
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1023?src=pr&el=h1) Report
> Merging [#1023](https://codecov.io/gh/privacyidea/privacyidea/pull/1023?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/ccdf320c236c5f50b58df6717006cf4ca22d51f3?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `98.07%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/graphs/tree.svg?src=pr&token=7nHLZki60B&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1023?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1023      +/-   ##
==========================================
+ Coverage   95.41%   95.42%   +<.01%
==========================================
Files         131      131
Lines       16211    16251      +40
==========================================
+ Hits        15468    15507      +39
- Misses        743      744       +1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1023?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.34% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/event.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50LnB5) | `98.93% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/resolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVyLnB5) | `96.64% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/realm.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3JlYWxtLnB5) | `100% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/smsprovider/SMSProvider.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Ntc3Byb3ZpZGVyL1NNU1Byb3ZpZGVyLnB5) | `92.42% <0%> (-1.43%)` | :arrow_down: |
| [privacyidea/api/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3BvbGljeS5weQ==) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/resolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Jlc29sdmVyLnB5) | `92.45% <100%> (+0.29%)` | :arrow_up: |
| [privacyidea/lib/decorators.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2RlY29yYXRvcnMucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/realm.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3JlYWxtLnB5) | `98.64% <100%> (+0.03%)` | :arrow_up: |
| [privacyidea/api/event.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2V2ZW50LnB5) | `100% <100%> (ø)` | :arrow_up: |
| ... and [2 more](https://codecov.io/gh/privacyidea/privacyidea/pull/1023/diff?src=pr&el=tree-more) | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1023?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1023?src=pr&el=footer). Last update [ccdf320...eb7778e](https://codecov.io/gh/privacyidea/privacyidea/pull/1023?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Thank you for the PR and all your work! I think returning 404s if a resource cannot be found is a good idea. However, I'm currently not sure about the specifics of the implementation. Right now, ``check_resource_exists`` queries the database to check if the referenced object exists. But the decorated function will query the database *again* with the same SELECT statement to actually retrieve the referenced object. Maybe SQLAlchemy does some caching here -- we would need to check that. Otherwise, this seems a little inefficient to me.
So honestly, I currently don't know how to implement this while keeping modularity and efficiency in mind :)
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hi @p53, just a quick update: Cornelius and I had some discussions about how to implement 404s for nonexistent resources consistently in privacyIDEA. As it turns out, similar situations also occur at the library level, where we couldn't use decorators as above -- I guess we we need to further look into this to find a good consistent solution. Thank you for all your work so far, I'll keep you posted!
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> We actually need to distinguish two cases here:
* There are some API endpoints which return a HTTP500 if a non-existent resource is referenced, e.g. the ``DELETE /event/:id`` endpoint you mentioned earlier. Modifying privacyIDEA such that it instead raises a 404 is no problem here.
* There are others which return a HTTP200 if a non-existent resource is referenced, but indicate this in the JSON response, e.g.
```
$ http DELETE http://localhost:5000/policy/doesnotexist PI-Authorization:$TOKEN
...
"result": {
"status": true,
"value": false
}
```
While I agree that returning a HTTP404 would be more appropriate, I don't think we should just modify this behavior now, as this would break backwards compatibility. Maybe we could start with just the requests which currently result in a HTTP500.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Deleting a non existing event results in **500** and a non-existing policy in **200**? This is indeed annoying. :-/
You are right. the 500er equals to status=false, so this is not a big difference. But the 200 Resp Code equals to status=true. This in fact is a rather big difference.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Based on your PR @p53 (thanks again!) and our discussions, I tried something in 834e9cd3e49aedbb77ece8c9b7bca070384f823:
This adds a new library function ``fetch_one_resource`` which performs a SQLAlchemy query and returns exactly one result. If the result set is empty, a ``ResourceNotFoundError`` is raised. Similarly to the PR, an error handler transforms this into a HTTP 404.
I think this is more practical than the API decorator approach, as now we can handle non-existent resources at the library level. This has, e.g., the advantage that we would also get sensible error messages in ``pi-manage``. What do you think?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Recently we were working on performance aspects.
And I think it is not a good idea (it might have been mine? ;-) to add an extra SQL request on every request.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1023?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1023?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1023'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>