### PR TITLE
Remove sms.Provider from tokeninfo

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -499,7 +499,7 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
         var entries = ["radius.server", "radius.secret", "remote.server",
             "radius.identifier",
             "totp.hashlib", "hotp.hashlib", "email.mailserver",
-            "email.mailfrom", "sms.Provider", "yubico.id", "tiqr.regServer"];
+            "email.mailfrom", "yubico.id", "tiqr.regServer"];
         entries.forEach(function(entry) {
             if (!$scope.form[entry]) {
                 // preset the UI

--- a/privacyidea/static/components/token/views/token.enroll.sms.html
+++ b/privacyidea/static/components/token/views/token.enroll.sms.html
@@ -4,7 +4,7 @@
 
 <h4 translate>Token data</h4>
 
-<div ng-hide="form['sms.Provider']" translate class="bg-danger">
+<div translate class="bg-info">
     For SMS tokens to work properly you need to set the
     <a ui-sref="config.tokens({tokentype:'sms'})">SMS Token Config</a>!
 </div>


### PR DESCRIPTION
The sms.Provider is a deprecated config, that is
not used anymore.

Closes #993
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1051%23issuecomment-387047492%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1051%23issuecomment-387108943%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1051%23issuecomment-387317788%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1051%23issuecomment-387047492%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231051%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/2c8870b43d11d25750b1e038ee381014e93b771d%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051/graphs/tree.svg%3Fwidth%3D650%26src%3Dpr%26token%3D7nHLZki60B%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231051%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.4%25%20%20%2095.41%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016209%20%20%20%2016209%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015464%20%20%20%2015466%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20745%20%20%20%20%20%20743%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B2c8870b...abec841%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1051%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-05-07T12%3A20%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20good%20to%20me%21%5Cr%5CnBut%20should%20we%2C%20in%20addition%2C%20also%20remove%20this%20from%20configController.js%3F%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/4b58bd5d9a7a7423a03b8bdacd693869ec760afc/privacyidea/static/components/config/controllers/configControllers.js%23L406%22%2C%20%22created_at%22%3A%20%222018-05-07T15%3A47%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20checked%20this%20and%20I%20am%20not%20sure%20about%20this.%20This%20is%20the%20system%20wide%20config%20that%20is%20loaded%20as%20deprecated%20config%20for%20displaying%20reasons.%20I%20%5C%22only%5C%22%20removed%20the%20token%20specific%20sms-provider.%22%2C%20%22created_at%22%3A%20%222018-05-08T07%3A56%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1051#issuecomment-387047492'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1051?src=pr&el=h1) Report
> Merging [#1051](https://codecov.io/gh/privacyidea/privacyidea/pull/1051?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/2c8870b43d11d25750b1e038ee381014e93b771d?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1051/graphs/tree.svg?width=650&src=pr&token=7nHLZki60B&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1051?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1051      +/-   ##
==========================================
+ Coverage    95.4%   95.41%   +0.01%
==========================================
Files         131      131
Lines       16209    16209
==========================================
+ Hits        15464    15466       +2
+ Misses        745      743       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1051?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1051/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1051?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1051?src=pr&el=footer). Last update [2c8870b...abec841](https://codecov.io/gh/privacyidea/privacyidea/pull/1051?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Looks good to me!
But should we, in addition, also remove this from configController.js?
https://github.com/privacyidea/privacyidea/blob/4b58bd5d9a7a7423a03b8bdacd693869ec760afc/privacyidea/static/components/config/controllers/configControllers.js#L406
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I checked this and I am not sure about this. This is the system wide config that is loaded as deprecated config for displaying reasons. I "only" removed the token specific sms-provider.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1051?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1051?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1051'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>