### PR TITLE
Allow login wiht objectGUID

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -489,7 +489,11 @@ class IdResolver (UserIdResolver):
             for map_k, map_v in self.userinfo.items():
                 if ldap_k == map_v:
                     if ldap_k == "objectGUID":
-                        ret[map_k] = ldap_v[0]
+                        # An objectGUID should be no list, since it is unique
+                        if type(ldap_v) == basestring:
+                            ret[map_k] = ldap_v
+                        else:
+                            raise Exception("The LDAP returns an objectGUID, that is no string: {0!s}".format(type(ldap_v)))
                     elif type(ldap_v) == list and map_k not in self.multivalueattributes:
                         # lists that are not in self.multivalueattributes return first value
                         # as a string. Multi-value-attributes are returned as a list
@@ -686,7 +690,7 @@ class IdResolver (UserIdResolver):
         self.timeout = float(config.get("TIMEOUT", 5))
         self.cache_timeout = int(config.get("CACHE_TIMEOUT", 120))
         self.sizelimit = int(config.get("SIZELIMIT", 500))
-        self.loginname_attribute = config.get("LOGINNAMEATTRIBUTE","").split(",")
+        self.loginname_attribute = [la.strip() for la in config.get("LOGINNAMEATTRIBUTE","").split(",")]
         self.searchfilter = config.get("LDAPSEARCHFILTER")
         userinfo = config.get("USERINFO", "{}")
         self.userinfo = yaml.safe_load(userinfo)

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -490,8 +490,8 @@ class IdResolver (UserIdResolver):
                 if ldap_k == map_v:
                     if ldap_k == "objectGUID":
                         # An objectGUID should be no list, since it is unique
-                        if type(ldap_v) == basestring:
-                            ret[map_k] = ldap_v
+                        if isinstance(ldap_v, basestring):
+                            ret[map_k] = ldap_v.strip("{").strip("}")
                         else:
                             raise Exception("The LDAP returns an objectGUID, that is no string: {0!s}".format(type(ldap_v)))
                     elif type(ldap_v) == list and map_k not in self.multivalueattributes:
@@ -545,12 +545,16 @@ class IdResolver (UserIdResolver):
                     # This happens if we have a self.loginname_attribute like ["sAMAccountName","objectGUID"],
                     # the user logs in with his sAMAccountName, which can
                     # not be transformed to a UUID
-                    log.debug("Can not transform {0!s} to a objectGUID.".format(login_name))
+                    log.debug(u"Can not transform {0!s} to a objectGUID.".format(login_name))
 
             loginname_filter = u"|" + loginname_filter
         else:
+            if self.loginname_attribute[0].lower() == "objectguid":
+                search_login_name = trim_objectGUID(login_name)
+            else:
+                search_login_name = login_name
             loginname_filter = u"{!s}={!s}".format(self.loginname_attribute[0],
-                                                   login_name)
+                                                   search_login_name)
 
         log.debug("login name filter: {!r}".format(loginname_filter))
         filter = u"(&{0!s}({1!s}))".format(self.searchfilter, loginname_filter)

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -1646,6 +1646,42 @@ class LDAPResolverTestCase(MyTestCase):
                             ret[1])
 
 
+    @ldap3mock.activate
+    def test_30_login_with_objectGUID(self):
+        ldap3mock.setLDAPDirectory(LDAPDirectory)
+        classes = 'top, inetOrgPerson'
+        y = LDAPResolver()
+        y.loadConfig({'LDAPURI': 'ldap://localhost',
+                      'LDAPBASE': 'o=test',
+                      'BINDDN': 'cn=manager,ou=example,o=test',
+                      'BINDPW': 'ldaptest',
+                      'LOGINNAMEATTRIBUTE': 'cn,objectGUID, email',
+                      'LDAPSEARCHFILTER': '(cn=*)',
+                      'USERINFO': '{ "username": "cn",'
+                                  '"phone" : "telephoneNumber", '
+                                  '"mobile" : "mobile",'
+                                  '"email" : "email",'
+                                  '"userid" : "objectGUID",'
+                                  '"password" : "userPassword",'
+                                  '"surname" : "sn", '
+                                  '"givenname" : "givenName", '
+                                  '"accountExpires": "accountExpires" }',
+                      'UIDTYPE': 'objectGUID',
+                      'DN_TEMPLATE': 'cn=<username>,ou=example,o=test',
+                      'OBJECT_CLASSES': classes,
+                      'NOREFERRALS': True,
+                      'CACHE_TIMEOUT': 0
+                      })
+
+        # Alice, the email address and objectGUID of alice return the same uid.
+        uid = y.getUserId("alice")
+        self.assertEqual(uid, objectGUIDs[0])
+        uid = y.getUserId(objectGUIDs[0])
+        self.assertEqual(uid, objectGUIDs[0])
+        uid = y.getUserId("alice@test.com")
+        self.assertEqual(uid, objectGUIDs[0])
+
+
 class BaseResolverTestCase(MyTestCase):
 
     def test_00_basefunctions(self):

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -1681,6 +1681,39 @@ class LDAPResolverTestCase(MyTestCase):
         uid = y.getUserId("alice@test.com")
         self.assertEqual(uid, objectGUIDs[0])
 
+    @ldap3mock.activate
+    def test_31_login_with_objectGUID_only(self):
+        ldap3mock.setLDAPDirectory(LDAPDirectory)
+        classes = 'top, inetOrgPerson'
+        y = LDAPResolver()
+        y.loadConfig({'LDAPURI': 'ldap://localhost',
+                      'LDAPBASE': 'o=test',
+                      'BINDDN': 'cn=manager,ou=example,o=test',
+                      'BINDPW': 'ldaptest',
+                      'LOGINNAMEATTRIBUTE': 'objectGUID',
+                      'LDAPSEARCHFILTER': '(cn=*)',
+                      'USERINFO': '{ "username": "cn",'
+                                  '"phone" : "telephoneNumber", '
+                                  '"mobile" : "mobile",'
+                                  '"email" : "email",'
+                                  '"userid" : "objectGUID",'
+                                  '"password" : "userPassword",'
+                                  '"surname" : "sn", '
+                                  '"givenname" : "givenName", '
+                                  '"accountExpires": "accountExpires" }',
+                      'UIDTYPE': 'objectGUID',
+                      'DN_TEMPLATE': 'cn=<username>,ou=example,o=test',
+                      'OBJECT_CLASSES': classes,
+                      'NOREFERRALS': True,
+                      'CACHE_TIMEOUT': 0
+                      })
+
+        # We can now authenticate using the objectGUID
+        uid = y.getUserId(objectGUIDs[0])
+        self.assertEqual(uid, objectGUIDs[0])
+
+        info = y.getUserInfo(uid)
+        self.assertEqual(info['username'], objectGUIDs[0])
 
 class BaseResolverTestCase(MyTestCase):
 


### PR DESCRIPTION
Closes #1076
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392243905%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392495254%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392529416%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392534606%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392553719%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392574674%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392688934%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392689495%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191340810%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191344619%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191344826%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191366545%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191366962%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191367852%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191368138%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191369757%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191369986%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191370112%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191370460%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392752014%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392799403%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23issuecomment-392243905%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231078%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/67c23729ef66ad7160449f8841c335e3fb86a50a%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078/graphs/tree.svg%3Fsrc%3Dpr%26token%3D7nHLZki60B%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231078%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.46%25%20%20%2095.48%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016269%20%20%20%2016275%20%20%20%20%20%20%20%2B6%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015532%20%20%20%2015540%20%20%20%20%20%20%20%2B8%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20737%20%20%20%20%20%20735%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6093.89%25%20%3C100%25%3E%20%28%2B0.07%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B67c2372...5357655%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1078%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-05-26T07%3A39%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%20is%20one%20remaining%20issue%20if%20we%20set%20the%20login%20name%20attribute%20to%20%60%60objectGUID%60%60%20only.%5Cr%5Cn%2A%20Under%20ldap3%202.5%2C%20all%20login%20names%20are%20considered%20to%20be%20%60%60%7B%60%60%5Cr%5Cn%2A%20Under%20ldap3%202.1.1%2C%20all%20login%20names%20consist%20only%20of%20the%20first%20character%5Cr%5Cn%5Cr%5CnThis%20is%20due%20to%20this%20line%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/67c23729ef66ad7160449f8841c335e3fb86a50a/privacyidea/lib/resolvers/LDAPIdResolver.py%23L492%5Cr%5CnUnder%20current%20ldap3%20versions%2C%20the%20objectGUID%20is%20returned%20as%20a%20string%2C%20and%20this%20line%20only%20picks%20the%20first%20character.%5Cr%5CnUnder%20ldap3%202.5%2C%20this%20is%20%5C%22%7B%5C%22%2C%20because%20objectGUIDs%20are%20wrapped%20in%20curly%20braces%20here.%20We%20will%20have%20to%20strip%20them%2C%20as%20we%20do%20in%20%60%60_get_uid%60%60%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/67c23729ef66ad7160449f8841c335e3fb86a50a/privacyidea/lib/resolvers/LDAPIdResolver.py%23L369%22%2C%20%22created_at%22%3A%20%222018-05-28T11%3A06%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Who%20wrote%20this%3F%20%20Obviously%20an%20objectGUID%20will%20never%20be%20a%20list%3F%20Or%20should%20be%20check%20if%20this%20is%20a%20list%3F%5Cr%5CnI%20gues%20we%20would%20only%20have%20to%20change%20this%20to%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Epython%5Cr%5Cnret%5Bmap_k%5D%20%3D%20ldap_v%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cn%5Cr%5Cn...and%20strip%20curly%20brackets%20if%20necessary.%22%2C%20%22created_at%22%3A%20%222018-05-28T13%3A38%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20pushed%20another%20attempt.%5Cr%5CnI%20do%20not%20see%20a%20problem%20with%20curly%20brackets%3F%5Cr%5Cn%5Cr%5CnE.g.%20owncloud%20authenticates%20with%20such%204f6e2018-c7ae-4670-9e39-da199005c879%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn4f6e2018-c7ae-4670-9e39-da199005c879%5Cr%5Cn--%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn4f6e2018-c7ae-4670-9e39-da199005c879%5Cr%5Cn--%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-05-28T13%3A58%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20look%20at%20the%20rest%20of%20the%20PR%20tomorrow%20--%20just%20regarding%20the%20curly%20braces%20thing%3A%20For%20me%2C%20with%20ldap3%202.5%20and%20if%20I%20configure%20objectGUID%20to%20be%20the%20only%20login%20name%20attribute%2C%20the%20user%20view%20displays%20objectGUIDs%20with%20curly%20braces%20as%20the%20username.%20Maybe%20we%20should%20strip%20them%2C%20for%20the%20sake%20of%20consistency.%22%2C%20%22created_at%22%3A%20%222018-05-28T15%3A21%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20I%20am%20wondering%20if%20we%20really%20want%20to%20allow%20the%20objectGUID%20to%20be%20the%20only%20login_attribute...%22%2C%20%22created_at%22%3A%20%222018-05-28T17%3A27%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20good%20point.%20But%20then%2C%20we%20should%20forbid%20having%20%60%60objectGUID%60%60%20%28or%20%60%60entryUUID%60%60%29%20as%20the%20first%20item%20in%20the%20%5C%22loginname%20attribute%5C%22%20list%20in%20general.%22%2C%20%22created_at%22%3A%20%222018-05-29T08%3A05%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Somehow%20you%20are%20right.%20But%20%28SISO%29%20we%20also%20do%20not%20forbid%20to%20enter%20%5C%22DN%5C%22%20in%20the%20login%20attribute.%20And%20I%20wonder%20what%20would%20happen%20then...%5Cr%5CnHonestly%20I%20currently%20have%20no%20clue%20how%20to%20fix%20the%20%60%60objectGUID%60%60%20as%20the%20only%20attribute.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-05-29T08%3A08%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20good%20to%20me%21%20IMHO%2C%20we%20can%20merge%20this%20when%20Travis%20has%20completed.%5Cr%5Cn%5Cr%5CnI%20noticed%20one%20thing%2C%20though%3A%20Assume%20we%20have%20login%20name%20attribute%20set%20to%20%60%60objectGUID%2CsAMAccountName%60%60.%20If%20a%20user%20now%20authenticates%20using%20the%20sAMAccountName%20%28e.g.%20%60%60weber%60%60%29%2C%20the%20audit%20log%20shows%20%60%60weber%60%60%20as%20the%20user%20for%20the%20%60%60/validate/check%60%60%20request%2C%20and%20the%20item%20links%20to%20%60%60http%3A//localhost%3A5000/%23/user/details/dc/weber%60%60.%20However%2C%20when%20we%20click%20this%2C%20we%20don%27t%20see%20the%20full%20list%20of%20user%20attributes%20%28but%20the%20list%20of%20tokens%20is%20displayed%20correctly%29.%5Cr%5CnThis%20is%20because%20%60%60getUserList%60%60%20is%20given%20a%20search%20dictionary%20with%20%60%60%7B%5C%22username%5C%22%3A%20%5C%22weber%5C%22%7D%60%60%2C%20but%20it%20constructs%20the%20filter%20only%20using%20the%20primary%20login%20name%20attribute%2C%20i.e.%20%60%60objectGUID%60%60.%22%2C%20%22created_at%22%3A%20%222018-05-29T12%3A04%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20unit%20test.%20I%20think%20when%20the%20codecov%20increases%2C%20this%20is%20due%20to%20be%20merged%21%22%2C%20%22created_at%22%3A%20%222018-05-29T14%3A34%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20535765578ee1b29137eabffc2255788ace7fb883%20privacyidea/lib/resolvers/LDAPIdResolver.py%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191366545%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK.%22%2C%20%22created_at%22%3A%20%222018-05-29T09%3A53%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222018-05-29T10%3A05%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL529-549%22%7D%2C%20%22Pull%20de94e4d5124382d96fff0c70120c1484e530602a%20privacyidea/lib/resolvers/LDAPIdResolver.py%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191344826%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%2C%20for%20consistency%2C%20we%20should%20strip%20%60%60%7B%60%60%20and%20%60%60%7D%60%60%20here.%20Otherwise%2C%20we%20will%20get%20different%20values%20for%20ldap3%202.1.1%20and%20ldap3%202.5.%22%2C%20%22created_at%22%3A%20%222018-05-29T08%3A41%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%20strip%20curly%20braces%22%2C%20%22created_at%22%3A%20%222018-05-29T09%3A59%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222018-05-29T10%3A08%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL489-500%22%7D%2C%20%22Pull%20de94e4d5124382d96fff0c70120c1484e530602a%20privacyidea/lib/resolvers/LDAPIdResolver.py%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191340810%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20this%20won%27t%20work%2C%20because%20type%28%5C%22%5C%22%29%20is%20%60%60str%60%60%20and%20type%28u%5C%22%5C%22%29%20is%20%60%60unicode%60%60.%20Rather%2C%20we%20should%20use%20%60%60isinstance%28ldap_v%2C%20basestring%29%60%60.%22%2C%20%22created_at%22%3A%20%222018-05-29T08%3A28%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%22%2C%20%22created_at%22%3A%20%222018-05-29T09%3A55%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222018-05-29T10%3A06%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL489-500%22%7D%2C%20%22Pull%20de94e4d5124382d96fff0c70120c1484e530602a%20privacyidea/lib/resolvers/LDAPIdResolver.py%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1078%23discussion_r191344619%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20think%20we%20can%20get%20objectGUID%20working%20as%20the%20only%20login%20name%20attribute%20by%20adding%20the%20%60%60trim_objectGUID%60%60%20special%20case%20here.%22%2C%20%22created_at%22%3A%20%222018-05-29T08%3A40%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%22%2C%20%22created_at%22%3A%20%222018-05-29T09%3A58%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222018-05-29T10%3A07%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL533-553%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1078#issuecomment-392243905'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1078?src=pr&el=h1) Report
> Merging [#1078](https://codecov.io/gh/privacyidea/privacyidea/pull/1078?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/67c23729ef66ad7160449f8841c335e3fb86a50a?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1078/graphs/tree.svg?src=pr&token=7nHLZki60B&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1078?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1078      +/-   ##
==========================================
+ Coverage   95.46%   95.48%   +0.01%
==========================================
Files         131      131
Lines       16269    16275       +6
==========================================
+ Hits        15532    15540       +8
+ Misses        737      735       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1078?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1078/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `93.89% <100%> (+0.07%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1078/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1078?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1078?src=pr&el=footer). Last update [67c2372...5357655](https://codecov.io/gh/privacyidea/privacyidea/pull/1078?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> There is one remaining issue if we set the login name attribute to ``objectGUID`` only.
* Under ldap3 2.5, all login names are considered to be ``{``
* Under ldap3 2.1.1, all login names consist only of the first character
This is due to this line:
https://github.com/privacyidea/privacyidea/blob/67c23729ef66ad7160449f8841c335e3fb86a50a/privacyidea/lib/resolvers/LDAPIdResolver.py#L492
Under current ldap3 versions, the objectGUID is returned as a string, and this line only picks the first character.
Under ldap3 2.5, this is "{", because objectGUIDs are wrapped in curly braces here. We will have to strip them, as we do in ``_get_uid``:
https://github.com/privacyidea/privacyidea/blob/67c23729ef66ad7160449f8841c335e3fb86a50a/privacyidea/lib/resolvers/LDAPIdResolver.py#L369
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Who wrote this?  Obviously an objectGUID will never be a list? Or should be check if this is a list?
I gues we would only have to change this to
~~~~python
ret[map_k] = ldap_v
~~~~
...and strip curly brackets if necessary.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I pushed another attempt.
I do not see a problem with curly brackets?
E.g. owncloud authenticates with such 4f6e2018-c7ae-4670-9e39-da199005c879
4f6e2018-c7ae-4670-9e39-da199005c879
--
4f6e2018-c7ae-4670-9e39-da199005c879
--
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I'll look at the rest of the PR tomorrow -- just regarding the curly braces thing: For me, with ldap3 2.5 and if I configure objectGUID to be the only login name attribute, the user view displays objectGUIDs with curly braces as the username. Maybe we should strip them, for the sake of consistency.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Hm, I am wondering if we really want to allow the objectGUID to be the only login_attribute...
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, good point. But then, we should forbid having ``objectGUID`` (or ``entryUUID``) as the first item in the "loginname attribute" list in general.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Somehow you are right. But (SISO) we also do not forbid to enter "DN" in the login attribute. And I wonder what would happen then...
Honestly I currently have no clue how to fix the ``objectGUID`` as the only attribute.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Looks good to me! IMHO, we can merge this when Travis has completed.
I noticed one thing, though: Assume we have login name attribute set to ``objectGUID,sAMAccountName``. If a user now authenticates using the sAMAccountName (e.g. ``weber``), the audit log shows ``weber`` as the user for the ``/validate/check`` request, and the item links to ``http://localhost:5000/#/user/details/dc/weber``. However, when we click this, we don't see the full list of user attributes (but the list of tokens is displayed correctly).
This is because ``getUserList`` is given a search dictionary with ``{"username": "weber"}``, but it constructs the filter only using the primary login name attribute, i.e. ``objectGUID``.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Thanks for the unit test. I think when the codecov increases, this is due to be merged!
- [x] <a href='#crh-comment-Pull de94e4d5124382d96fff0c70120c1484e530602a privacyidea/lib/resolvers/LDAPIdResolver.py 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1078#discussion_r191340810'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L489-500</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think this won't work, because type("") is ``str`` and type(u"") is ``unicode``. Rather, we should use ``isinstance(ldap_v, basestring)``.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done
- [x] <a href='#crh-comment-Pull de94e4d5124382d96fff0c70120c1484e530602a privacyidea/lib/resolvers/LDAPIdResolver.py 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1078#discussion_r191344619'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L533-553</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I would think we can get objectGUID working as the only login name attribute by adding the ``trim_objectGUID`` special case here.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done
- [x] <a href='#crh-comment-Pull de94e4d5124382d96fff0c70120c1484e530602a privacyidea/lib/resolvers/LDAPIdResolver.py 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1078#discussion_r191344826'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L489-500</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think, for consistency, we should strip ``{`` and ``}`` here. Otherwise, we will get different values for ldap3 2.1.1 and ldap3 2.5.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK strip curly braces
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done
- [x] <a href='#crh-comment-Pull 535765578ee1b29137eabffc2255788ace7fb883 privacyidea/lib/resolvers/LDAPIdResolver.py 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1078#discussion_r191366545'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L529-549</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1078?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1078?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1078'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>