### PR TITLE
1086/subscription error code

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -47,7 +47,7 @@ from flask import (Blueprint,
 from .lib.utils import (send_result, get_all_params,
                         verify_auth_token)
 from ..lib.crypto import geturandom, init_hsm
-from ..lib.error import AuthError
+from ..lib.error import AuthError, ERROR
 from ..lib.auth import verify_db_admin, db_admin_exist
 import jwt
 from functools import wraps
@@ -190,9 +190,8 @@ def get_auth_token():
     # "remote_user" = authenticated by webserver
     authtype = "password"
     if username is None:
-        raise AuthError("Authentication failure",
-                        "missing Username",
-                        status=401)
+        raise AuthError("Authentication failure. missing Username",
+                        id=ERROR.AUTHENTICATE_MISSING_USERNAME)
     # Verify the password
     admin_auth = False
     user_auth = False
@@ -253,9 +252,8 @@ def get_auth_token():
                                 "administrator": username})
 
     if not admin_auth and not user_auth:
-        raise AuthError("Authentication failure",
-                        "Wrong credentials", status=401,
-                        details=details or {})
+        raise AuthError("Authentication failure. Wrong credentials",
+                        id=ERROR.AUTHENTICATE_WRONG_CREDENTIALS)
     else:
         g.audit_object.log({"success": True})
 

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -256,7 +256,7 @@ def policy_error(error):
     if "audit_object" in g:
         g.audit_object.log({"info": error.message})
         g.audit_object.finalize_log()
-    return send_error(error.message), error.id
+    return send_error(error.message, error_code=error.id), 403
 
 
 @system_blueprint.app_errorhandler(privacyIDEAError)

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -231,11 +231,10 @@ def after_request(response):
 @postrequest(sign_response, request=request)
 def auth_error(error):
     if "audit_object" in g:
-        g.audit_object.log({"info": error.description})
+        g.audit_object.log({"info": error.message})
         g.audit_object.finalize_log()
-    return send_error(error.description,
-                      error_code=-401,
-                      details=error.details), error.status_code
+    return send_error(error.message,
+                      error_code=error.id), 401
 
 
 @system_blueprint.errorhandler(PolicyError)

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -24,7 +24,7 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from ...lib.error import (ParameterError,
-                          AuthError)
+                          AuthError, ERROR)
 from ...lib.log import log_with
 import time
 import threading
@@ -276,24 +276,21 @@ def verify_auth_token(auth_token, required_role=None):
     if required_role is None:
         required_role = ["admin", "user"]
     if auth_token is None:
-        raise AuthError("Authentication failure",
-                        "missing Authorization header",
-                        status=401)
+        raise AuthError("Authentication failure. Missing Authorization header.",
+                        id=ERROR.AUTHENTICATE_AUTH_HEADER)
     try:
         r = jwt.decode(auth_token, current_app.secret_key)
     except jwt.DecodeError as err:
-        raise AuthError("Authentication failure",
-                        "error during decoding your token: {0!s}".format(err),
-                        status=401)
+        raise AuthError("Authentication failure. Error during decoding your token: {0!s}".format(err),
+                        id=ERROR.AUTHENTICATE_DECODING_ERROR)
     except jwt.ExpiredSignature as err:
-        raise AuthError("Authentication failure",
-                        "Your token has expired: {0!s}".format(err),
-                        status=401)
+        raise AuthError("Authentication failure. Your token has expired: {0!s}".format(err),
+                        id=ERROR.AUTHENTICATE_TOKEN_EXPIRED)
     if required_role and r.get("role") not in required_role:
         # If we require a certain role like "admin", but the users role does
         # not match
-        raise AuthError("Authentication failure",
+        raise AuthError("Authentication failure. "
                         "You do not have the necessary role (%s) to access "
                         "this resource!" % required_role,
-                        status=401)
+                        id=ERROR.AUTHENTICATE_MISSING_RIGHT)
     return r

--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -40,6 +40,13 @@ class ERROR:
     POLICY = 303
     VALIDATE = 401
     REGISTRATION = 402
+    AUTHENTICATE = 403
+    AUTHENTICATE_WRONG_CREDENTIALS = 4031
+    AUTHENTICATE_MISSING_USERNAME = 4032
+    AUTHENTICATE_AUTH_HEADER = 4033
+    AUTHENTICATE_DECODING_ERROR = 4304
+    AUTHENTICATE_TOKEN_EXPIRED = 4305
+    AUTHENTICATE_MISSING_RIGHT = 4306
     CA = 503
     HSM = 707
     SELFSERVICE = 807
@@ -101,32 +108,9 @@ class SubscriptionError(privacyIDEAError):
         return ret
 
 
-class BaseError(Exception):
-    def __init__(self, error, description, status=400, headers=None):
-        Exception.__init__(self)
-        self.error = error
-        self.description = description
-        self.status_code = status
-        self.headers = headers
-        
-    def to_dict(self):
-        return {"status_code": self.status_code,
-                "error": self.error,
-                "description": self.description}
-        
-    def __repr__(self):
-        ret = '{0!s}(error={1!r}, description={2!r}, id={3:d})'.format(type(self).__name__,
-                                                       self.error,
-                                                       self.description,
-                                                       self.status_code)
-        return ret
-
-
-class AuthError(BaseError):
-    def __init__(self, error, description, status=401, headers=None,
-                 details=None):
-        self.details = details
-        BaseError.__init__(self, error, description, status, headers)
+class AuthError(privacyIDEAError):
+    def __init__(self, description, id=ERROR.AUTHENTICATE):
+        privacyIDEAError.__init__(self, description=description, id=id)
         
 
 class PolicyError(privacyIDEAError):

--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -33,6 +33,14 @@ import logging
 log = logging.getLogger(__name__)
 
 
+class ERROR:
+    SUBSCRIPTION = 101
+    POLICY = 403
+    CA = 503
+    HSM = 707
+    SELFSERVICE = 807
+
+
 class privacyIDEAError(Exception):
 
     def __init__(self, description=u"privacyIDEAError!", id=10):
@@ -70,13 +78,12 @@ class privacyIDEAError(Exception):
         return ret
 
 
-class SubscriptionError(Exception):
-    def __init__(self, description=None, application=None,
-                 id=101):
+class SubscriptionError(privacyIDEAError):
+    def __init__(self, description=None, application=None, id=ERROR.SUBSCRIPTION):
         self.id = id
         self.message = description
         self.application = application
-        Exception.__init__(self, description)
+        privacyIDEAError.__init__(self, description, id=self.id)
 
     def __str__(self):
         return self.__repr__()
@@ -116,7 +123,7 @@ class AuthError(BaseError):
         
 
 class PolicyError(privacyIDEAError):
-    def __init__(self, description, id=403):
+    def __init__(self, description, id=ERROR.POLICY):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 
@@ -140,7 +147,7 @@ class ConfigAdminError(privacyIDEAError):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 class CAError(privacyIDEAError):
-    def __init__(self, description="CA error!", id=503):
+    def __init__(self, description="CA error!", id=ERROR.CA):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 
@@ -155,12 +162,12 @@ class ServerError(privacyIDEAError):
 
 
 class HSMException(privacyIDEAError):
-    def __init__(self, description="hsm error!", id=707):
+    def __init__(self, description="hsm error!", id=ERROR.HSM):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 
 class SelfserviceException(privacyIDEAError):
-    def __init__(self, description="selfservice error!", id=807):
+    def __init__(self, description="selfservice error!", id=ERROR.SELFSERVICE):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 

--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -35,10 +35,17 @@ log = logging.getLogger(__name__)
 
 class ERROR:
     SUBSCRIPTION = 101
-    POLICY = 403
+    TOKENADMIN = 301
+    CONFIGADMIN = 302
+    POLICY = 303
+    VALIDATE = 401
+    REGISTRATION = 402
     CA = 503
     HSM = 707
     SELFSERVICE = 807
+    SERVER = 903
+    USER = 904
+    PARAMETER = 905
 
 
 class privacyIDEAError(Exception):
@@ -128,23 +135,24 @@ class PolicyError(privacyIDEAError):
 
 
 class ValidateError(privacyIDEAError):
-    def __init__(self, description="validation error!", id=10):
+    def __init__(self, description="validation error!", id=ERROR.VALIDATE):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 
 class RegistrationError(privacyIDEAError):
-    def __init__(self, description="registraion error!", id=10):
+    def __init__(self, description="registraion error!", id=ERROR.REGISTRATION):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 
 class TokenAdminError(privacyIDEAError):
-    def __init__(self, description="token admin error!", id=10):
+    def __init__(self, description="token admin error!", id=ERROR.TOKENADMIN):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 
 class ConfigAdminError(privacyIDEAError):
-    def __init__(self, description="config admin error!", id=10):
+    def __init__(self, description="config admin error!", id=ERROR.CONFIGADMIN):
         privacyIDEAError.__init__(self, description=description, id=id)
+
 
 class CAError(privacyIDEAError):
     def __init__(self, description="CA error!", id=ERROR.CA):
@@ -152,12 +160,12 @@ class CAError(privacyIDEAError):
 
 
 class UserError(privacyIDEAError):
-    def __init__(self, description="user error!", id=905):
+    def __init__(self, description="user error!", id=ERROR.USER):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 
 class ServerError(privacyIDEAError):
-    def __init__(self, description="server error!", id=905):
+    def __init__(self, description="server error!", id=ERROR.SERVER):
         privacyIDEAError.__init__(self, description=description, id=id)
 
 
@@ -174,5 +182,5 @@ class SelfserviceException(privacyIDEAError):
 class ParameterError(privacyIDEAError):
     USER_OR_SERIAL = _('You either need to provide user or serial')
 
-    def __init__(self, description="unspecified parameter error!", id=905):
+    def __init__(self, description="unspecified parameter error!", id=ERROR.PARAMETER):
         privacyIDEAError.__init__(self, description=description, id=id)

--- a/tests/test_api_register.py
+++ b/tests/test_api_register.py
@@ -10,6 +10,7 @@ import smtpmock
 from privacyidea.lib.config import set_privacyidea_config
 from privacyidea.lib.passwordreset import create_recoverycode
 from privacyidea.lib.user import User
+from privacyidea.lib.error import ERROR
 
 
 class RegisterTestCase(MyTestCase):
@@ -82,8 +83,9 @@ class RegisterTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
             data = json.loads(res.data)
+            self.assertEqual(data.get("result").get("error").get("code"), ERROR.REGISTRATION)
             self.assertEqual(data.get("result").get("error").get("message"),
-                         u'ERR10: No SMTP server configuration specified!')
+                         u'ERR402: No SMTP server configuration specified!')
 
         # Set SMTP config and policy
         add_smtpserver("myserver", "1.2.3.4", sender="pi@localhost")

--- a/tests/test_api_u2f.py
+++ b/tests/test_api_u2f.py
@@ -9,6 +9,7 @@ from privacyidea.lib.tokens.u2f import (sign_challenge, check_response,
 from privacyidea.lib.policy import set_policy, delete_policy, SCOPE
 from privacyidea.lib.tokens.u2ftoken import U2FACTION
 from privacyidea.models import Challenge
+from privacyidea.lib.error import ERROR
 
 
 PWFILE = "tests/testdata/passwords"
@@ -323,6 +324,7 @@ class APIU2fTestCase(MyTestCase):
             self.assertEqual(res.status_code, 403)
             result = json.loads(res.data).get("result")
             self.assertEqual(result.get("status"), False)
+            self.assertEqual(result.get("error").get("code"), ERROR.POLICY)
             self.assertEqual(result.get("error").get("message"),
                              u'The U2F device is not allowed to authenticate due to policy restriction.')
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -2030,9 +2030,10 @@ class ValidateAPITestCase(MyTestCase):
                                            data={"user": "cornelius",
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
-            self.assertEqual(res.status_code, ERROR.POLICY)
+            self.assertEqual(res.status_code, 403)
             result = json.loads(res.data).get("result")
             self.assertEqual(result.get("status"), False)
+            self.assertEqual(result.get("error").get("code"), ERROR.POLICY)
             detail = json.loads(res.data).get("detail")
             self.assertEqual(detail, None)
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -12,7 +12,7 @@ from privacyidea.lib.config import (set_privacyidea_config, get_token_types,
 from privacyidea.lib.token import (get_tokens, init_token, remove_token,
                                    reset_token, enable_token, revoke_token)
 from privacyidea.lib.policy import SCOPE, ACTION, set_policy, delete_policy
-from privacyidea.lib.error import TokenAdminError
+from privacyidea.lib.error import ERROR
 from privacyidea.lib.resolver import save_resolver, get_resolver_list
 from privacyidea.lib.realm import set_realm, set_default_realm
 
@@ -462,7 +462,7 @@ class AAValidateOfflineTestCase(MyTestCase):
             data = json.loads(res.data)
             self.assertTrue(res.status_code == 400, res)
             self.assertEqual(data.get("result").get("error").get("message"),
-                             u"ERR10: You provided a wrong OTP value.")
+                             u"ERR401: You provided a wrong OTP value.")
         # The failed refill should not modify the token counter!
         self.assertEqual(old_counter, token_obj.token.count)
 
@@ -2030,7 +2030,7 @@ class ValidateAPITestCase(MyTestCase):
                                            data={"user": "cornelius",
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 403, res)
+            self.assertEqual(res.status_code, ERROR.POLICY)
             result = json.loads(res.data).get("result")
             self.assertEqual(result.get("status"), False)
             detail = json.loads(res.data).get("detail")
@@ -2046,7 +2046,7 @@ class ValidateAPITestCase(MyTestCase):
                                            data={"user": "passthru",
                                                  "pass": "pthru"}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 200)
             result = json.loads(res.data).get("result")
             self.assertEqual(result.get("value"), True)
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1087%23issuecomment-394065525%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1087%23discussion_r192696797%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1087%23discussion_r192715284%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1087%23issuecomment-394384599%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1087%23issuecomment-394469534%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1087%23issuecomment-394611081%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1087%23issuecomment-394065525%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231087%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/625a1213b98c4306eac2b7d4017891edc1c8b7ec%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231087%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.62%25%20%20%2095.63%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016280%20%20%20%2016293%20%20%20%20%20%20%2B13%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015568%20%20%20%2015581%20%20%20%20%20%20%2B13%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20712%20%20%20%20%20%20712%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/error.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5%29%20%7C%20%6088.46%25%20%3C100%25%3E%20%28%2B1.64%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/before%5C%5C_after.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ%3D%3D%29%20%7C%20%6097.34%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B625a121...a4895d6%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1087%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-02T07%3A17%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Overall%2C%20I%20like%20this%20PR%20because%20it%20makes%20error%20handling%20more%20consistent%21%5Cr%5CnHowever%2C%20I%20saw%20that%20there%20are%20still%20some%20instances%20in%20which%20negative%20error%20codes%20are%20passed%20to%20%60%60send_error%60%60%2C%20e.g.%20in%20%60%60auth_error%60%60%3A%20https%3A//github.com/privacyidea/privacyidea/blob/a4895d6a2ba26fb39d59cda28b18cbffc7b30dc8/privacyidea/api/before_after.py%23L237%5Cr%5Cn%5Cr%5Cn...%20do%20we%20also%20want%20to%20change%20this%20error%20code%20here%3F%20Or%20should%20these%20stay%20negative%3F%22%2C%20%22created_at%22%3A%20%222018-06-04T14%3A56%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20you%20are%20right.%20The%20thing%20is%2C%20we%20have%20a%20%60%60BaseError%60%60%20and%20a%20%60%60privacyIDEAError%60%60.%20I%20am%20wondering%20why%20we%20have%20a%20%60%60BaseError%60%60%20which%20is%20the%20base%20class%20only%20for%20the%20%60%60AuthError%60%60.%5Cr%5Cn%5Cr%5CnWe%20could%20change%20this%20all%20to%20remove%20the%20%60%60BaseError%60%60%20and%20also%20inherit%20the%20%60%60AuthError%60%60%20from%20the%20%60%60privacyIDEAError%60%60.%22%2C%20%22created_at%22%3A%20%222018-06-04T19%3A25%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20wondered%20about%20this%20as%20well.%20I%20think%20one%20difference%20is%20that%20one%20can%20set%20the%20HTTP%20status%20code%20of%20an%20%60%60AuthError%60%60.%20However%2C%20it%20seems%20like%20all%20current%20%60%60AuthError%60%60%20instances%20have%20error%20code%20401%20anway.%22%2C%20%22created_at%22%3A%20%222018-06-05T07%3A33%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a4895d6a2ba26fb39d59cda28b18cbffc7b30dc8%20privacyidea/lib/error.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1087%23discussion_r192696797%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22One%20question%3A%20Do%20I%20understand%20correctly%20that%20these%20do%20not%20correspond%20to%20HTTP%20error%20codes%2C%20these%20are%20just%20the%20codes%20used%20in%20the%20privacyIDEA%20response%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-04T10%3A36%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20These%20are%20error%20codes%20in%20the%20JSON%20response%5Cr%5Cn%5Cr%5Cn%20%20%20%20%7B%20status%3A%20False%2C%5Cr%5Cn%20%20%20%20%20%20error%3A%20%7B%20code%3A%20...%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%3A%20....%20%7D%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-04T11%3A56%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/error.py%3AL33-54%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1087#issuecomment-394065525'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1087?src=pr&el=h1) Report
> Merging [#1087](https://codecov.io/gh/privacyidea/privacyidea/pull/1087?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/625a1213b98c4306eac2b7d4017891edc1c8b7ec?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1087/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1087?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1087      +/-   ##
==========================================
+ Coverage   95.62%   95.63%   +<.01%
==========================================
Files         131      131
Lines       16280    16293      +13
==========================================
+ Hits        15568    15581      +13
Misses        712      712
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1087?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/error.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1087/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5) | `88.46% <100%> (+1.64%)` | :arrow_up: |
| [privacyidea/api/before\_after.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1087/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ==) | `97.34% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1087?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1087?src=pr&el=footer). Last update [625a121...a4895d6](https://codecov.io/gh/privacyidea/privacyidea/pull/1087?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Overall, I like this PR because it makes error handling more consistent!
However, I saw that there are still some instances in which negative error codes are passed to ``send_error``, e.g. in ``auth_error``: https://github.com/privacyidea/privacyidea/blob/a4895d6a2ba26fb39d59cda28b18cbffc7b30dc8/privacyidea/api/before_after.py#L237
... do we also want to change this error code here? Or should these stay negative?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think you are right. The thing is, we have a ``BaseError`` and a ``privacyIDEAError``. I am wondering why we have a ``BaseError`` which is the base class only for the ``AuthError``.
We could change this all to remove the ``BaseError`` and also inherit the ``AuthError`` from the ``privacyIDEAError``.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I have wondered about this as well. I think one difference is that one can set the HTTP status code of an ``AuthError``. However, it seems like all current ``AuthError`` instances have error code 401 anway.
- [ ] <a href='#crh-comment-Pull a4895d6a2ba26fb39d59cda28b18cbffc7b30dc8 privacyidea/lib/error.py 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1087#discussion_r192696797'>File: privacyidea/lib/error.py:L33-54</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> One question: Do I understand correctly that these do not correspond to HTTP error codes, these are just the codes used in the privacyIDEA response?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Yes. These are error codes in the JSON response
{ status: False,
error: { code: ...,
message: .... }


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1087?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1087?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1087'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>