### PR TITLE
Fix the scrollbar issue. Finally.

### DIFF
--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -388,7 +388,7 @@ angular.module("privacyideaApp")
     $scope.nextWelcome = function() {
         $scope.welcomeStep += 1;
         if ($scope.welcomeStep === 4) {
-            $('#dialogWelcome').modal().hide();
+            $('#dialogWelcome').modal("hide");
             // Hack, since we can not close the modal and thus the body
             // keeps the modal-open and thus has no scroll-bars
             $("body").removeClass("modal-open");

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -87,7 +87,7 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
             if (($scope.subscription_state === 0 && !$scope.hide_welcome) ||
                 ($scope.subscription_state === 1) ||
                 ($scope.subscription_state === 2)) {
-                $('#dialogWelcome').modal();
+                $('#dialogWelcome').modal("show");
                 $("body").addClass("modal-open");
             }
         }


### PR DESCRIPTION
Closes #1020
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1079%23issuecomment-392286725%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1079%23issuecomment-392312695%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1079%23issuecomment-392491523%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1079%23issuecomment-392491746%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1079%23issuecomment-392496654%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1079%23issuecomment-392497252%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1079%23issuecomment-392286725%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20the%20dialog%20would%20not%20be%20displayed%20the%20second%20login%2C%20the%20admin%20would%20not%20step%20trhough%20the%20dialog%20and%20would%20not%20end%20up%20at%20the%20point%2C%20where%20the%20%5C%22modal-open%5C%22%20is%20removed%20from%20the%20body.%22%2C%20%22created_at%22%3A%20%222018-05-26T20%3A37%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231079%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/67c23729ef66ad7160449f8841c335e3fb86a50a%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231079%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.46%25%20%20%2095.48%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016269%20%20%20%2016269%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015532%20%20%20%2015534%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20737%20%20%20%20%20%20735%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B67c2372...56bdcce%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1079%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-05-27T07%3A58%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixes%20%231020%20for%20me.%20Very%20cool%21%5Cr%5CnI%20saw%20we%20have%20a%20similar%20situation%20here%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/67c23729ef66ad7160449f8841c335e3fb86a50a/privacyidea/static/components/login/controllers/loginControllers.js%23L360%5Cr%5Cnthough%20there%20we%20have%20a%20workaround%20that%20removes%20the%20%60%60modal-open%60%60%20class%20from%20the%20body.%20Do%20we%20also%20want%20to%20change%20this%20line%20to%20%60%60.modal%28%5C%22hide%5C%22%29%60%60%3F%22%2C%20%22created_at%22%3A%20%222018-05-28T10%3A50%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Would%20it%20work%3F%22%2C%20%22created_at%22%3A%20%222018-05-28T10%3A51%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20idea%20--%20it%20just%20seems%20like%20%60%60.modal%28%29.hide%28%29%60%60%20is%20not%20the%20right%20way%20to%20use%20the%20modal%20API%20%3A%29%5Cr%5CnThough%20the%20scrollbar%20issue%20does%20not%20seem%20to%20appear%20with%20the%20lock%20screen%2C%20because%20of%20the%20%60%60removeClass%60%60%20workaround.%22%2C%20%22created_at%22%3A%20%222018-05-28T11%3A10%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20would%20like%20to%20keep%20it%20this%20way%20in%20the%20first%20step.%5Cr%5CnSo%20If%20you%20are%20ok%20with%20it%2C%20I%20am%20happy%20with%20a%20merge%21%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-05-28T11%3A12%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1079#issuecomment-392286725'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> If the dialog would not be displayed the second login, the admin would not step trhough the dialog and would not end up at the point, where the "modal-open" is removed from the body.
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1079?src=pr&el=h1) Report
> Merging [#1079](https://codecov.io/gh/privacyidea/privacyidea/pull/1079?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/67c23729ef66ad7160449f8841c335e3fb86a50a?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1079/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1079?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1079      +/-   ##
==========================================
+ Coverage   95.46%   95.48%   +0.01%
==========================================
Files         131      131
Lines       16269    16269
==========================================
+ Hits        15532    15534       +2
+ Misses        737      735       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1079?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1079/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1079?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1079?src=pr&el=footer). Last update [67c2372...56bdcce](https://codecov.io/gh/privacyidea/privacyidea/pull/1079?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Fixes #1020 for me. Very cool!
I saw we have a similar situation here:
https://github.com/privacyidea/privacyidea/blob/67c23729ef66ad7160449f8841c335e3fb86a50a/privacyidea/static/components/login/controllers/loginControllers.js#L360
though there we have a workaround that removes the ``modal-open`` class from the body. Do we also want to change this line to ``.modal("hide")``?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Would it work?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> No idea -- it just seems like ``.modal().hide()`` is not the right way to use the modal API :)
Though the scrollbar issue does not seem to appear with the lock screen, because of the ``removeClass`` workaround.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I would like to keep it this way in the first step.
So If you are ok with it, I am happy with a merge! ;-)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1079?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1079?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1079'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>