### PR TITLE
Add a privacyidea-standalone script

### DIFF
--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import json
+
+import sqlalchemy
+import sys
+import warnings
+import webbrowser
+
+from flask_script import Manager, Server
+from privacyidea.app import create_app
+
+
+warnings.simplefilter("ignore", category=sqlalchemy.exc.SAWarning)
+
+
+class Configure(Server):
+    help = description = "Run a local webserver to configure privacyIDEA"
+
+    def __call__(self, *args, **kwargs):
+        webbrowser.open('http://{}:{}'.format(self.host, self.port))
+        Server.__call__(self, *args, **kwargs)
+
+
+app = create_app(config_name='production', silent=True)
+manager = Manager(app, with_default_commands=False)
+manager.add_command("configure", Configure())
+
+def read_credentials(file):
+    """
+    read username and password from a file. This could be sys.stdin.
+
+    The first line specifies the username, the second line specifies the password.
+
+    :param file: a Python file object
+    :return: a tuple (user, password)
+    """
+    username = sys.stdin.readline().strip()
+    password = sys.stdin.readline().strip()
+    return username, password
+
+
+@manager.option('-r', '--response', dest='show_response', action='store_true',
+                help='Print the JSON response of privacyIDEA to standard output')
+def check(show_response=False):
+    """ Check the given username and password against privacyIDEA """
+    user, password = read_credentials(sys.stdin)
+    exitcode = 255
+    try:
+        with app.test_request_context('/validate/check', method='POST',
+                                      data={'user': user, 'pass': password}):
+            response = app.full_dispatch_request()
+            data = json.loads(response.data)
+            result = data.get('result', {})
+            if result['value'] is True:
+                exitcode = 0
+            else:
+                exitcode = 1
+            if show_response:
+                print response.data
+    except Exception, e:
+        print e
+    sys.exit(exitcode)
+
+
+if __name__ == '__main__':
+    manager.run()

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -228,7 +228,7 @@ def check(show_response=False):
             if show_response:
                 print response.data
     except Exception, e:
-        print e
+        print repr(e)
     sys.exit(exitcode)
 
 

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -1,5 +1,49 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
+# 2018-08-06 Friedrich Weber <friedrich.weber@netknights.it>
+#            Add standalone tool
+#
+# Copyright (c) 2018, Friedrich Weber
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+__doc__ = """
+This script can be used to create a self-contained local privacyIDEA
+instance that does not require a web server to run. Instead,
+authentication requests are validated via the command line.
+
+The ``create`` command launches a wizard that creates a new instance.
+The ``configure`` command starts a local development server that can
+be used to setup tokens. This server must not be exposed to the network!
+The ``check`` command can then be used to authenticate users."""
+
 import json
 import os
 import string
@@ -9,7 +53,6 @@ from functools import wraps
 import sqlalchemy
 import sys
 import warnings
-import webbrowser
 
 from flask_script import Manager, Server
 from tempfile import NamedTemporaryFile
@@ -80,11 +123,10 @@ class Configure(Server):
 
     @require_instance
     def __call__(self, *args, **kwargs):
-        webbrowser.open('http://{}:{}'.format(self.host, self.port))
         Server.__call__(self, *args, **kwargs)
 
 
-manager = Manager(_app_factory, with_default_commands=False)
+manager = Manager(_app_factory, with_default_commands=False, description=__doc__)
 manager.add_command("configure", Configure())
 manager.add_option('-i', '--instance', dest='instance', required=False, default=os.path.expanduser('~/.privacyidea'),
                    help='Location of the privacyIDEA instance (defaults to ~/.privacyidea)')
@@ -212,7 +254,15 @@ def create():
                 help='Print the JSON response of privacyIDEA to standard output')
 @require_instance
 def check(show_response=False):
-    """ Check the given username and password against privacyIDEA """
+    """
+    Check the given username and password against privacyIDEA.
+    This command reads two lines from standard input: The first line is
+    the username, the second line is the password (which consists of a
+    static part and the OTP).
+
+    This commands exits with return code 0 if the user could be authenticated
+    successfully.
+    """
     user, password = read_credentials(sys.stdin)
     exitcode = 255
     try:

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import json
 import os
+import string
 import subprocess
 from functools import wraps
 
@@ -44,7 +45,7 @@ def _app_factory(instance):
     """
     Create a Flask app object with the given privacyIDEA standalone instance.
     """
-    config_file = os.path.join(instance, 'pi.cfg')
+    config_file = os.path.abspath(os.path.join(instance, 'pi.cfg'))
     app = create_app(config_name='production', config_file=config_file, silent=True)
     app.instance_directory = instance
     return app
@@ -92,6 +93,19 @@ def read_credentials(file):
     return username, password
 
 
+PEPPER_CHARSET = string.ascii_letters + string.digits + '_'
+
+
+def create_pepper(length=24, chunk_size=8, charset=PEPPER_CHARSET):
+    pepper = b''
+    while len(pepper) < length:
+        random_bytes = DefaultSecurityModule.random(chunk_size)
+        printable_bytes = ''.join(b for b in random_bytes if b in charset)
+        pepper += printable_bytes
+    return pepper[:length]
+
+
+
 @manager.command
 def create():
     """ Create a new privacyIDEA instance """
@@ -102,7 +116,7 @@ def create():
 
     # create SECRET_KEY and PI_PEPPER
     secret_key = DefaultSecurityModule.random(24)
-    pi_pepper = DefaultSecurityModule.random(24)
+    pi_pepper = create_pepper()
 
     # create a pi.cfg
     pi_cfg = os.path.join(instance_dir, 'pi.cfg')
@@ -117,7 +131,8 @@ def create():
     invoke_pi_manage(['create_audit_keys'], pi_cfg)
     invoke_pi_manage(['createdb'], pi_cfg)
 
-    invoke_pi_manage(['admin', 'add', 'admin', '-p', 'test'], pi_cfg)
+    print 'Please enter a password for the new admin `super`.'
+    invoke_pi_manage(['admin', 'add', 'super'], pi_cfg)
 
 
 @manager.option('-r', '--response', dest='show_response', action='store_true',

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import json
+import os
+import subprocess
+from functools import wraps
 
 import sqlalchemy
 import sys
@@ -9,22 +12,71 @@ import webbrowser
 
 from flask_script import Manager, Server
 from privacyidea.app import create_app
-
+from privacyidea.lib.security.default import DefaultSecurityModule
 
 warnings.simplefilter("ignore", category=sqlalchemy.exc.SAWarning)
+
+PI_CFG_TEMPLATE = """import os, logging
+
+INSTANCE_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+PI_ENCFILE = os.path.join(INSTANCE_DIRECTORY, 'encKey')
+PI_AUDIT_KEY_PRIVATE = os.path.join(INSTANCE_DIRECTORY, 'private.pem')
+PI_AUDIT_KEY_PUBLIC = os.path.join(INSTANCE_DIRECTORY, 'public.pem')
+PI_LOGFILE = os.path.join(INSTANCE_DIRECTORY, 'privacyidea.log')
+PI_LOGLEVEL = logging.INFO
+SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(INSTANCE_DIRECTORY, 'privacyidea.sqlite')
+
+SECRET_KEY = b'{secret_key}'
+PI_PEPPER = b'{pi_pepper}'
+
+"""
+
+RSA_KEYSIZE = 2048
+
+
+def invoke_pi_manage(commandline, pi_cfg):
+    environment = os.environ.copy()
+    environment['PRIVACYIDEA_CONFIGFILE'] = pi_cfg
+    subprocess.check_call(['pi-manage'] + commandline, env=environment)
+
+
+def _app_factory(instance):
+    """
+    Create a Flask app object with the given privacyIDEA standalone instance.
+    """
+    config_file = os.path.join(instance, 'pi.cfg')
+    app = create_app(config_name='production', config_file=config_file, silent=True)
+    app.instance_directory = instance
+    return app
+
+
+def require_instance(f):
+    @wraps(f)
+    def deco(*args, **kwargs):
+        config_file = os.path.join(manager.app.instance_directory, 'pi.cfg')
+        if not os.path.exists(config_file):
+            raise RuntimeError(
+                "{!r} does not exist! Create a new instance using ``privacyidea-standalone create``.".format(
+                    config_file
+                ))
+        return f(*args, **kwargs)
+    return deco
 
 
 class Configure(Server):
     help = description = "Run a local webserver to configure privacyIDEA"
 
+    @require_instance
     def __call__(self, *args, **kwargs):
         webbrowser.open('http://{}:{}'.format(self.host, self.port))
         Server.__call__(self, *args, **kwargs)
 
 
-app = create_app(config_name='production', silent=True)
-manager = Manager(app, with_default_commands=False)
+manager = Manager(_app_factory, with_default_commands=False)
 manager.add_command("configure", Configure())
+manager.add_option('-i', '--instance', dest='instance', required=False, default=os.path.expanduser('~/.privacyidea'),
+                   help='Location of the privacyIDEA instance (defaults to ~/.privacyidea)')
+
 
 def read_credentials(file):
     """
@@ -35,23 +87,52 @@ def read_credentials(file):
     :param file: a Python file object
     :return: a tuple (user, password)
     """
-    username = sys.stdin.readline().strip()
-    password = sys.stdin.readline().strip()
+    username = file.readline().strip()
+    password = file.readline().strip()
     return username, password
+
+
+@manager.command
+def create():
+    """ Create a new privacyIDEA instance """
+    instance_dir = os.path.abspath(manager.app.instance_directory)
+    if os.path.exists(manager.app.instance_directory):
+        raise RuntimeError("Instance at {!r} exists already!".format(manager.app.instance_directory))
+    os.makedirs(instance_dir)
+
+    # create SECRET_KEY and PI_PEPPER
+    secret_key = DefaultSecurityModule.random(24)
+    pi_pepper = DefaultSecurityModule.random(24)
+
+    # create a pi.cfg
+    pi_cfg = os.path.join(instance_dir, 'pi.cfg')
+    with open(pi_cfg, 'w') as f:
+        f.write(PI_CFG_TEMPLATE.format(
+            secret_key=secret_key.encode('string-escape'),
+            pi_pepper=pi_pepper.encode('string-escape')
+        ))
+
+    # create an enckey
+    invoke_pi_manage(['create_enckey'], pi_cfg)
+    invoke_pi_manage(['create_audit_keys'], pi_cfg)
+    invoke_pi_manage(['createdb'], pi_cfg)
+
+    invoke_pi_manage(['admin', 'add', 'admin', '-p', 'test'], pi_cfg)
 
 
 @manager.option('-r', '--response', dest='show_response', action='store_true',
                 help='Print the JSON response of privacyIDEA to standard output')
+@require_instance
 def check(show_response=False):
     """ Check the given username and password against privacyIDEA """
     user, password = read_credentials(sys.stdin)
     exitcode = 255
     try:
-        with app.test_request_context('/validate/check', method='POST',
+        with manager.app.test_request_context('/validate/check', method='POST',
                                       data={'user': user, 'pass': password}):
-            response = app.full_dispatch_request()
+            response = manager.app.full_dispatch_request()
             data = json.loads(response.data)
-            result = data.get('result', {})
+            result = data['result']
             if result['value'] is True:
                 exitcode = 0
             else:

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -12,6 +12,8 @@ import warnings
 import webbrowser
 
 from flask_script import Manager, Server
+from tempfile import NamedTemporaryFile
+
 from privacyidea.app import create_app
 from privacyidea.lib.security.default import DefaultSecurityModule
 
@@ -33,9 +35,15 @@ PI_PEPPER = b'{pi_pepper}'
 """
 
 RSA_KEYSIZE = 2048
+PEPPER_CHARSET = string.ascii_letters + string.digits + '_'
 
 
 def invoke_pi_manage(commandline, pi_cfg):
+    """
+    Invoke ``pi-manage`` with arguments, setting PRIVACYIDEA_CONFIGFILE TO ``pi_cfg``.
+    :param commandline: arguments to pass as a list
+    :param pi_cfg: location of the privacyIDEA config file
+    """
     environment = os.environ.copy()
     environment['PRIVACYIDEA_CONFIGFILE'] = pi_cfg
     subprocess.check_call(['pi-manage'] + commandline, env=environment)
@@ -52,6 +60,9 @@ def _app_factory(instance):
 
 
 def require_instance(f):
+    """
+    Decorator that marks commands that require an already set-up instance directory
+    """
     @wraps(f)
     def deco(*args, **kwargs):
         config_file = os.path.join(manager.app.instance_directory, 'pi.cfg')
@@ -93,10 +104,15 @@ def read_credentials(file):
     return username, password
 
 
-PEPPER_CHARSET = string.ascii_letters + string.digits + '_'
-
-
 def create_pepper(length=24, chunk_size=8, charset=PEPPER_CHARSET):
+    """
+    create a valid PI_PEPPER value of a given length from urandom,
+    choosing characters from a given charset
+    :param length: pepper length to generate
+    :param chunk_size: number of bytes to read from urandom per iteration
+    :param charset: list of valid characters
+    :return: a bytestring of the specified length
+    """
     pepper = b''
     while len(pepper) < length:
         random_bytes = DefaultSecurityModule.random(chunk_size)
@@ -104,6 +120,37 @@ def create_pepper(length=24, chunk_size=8, charset=PEPPER_CHARSET):
         pepper += printable_bytes
     return pepper[:length]
 
+
+def choice(question, choices, case_insensitive=True):
+    """
+    Ask a question interactively until one of the given choices is selected.
+    Return the choice then.
+    :param question: Question to ask the user as a string
+    :param choices: Dictionary mapping user answers to return values
+    :param case_insensitive: Set to true if the answer should be handled case-insensitively.
+                             Then, ``choices`` should contain only lowercase keys.
+    :return: a value of ``choices``
+    """
+    while True:
+        answer = raw_input(question)
+        if case_insensitive:
+            answer = answer.lower()
+        if answer in choices:
+            return choices[answer]
+        else:
+            print '{!r} is not a valid answer.'.format(answer)
+
+
+def yesno(question, default):
+    """
+    Ask a y/n question with a default value.
+    :param question: Question to ask the user as a string
+    :param default: Default return value (boolean)
+    :return: boolean
+    """
+    return choice(question, {'y': True,
+                             'n': False,
+                             '': default})
 
 
 @manager.command
@@ -131,8 +178,34 @@ def create():
     invoke_pi_manage(['create_audit_keys'], pi_cfg)
     invoke_pi_manage(['createdb'], pi_cfg)
 
+    print
     print 'Please enter a password for the new admin `super`.'
     invoke_pi_manage(['admin', 'add', 'super'], pi_cfg)
+
+    # create users
+    if yesno('Would you like to create a default resolver and realm (Y/n)? ', True):
+        print 'There are two possibilities to create a resolver:'
+        print ' 1) We can create a table in the privacyIDEA SQLite database to store the users.'
+        print '    You can add users via the privacyIDEA Web UI.'
+        print ' 2) We can create a resolver that contains the users from /etc/passwd'
+        print
+        create_sql_resolver = choice('Please choose (default=1): ', {
+            '1': True,
+            '2': False,
+            '': True
+        })
+        if create_sql_resolver:
+            invoke_pi_manage(['resolver', 'create_internal', 'defresolver'], pi_cfg)
+        else:
+            with NamedTemporaryFile(delete=False) as f:
+                f.write('{"fileName": "/etc/passwd"}')
+            invoke_pi_manage(['resolver', 'create', 'defresolver', 'passwdresolver', f.name], pi_cfg)
+            os.unlink(f.name)
+        invoke_pi_manage(['realm', 'create', 'defrealm', 'defresolver'], pi_cfg)
+
+    print
+    print 'Configuration is complete. You can now configure privacyIDEA in the web browser by running'
+    print "  privacyidea-standalone -i '{}' configure".format(instance_dir.encode('string-escape'))
 
 
 @manager.option('-r', '--response', dest='show_response', action='store_true',


### PR DESCRIPTION
This adds a simple standalone privacyIDEA script like we talked about in #1043. It can be used as follows:

```shell
$ privacyidea-standalone -i my-small-instance/ create 
# will create a directory my-small-instance/ which contains the pi.cfg, keys, SQLite database and logfile
# will create an admin `super` and ask for a password
# asks if it should create a default resolver and realm.
# if yes, it offers two possibilites: it can create a SQLidresolver via create_internal, or a PasswdResolver pointing to /etc/passwd
$ privacyidea-standalone -i my-small-instance/ configure
# starts a development server (like runserver) and the webbrowser
$ echo 'foobar\nhuhu' | privacyidea-standalone -i my-small-instance check; echo $?
# tries to authenticate the user ``foobar`` with password ``huhu``.
# exit code is 0 in case of success
0
$ echo 'foobar\nwrong' | privacyidea-standalone -i my-small-instance check -r 
# ``-r`` prints the JSON response
{"jsonrpc": "2.0", "signature": "...", "detail": {"message": "wrong otp pin", "threadid": 140127194047680}, "versionnumber": "2.23.dev1", "version": "privacyIDEA 2.23.dev1", "result": {"status": true, "value": false}, "time": 1528373720.150901, "id": 1}
```

This is really just a work-in-progress, let me know what you think :)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-395401311%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-395406704%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-395413289%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-395420379%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-395432904%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-395441953%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-410657522%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-410738761%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1090%23issuecomment-395401311%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231090%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/a8eab397534a5b59fb62f0c04a544c46ec81192d%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231090%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.62%25%20%20%2095.64%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016290%20%20%20%2016290%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015578%20%20%20%2015581%20%20%20%20%20%20%20%2B3%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20712%20%20%20%20%20%20709%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B2.5%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Ba8eab39...b220d1a%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1090%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-07T12%3A23%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22My%20first%20thought%20was%3A%20why%20not%20add%20this%20to%20%60%60pi-manage%60%60.%20We%20can%20already%20use%20pi-manage%20to%20initialize%20the%20database%2C%20create%20encryption%20key%2C%20create%20audit%20keys.%5Cr%5Cn%5Cr%5CnWhy%20not%20use%20pi-manage%20to%20also%20bootstrap%20the%20config%20in%20pi.cfg%20%28if%20this%20technically%20works%20out%29.%5Cr%5Cn%5Cr%5CnI%20think%20I%20would%20like%20this%20a%20lot%3A%5Cr%5Cn%5Cr%5Cn1.%20Create%20a%20basic%20configuration%20%28pi.cfg%29%20file%3A%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Eshell%5Cr%5Cn%20%20%20%20pi-manage%20bootstrap%20-i%20%5Bstandalone%7Cwebserver%5D%20%3Cdirectory%3E%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cn%5Cr%5Cn%5C%22webserver%5C%22%20beeing%20the%20default%20and%20directory%20defaulting%20to%20/etc/privacyidea.%5Cr%5Cn%5Cr%5CnThis%20would%20create%20the%20pi.cfg%20file%20%28if%20it%20does%20not%20exist%2C%20yet%20-%20do%20not%20overwrite%29.%20%5Cr%5Cn%5Cr%5Cn2.%20Create%20enckey%20and%20signing%20keys%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Eshell%5Cr%5Cn%20%20%20%20pi-manage%20create_enckey%5Cr%5Cn%20%20%20%20pi-manage%20create_audit_keys%5Cr%5Cn%20%20%20%20pi-manage%20create_pgp_keys%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cn3.%20Create%20DB%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Eshell%5Cr%5Cn%20%20%20%20pi-manage%20createdb%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cn%5Cr%5CnThen%20we%20could%20still%20run%20the%20webserver%20with%20runserver...%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-07T12%3A44%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20comments%21%5Cr%5Cn%5Cr%5CnHah%2C%20we%20already%20talked%20about%20integrating%20this%20into%20%60%60pi-manage%60%60%20over%20at%20%231043%20%3A%29%20It%27s%20true%20that%20we%20already%20have%20%60%60pi-manage%20validate%60%60%2C%20but%20it%20is%20less%20powerful%20than%20%60%60privacyidea-standalone%20validate%60%60%3A%20the%20latter%20accepts%20username%20and%20password%20via%20stdin%2C%20so%20they%20do%20not%20appear%20in%20the%20process%20list%2C%20and%20it%20signals%20success%20and%20failure%20by%20return%20codes.%20So%20it%20can%20be%20integrated%20into%20scripts%20more%20easily.%5Cr%5Cn%5Cr%5CnYes%2C%20%60%60privacyidea-standalone%60%60%20actually%20invokes%20%60%60pi-manage%60%60%20for%20most%20of%20the%20bootstrapping.%20The%20only%20exception%20is%20writing%20the%20initial%20%60%60pi.cfg%60%60.%20We%20could%20of%20course%20move%20this%20functionality%20to%20a%20new%20%60%60pi-manage%60%60%20command.%5Cr%5Cn%5Cr%5CnI%20agree%20that%20everything%20%60%60privacyidea-standalone%20create%60%60%20does%20can%20be%20achieved%20by%20running%20some%20%60%60pi-manage%60%60%20commands.%20But%20if%20we%20also%20have%20a%20separate%20script%20as%20a%20%5C%22layer%20above%20pi-manage%5C%22%2C%20we%20can%20just%20tell%20people%20who%20want%20to%20run%20privacyIDEA%20%5C%22just%5C%22%20as%20a%20tool%20without%20a%20webserver%3A%20%5C%22Just%20run%20%60%60privacyidea-standalone%60%60%2C%20it%20only%20has%20three%20commands%20and%20can%20do%20everything%20you%20want%5C%22.%20And%20if%20they%20want%20to%20do%20something%20more%20advanced%2C%20they%20can%20still%20use%20%60%60pi-manage%60%60.%22%2C%20%22created_at%22%3A%20%222018-06-07T13%3A06%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20we%20could%20change%20%60%60pi-manage%20validate%60%60.%5Cr%5Cn%5Cr%5CnI%20get%20your%20points.%20I%20recently%20added%20two%20other%20%60%60privacyidea-xyz%60%60%20tools%20and%20we%20are%20getting%20a%20lot%20of%20those%20tools%21%20%3B-%29%5Cr%5CnThe%20management%20script%20%20%60%60pi-manage%20%60%60%20is%20based%20on%20a%20manage%20tool%20idea%20from%20ruby%20-%20or%20was%20it%20go%3F%20I%20think%20ruby.%20Or%20django%3F%5Cr%5CnAnyways%3A%20Just%20as%20puzzling%20to%20use%20a%20toolchain%20of%20several%20pi-manage%20commands%20it%20can%20be%20puzzling%20to%20the%20user%20to%20actually%20find%20the%20right%20of%20the%2030%20scripts%2C%20to%20get%20started...%20%3B-%29%5Cr%5Cn%5Cr%5Cn%3E%20%5C%22I%20installed%20privacyIDEA.%20What%20should%20I%20do%20now%3F%5C%22%5Cr%5Cn%5Cr%5CnThis%20way%20we%20could%20always%20say%3A%20%2A%5C%22No%20matter%20what%3A%20The%20first%20thing%20you%20need%20to%20do%20after%20installing%20the%20privacyIDEA%20code%2C%20is%20to%20use%20the%20pi-manage%20script.%5C%22%2A%22%2C%20%22created_at%22%3A%20%222018-06-07T13%3A29%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20I%20think%20the%20large%20majority%20of%20users%20want%20to%20use%20privacyIDEA%20with%20a%20real%20web%20and%20database%20server%20and%20a%20LDAP%20user%20resolver.%20They%20use%20our%20distribution%20packages%20which%20bootstraps%20%60%60pi.cfg%60%60%20and%20for%20them%2C%20%60%60pi-manage%60%60%20already%20is%20the%20go-to%20script%20to%20manage%20privacyIDEA.%5Cr%5Cn%5Cr%5CnOn%20the%20other%20hand%2C%20the%20target%20audience%20of%20the%20standalone%20script%20would%20be%20nerds%20who%20do%20not%20want%20to%20run%20a%20web%20server%20and%20are%20fine%20with%20SQLite%20as%20a%20database%20backend%20and%20user%20store.%20Sure%2C%20we%20can%20already%20set%20this%20up%20with%20a%20chain%20of%20pi-manage%20commands%2C%20but%20I%20think%20it%20would%20be%20cool%20to%20have%20a%20simple%20single%20command%2C%20a%20%5C%22wizard%5C%22.%20But%20I%27m%20not%20sure%20if%20we%20should%20clutter%20the%20%60%60pi-manage%60%60%20interface%20with%20that%20functionality%2C%20because%20they%20will%20only%20be%20interesting%20for%20that%20small%20minority%20of%20users.%20I%20think%20having%20a%20separate%20script%20instead%20would%2C%20in%20this%20case%2C%20be%20more%20adequate%20because%20the%20vast%20majority%20of%20users%20will%20never%20need%20this.%5Cr%5Cn%5Cr%5CnI%20forgot%20to%20mention%20that%20the%20%60%60pi.cfg%60%60%20created%20by%20%60%60privacyidea-standalone%60%60%20is%20also%20somewhat%20special%20because%20it%20does%20not%20contain%20absolute%20paths.%20So%20the%20directory%20is%20really%20a%20self-contained%20privacyIDEA%20instance.%20It%20also%20includes%20the%20logs%2C%20for%20instance.%20I%20guess%20most%20users%20wouldn%27t%20want%20anything%20like%20this%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-06-07T14%3A06%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20I%20think%20having%20a%20separate%20script%20instead%20would%2C%20in%20this%20case%2C%20be%20more%20adequate%20because%20the%20vast%20majority%20of%20users%20will%20never%20need%20this.%5Cr%5Cn%5Cr%5CnI%20do%20not%20think%20so.%20%20%3B-%29%5Cr%5Cnif%5Cr%5Cn%20%20%20%5Cr%5Cn%20%20%20%20pi-manage%20bootstrap%5Cr%5Cn%5Cr%5Cnwould%20actually%20_create_%20a%20pi.cfg%20file%2C%20many%20people%20who%20are%20installing%20on%20a%20distribution%20like%20suse%20or%20redhat%20without%20using%20a%20package%20but%20running%20in%20a%20webserver%2C%20might%20use%20this.%20...instead%20of%20writing%20a%20pi.cfg%20from%20the%20scratch%20or%20finding%20an%20example.%5Cr%5CnYou%20see%3A%20e.g.%20if%20on%20RedHat%20system%20you%20install%20the%20%2Aprivacyidea%2A%20package%20but%20not%20the%20%2Aprivacyidea-server%2A%20meta%20package%20all%20the%20configuration%20of%20pi.cfg%20is%20missing.%20Although%20you%20plan%20to%20run%20in%20nginx%2C%20with%20an%20oracle%20db.%20But%20the%20meta%20packate%20does%20not%20provide%20this.%5Cr%5Cn%5Cr%5CnIn%20this%20scenario%20you%20would%20have%20to%20create%20the%20pi.cfg%20%28and%20all%20the%20secrets%20and%20peppers%29%20manually.%20Cool%2C%20if%20there%20was%20some%20pi-manage%20bootstrap%20command%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-06-07T14%3A30%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22unfortunately%20%60flask_script%60%20is%20deprecated%20%28See%20%231121%29%20but%20using%20%5BFlask%20CLI%5D%28http%3A//flask.pocoo.org/docs/1.0/cli/%29%20is%20quite%20straight%20forward.%22%2C%20%22created_at%22%3A%20%222018-08-06T10%3A07%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20the%20help%20and%20description%20%28and%20did%20some%20other%20minor%20tweaks%29.%5Cr%5Cn%5Cr%5CnRegarding%20the%20flask_script%20issue%3A%20I%20think%20we%20cannot%20start%20using%20%60%60flask.cli%60%60%20here%20because%20we%20have%20to%20support%20Flask%200.10.1%20on%20Xenial%20%3A-/%20But%20even%20though%20it%20is%20deprecated%2C%20flask-script%20seems%20to%20work%20fine%20with%20Flask%201.0.2%3F%22%2C%20%22created_at%22%3A%20%222018-08-06T15%3A01%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1090#issuecomment-395401311'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1090?src=pr&el=h1) Report
> Merging [#1090](https://codecov.io/gh/privacyidea/privacyidea/pull/1090?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/a8eab397534a5b59fb62f0c04a544c46ec81192d?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1090/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1090?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1090      +/-   ##
==========================================
+ Coverage   95.62%   95.64%   +0.01%
==========================================
Files         131      131
Lines       16290    16290
==========================================
+ Hits        15578    15581       +3
+ Misses        712      709       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1090?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1090/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+2.5%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1090?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1090?src=pr&el=footer). Last update [a8eab39...b220d1a](https://codecov.io/gh/privacyidea/privacyidea/pull/1090?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> My first thought was: why not add this to ``pi-manage``. We can already use pi-manage to initialize the database, create encryption key, create audit keys.
Why not use pi-manage to also bootstrap the config in pi.cfg (if this technically works out).
I think I would like this a lot:
1. Create a basic configuration (pi.cfg) file:
~~~~shell
pi-manage bootstrap -i [standalone|webserver] <directory>
~~~~
"webserver" beeing the default and directory defaulting to /etc/privacyidea.
This would create the pi.cfg file (if it does not exist, yet - do not overwrite).
2. Create enckey and signing keys
~~~~shell
pi-manage create_enckey
pi-manage create_audit_keys
pi-manage create_pgp_keys
~~~~
3. Create DB
~~~~shell
pi-manage createdb
~~~~
Then we could still run the webserver with runserver...
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Thanks for the comments!
Hah, we already talked about integrating this into ``pi-manage`` over at #1043 :) It's true that we already have ``pi-manage validate``, but it is less powerful than ``privacyidea-standalone validate``: the latter accepts username and password via stdin, so they do not appear in the process list, and it signals success and failure by return codes. So it can be integrated into scripts more easily.
Yes, ``privacyidea-standalone`` actually invokes ``pi-manage`` for most of the bootstrapping. The only exception is writing the initial ``pi.cfg``. We could of course move this functionality to a new ``pi-manage`` command.
I agree that everything ``privacyidea-standalone create`` does can be achieved by running some ``pi-manage`` commands. But if we also have a separate script as a "layer above pi-manage", we can just tell people who want to run privacyIDEA "just" as a tool without a webserver: "Just run ``privacyidea-standalone``, it only has three commands and can do everything you want". And if they want to do something more advanced, they can still use ``pi-manage``.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Well, we could change ``pi-manage validate``.
I get your points. I recently added two other ``privacyidea-xyz`` tools and we are getting a lot of those tools! ;-)
The management script  ``pi-manage `` is based on a manage tool idea from ruby - or was it go? I think ruby. Or django?
Anyways: Just as puzzling to use a toolchain of several pi-manage commands it can be puzzling to the user to actually find the right of the 30 scripts, to get started... ;-)
> "I installed privacyIDEA. What should I do now?"
This way we could always say: *"No matter what: The first thing you need to do after installing the privacyIDEA code, is to use the pi-manage script."*
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Well, I think the large majority of users want to use privacyIDEA with a real web and database server and a LDAP user resolver. They use our distribution packages which bootstraps ``pi.cfg`` and for them, ``pi-manage`` already is the go-to script to manage privacyIDEA.
On the other hand, the target audience of the standalone script would be nerds who do not want to run a web server and are fine with SQLite as a database backend and user store. Sure, we can already set this up with a chain of pi-manage commands, but I think it would be cool to have a simple single command, a "wizard". But I'm not sure if we should clutter the ``pi-manage`` interface with that functionality, because they will only be interesting for that small minority of users. I think having a separate script instead would, in this case, be more adequate because the vast majority of users will never need this.
I forgot to mention that the ``pi.cfg`` created by ``privacyidea-standalone`` is also somewhat special because it does not contain absolute paths. So the directory is really a self-contained privacyIDEA instance. It also includes the logs, for instance. I guess most users wouldn't want anything like this :)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> > I think having a separate script instead would, in this case, be more adequate because the vast majority of users will never need this.
I do not think so.  ;-)
if
pi-manage bootstrap
would actually _create_ a pi.cfg file, many people who are installing on a distribution like suse or redhat without using a package but running in a webserver, might use this. ...instead of writing a pi.cfg from the scratch or finding an example.
You see: e.g. if on RedHat system you install the *privacyidea* package but not the *privacyidea-server* meta package all the configuration of pi.cfg is missing. Although you plan to run in nginx, with an oracle db. But the meta packate does not provide this.
In this scenario you would have to create the pi.cfg (and all the secrets and peppers) manually. Cool, if there was some pi-manage bootstrap command ;-)
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> unfortunately `flask_script` is deprecated (See #1121) but using [Flask CLI](http://flask.pocoo.org/docs/1.0/cli/) is quite straight forward.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I've added the help and description (and did some other minor tweaks).
Regarding the flask_script issue: I think we cannot start using ``flask.cli`` here because we have to support Flask 0.10.1 on Xenial :-/ But even though it is deprecated, flask-script seems to work fine with Flask 1.0.2?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1090?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1090?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1090'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>