### PR TITLE
Improve counter event handler

### DIFF
--- a/doc/eventhandler/counterhandler.rst
+++ b/doc/eventhandler/counterhandler.rst
@@ -7,7 +7,7 @@ Counter Handler Module
 
 The counter event handler module is used to count certain events.
 You can define arbitrary counter names and each occurrence of an event will
-increase the counter in the counter table.
+modify the counter in the counter table according to the selected action.
 
 These counters can be used to graph time series of failed authentication, assigned tokens,
 user numbers or any other data with any condition over time.
@@ -15,16 +15,31 @@ user numbers or any other data with any condition over time.
 Possible Actions
 ~~~~~~~~~~~~~~~~
 
-increase_counter
-................
+.. describe:: increase_counter
 
 This action increases the counter in the database table ``eventcounter``.
+If the counter does not exists, it will be created and increased.
+
+.. describe:: decrease_counter
+
+This action decreases the counter in the database table ``eventcounter``.
+If the counter does not exists, it will be created and decreased.
+
+  .. note::  This action will not decrease the counter beyond zero unless the option ``allow_negative_values`` is enabled.
+
+.. describe:: reset_counter
+
+This action resets the counter in the database table ``eventcounter`` to zero.
+
 
 Possible Options
 ~~~~~~~~~~~~~~~~
 
-counter_name
-............
+.. describe:: counter_name
 
 This is the name of the counter in the database.
 You can have as many counters in as many event handlers as you like.
+
+.. describe:: allow_negative_values
+
+Only available for the ``decrease_counter`` action. Allows the counter to become negative.

--- a/doc/eventhandler/counterhandler.rst
+++ b/doc/eventhandler/counterhandler.rst
@@ -15,31 +15,45 @@ user numbers or any other data with any condition over time.
 Possible Actions
 ~~~~~~~~~~~~~~~~
 
-.. describe:: increase_counter
+increase_counter
+................
 
 This action increases the counter in the database table ``eventcounter``.
 If the counter does not exists, it will be created and increased.
 
-.. describe:: decrease_counter
+decrease_counter
+................
 
 This action decreases the counter in the database table ``eventcounter``.
 If the counter does not exists, it will be created and decreased.
 
-  .. note::  This action will not decrease the counter beyond zero unless the option ``allow_negative_values`` is enabled.
+  .. note::  This action will not decrease the counter beyond zero unless the option
+    :ref:`pi_doc_eventhandler_counter` is enabled.
 
-.. describe:: reset_counter
+reset_counter
+.............
 
-This action resets the counter in the database table ``eventcounter`` to zero.
+This action resets the counter in the database table ``eventcounter`` to ``zero``.
 
 
 Possible Options
 ~~~~~~~~~~~~~~~~
 
-.. describe:: counter_name
+counter_name
+............
 
 This is the name of the counter in the database.
 You can have as many counters in as many event handlers as you like.
 
-.. describe:: allow_negative_values
+.. _pi_doc_eventhandler_counter:
 
-Only available for the ``decrease_counter`` action. Allows the counter to become negative.
+allow_negative_values
+.....................
+
+Only available for the ``decrease_counter`` action. Allows the counter to become negative. If set
+ to ``False`` (default) decreasing stops at ``zero``.
+ .. note:: Since the option ``allow_negative_values`` is an attribute of the counter event
+ handler action (and not the counter itself in the database) it is possible to define multiple
+ event handler accessing the same counter. Thus if a negative counter is accessed by an event
+ handler with the option ``allow_negative_values`` set to true, the counter will be reset to
+ ``zero``

--- a/privacyidea/lib/counter.py
+++ b/privacyidea/lib/counter.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2018-26-09 Paul Lettich <paul.lettich@netknights.it>
+#             Add decrease/reset functions
 #  2018-03-01 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #
 #  Copyright (C) 2018 Cornelius Kölbel
@@ -21,7 +23,7 @@
 """
 This module is used to modify counters in the database
 """
-from privacyidea.models import EventCounter, EventHandlerOption
+from privacyidea.models import EventCounter
 
 
 def increase(counter_name):

--- a/privacyidea/lib/counter.py
+++ b/privacyidea/lib/counter.py
@@ -21,13 +21,13 @@
 """
 This module is used to modify counters in the database
 """
-from privacyidea.models import EventCounter
+from privacyidea.models import EventCounter, EventHandlerOption
 
 
 def increase(counter_name):
     """
     Increase the counter value in the database.
-    If the counter does not exist, yet, create the counter.
+    If the counter does not exist yet, create the counter.
 
     :param counter_name: The name/identifier of the counter
     :return: the new integer value of the counter
@@ -38,3 +38,35 @@ def increase(counter_name):
         counter.save()
     counter.increase()
     return counter.counter_value
+
+
+def decrease(counter_name, allow_negative=False):
+    """
+    Decrease the counter value in the database.
+    If the counter does not exist yet, create the counter.
+    Also checks whether the counter is allowed to become negative.
+
+    :param counter_name: The name/identifier of the counter
+    :param allow_negative: Whether the counter can become negative
+    :return: the new integer value of the counter
+    """
+    counter = EventCounter.query.filter_by(counter_name=counter_name).first()
+    if not counter:
+        counter = EventCounter(counter_name, 0)
+        counter.save()
+    counter.decrease(allow_negative)
+    return counter.counter_value
+
+
+def reset(counter_name):
+    """
+    Reset the counter value in the database to 0.
+    If the counter does not exist yet, create the counter.
+    :param counter_name: The name/identifier of the counter
+    :return:
+    """
+    counter = EventCounter.query.filter_by(counter_name=counter_name).first()
+    if not counter:
+        counter = EventCounter(counter_name, 0)
+        counter.save()
+    counter.reset()

--- a/privacyidea/lib/eventhandler/counterhandler.py
+++ b/privacyidea/lib/eventhandler/counterhandler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 #  2018-02-28 Cornelius Kölbel <cornelius.koelbel@netknights.it>
-#             Initial writup
+#             Initial writeup
 #
 # License:  AGPLv3
 # (c) 2018. Cornelius Kölbel
@@ -20,13 +20,13 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-__doc__ = """This is the event handler module for increasing database counters.
+__doc__ = """This is the event handler module for
+increasing/decreasing/resetting database counters.
 These counters can be used by rrdtool to monitor values and print time series of
 certain parameters.
 """
 from privacyidea.lib.eventhandler.base import BaseEventHandler
-from privacyidea.lib import _
-from privacyidea.lib.counter import increase
+from privacyidea.lib.counter import increase, decrease, reset
 import logging
 import traceback
 
@@ -51,12 +51,24 @@ class CounterEventHandler(BaseEventHandler):
 
         :return: dict with actions
         """
-        actions = {"increase_counter":
-                        {"counter_name": {
-                            "type": "str",
-                            "description": _("The identifier/key of the counter.")}
-                        }
-        }
+        actions = {'increase_counter': {
+            "counter_name": {
+                "type": "str",
+                "description": _("The identifier/key of the counter.")}
+            },
+            'decrease_counter': {
+                "counter_name": {
+                    "type": "str",
+                    "description": _("The identifier/key of the counter.")},
+                'allow_negative_values': {
+                    "type": "bool",
+                    "description": _("Don't stop counter if it reaches zero.")}
+            },
+            'reset_counter': {
+                "counter_name": {
+                    "type": "str",
+                    "description": _("The identifier/key of the counter.")}
+        }}
         return actions
 
     def do(self, action, options=None):
@@ -70,15 +82,23 @@ class CounterEventHandler(BaseEventHandler):
         :return:
         """
         ret = True
-        #g = options.get("g")
+        # g = options.get("g")
         handler_def = options.get("handler_def")
         handler_options = handler_def.get("options", {})
+        counter_name = handler_options.get("counter_name")
 
         if action == "increase_counter":
-            counter_name = handler_options.get("counter_name")
             r = increase(counter_name)
             log.debug(u"Increased the counter {0!s} to {1!s}.".format(counter_name,
                                                                       r))
+        elif action == "decrease_counter":
+            allow_negative = handler_options.get("allow_negative_values")
+            r = decrease(counter_name, allow_negative)
+            log.debug(u"Decreased the counter {0!s} to {1!s}.".format(counter_name,
+                                                                      r))
+        elif action == "reset_counter":
+            reset(counter_name)
+            log.debug(u"Reset the counter {0!s} to 0.".format(counter_name))
 
         return ret
 

--- a/privacyidea/lib/eventhandler/counterhandler.py
+++ b/privacyidea/lib/eventhandler/counterhandler.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2018-23-09 Paul Lettich <paul.lettich@netknights.it>
+#             Add decrease and reset counter actions
 #  2018-02-28 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Initial writeup
 #
@@ -26,6 +28,7 @@ These counters can be used by rrdtool to monitor values and print time series of
 certain parameters.
 """
 from privacyidea.lib.eventhandler.base import BaseEventHandler
+from privacyidea.lib import _
 from privacyidea.lib.counter import increase, decrease, reset
 import logging
 import traceback
@@ -51,12 +54,12 @@ class CounterEventHandler(BaseEventHandler):
 
         :return: dict with actions
         """
-        actions = {'increase_counter': {
+        actions = {"increase_counter": {
             "counter_name": {
                 "type": "str",
                 "description": _("The identifier/key of the counter.")}
             },
-            'decrease_counter': {
+            "decrease_counter": {
                 "counter_name": {
                     "type": "str",
                     "description": _("The identifier/key of the counter.")},
@@ -64,7 +67,7 @@ class CounterEventHandler(BaseEventHandler):
                     "type": "bool",
                     "description": _("Don't stop counter if it reaches zero.")}
             },
-            'reset_counter': {
+            "reset_counter": {
                 "counter_name": {
                     "type": "str",
                     "description": _("The identifier/key of the counter.")}
@@ -82,7 +85,7 @@ class CounterEventHandler(BaseEventHandler):
         :return:
         """
         ret = True
-        # g = options.get("g")
+        #g = options.get("g")
         handler_def = options.get("handler_def")
         handler_options = handler_def.get("options", {})
         counter_name = handler_options.get("counter_name")
@@ -101,4 +104,3 @@ class CounterEventHandler(BaseEventHandler):
             log.debug(u"Reset the counter {0!s} to 0.".format(counter_name))
 
         return ret
-

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2018-25-09 Paul Lettich <paul.lettich@netknights.it>
+#             Add decrease/reset methods to EventCounter
 #  2017-10-30 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add timeout and retries to radiuserver
 #  2017-08-24 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -2333,11 +2335,11 @@ class EventCounter(db.Model):
         :param allow_negative:
         :return:
         """
-        if self.counter_value == 0 and not allow_negative:
-            # leave counter at zero, nothing to save
-            # TODO: what should be done if the counter is already negative?
-            return
-        self.counter_value = self.counter_value - 1
+        if self.counter_value <= 0 and not allow_negative:
+            # set counter to zero
+            self.counter_value = 0
+        else:
+            self.counter_value = self.counter_value - 1
         self.save()
 
     def reset(self):

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2297,7 +2297,7 @@ class Subscription(MethodsMixin, db.Model):
 
 class EventCounter(db.Model):
     """
-    This table stores counters of the event hanlder "Counter".
+    This table stores counters of the event handler "Counter".
     """
     __tablename__ = 'eventcounter'
     counter_name = db.Column(db.Unicode(80), nullable=False, primary_key=True)
@@ -2325,6 +2325,27 @@ class EventCounter(db.Model):
         :return:
         """
         self.counter_value = self.counter_value + 1
+        self.save()
+
+    def decrease(self, allow_negative=False):
+        """
+        Decrease the value of a counter, stop at zero if allow_negative not given
+        :param allow_negative:
+        :return:
+        """
+        if self.counter_value == 0 and not allow_negative:
+            # leave counter at zero, nothing to save
+            # TODO: what should be done if the counter is already negative?
+            return
+        self.counter_value = self.counter_value - 1
+        self.save()
+
+    def reset(self):
+        """
+        Reset the value of a counter
+        :return:
+        """
+        self.counter_value = 0
         self.save()
 
 

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -705,6 +705,27 @@ class TokenModelTestCase(MyTestCase):
         counter3 = EventCounter.query.filter_by(counter_name="test_counter").first()
         self.assertEqual(counter3.counter_value, 12)
 
-        counter3.delete()
-        counter3 = EventCounter.query.filter_by(counter_name="test_counter").first()
-        self.assertEqual(counter3, None)
+        counter3.decrease()
+
+        counter4 = EventCounter.query.filter_by(counter_name="test_counter").first()
+        self.assertEqual(counter4.counter_value, 11)
+
+        counter4.decrease(allow_negative=True)
+
+        counter5 = EventCounter.query.filter_by(counter_name="test_counter").first()
+        self.assertEqual(counter5.counter_value, 10)
+
+        counter5.reset()
+
+        counter6 = EventCounter.query.filter_by(counter_name="test_counter").first()
+        self.assertEqual(counter6.counter_value, 0)
+
+        counter6.decrease(allow_negative=True)
+        counter6.decrease(allow_negative=True)
+
+        counter7 = EventCounter.query.filter_by(counter_name="test_counter").first()
+        self.assertEqual(counter7.counter_value, -2)
+
+        counter7.delete()
+        counter8 = EventCounter.query.filter_by(counter_name="test_counter").first()
+        self.assertEqual(counter8, None)

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -726,6 +726,11 @@ class TokenModelTestCase(MyTestCase):
         counter7 = EventCounter.query.filter_by(counter_name="test_counter").first()
         self.assertEqual(counter7.counter_value, -2)
 
-        counter7.delete()
+        counter7.decrease(allow_negative=False)
+
         counter8 = EventCounter.query.filter_by(counter_name="test_counter").first()
-        self.assertEqual(counter8, None)
+        self.assertEqual(counter8.counter_value, 0)
+
+        counter8.delete()
+        counter9 = EventCounter.query.filter_by(counter_name="test_counter").first()
+        self.assertEqual(counter9, None)

--- a/tests/test_lib_counter.py
+++ b/tests/test_lib_counter.py
@@ -4,7 +4,7 @@ This tests the files
 """
 
 from .base import MyTestCase
-from privacyidea.lib.counter import increase
+from privacyidea.lib.counter import increase, decrease, reset
 from privacyidea.models import EventCounter
 
 
@@ -31,3 +31,41 @@ class CounterTestCase(MyTestCase):
 
         counter = EventCounter.query.filter_by(counter_name="hallo_counter").first()
         self.assertEqual(counter.counter_value, 2)
+
+    def test_01_increase_and_decrease(self):
+        r = increase("hallo_counter1")
+        self.assertEqual(r, 1)
+
+        for x in range(1, 5):
+            increase("hallo_counter1")
+
+        counter = EventCounter.query.filter_by(counter_name="hallo_counter1").first()
+        self.assertEqual(counter.counter_value, 5)
+
+        r = decrease("hallo_counter1")
+        self.assertEqual(r, 4)
+
+        for x in range(1, 8):
+            decrease("hallo_counter1")
+
+        counter = EventCounter.query.filter_by(counter_name="hallo_counter1").first()
+        self.assertEqual(counter.counter_value, 0)
+
+    def test_02_decrease_beyond_zero(self):
+        r = increase("hallo_counter2")
+        self.assertEqual(r, 1)
+
+        for x in range(1, 8):
+            decrease("hallo_counter2", allow_negative=True)
+
+        counter = EventCounter.query.filter_by(counter_name="hallo_counter2").first()
+        self.assertEqual(counter.counter_value, -6)
+
+    def test_03_decrease_and_reset(self):
+        r = decrease("hallo_counter3", allow_negative=True)
+        self.assertEqual(r, -1)
+
+        reset("hallo_counter3")
+
+        counter = EventCounter.query.filter_by(counter_name="hallo_counter3").first()
+        self.assertEqual(counter.counter_value, 0)

--- a/tests/test_lib_counter.py
+++ b/tests/test_lib_counter.py
@@ -69,3 +69,9 @@ class CounterTestCase(MyTestCase):
 
         counter = EventCounter.query.filter_by(counter_name="hallo_counter3").first()
         self.assertEqual(counter.counter_value, 0)
+
+    def test_04_reset_non_existing_counter(self):
+        reset("hallo_counter4")
+
+        counter = EventCounter.query.filter_by(counter_name="hallo_counter4").first()
+        self.assertEqual(counter.counter_value, 0)

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -427,7 +427,7 @@ class BaseEventHandlerTestCase(MyTestCase):
 
 class CounterEventTestCase(MyTestCase):
 
-    def test_01_increase_counter(self):
+    def test_01_event_counter(self):
         g = FakeFlaskG()
         audit_object = FakeAudit()
         g.logged_in_user = {"username": "admin",
@@ -464,6 +464,20 @@ class CounterEventTestCase(MyTestCase):
 
         counter = EventCounter.query.filter_by(counter_name="hallo_counter").first()
         self.assertEqual(counter.counter_value, 2)
+
+        if 'decrease_counter' in t_handler.actions:
+            t_handler.do("decrease_counter", options=options)
+            t_handler.do("decrease_counter", options=options)
+            t_handler.do("decrease_counter", options=options)
+            counter = EventCounter.query.filter_by(counter_name="hallo_counter").first()
+            self.assertEqual(counter.counter_value, 0)
+            options['handler_def']['options']['allow_negative_values'] = True
+            t_handler.do("decrease_counter", options=options)
+            counter = EventCounter.query.filter_by(counter_name="hallo_counter").first()
+            self.assertEqual(counter.counter_value, -1)
+            t_handler.do("reset_counter", options=options)
+            counter = EventCounter.query.filter_by(counter_name="hallo_counter").first()
+            self.assertEqual(counter.counter_value, 0)
 
 
 class ScriptEventTestCase(MyTestCase):


### PR DESCRIPTION
Add a decrease_counter and reset_counter action to the counter event handler.
Updated corresponding test cases.
Fixes #991
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23issuecomment-387458964%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186831816%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186832639%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186834160%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186834422%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186835504%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186962097%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186977221%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r187555340%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r187555344%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r187555479%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r187555483%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r187555782%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23issuecomment-387458964%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231056%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/519b0d1730d17c6b69a8b8b3c9379d576f7d3f7b%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6060%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26width%3D650%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231056%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.41%25%20%20%2095.41%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016211%20%20%20%2016382%20%20%20%20%20%2B171%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015468%20%20%20%2015631%20%20%20%20%20%2B163%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20743%20%20%20%20%20%20751%20%20%20%20%20%20%20%2B8%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.76%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/counter.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NvdW50ZXIucHk%3D%29%20%7C%20%6090.9%25%20%3C100%25%3E%20%28-9.1%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/counterhandler.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9jb3VudGVyaGFuZGxlci5weQ%3D%3D%29%20%7C%20%6067.85%25%20%3C27.27%25%3E%20%28-23.06%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policydecorators.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk%3D%29%20%7C%20%6098.51%25%20%3C0%25%3E%20%28%2B0.59%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/usernotification.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci91c2Vybm90aWZpY2F0aW9uLnB5%29%20%7C%20%6093.86%25%20%3C0%25%3E%20%28%2B3.43%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B519b0d1...9ba1b67%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1056%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-05-08T16%3A19%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/8655789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200749b2697147ba8dfbfad0a32069f77ec29dd58e%20privacyidea/lib/eventhandler/counterhandler.py%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186834422%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20prefer%20no%20space%20here%21%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-05-08T19%3A03%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-05-11T08%3A45%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/counterhandler.py%3AL82-105%22%7D%2C%20%22Pull%200749b2697147ba8dfbfad0a32069f77ec29dd58e%20doc/eventhandler/counterhandler.rst%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186831816%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20did%20you%20change%20this%20to%20%2A%2Adescribe%2A%2A%3F%20The%20same%20heading%20is%20used%20in%20other%20docs.%5Cr%5CnAll%20other%20events%20use%20sub%20headers%2C%20too.%5Cr%5CnThe%20interesting%20thing%20about%20this%2C%20is%20that%20you%20can%20simply%20share%20a%20permanent%20link%20to%20this%20part%20of%20the%20doc.%5Cr%5CnSeems%20not%20to%20work%20with%20%2A%2Adescribe%2A%2A.%22%2C%20%22created_at%22%3A%20%222018-05-08T18%3A54%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22just%20thought%20it%20looks%20nicer%20%3A-%29%5Cr%5CnMaybe%20we%20can%20change%20the%20sphinx%20config%20to%20avoid%20numbering%20all%20levels%20of%20subsections.%20It%20gets%20confusing%20if%20the%20length%20of%20the%20section%20number%20surpasses%20the%20text...%22%2C%20%22created_at%22%3A%20%222018-05-09T08%3A06%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right.%20Skipping%20chapter%20numbering%20for%20lower%20levels%20might%20make%20sense.%5Cr%5CnJust%20let%20us%20keep%20this%20in%20a%20consistent%20way%20through%20the%20documentation%20and%20not%20change%20this%20in%20this%20PR.%22%2C%20%22created_at%22%3A%20%222018-05-09T09%3A02%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-05-11T08%3A45%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/eventhandler/counterhandler.rst%3AL7-46%22%7D%2C%20%22Pull%200749b2697147ba8dfbfad0a32069f77ec29dd58e%20privacyidea/lib/eventhandler/counterhandler.py%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186834160%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20must%20not%20remove%20this.%5Cr%5Cn%5Cr%5CnMy%20ui%20throws%5Cr%5Cn%5Cr%5Cn%20%20%20%20global%20name%20%27_%27%20is%20not%20defined%22%2C%20%22created_at%22%3A%20%222018-05-08T19%3A02%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-05-11T08%3A45%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/counterhandler.py%3AL20-33%22%7D%2C%20%22Pull%200749b2697147ba8dfbfad0a32069f77ec29dd58e%20privacyidea/lib/eventhandler/counterhandler.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186832639%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20can%20add%20a%20short%20info%20about%20adding%20decrease%20and%20reset.%22%2C%20%22created_at%22%3A%20%222018-05-08T18%3A57%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-05-11T08%3A47%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/counterhandler.py%3AL1-8%22%7D%2C%20%22Pull%200749b2697147ba8dfbfad0a32069f77ec29dd58e%20privacyidea/models.py%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1056%23discussion_r186835504%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20would%20mean%2C%20that%20the%20event%20handler%20was%20changed%20after%20the%20counter%20decreased%20under%20zero%20by%20previous%20events.%5Cr%5CnSo%20the%20current%20event%20handler%20definition%20would%20be%3A%20%5C%22Be%20not%20negative%5C%22.%5Cr%5Cn%5Cr%5CnMaybe%20we%20should%20reset%20the%20counter%20in%20this%20case%20to%20zero%3F%22%2C%20%22created_at%22%3A%20%222018-05-08T19%3A07%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-05-11T08%3A45%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL2327-2354%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1056#issuecomment-387458964'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars0.githubusercontent.com/u/8655789?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1056?src=pr&el=h1) Report
> Merging [#1056](https://codecov.io/gh/privacyidea/privacyidea/pull/1056?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/519b0d1730d17c6b69a8b8b3c9379d576f7d3f7b?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `60%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1056/graphs/tree.svg?token=7nHLZki60B&width=650&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1056?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1056      +/-   ##
==========================================
- Coverage   95.41%   95.41%   -0.01%
==========================================
Files         131      131
Lines       16211    16382     +171
==========================================
+ Hits        15468    15631     +163
- Misses        743      751       +8
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1056?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1056/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.76% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/counter.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1056/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NvdW50ZXIucHk=) | `90.9% <100%> (-9.1%)` | :arrow_down: |
| [privacyidea/lib/eventhandler/counterhandler.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1056/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9jb3VudGVyaGFuZGxlci5weQ==) | `67.85% <27.27%> (-23.06%)` | :arrow_down: |
| [privacyidea/lib/policydecorators.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1056/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk=) | `98.51% <0%> (+0.59%)` | :arrow_up: |
| [privacyidea/lib/eventhandler/usernotification.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1056/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci91c2Vybm90aWZpY2F0aW9uLnB5) | `93.86% <0%> (+3.43%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1056?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1056?src=pr&el=footer). Last update [519b0d1...9ba1b67](https://codecov.io/gh/privacyidea/privacyidea/pull/1056?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull 0749b2697147ba8dfbfad0a32069f77ec29dd58e doc/eventhandler/counterhandler.rst 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1056#discussion_r186831816'>File: doc/eventhandler/counterhandler.rst:L7-46</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Why did you change this to **describe**? The same heading is used in other docs.
All other events use sub headers, too.
The interesting thing about this, is that you can simply share a permanent link to this part of the doc.
Seems not to work with **describe**.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> just thought it looks nicer :-)
Maybe we can change the sphinx config to avoid numbering all levels of subsections. It gets confusing if the length of the section number surpasses the text...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are right. Skipping chapter numbering for lower levels might make sense.
Just let us keep this in a consistent way through the documentation and not change this in this PR.
- [x] <a href='#crh-comment-Pull 0749b2697147ba8dfbfad0a32069f77ec29dd58e privacyidea/lib/eventhandler/counterhandler.py 2'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1056#discussion_r186832639'>File: privacyidea/lib/eventhandler/counterhandler.py:L1-8</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You can add a short info about adding decrease and reset.
- [x] <a href='#crh-comment-Pull 0749b2697147ba8dfbfad0a32069f77ec29dd58e privacyidea/lib/eventhandler/counterhandler.py 20'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1056#discussion_r186834160'>File: privacyidea/lib/eventhandler/counterhandler.py:L20-33</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You must not remove this.
My ui throws
global name '_' is not defined
- [x] <a href='#crh-comment-Pull 0749b2697147ba8dfbfad0a32069f77ec29dd58e privacyidea/lib/eventhandler/counterhandler.py 62'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1056#discussion_r186834422'>File: privacyidea/lib/eventhandler/counterhandler.py:L82-105</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I prefer no space here! ;-)
- [x] <a href='#crh-comment-Pull 0749b2697147ba8dfbfad0a32069f77ec29dd58e privacyidea/models.py 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1056#discussion_r186835504'>File: privacyidea/models.py:L2327-2354</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This would mean, that the event handler was changed after the counter decreased under zero by previous events.
So the current event handler definition would be: "Be not negative".
Maybe we should reset the counter in this case to zero?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1056?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1056?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1056'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>