### PR TITLE
Add support for multiple where conditions in SQL resolver

### DIFF
--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -126,17 +126,19 @@ class IdResolver (UserIdResolver):
         :return: list of filter conditions
         """
         if where:
-            # this might result in errors if the
-            # administrator enters nonsense
-            (w_column, w_cond, w_value) = where.split()
-            if w_cond.lower() == "like":
-                conditions.append(getattr(table, w_column).like(w_value))
-            elif w_cond == "==":
-                conditions.append(getattr(table, w_column) == w_value)
-            elif w_cond == ">":
-                conditions.append(getattr(table, w_column) > w_value)
-            elif w_cond == "<":
-                conditions.append(getattr(table, w_column) < w_value)
+            parts = where.split("and")
+            for part in parts:
+                # this might result in errors if the
+                # administrator enters nonsense
+                (w_column, w_cond, w_value) = part.split()
+                if w_cond.lower() == "like":
+                    conditions.append(getattr(table, w_column).like(w_value))
+                elif w_cond == "==":
+                    conditions.append(getattr(table, w_column) == w_value)
+                elif w_cond == ">":
+                    conditions.append(getattr(table, w_column) > w_value)
+                elif w_cond == "<":
+                    conditions.append(getattr(table, w_column) < w_value)
 
         return conditions
 

--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -126,7 +126,7 @@ class IdResolver (UserIdResolver):
         :return: list of filter conditions
         """
         if where:
-            parts = where.split("and")
+            parts = where.split(" and ")
             for part in parts:
                 # this might result in errors if the
                 # administrator enters nonsense

--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -30,6 +30,7 @@ The file is tested in tests/test_lib_resolver.py
 
 import logging
 import yaml
+import re
 
 from UserIdResolver import UserIdResolver
 
@@ -126,7 +127,7 @@ class IdResolver (UserIdResolver):
         :return: list of filter conditions
         """
         if where:
-            parts = where.split(" and ")
+            parts = re.split(' and ', where, flags=re.IGNORECASE)
             for part in parts:
                 # this might result in errors if the
                 # administrator enters nonsense

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -300,6 +300,12 @@ class SQLResolverTestCase(MyTestCase):
                                                               "== test"}.items()))
         userlist = y.getUserList()
         self.assertTrue(len(userlist) == 0, userlist)
+        
+        y = SQLResolver()
+        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
+                                                              "chandler"}.items()))
+        userlist = y.getUserList()
+        self.assertTrue(len(userlist) == 0, userlist)
 
     def test_99_testconnection_fail(self):
         y = SQLResolver()

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -285,6 +285,21 @@ class SQLResolverTestCase(MyTestCase):
         self.assertFalse(uid)
         uid = y.getUserId("achmed")
         self.assertFalse(uid)
+        
+    def test_06_append_where_filter(self):
+        y = SQLResolver()
+        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
+                                                              "hans and name "
+                                                              "== dampf"}.items()))
+        userlist = y.getUserList()
+        self.assertTrue(len(userlist) == 1, userlist)
+        
+        y = SQLResolver()
+        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
+                                                              "hans and name "
+                                                              "== test"}.items()))
+        userlist = y.getUserList()
+        self.assertTrue(len(userlist) == 0, userlist)
 
     def test_99_testconnection_fail(self):
         y = SQLResolver()

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -296,6 +296,13 @@ class SQLResolverTestCase(MyTestCase):
         
         y = SQLResolver()
         y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
+                                                              "hans AND name "
+                                                              "== dampf"}.items()))
+        userlist = y.getUserList()
+        self.assertTrue(len(userlist) == 1, userlist)
+        
+        y = SQLResolver()
+        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
                                                               "hans and name "
                                                               "== test"}.items()))
         userlist = y.getUserList()


### PR DESCRIPTION
This adds support for multiple where conditions (only and is possible, needs to be spelled lower case) in the SQL resolver.

Test cases are included. I did not succeed in checking only the _append_where_condition method, so I'm also using the user list for this purpose.

See #1039
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1041%23issuecomment-386247494%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1041%23issuecomment-386283940%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1041%23issuecomment-386292218%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1041%23discussion_r186075289%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1041%23discussion_r186087693%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1041%23issuecomment-386247494%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20%40andyboeh%2C%20thank%20you%20for%20the%20PR%21%20I%27ve%20only%20had%20a%20quick%20look%20yet%2C%20but%20I%27m%20a%20bit%20worried%20about%20breaking%20existing%20installations%20if%20the%20user-supplied%20WHERE%20clause%20contains%20the%20string%20%60%60and%60%60%20somewhere%2C%20e.g.%20%60%60givenname%20%3D%3D%20chandler%60%60.%20I%20think%20this%20would%20create%20a%20malformed%20condition%20because%5Cr%5Cn%60%60%60python%5Cr%5Cn%3E%3E%3E%20%5C%22givenname%20%3D%3D%20chandler%5C%22.split%28%5C%22and%5C%22%29%5Cr%5Cn%5B%27givenname%20%3D%3D%20ch%27%2C%20%27ler%27%5D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnMaybe%20it%20would%20be%20better%20to%20split%20the%20WHERE%20clause%20at%20spaces%20like%20before%2C%20and%20then%20iterate%20over%20it%20and%20add%20a%20condition%20only%20if%20the%20next%20token%20is%20%5C%22and%5C%22%3F%22%2C%20%22created_at%22%3A%20%222018-05-03T10%3A05%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20completely%20right%2C%20that%20is%20a%20bad%20mistake%20and%20an%20example%20of%20a%20bad%20test%20case%21%5Cr%5CnI%27m%20going%20to%20refactor%20that%2C%20splitting%20for%20%5C%22and%5C%22%20first%20was%20just%20the%20most%20ovious%20way%20to%20go.%20Another%20possiblity%20would%20be%20probably%20to%20split%20at%20%5C%22%20and%20%5C%22%20%28note%20the%20spaces%29%20instead.%20I%27ll%20add%20another%20test%20case%20for%20%5C%22chandler%5C%22%2C%20as%20you%20suggested.%22%2C%20%22created_at%22%3A%20%222018-05-03T12%3A48%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3099753%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231041%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/c8cb96c74b97815339914a92fbc94b43a97d788a%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041/graphs/tree.svg%3Fwidth%3D650%26src%3Dpr%26token%3D7nHLZki60B%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231041%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.41%25%20%20%2095.41%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016199%20%20%20%2016201%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015456%20%20%20%2015458%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20743%20%20%20%20%20%20743%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/SQLIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TUUxJZFJlc29sdmVyLnB5%29%20%7C%20%6097.44%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bc8cb96c...a0dde78%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1041%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-05-03T13%3A18%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a0dde786a09e086c7511e82002b1925e395723da%20privacyidea/lib/resolvers/SQLIdResolver.py%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1041%23discussion_r186075289%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Many%20people%20use%20a%20capital%20%5C%22AND%5C%22%20in%20an%20SQL%20syntax.%20Do%20you%20thing%20we%20should%20split%20for%20%60%60%5C%22%20AND%20%5C%22%60%60.%20Currently%20I%20can%20not%20think%20about%20an%20_easy_%20way%20to%20split%20for%20lower%20or%20upper%20AND.%22%2C%20%22created_at%22%3A%20%222018-05-04T13%3A04%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20could%20also%20use%20%60%60re.split%60%60%3A%5Cr%5Cn%60%60%60python%5Cr%5Cn%3E%3E%3E%20x%20%3D%20%27a%20%3D%3D%20x%20and%20b%20LIKE%20c%20AND%20c%20%3D%3D%20d%20aNd%20foo%20%3C%20bar%27%5Cr%5Cn%3E%3E%3E%20re.split%28%27%20and%20%27%2C%20x%2C%20flags%3Dre.IGNORECASE%29%5Cr%5Cn%5B%27a%20%3D%3D%20x%27%2C%20%27b%20LIKE%20c%27%2C%20%27c%20%3D%3D%20d%27%2C%20%27foo%20%3C%20bar%27%5D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222018-05-04T13%3A49%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/SQLIdResolver.py%3AL126-145%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1041#issuecomment-386247494'>General Comment</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hi @andyboeh, thank you for the PR! I've only had a quick look yet, but I'm a bit worried about breaking existing installations if the user-supplied WHERE clause contains the string ``and`` somewhere, e.g. ``givenname == chandler``. I think this would create a malformed condition because
```python
>>> "givenname == chandler".split("and")
['givenname == ch', 'ler']
```
Maybe it would be better to split the WHERE clause at spaces like before, and then iterate over it and add a condition only if the next token is "and"?
- <a href='https://github.com/andyboeh'><img border=0 src='https://avatars3.githubusercontent.com/u/3099753?v=4' height=16 width=16></a> You are completely right, that is a bad mistake and an example of a bad test case!
I'm going to refactor that, splitting for "and" first was just the most ovious way to go. Another possiblity would be probably to split at " and " (note the spaces) instead. I'll add another test case for "chandler", as you suggested.
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1041?src=pr&el=h1) Report
> Merging [#1041](https://codecov.io/gh/privacyidea/privacyidea/pull/1041?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/c8cb96c74b97815339914a92fbc94b43a97d788a?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1041/graphs/tree.svg?width=650&src=pr&token=7nHLZki60B&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1041?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1041      +/-   ##
==========================================
+ Coverage   95.41%   95.41%   +<.01%
==========================================
Files         131      131
Lines       16199    16201       +2
==========================================
+ Hits        15456    15458       +2
Misses        743      743
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1041?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/SQLIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1041/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TUUxJZFJlc29sdmVyLnB5) | `97.44% <100%> (+0.01%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1041?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1041?src=pr&el=footer). Last update [c8cb96c...a0dde78](https://codecov.io/gh/privacyidea/privacyidea/pull/1041?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull a0dde786a09e086c7511e82002b1925e395723da privacyidea/lib/resolvers/SQLIdResolver.py 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1041#discussion_r186075289'>File: privacyidea/lib/resolvers/SQLIdResolver.py:L126-145</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Many people use a capital "AND" in an SQL syntax. Do you thing we should split for ``" AND "``. Currently I can not think about an _easy_ way to split for lower or upper AND.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> We could also use ``re.split``:
```python
>>> x = 'a == x and b LIKE c AND c == d aNd foo < bar'
>>> re.split(' and ', x, flags=re.IGNORECASE)
['a == x', 'b LIKE c', 'c == d', 'foo < bar']
```


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1041?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1041?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1041'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>