### PR TITLE
Add ProxyFix to support X-FORWARDED-FOR

### DIFF
--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -24,6 +24,7 @@ import os.path
 import logging
 import logging.config
 import sys
+from werkzeug.contrib.fixers import ProxyFix
 from flask import Flask, request
 
 import privacyidea.api.before_after
@@ -118,6 +119,7 @@ def create_app(config_name="development",
               config_file))
     app = Flask(__name__, static_folder="static",
                 template_folder="static/templates")
+    app.wsgi_app = ProxyFix(app.wsgi_app)
     if config_name:
         app.config.from_object(config[config_name])
 


### PR DESCRIPTION
As I was deploying PrivacyIDEA behind a web server. I have noticed that PrivacyIDEA cannot detect the client ip and appearing as `127.0.0.1` although I am passing `X-FORWARDED-FOR` / `X-REAL-IP`. This issue related to Flask more than PrivacyIDEA and the fix should be by using [ProxyFix](http://werkzeug.pocoo.org/docs/0.14/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix). If there is another way that is already supported in PrivacyIDEA other than my suggestion I would be happy if you guided me to it.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1025%23issuecomment-382413918%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1025%23issuecomment-384183479%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1025%23issuecomment-384466757%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1025%23issuecomment-384543847%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1025%23issuecomment-382413918%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231025%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/050e22cff3865b366f76367251c1d9e8c6e27117%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025/graphs/tree.svg%3Fwidth%3D650%26src%3Dpr%26token%3D7nHLZki60B%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231025%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.39%25%20%20%2095.38%25%20%20%20-0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016211%20%20%20%2016213%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2015465%20%20%20%2015465%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20746%20%20%20%20%20%20748%20%20%20%20%20%20%20%2B2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/app.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBwLnB5%29%20%7C%20%6089.83%25%20%3C100%25%3E%20%28%2B0.17%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6091.66%25%20%3C0%25%3E%20%28-1.67%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B050e22c...9fe44c4%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1025%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-18T14%3A49%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thank%20you%20for%20the%20PR%21%20I%20had%20a%20look%20at%20ProxyFix%2C%20and%20its%20%5Bdocumentation%20states%5D%28http%3A//werkzeug.pocoo.org/docs/0.14/contrib/fixers/%23werkzeug.contrib.fixers.ProxyFix%29%3A%5Cr%5Cn%3E%20Do%20not%20use%20this%20middleware%20in%20non-proxy%20setups%20for%20security%20reasons.%5Cr%5Cn%5Cr%5Cnso%20we%20should%20probably%20only%20add%20the%20middleware%20in%20proxy%20setups%2C%20if%20any.%20Processing%20X-Forwarded-For%20also%20seems%20to%20have%20some%20%5Bsecurity%20implications%5D%28http%3A//totaluptime.com/kb/prevent-x-forwarded-for-spoofing-or-manipulation/%29%20on%20its%20own.%5Cr%5Cn%5Cr%5CnApart%20from%20that%2C%20we%20already%20had%20had%20an%20issue%20for%20proxy%20setups%2C%20%23356%2C%20but%20I%20wasn%27t%20around%20then%20and%20don%27t%20know%20how%20this%20works%20%3A%29%20So%20it%20might%20be%20possible%20to%20do%20this%20in%20current%20privacyIDEA%20already.%22%2C%20%22created_at%22%3A%20%222018-04-25T07%3A11%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hello%20Friedrich%2C%5Cr%5CnI%20get%20this%20correctly%2C%20You%20mean%20that%20we%20can%20modify%20the%20current%20pull%20request%20to%20make%20it%20work%20only%20if%20it%20detects%20%60X-FORWARDED-FOR%60%20header%20%3F%20or%20You%20mean%20that%20we%20should%20modify%20the%20line%20as%20Cornelius%20said%20%3F%20in%20here%5Cr%5Cn%60%60%60%5Cr%5Cng.client_ip%20%3D%20request.environ.get%28%5C%22X-Forwarded-For%5C%22%29%20or%20request.remote_addr%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222018-04-25T23%3A37%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/4104127%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mostafahussein%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20Mostafa%2C%5Cr%5CnI%20just%20tested%20this%20quickly%2C%20and%20we%20should%20already%20support%20X-Forwarded-For%20%28via%20%60%60request.access_route%60%60%29.%20But%20you%20have%20to%20add%20the%20proxy%20IP%20to%20the%20list%20of%20IPs%20that%20are%20authorized%20to%20override%20the%20client%2C%20like%20described%20%5Bhere%5D%28http%3A//privacyidea.readthedocs.io/en/latest/configuration/system_config.html%23override-authorization-client%29.%20Could%20you%20try%20this%3F%22%2C%20%22created_at%22%3A%20%222018-04-26T07%3A37%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1025#issuecomment-382413918'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1025?src=pr&el=h1) Report
> Merging [#1025](https://codecov.io/gh/privacyidea/privacyidea/pull/1025?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/050e22cff3865b366f76367251c1d9e8c6e27117?src=pr&el=desc) will **decrease** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1025/graphs/tree.svg?width=650&src=pr&token=7nHLZki60B&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1025?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1025      +/-   ##
==========================================
- Coverage   95.39%   95.38%   -0.02%
==========================================
Files         131      131
Lines       16211    16213       +2
==========================================
Hits        15465    15465
- Misses        746      748       +2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1025?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/app.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1025/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBwLnB5) | `89.83% <100%> (+0.17%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1025/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `91.66% <0%> (-1.67%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1025?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1025?src=pr&el=footer). Last update [050e22c...9fe44c4](https://codecov.io/gh/privacyidea/privacyidea/pull/1025?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Thank you for the PR! I had a look at ProxyFix, and its [documentation states](http://werkzeug.pocoo.org/docs/0.14/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix):
> Do not use this middleware in non-proxy setups for security reasons.
so we should probably only add the middleware in proxy setups, if any. Processing X-Forwarded-For also seems to have some [security implications](http://totaluptime.com/kb/prevent-x-forwarded-for-spoofing-or-manipulation/) on its own.
Apart from that, we already had had an issue for proxy setups, #356, but I wasn't around then and don't know how this works :) So it might be possible to do this in current privacyIDEA already.
- <a href='https://github.com/mostafahussein'><img border=0 src='https://avatars2.githubusercontent.com/u/4104127?v=4' height=16 width=16></a> Hello Friedrich,
I get this correctly, You mean that we can modify the current pull request to make it work only if it detects `X-FORWARDED-FOR` header ? or You mean that we should modify the line as Cornelius said ? in here
```
g.client_ip = request.environ.get("X-Forwarded-For") or request.remote_addr
```
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hi Mostafa,
I just tested this quickly, and we should already support X-Forwarded-For (via ``request.access_route``). But you have to add the proxy IP to the list of IPs that are authorized to override the client, like described [here](http://privacyidea.readthedocs.io/en/latest/configuration/system_config.html#override-authorization-client). Could you try this?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1025?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1025?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1025'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>