### PR TITLE
WIP: Write shorter messages to audit log

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -710,7 +710,7 @@ def autoassign(request, response):
 
                                 g.audit_object.log(
                                     {"success": True,
-                                     "action_info":
+                                     "info":
                                          "Token assigned via auto assignment",
                                      "serial": token_obj.token.serial})
                                 break

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -347,7 +347,11 @@ def check():
     else:
         result, details = check_user_pass(user, password, options=options)
 
-    g.audit_object.log({"info": details.get("message"),
+    if "info" in details:
+        info = details.pop("info")
+    else:
+        info = details.get("message")
+    g.audit_object.log({"info": info,
                         "success": result,
                         "serial": serial or details.get("serial"),
                         "tokentype": details.get("type")})
@@ -445,7 +449,11 @@ def samlcheck():
             for k, v in ui.iteritems():
                 result_obj["attributes"][k] = v
 
-    g.audit_object.log({"info": details.get("message"),
+    if "info" in details:
+        info = details.pop("info")
+    else:
+        info = details.get("message")
+    g.audit_object.log({"info": info,
                         "success": auth,
                         "serial": details.get("serial"),
                         "tokentype": details.get("type"),

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -347,11 +347,7 @@ def check():
     else:
         result, details = check_user_pass(user, password, options=options)
 
-    if "info" in details:
-        info = details.pop("info")
-    else:
-        info = details.get("message")
-    g.audit_object.log({"info": info,
+    g.audit_object.log({"info": details.get("message"),
                         "success": result,
                         "serial": serial or details.get("serial"),
                         "tokentype": details.get("type")})
@@ -449,11 +445,7 @@ def samlcheck():
             for k, v in ui.iteritems():
                 result_obj["attributes"][k] = v
 
-    if "info" in details:
-        info = details.pop("info")
-    else:
-        info = details.get("message")
-    g.audit_object.log({"info": info,
+    g.audit_object.log({"info": details.get("message"),
                         "success": auth,
                         "serial": details.get("serial"),
                         "tokentype": details.get("type"),

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -227,9 +227,10 @@ def auth_user_has_no_token(wrapped_function, user_object, passw,
             # Now we need to check, if the user really has no token.
             tokencount = get_tokens(user=user_object, count=True)
             if tokencount == 0:
+                policy_name = pass_no_token[0].get("name")
                 return True, {"message": "The user has no token, but is "
-                                         "accepted due to policy '%s'." %
-                                         pass_no_token[0].get("name")}
+                                         "accepted due to policy '%s'." % policy_name,
+                              "info": u"user has no token, accepted by '{!s}'".format(policy_name)}
 
     # If nothing else returned, we return the wrapped function
     return wrapped_function(user_object, passw, options)
@@ -265,9 +266,11 @@ def auth_user_does_not_exist(wrapped_function, user_object, passw,
         if pass_no_user:
             # Check if user object exists
             if not user_object.exist():
+                policy_name = pass_no_user[0].get("name")
                 return True, {"message": "The user does not exist, but is "
                                          "accepted due to policy '%s'." %
-                                         pass_no_user[0].get("name")}
+                                         policy_name,
+                              "info": u"user does not exist, accepted due to '{!s}'".format(policy_name)}
 
     # If nothing else returned, we return the wrapped function
     return wrapped_function(user_object, passw, options)
@@ -312,7 +315,9 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
                 if user_object.check_password(passw):
                     return True, {"message": "The user authenticated against "
                                              "his userstore according to "
-                                             "policy '%s'." % policy_name}
+                                             "policy '%s'." % policy_name,
+                                  "info": u"against userstore according to '{!s}'".format(
+                                      policy_name)}
             else:
                 # We are doing RADIUS passthru
                 log.info("Forwarding the authentication request to the radius "
@@ -323,7 +328,9 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
                     return True, {'message': "The user authenticated against "
                                              "the RADIUS server %s according "
                                              "to policy '%s'." %
-                                             (pass_thru_action, policy_name)}
+                                             (pass_thru_action, policy_name),
+                                  'info': u"against RADIUS server {!s} according to '{!s}'".format(
+                                      pass_thru_action, policy_name)}
 
     # If nothing else returned, we return the wrapped function
     return wrapped_function(user_object, passw, options)

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -227,10 +227,8 @@ def auth_user_has_no_token(wrapped_function, user_object, passw,
             # Now we need to check, if the user really has no token.
             tokencount = get_tokens(user=user_object, count=True)
             if tokencount == 0:
-                policy_name = pass_no_token[0].get("name")
-                return True, {"message": "The user has no token, but is "
-                                         "accepted due to policy '%s'." % policy_name,
-                              "info": u"user has no token, accepted by '{!s}'".format(policy_name)}
+                return True, {"message": u"user has no token, accepted by '{!s}'".format(
+                    pass_no_token[0].get("name"))}
 
     # If nothing else returned, we return the wrapped function
     return wrapped_function(user_object, passw, options)
@@ -266,11 +264,8 @@ def auth_user_does_not_exist(wrapped_function, user_object, passw,
         if pass_no_user:
             # Check if user object exists
             if not user_object.exist():
-                policy_name = pass_no_user[0].get("name")
-                return True, {"message": "The user does not exist, but is "
-                                         "accepted due to policy '%s'." %
-                                         policy_name,
-                              "info": u"user does not exist, accepted due to '{!s}'".format(policy_name)}
+                return True, {"message": u"user does not exist, accepted due to '{!s}'".format(
+                    pass_no_user[0].get("name"))}
 
     # If nothing else returned, we return the wrapped function
     return wrapped_function(user_object, passw, options)
@@ -313,10 +308,7 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
             if pass_thru_action in ["userstore", True]:
                 # Now we need to check the userstore password
                 if user_object.check_password(passw):
-                    return True, {"message": "The user authenticated against "
-                                             "his userstore according to "
-                                             "policy '%s'." % policy_name,
-                                  "info": u"against userstore according to '{!s}'".format(
+                    return True, {"message": u"against userstore according to '{!s}'".format(
                                       policy_name)}
             else:
                 # We are doing RADIUS passthru
@@ -325,11 +317,7 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
                 radius = get_radius(pass_thru_action)
                 r = radius.request(radius.config, user_object.login, passw)
                 if r:
-                    return True, {'message': "The user authenticated against "
-                                             "the RADIUS server %s according "
-                                             "to policy '%s'." %
-                                             (pass_thru_action, policy_name),
-                                  'info': u"against RADIUS server {!s} according to '{!s}'".format(
+                    return True, {'message': u"against RADIUS server {!s} according to '{!s}'".format(
                                       pass_thru_action, policy_name)}
 
     # If nothing else returned, we return the wrapped function

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -227,7 +227,7 @@ def auth_user_has_no_token(wrapped_function, user_object, passw,
             # Now we need to check, if the user really has no token.
             tokencount = get_tokens(user=user_object, count=True)
             if tokencount == 0:
-                return True, {"message": u"user has no token, accepted by '{!s}'".format(
+                return True, {"message": u"user has no token, accepted due to '{!s}'".format(
                     pass_no_token[0].get("name"))}
 
     # If nothing else returned, we return the wrapped function
@@ -308,7 +308,7 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
             if pass_thru_action in ["userstore", True]:
                 # Now we need to check the userstore password
                 if user_object.check_password(passw):
-                    return True, {"message": u"against userstore according to '{!s}'".format(
+                    return True, {"message": u"against userstore due to '{!s}'".format(
                                       policy_name)}
             else:
                 # We are doing RADIUS passthru
@@ -317,7 +317,7 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
                 radius = get_radius(pass_thru_action)
                 r = radius.request(radius.config, user_object.login, passw)
                 if r:
-                    return True, {'message': u"against RADIUS server {!s} according to '{!s}'".format(
+                    return True, {'message': u"against RADIUS server {!s} due to '{!s}'".format(
                                       pass_thru_action, policy_name)}
 
     # If nothing else returned, we return the wrapped function

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1545,7 +1545,7 @@ class ValidateAPITestCase(MyTestCase):
             detail = json.loads(res.data).get("detail")
             self.assertEqual(detail.get("message"),
                              u"user has no token, "
-                             u"accepted due to policy 'pass_no'")
+                             u"accepted due to 'pass_no'")
 
         r = get_tokens(user=User(user, self.realm2), count=True)
         self.assertEqual(r, 1)

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1527,8 +1527,8 @@ class ValidateAPITestCase(MyTestCase):
             self.assertEqual(result.get("value"), True)
             detail = json.loads(res.data).get("detail")
             self.assertEqual(detail.get("message"),
-                             u"The user does not exist, but is accepted "
-                             u"due to policy 'pass_no'.")
+                             u"user does not exist, accepted "
+                             u"due to 'pass_no'")
 
         r = get_tokens(user=User(user, self.realm2), count=True)
         self.assertEqual(r, 1)
@@ -1544,8 +1544,8 @@ class ValidateAPITestCase(MyTestCase):
             self.assertEqual(result.get("value"), True)
             detail = json.loads(res.data).get("detail")
             self.assertEqual(detail.get("message"),
-                             u"The user has no token, but is "
-                             u"accepted due to policy 'pass_no'.")
+                             u"user has no token, "
+                             u"accepted due to policy 'pass_no'")
 
         r = get_tokens(user=User(user, self.realm2), count=True)
         self.assertEqual(r, 1)
@@ -1600,7 +1600,7 @@ class ValidateAPITestCase(MyTestCase):
             self.assertTrue(res.status_code == 200, res)
             detail = json.loads(res.data).get("detail")
             self.assertEqual(detail.get("message"),
-                             u'The user does not exist, but is accepted due to policy \'pol1\'.')
+                             u'user does not exist, accepted due to \'pol1\'')
         delete_policy("pol1")
 
     @responses.activate

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -185,8 +185,8 @@ class LibPolicyTestCase(MyTestCase):
                                         options=options)
         self.assertTrue(rv[0])
         self.assertEqual(rv[1].get("message"),
-                         u"The user does not exist, but is accepted due "
-                         u"to policy 'pol1'.")
+                         u"user does not exist, accepted due "
+                         u"to 'pol1'")
         delete_policy("pol1")
 
     def test_04a_user_does_not_exist_without_resolver(self):
@@ -210,8 +210,8 @@ class LibPolicyTestCase(MyTestCase):
                                       options=options)
         self.assertTrue(rv[0])
         self.assertEqual(rv[1].get("message"),
-                         u"The user does not exist, but is accepted due "
-                         u"to policy 'pol1'.")
+                         u"user does not exist, accepted due "
+                         u"to 'pol1'")
         delete_policy("pol1")
 
     def test_05_user_has_no_tokens(self):
@@ -235,8 +235,8 @@ class LibPolicyTestCase(MyTestCase):
                                       options=options)
         self.assertTrue(rv[0])
         self.assertEqual(rv[1].get("message"),
-                         u"The user has no token, but is accepted due to "
-                         u"policy 'pol1'.")
+                         u"user has no token, accepted due to "
+                         u"'pol1'")
         delete_policy("pol1")
 
     @radiusmock.activate
@@ -263,8 +263,7 @@ class LibPolicyTestCase(MyTestCase):
                                 options=options)
         self.assertTrue(rv[0])
         self.assertEqual(rv[1].get("message"),
-                         u"The user authenticated against his userstore "
-                         u"according to policy 'pol1'.")
+                         u"against userstore due to 'pol1'")
 
         # Now set a PASSTHRU policy to the userstore (new style)
         set_policy(name="pol1",
@@ -277,8 +276,7 @@ class LibPolicyTestCase(MyTestCase):
                                 options=options)
         self.assertTrue(rv[0])
         self.assertEqual(rv[1].get("message"),
-                         u"The user authenticated against his userstore "
-                         u"according to policy 'pol1'.")
+                         u"against userstore due to 'pol1'")
 
         # Now set a PASSTHRU policy to a RADIUS config (new style)
         radiusmock.setdata(success=True)
@@ -295,8 +293,7 @@ class LibPolicyTestCase(MyTestCase):
                                 options=options)
         self.assertTrue(rv[0])
         self.assertEqual(rv[1].get("message"),
-                         u"The user authenticated against the RADIUS server "
-                         u"radiusconfig1 according to policy 'pol1'.")
+                         u"against RADIUS server radiusconfig1 due to 'pol1'")
 
         # Now assign a token to the user. If the user has a token and the
         # passthru policy is set, the user must not be able to authenticate


### PR DESCRIPTION
The policies in question add helpful human-readable ``message``s to the JSON responses, which are also used for the ``info`` value in the audit log. I wouldn't like to shorten them -- so I added a temporary ``info`` field for shorter messages, which will be used if present.

I'm not so happy with the solution, so comments are of course very welcome!

Closes #1037
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1054%23discussion_r186450584%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1054%23discussion_r186454332%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1054%23issuecomment-387155124%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1054%23issuecomment-387156628%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1054%23issuecomment-387183542%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1054%23issuecomment-387155124%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231054%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/2c8870b43d11d25750b1e038ee381014e93b771d%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.23%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26height%3D150%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231054%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.4%25%20%20%2095.64%25%20%20%20%2B0.23%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016209%20%20%20%2017022%20%20%20%20%20%2B813%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015464%20%20%20%2016280%20%20%20%20%20%2B816%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20745%20%20%20%20%20%20742%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6096.29%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policydecorators.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk%3D%29%20%7C%20%6097.92%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/radiusserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3JhZGl1c3NlcnZlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/radiusserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3JhZGl1c3NlcnZlci5weQ%3D%3D%29%20%7C%20%6097.59%25%20%3C0%25%3E%20%28%2B0.18%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6099.21%25%20%3C0%25%3E%20%28%2B0.45%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/SQLIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TUUxJZFJlc29sdmVyLnB5%29%20%7C%20%6098.02%25%20%3C0%25%3E%20%28%2B0.55%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5%29%20%7C%20%6097.36%25%20%3C0%25%3E%20%28%2B0.59%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/auditmodules/sqlaudit.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2F1ZGl0bW9kdWxlcy9zcWxhdWRpdC5weQ%3D%3D%29%20%7C%20%6094.83%25%20%3C0%25%3E%20%28%2B1.53%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B2c8870b...1f27c0e%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1054%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-05-07T18%3A17%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Alright%21%20I%20was%20a%20bit%20hesitant%20to%20change%20them%20because%20they%20are%20user-facing.%20I%20pushed%20a%20new%20version%20and%20also%20modified%20the%20unit%20tests%20to%20work%20with%20the%20shorter%20strings.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-05-07T18%3A21%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20good%20to%20me%20%3A-%29%20thx%21%22%2C%20%22created_at%22%3A%20%222018-05-07T19%3A55%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20fa20585fd2603fad1d5c15f693150d09470aa638%20privacyidea/api/lib/postpolicy.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1054%23discussion_r186450584%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20changed%20this%20to%20%60%60info%60%60%20because%20the%20%60%60action_info%60%60%20value%20never%20ends%20up%20in%20the%20audit%20log.%22%2C%20%22created_at%22%3A%20%222018-05-07T15%3A00%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20the%20texts%20you%20changed%20are%20ok.%20So%20you%20could%20directly%20add%20them%20to%20the%20%5C%22message%5C%22%20key.%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%5C%22message%5C%22%3A%20u%5C%22user%20has%20no%20token%2C%20accepted%20by%20%27%7B%21s%7D%27%5C%22.format%28policy_name%29%5Cr%5Cn%5Cr%5CnI%20think%20the%20double%20entries%20of%20message%20and%20info%20are%20a%20bit%20too%20confusing.%22%2C%20%22created_at%22%3A%20%222018-05-07T15%3A13%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/lib/postpolicy.py%3AL710-717%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull fa20585fd2603fad1d5c15f693150d09470aa638 privacyidea/api/lib/postpolicy.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1054#discussion_r186450584'>File: privacyidea/api/lib/postpolicy.py:L710-717</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I changed this to ``info`` because the ``action_info`` value never ends up in the audit log.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think the texts you changed are ok. So you could directly add them to the "message" key.
"message": u"user has no token, accepted by '{!s}'".format(policy_name)
I think the double entries of message and info are a bit too confusing.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1054#issuecomment-387155124'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1054?src=pr&el=h1) Report
> Merging [#1054](https://codecov.io/gh/privacyidea/privacyidea/pull/1054?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/2c8870b43d11d25750b1e038ee381014e93b771d?src=pr&el=desc) will **increase** coverage by `0.23%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/graphs/tree.svg?token=7nHLZki60B&src=pr&height=150&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/1054?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1054      +/-   ##
==========================================
+ Coverage    95.4%   95.64%   +0.23%
==========================================
Files         131      131
Lines       16209    17022     +813
==========================================
+ Hits        15464    16280     +816
+ Misses        745      742       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1054?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `96.29% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/policydecorators.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk=) | `97.92% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/radiusserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3JhZGl1c3NlcnZlci5weQ==) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/radiusserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3JhZGl1c3NlcnZlci5weQ==) | `97.59% <0%> (+0.18%)` | :arrow_up: |
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `99.21% <0%> (+0.45%)` | :arrow_up: |
| [privacyidea/lib/resolvers/SQLIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TUUxJZFJlc29sdmVyLnB5) | `98.02% <0%> (+0.55%)` | :arrow_up: |
| [privacyidea/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5) | `97.36% <0%> (+0.59%)` | :arrow_up: |
| [privacyidea/lib/auditmodules/sqlaudit.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2F1ZGl0bW9kdWxlcy9zcWxhdWRpdC5weQ==) | `94.83% <0%> (+1.53%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1054/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1054?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1054?src=pr&el=footer). Last update [2c8870b...1f27c0e](https://codecov.io/gh/privacyidea/privacyidea/pull/1054?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Alright! I was a bit hesitant to change them because they are user-facing. I pushed a new version and also modified the unit tests to work with the shorter strings. What do you think?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Looks good to me :-) thx!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1054?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1054?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1054'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>