### PR TITLE
Allow seconds to be used in auth_cache

### DIFF
--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -382,33 +382,6 @@ def get_data_from_params(params, exclude_params, config_description, module,
     return data, types, desc
 
 
-def parse_timedelta(delta):
-    """
-    This parses a string that contains a time delta for the last_auth policy
-    in the format like
-    1m (minute), 1h, 1d, 1y.
-
-    :param delta: The time delta
-    :type delta: basestring
-    :return: timedelta
-    """
-    delta = delta.strip().replace(" ", "")
-    time_specifier = delta[-1].lower()
-    if time_specifier not in ["m", "h", "d", "y"]:
-        raise Exception("Invalid time specifier")
-    time = int(delta[:-1])
-    if time_specifier == "h":
-        td = timedelta(hours=time)
-    elif time_specifier == "d":
-        td = timedelta(days=time)
-    elif time_specifier == "y":
-        td = timedelta(days=time*365)
-    else:
-        td = timedelta(minutes=time)
-
-    return td
-
-
 def parse_timelimit(limit):
     """
     This parses a string that contains a timelimit in the format
@@ -779,10 +752,10 @@ def parse_legacy_time(ts, return_date=False):
         return d.strftime(DATE_FORMAT)
 
 
-def parse_time_delta(s):
+def parse_timedelta(s):
     """
     parses a string like +5d or -30m and returns a timedelta.
-    Allowed identifiers are s, m, h, d.
+    Allowed identifiers are s, m, h, d, y.
     
     :param s: a string like +30m or -5d
     :return: timedelta 
@@ -791,7 +764,7 @@ def parse_time_delta(s):
     minutes = 0
     hours = 0
     days = 0
-    m = re.match("([+-])(\d+)([smhd])$", s)
+    m = re.match("\s*([+-]?)\s*(\d+)\s*([smhdy])\s*$", s)
     if not m:
         log.warning("Unsupported timedelta: {0!r}".format(s))
         raise Exception("Unsupported timedelta")
@@ -806,6 +779,8 @@ def parse_time_delta(s):
         hours = count
     elif m.group(3) == "d":
         days = count
+    elif m.group(3) == "y":
+        days = 365 * count
 
     td = timedelta(seconds=seconds, minutes=minutes, hours=hours, days=days)
     return td
@@ -834,7 +809,7 @@ def parse_time_offset_from_now(s):
         s2 = m.group(2)
         s3 = m.group(3)
         s = s1 + s3
-        td = parse_time_delta(s2)
+        td = parse_timedelta(s2)
 
     return s, td
 

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -4,14 +4,14 @@ This tests the file lib.utils
 """
 from .base import MyTestCase
 
-from privacyidea.lib.utils import (parse_timelimit, parse_timedelta,
+from privacyidea.lib.utils import (parse_timelimit,
                                    check_time_in_range, parse_proxy,
                                    check_proxy, reduce_realms, is_true,
                                    parse_date, compare_condition,
                                    get_data_from_params, parse_legacy_time,
                                    int_to_hex, compare_value_value,
                                    parse_time_offset_from_now,
-                                   parse_time_delta, to_unicode,
+                                   parse_timedelta, to_unicode,
                                    hash_password, PasswordHash, check_ssha,
                                    check_sha, otrs_sha256, parse_int)
 from datetime import timedelta, datetime
@@ -329,19 +329,21 @@ class UtilsTestCase(MyTestCase):
             ">", datetime.now(tzlocal()).strftime(DATE_FORMAT)))
 
     def test_13_parse_time_offset_from_now(self):
-        td = parse_time_delta("+5s")
+        td = parse_timedelta("+5s")
         self.assertEqual(td, timedelta(seconds=5))
-        td = parse_time_delta("-12m")
+        td = parse_timedelta("-12m")
         self.assertEqual(td, timedelta(minutes=-12))
-        td = parse_time_delta("+123h")
+        td = parse_timedelta("+123h")
         self.assertEqual(td, timedelta(hours=123))
-        td = parse_time_delta("+2d")
+        td = parse_timedelta("+2d")
         self.assertEqual(td, timedelta(days=2))
 
-        # Does not start with plus or minus
-        self.assertRaises(Exception, parse_time_delta, "12d")
+        # It is allowed to start without a +/- which would mean a +
+        td = parse_timedelta("12d")
+        self.assertEqual(td, timedelta(days=12))
+
         # Does not contains numbers
-        self.assertRaises(Exception, parse_time_delta, "+twod")
+        self.assertRaises(Exception, parse_timedelta, "+twod")
 
         s, td = parse_time_offset_from_now("Hello {now}+5d with 5 days.")
         self.assertEqual(s, "Hello {now} with 5 days.")


### PR DESCRIPTION
Consolidate two parse time delta functions and
allow seconds to be used in the authentication cache.

Closes #1033
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1035%23issuecomment-383835231%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1035%23discussion_r183715271%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1035%23discussion_r183752356%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1035%23discussion_r183753689%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1035%23issuecomment-383835231%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231035%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/834ff2f77c37863244a94a58ae7b159d70bbc809%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231035%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.39%25%20%20%2095.41%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016211%20%20%20%2016199%20%20%20%20%20%20-12%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2015465%20%20%20%2015456%20%20%20%20%20%20%20-9%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20746%20%20%20%20%20%20743%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5%29%20%7C%20%6096.68%25%20%3C100%25%3E%20%28-0.09%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B2.5%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B834ff2f...917edcd%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1035%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-04-24T07%3A42%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20917edcd3e54c205638a5a47019a0f93b1ed0ce10%20privacyidea/lib/utils.py%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1035%23discussion_r183715271%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20we%20need%20a%20safeguard%20for%20callers%20which%20expect%20positive%20timedeltas%3F%20Like%20an%20argument%20%60%60ensure_positive%3DTrue%60%60%20%28as%20e.g.%20for%20the%20auth%20cache%29%3F%5Cr%5Cn%5Cr%5CnBut%20I%20guess%20following%20shit-in-shit-out%20would%20also%20be%20OK...%22%2C%20%22created_at%22%3A%20%222018-04-24T12%3A48%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%20there%20was%20no%20safeguard%20in%20the%20past.%20I%20in%20the%20past%20the%20old%20method%20would%20be%20called%20with%20a%20%5C%22-7d%5C%22%20it%20would%20actually%20result%20in%20minus%207%20days%2C%20since%20the%20old%2C%20deprecated%20method%20simply%20did%20an%20%5Cr%5Cn%5Cr%5Cn%20%20int%28%5C%22-7%5C%22%29%5Cr%5Cn%5Cr%5Cnwhich%20had%20the%20same%20result.%22%2C%20%22created_at%22%3A%20%222018-04-24T14%3A28%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20yes%2C%20you%27re%20right.%22%2C%20%22created_at%22%3A%20%222018-04-24T14%3A32%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/utils.py%3AL752-762%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1035#issuecomment-383835231'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1035?src=pr&el=h1) Report
> Merging [#1035](https://codecov.io/gh/privacyidea/privacyidea/pull/1035?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/834ff2f77c37863244a94a58ae7b159d70bbc809?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1035/graphs/tree.svg?token=7nHLZki60B&src=pr&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1035?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1035      +/-   ##
==========================================
+ Coverage   95.39%   95.41%   +0.01%
==========================================
Files         131      131
Lines       16211    16199      -12
==========================================
- Hits        15465    15456       -9
+ Misses        746      743       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1035?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1035/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5) | `96.68% <100%> (-0.09%)` | :arrow_down: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1035/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+2.5%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1035?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1035?src=pr&el=footer). Last update [834ff2f...917edcd](https://codecov.io/gh/privacyidea/privacyidea/pull/1035?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 917edcd3e54c205638a5a47019a0f93b1ed0ce10 privacyidea/lib/utils.py 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1035#discussion_r183715271'>File: privacyidea/lib/utils.py:L752-762</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Do we need a safeguard for callers which expect positive timedeltas? Like an argument ``ensure_positive=True`` (as e.g. for the auth cache)?
But I guess following shit-in-shit-out would also be OK...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Actually there was no safeguard in the past. I in the past the old method would be called with a "-7d" it would actually result in minus 7 days, since the old, deprecated method simply did an
int("-7")
which had the same result.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah yes, you're right.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1035?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1035?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1035'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>