### PR TITLE
Add models and base class for periodic tasks

### DIFF
--- a/migrations/versions/2c9430cfc66b_.py
+++ b/migrations/versions/2c9430cfc66b_.py
@@ -18,11 +18,11 @@ def upgrade():
     try:
         op.create_table('periodictask',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('name', sa.Unicode(), nullable=False),
+        sa.Column('name', sa.Unicode(length=64), nullable=False),
         sa.Column('active', sa.Boolean(), nullable=False),
-        sa.Column('interval', sa.Interval(), nullable=False),
+        sa.Column('interval', sa.Unicode(length=256), nullable=False),
         sa.Column('nodes', sa.Unicode(length=256), nullable=False),
-        sa.Column('taskmodule', sa.Unicode(length=255), nullable=False),
+        sa.Column('taskmodule', sa.Unicode(length=256), nullable=False),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('name')
         )
@@ -38,7 +38,7 @@ def upgrade():
         op.create_table('periodictaskoption',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('periodictask_id', sa.Integer(), nullable=True),
-        sa.Column('key', sa.Unicode(length=255), nullable=False),
+        sa.Column('key', sa.Unicode(length=256), nullable=False),
         sa.Column('value', sa.Unicode(length=2000), nullable=True),
         sa.ForeignKeyConstraint(['periodictask_id'], ['periodictask.id'], ),
         sa.PrimaryKeyConstraint('id'),

--- a/migrations/versions/2c9430cfc66b_.py
+++ b/migrations/versions/2c9430cfc66b_.py
@@ -1,0 +1,55 @@
+"""create periodictask, periodictaskoption, periodictasklastrun tables
+
+Revision ID: 2c9430cfc66b
+Revises: 204d8d4f351e
+Create Date: 2018-06-20 09:55:52.086626
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2c9430cfc66b'
+down_revision = '204d8d4f351e'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    try:
+        op.create_table('periodictask',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.Unicode(), nullable=False),
+        sa.Column('active', sa.Boolean(), nullable=False),
+        sa.Column('interval', sa.Interval(), nullable=False),
+        sa.Column('nodes', sa.Unicode(length=256), nullable=False),
+        sa.Column('taskmodule', sa.Unicode(length=255), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name')
+        )
+        op.create_table('periodictasklastrun',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('periodictask_id', sa.Integer(), nullable=True),
+        sa.Column('node', sa.Unicode(length=256), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['periodictask_id'], ['periodictask.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('periodictask_id', 'node', name='ptlrix_1')
+        )
+        op.create_table('periodictaskoption',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('periodictask_id', sa.Integer(), nullable=True),
+        sa.Column('key', sa.Unicode(length=255), nullable=False),
+        sa.Column('value', sa.Unicode(length=2000), nullable=True),
+        sa.ForeignKeyConstraint(['periodictask_id'], ['periodictask.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('periodictask_id', 'key', name='ptoix_1')
+        )
+    except Exception, exx:
+        print "Could not add tables for periodic tasks!"
+        print exx
+
+
+def downgrade():
+    op.drop_table('periodictaskoption')
+    op.drop_table('periodictasklastrun')
+    op.drop_table('periodictask')

--- a/privacyidea/lib/task/base.py
+++ b/privacyidea/lib/task/base.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#  2018-06-20 Friedrich Weber <friedrich.weber@netknights.it>
+#             Initial skeleton
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+__doc__ = """This is the base class for a task module.
+
+Tasks may be run periodically. Upon execution, a task
+can be given a set of options.
+"""
+
+
+class BaseTask(object):
+    """
+    A BaseTask returns a list of supported options.
+    """
+
+    identifier = "BaseTask"
+    description = "This is the base class of a task with no functionality"
+
+    def __init__(self):
+        pass
+
+    @property
+    def options(self):
+        """
+        A task may be given a dictionary of options. The allowed keys, their
+        descriptions and types are specified here.
+
+        For each option key, the returned dictionary contains one nested dictionary.
+        Each nested dictionary has keys "type", "desc" and "value".
+
+        :return: dict
+        """
+        return {}
+
+    def do(self, options=None):
+        """
+        This method executes the task with the given options.
+
+        :param options: a dictionary mapping unicodes to unicodes
+        :return: a boolean denoting success
+        """
+        return True

--- a/privacyidea/lib/task/base.py
+++ b/privacyidea/lib/task/base.py
@@ -47,11 +47,11 @@ class BaseTask(object):
         """
         return {}
 
-    def do(self, options=None):
+    def do(self, params=None):
         """
-        This method executes the task with the given options.
+        This method executes the task with the given parameters.
 
-        :param options: a dictionary mapping unicodes to unicodes
+        :param params: a dictionary
         :return: a boolean denoting success
         """
         return True

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2499,7 +2499,7 @@ class PeriodicTask(MethodsMixin, db.Model):
 
     def __init__(self, name, active, interval, node_list, taskmodule, options=None, id=None):
         """
-        :param name: Unique name of the node as unicode
+        :param name: Unique name of the periodic task as unicode
         :param active: a boolean
         :param interval: a unicode specifying the periodicity of the task
         :param node_list: a list of unicodes, denoting the node names that should execute that task.
@@ -2518,7 +2518,7 @@ class PeriodicTask(MethodsMixin, db.Model):
         self.nodes = u", ".join(node_list)
         self.taskmodule = taskmodule
         self.save()
-        # add the options to the event handler
+        # add the options to the periodic task
         options = options or {}
         for k, v in options.iteritems():
             PeriodicTaskOption(periodictask_id=self.id, key=k, value=v)

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2018-06-20 Friedrich Weber <friedrich.weber@netknights.it>
+#             Add PeriodicTask, PeriodicTaskOption, PeriodicTaskLastRun
 #  2018-25-09 Paul Lettich <paul.lettich@netknights.it>
 #             Add decrease/reset methods to EventCounter
 #  2017-10-30 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -2474,3 +2476,204 @@ class AuthCache(MethodsMixin, db.Model):
         self.authentication = authentication
         self.first_auth = first_auth
         self.last_auth = last_auth
+
+### Periodic Tasks
+
+class PeriodicTask(MethodsMixin, db.Model):
+    """
+    This class stores tasks that should be run periodically.
+    """
+    __tablename__ = 'periodictask'
+    id = db.Column(db.Integer, Sequence("periodictask_seq"), primary_key=True)
+    name = db.Column(db.Unicode(), unique=True, nullable=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    interval = db.Column(db.Interval, nullable=False)
+    nodes = db.Column(db.Unicode(256), nullable=False)
+    taskmodule = db.Column(db.Unicode(255), nullable=False)
+    options = db.relationship('PeriodicTaskOption',
+                              lazy='dynamic',
+                              backref='periodictask')
+    last_runs = db.relationship('PeriodicTaskLastRun',
+                                lazy='dynamic',
+                                backref='periodictask')
+
+    def __init__(self, name, active, interval, node_list, taskmodule, options=None, id=None):
+        """
+        :param name: Unique name of the node as unicode
+        :param active: a boolean
+        :param interval: a timedelta
+        :param node_list: a list of unicodes, denoting the node names that should execute that task.
+                          If we update an existing PeriodicTask entry, PeriodicTaskLastRun entries
+                          referring to nodes that are not present in ``node_list`` any more will be deleted.
+        :param taskmodule: a unicode
+        :param options: a dictionary of options, mapping unicode keys to values. Values will be converted to unicode.
+                        If we update an existing PeriodicTask entry, all options that have been set previously
+                        but are not present in ``options`` will be deleted.
+        :param id: the ID of an existing entry, if any
+        """
+        self.id = id
+        self.name = name
+        self.active = active
+        self.interval = interval
+        self.nodes = u", ".join(node_list)
+        self.taskmodule = taskmodule
+        self.save()
+        # add the options to the event handler
+        options = options or {}
+        for k, v in options.iteritems():
+            PeriodicTaskOption(periodictask_id=self.id, key=k, value=v)
+        # remove all leftover options
+        all_options = PeriodicTaskOption.query.filter_by(periodictask_id=self.id).all()
+        for option in all_options:
+            if option.key not in options:
+                PeriodicTaskOption.query.filter_by(id=option.id).delete()
+        # remove all leftover last_runs
+        all_last_runs = PeriodicTaskLastRun.query.filter_by(periodictask_id=self.id).all()
+        for last_run in all_last_runs:
+            if last_run.node not in node_list:
+                PeriodicTaskLastRun.query.filter_by(id=last_run.id).delete()
+        db.session.commit()
+
+    def get(self):
+        """
+        Return the serialized periodic task object including the options and last runs
+
+        :return: complete dict
+        """
+        return {"id": self.id,
+                "name": self.name,
+                "active": self.active,
+                "interval": self.interval,
+                "nodes": [node.strip() for node in self.nodes.split(",")],
+                "taskmodule": self.taskmodule,
+                "options": dict((option.key, option.value) for option in self.options),
+                "last_runs": dict((last_run.node, last_run.timestamp) for last_run in self.last_runs)}
+
+    def save(self):
+        """
+        If the entry has an ID set, update the entry. If not, create one.
+        :return: the entry ID
+        """
+        if self.id is None:
+            # create a new one
+            db.session.add(self)
+        else:
+            # update
+            PeriodicTask.query.filter_by(id=self.id).update({
+                "name": self.name,
+                "active": self.active,
+                "interval": self.interval,
+                "nodes": self.nodes,
+                "taskmodule": self.taskmodule,
+            })
+        db.session.commit()
+        return self.id
+
+    def delete(self):
+        ret = self.id
+        # delete all PeriodicTaskOptions and PeriodicTaskLastRuns before deleting myself
+        db.session.query(PeriodicTaskOption).filter_by(periodictask_id=ret).delete()
+        db.session.query(PeriodicTaskLastRun).filter_by(periodictask_id=ret).delete()
+        db.session.delete(self)
+        db.session.commit()
+        return ret
+
+    def set_last_run(self, node, timestamp):
+        """
+        Store the information that the last run of the periodic job occurred on ``node`` at ``timestamp``.
+        :param node: Node name as a string
+        :param timestamp: Timestamp as UTC datetime (without timezone information)
+        :return:
+        """
+        PeriodicTaskLastRun(self.id, node, timestamp)
+
+class PeriodicTaskOption(db.Model):
+    """
+    Each PeriodicTask entry can have additional options according to the
+    task module.
+    """
+    __tablename__ = 'periodictaskoption'
+    id = db.Column(db.Integer, Sequence("periodictaskopt_seq"),
+                   primary_key=True)
+    periodictask_id = db.Column(db.Integer, db.ForeignKey('periodictask.id'))
+    key = db.Column(db.Unicode(255), nullable=False)
+    value = db.Column(db.Unicode(2000), default=u'')
+
+    __table_args__ = (db.UniqueConstraint('periodictask_id',
+                                          'key',
+                                          name='ptoix_1'), {})
+
+    def __init__(self, periodictask_id, key, value):
+        self.periodictask_id = periodictask_id
+        self.key = key
+        self.value = convert_column_to_unicode(value)
+        self.save()
+
+    def save(self):
+        """
+        Create or update a PeriodicTaskOption entry, depending on the value of ``self.id``
+        :return: the entry ID
+        """
+        option = PeriodicTaskOption.query.filter_by(
+            periodictask_id=self.periodictask_id, key=self.key
+        ).first()
+        if option is None:
+            # create a new one
+            db.session.add(self)
+            ret = self.id
+        else:
+            # update
+            PeriodicTaskOption.query.filter_by(periodictask_id=self.periodictask_id, key=self.key).update({
+                'value': self.value,
+            })
+            ret = option.id
+        db.session.commit()
+        return ret
+
+class PeriodicTaskLastRun(db.Model):
+    """
+    Each PeriodicTask entry stores, for each node, the timestamp of the last successful run.
+    """
+    __tablename__ = 'periodictasklastrun'
+    id = db.Column(db.Integer, Sequence("periodictasklastrun_seq"),
+                   primary_key=True)
+    periodictask_id = db.Column(db.Integer, db.ForeignKey('periodictask.id'))
+    node = db.Column(db.Unicode(256), nullable=False)
+    timestamp = db.Column(db.DateTime(False), nullable=False)
+
+    __table_args__ = (db.UniqueConstraint('periodictask_id',
+                                          'node',
+                                          name='ptlrix_1'), {})
+
+    def __init__(self, periodictask_id, node, timestamp):
+        """
+        :param periodictask_id: ID of the periodic task we are referring to
+        :param node: Node name as unicode
+        :param timestamp: Time of the last run as a datetime. A timezone must not be set!
+                          We require the time to be given in UTC.
+        """
+        self.periodictask_id = periodictask_id
+        self.node = node
+        self.timestamp = timestamp
+        self.save()
+
+    def save(self):
+        """
+        Create or update a PeriodicTaskLastRun entry, depending on the value of ``self.id``.
+        :return: the entry id
+        """
+        last_run = PeriodicTaskLastRun.query.filter_by(
+            periodictask_id=self.periodictask_id, node=self.node,
+        ).first()
+        if last_run is None:
+            # create a new one
+            db.session.add(self)
+            ret = self.id
+        else:
+            # update
+            PeriodicTaskLastRun.query.filter_by(periodictask_id=self.periodictask_id, node=self.node).update({
+                'timestamp': self.timestamp,
+            })
+            ret = last_run.id
+        db.session.commit()
+        return ret

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2485,11 +2485,11 @@ class PeriodicTask(MethodsMixin, db.Model):
     """
     __tablename__ = 'periodictask'
     id = db.Column(db.Integer, Sequence("periodictask_seq"), primary_key=True)
-    name = db.Column(db.Unicode(), unique=True, nullable=False)
+    name = db.Column(db.Unicode(64), unique=True, nullable=False)
     active = db.Column(db.Boolean, default=True, nullable=False)
-    interval = db.Column(db.Interval, nullable=False)
+    interval = db.Column(db.Unicode(256), nullable=False)
     nodes = db.Column(db.Unicode(256), nullable=False)
-    taskmodule = db.Column(db.Unicode(255), nullable=False)
+    taskmodule = db.Column(db.Unicode(256), nullable=False)
     options = db.relationship('PeriodicTaskOption',
                               lazy='dynamic',
                               backref='periodictask')
@@ -2501,7 +2501,7 @@ class PeriodicTask(MethodsMixin, db.Model):
         """
         :param name: Unique name of the node as unicode
         :param active: a boolean
-        :param interval: a timedelta
+        :param interval: a unicode specifying the periodicity of the task
         :param node_list: a list of unicodes, denoting the node names that should execute that task.
                           If we update an existing PeriodicTask entry, PeriodicTaskLastRun entries
                           referring to nodes that are not present in ``node_list`` any more will be deleted.
@@ -2596,7 +2596,7 @@ class PeriodicTaskOption(db.Model):
     id = db.Column(db.Integer, Sequence("periodictaskopt_seq"),
                    primary_key=True)
     periodictask_id = db.Column(db.Integer, db.ForeignKey('periodictask.id'))
-    key = db.Column(db.Unicode(255), nullable=False)
+    key = db.Column(db.Unicode(256), nullable=False)
     value = db.Column(db.Unicode(2000), default=u'')
 
     __table_args__ = (db.UniqueConstraint('periodictask_id',

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -770,7 +770,7 @@ class TokenModelTestCase(MyTestCase):
 
         # assert we can update the task
         PeriodicTask("task one", True, "0 8 * * *", ["localhost", "otherhost"], "some.module", {
-            "key2": "value number 2",
+            "KEY2": "value number 2",
             "key 4": 1234
         }, id=task1.id)
         # the first run for otherhost
@@ -784,7 +784,7 @@ class TokenModelTestCase(MyTestCase):
                              "interval": "0 8 * * *",
                              "nodes": ["localhost", "otherhost"],
                              "taskmodule": "some.module",
-                             "options": {"key2": "value number 2",
+                             "options": {"KEY2": "value number 2",
                                          "key 4": "1234"},
                              "last_runs": {
                                  "localhost": datetime(2018, 3, 4, 5, 6, 7),
@@ -792,7 +792,7 @@ class TokenModelTestCase(MyTestCase):
                              }
                          })
         # assert all old options are removed
-        self.assertEqual(PeriodicTaskOption.query.filter_by(periodictask_id=task1.id, key="KEY2").count(), 0)
+        self.assertEqual(PeriodicTaskOption.query.filter_by(periodictask_id=task1.id, key="key3").count(), 0)
         # the second run for localhost
         task1.set_last_run("localhost", datetime(2018, 3, 4, 5, 6, 8))
         result = PeriodicTask.query.filter_by(name="task one").one().get()
@@ -804,7 +804,7 @@ class TokenModelTestCase(MyTestCase):
                              "interval": "0 8 * * *",
                              "nodes": ["localhost", "otherhost"],
                              "taskmodule": "some.module",
-                             "options": {"key2": "value number 2",
+                             "options": {"KEY2": "value number 2",
                                          "key 4": "1234"},
                              "last_runs": {
                                  "localhost": datetime(2018, 3, 4, 5, 6, 8),

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -738,12 +738,12 @@ class TokenModelTestCase(MyTestCase):
         self.assertEqual(counter9, None)
 
     def test_26_periodictask(self):
-        task1 = PeriodicTask("task1", False, timedelta(minutes=10), ["localhost"], "some.module", {
+        task1 = PeriodicTask("task1", False, "0 5 * * *", ["localhost"], "some.module", {
             "key1": "value2",
             "KEY2": True,
             "key3": u"öfføff",
         })
-        task2 = PeriodicTask("some other task", True, timedelta(hours=10), ["localhost"], "some.other.module", {
+        task2 = PeriodicTask("some other task", True, "0 6 * * *", ["localhost"], "some.other.module", {
             "foo": "bar"
         })
         self.assertEqual(PeriodicTask.query.filter_by(name="task1").one(), task1)
@@ -755,7 +755,7 @@ class TokenModelTestCase(MyTestCase):
             "id": task1.id,
             "name": "task1",
             "active": False,
-            "interval": timedelta(minutes=10),
+            "interval": "0 5 * * *",
             "nodes": ["localhost"],
             "taskmodule": "some.module",
             "options": {
@@ -769,7 +769,7 @@ class TokenModelTestCase(MyTestCase):
         task1.set_last_run("localhost", datetime(2018, 3, 4, 5, 6, 7))
 
         # assert we can update the task
-        PeriodicTask("task one", True, timedelta(minutes=15), ["localhost", "otherhost"], "some.module", {
+        PeriodicTask("task one", True, "0 8 * * *", ["localhost", "otherhost"], "some.module", {
             "key2": "value number 2",
             "key 4": 1234
         }, id=task1.id)
@@ -781,7 +781,7 @@ class TokenModelTestCase(MyTestCase):
                              "id": task1.id,
                              "active": True,
                              "name": "task one",
-                             "interval": timedelta(minutes=15),
+                             "interval": "0 8 * * *",
                              "nodes": ["localhost", "otherhost"],
                              "taskmodule": "some.module",
                              "options": {"key2": "value number 2",
@@ -801,7 +801,7 @@ class TokenModelTestCase(MyTestCase):
                              "id": task1.id,
                              "active": True,
                              "name": "task one",
-                             "interval": timedelta(minutes=15),
+                             "interval": "0 8 * * *",
                              "nodes": ["localhost", "otherhost"],
                              "taskmodule": "some.module",
                              "options": {"key2": "value number 2",
@@ -813,7 +813,7 @@ class TokenModelTestCase(MyTestCase):
                          })
 
         # remove "localhost", assert the last run is removed
-        PeriodicTask("task one", True, timedelta(minutes=15), ["otherhost"], "some.module", {"foo": "bar"}, id=task1.id)
+        PeriodicTask("task one", True, "0 8 * * *", ["otherhost"], "some.module", {"foo": "bar"}, id=task1.id)
         self.assertEqual(PeriodicTaskOption.query.filter_by(periodictask_id=task1.id).count(), 1)
         self.assertEqual(PeriodicTaskLastRun.query.filter_by(periodictask_id=task1.id).one().node, "otherhost")
 

--- a/tests/test_lib_tasks.py
+++ b/tests/test_lib_tasks.py
@@ -1,0 +1,26 @@
+"""
+This file contains the tests for tasks.
+
+In particular, this tests
+lib/task/base.py
+"""
+
+from privacyidea.lib.task.base import BaseTask
+from .base import MyTestCase
+
+
+class BaseTaskTestCase(MyTestCase):
+    def test_01_base_functions(self):
+        task = BaseTask()
+
+        self.assertEqual(task.identifier, "BaseTask")
+        self.assertIsInstance(task.description, basestring)
+        self.assertEqual(task.options, {})
+
+        result1 = task.do()
+        self.assertTrue(result1)
+
+        result2 = task.do({
+            "foo": "bar"
+        })
+        self.assertTrue(result2)


### PR DESCRIPTION
Working on #992.

Some comments, mostly about naming :-)
* In this first version, I decided to call these ... things we want to implement "periodic tasks". I know this isn't really consistent with the other table names due to the adjective -- but I found no better alternative :-) The table does not really contain "jobs" or just "tasks", because these sound like one-off routines for me. It doesn't contain "cron jobs" -- they are in the system cron tab :) It doesn't contain "runners" either -- I think a runner would rather be the script which is invoked in the system crontab. I also like "chores", but maybe that's a bit too obscure?
* But! I called the base class we were talking about ``BaseTask``, and I moved it to ``privacyidea.lib.task.base``. Let me explain why I omitted the "periodic" here: This is because the tasks themselves do not care if they are invoked periodically or not. e.g. the token janitor could of course be invoked every week. But it could also be invoked manually at some point by the administrator because he/she thinks there are too many tokens. For the actual implementation of the token janitor, this doesn't make any difference.

What do you think? Does my reasoning make sense to you? I think it's important that we come up with names that make sense to everyone, because we'll have to live with them :-)

And of course, I'm also happy for any comments on the actual code!
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23issuecomment-398679007%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23issuecomment-398703346%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23issuecomment-399034479%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23issuecomment-399860467%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23issuecomment-399862369%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196727864%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196728062%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196728140%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196728706%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196728942%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196765271%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196766041%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196769274%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196787599%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196791874%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197038529%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197038625%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197038767%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197701723%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197701726%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197701731%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197701735%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197702159%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197702324%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r197704495%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23issuecomment-398679007%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231106%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/206c5f806f7ea445d3c01ce5c1e3a4e77e7fc347%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6089.89%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231106%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.67%25%20%20%2095.64%25%20%20%20-0.04%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20132%20%20%20%20%20%20133%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016418%20%20%20%2016517%20%20%20%20%20%20%2B99%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015708%20%20%20%2015797%20%20%20%20%20%20%2B89%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20710%20%20%20%20%20%20720%20%20%20%20%20%20%2B10%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/task/base.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rhc2svYmFzZS5weQ%3D%3D%29%20%7C%20%600%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.85%25%20%3C100%25%3E%20%28%2B0.08%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B206c5f8...d321a01%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1106%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-20T09%3A06%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Your%20argumentation%20for%20naming%20makes%20totally%20sense%21%22%2C%20%22created_at%22%3A%20%222018-06-20T10%3A32%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20review%21%20I%20incorporated%20the%20changes.%22%2C%20%22created_at%22%3A%20%222018-06-21T09%3A17%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A37%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A45%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200a13e0a2992d570d4f51ec0a38670121147728f6%20privacyidea/lib/task/base.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196727864%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20options%20in%20the%20event%20handlers%20are%20not%20the%20configuration%20itself.%20But%20also%20request%20specific%20context%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20%7B%20%5C%22g%5C%22%3A%20g%2C%5Cr%5Cn%20%20%20%20%20%20%5C%22handler_def%5C%22%3A%20%3Chandler%20optiones%3E%20%7D%5Cr%5Cn%5Cr%5CnSo%20the%20naming%20of%20parameter%20%60%60options%60%60%20and%20the%20property%20%60%60options%60%60%20might%20be%20a%20bit%20misleading%2C%20because%20it%20is%20not%20the%20same.%20The%20property%20%60%60options%60%60%20returns%20the%20information%2C%20how%20the%20module%20can%20be%20configured.%20The%20paramter%20%60%60options%60%60%20can%20contain%20the%20configuration%20but%20it%20could%20also%20contain%20additional%20context.%5Cr%5Cn%5Cr%5CnWe%20should%20keep%20this%20in%20mind.%20Maybe%2C%20when%20implementing%20the%20rest%2C%20we%20realize%2C%20that%20we%20should%20change%20the%20naming.%20For%20now%2C%20I%20think%20it%20is%20ok.%22%2C%20%22created_at%22%3A%20%222018-06-20T10%3A39%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20good%20to%20know%21%5Cr%5CnYes%2C%20let%27s%20see%20what%20we%27ll%20need.%20I%20guess%20theoretically%2C%20we%20shouldn%27t%20need%20%60%60g%60%60%20because%20we%20are%20operating%20outside%20the%20request%20context.%22%2C%20%22created_at%22%3A%20%222018-06-21T07%3A45%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20we%20rename%20either%20the%20method%20%60%60options%60%60%20or%20the%20parameter%20%60%60options%60%60%3F%5Cr%5Cn%28we%20should%20not%20spent%20more%20than%2042%20seconds%20here%29%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A35%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A45%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/task/base.py%3AL1-58%22%7D%2C%20%22Pull%200a13e0a2992d570d4f51ec0a38670121147728f6%20privacyidea/models.py%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196787599%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22is%20this%20the%20%60node%60%20where%20the%20task%20should%20run%3F%22%2C%20%22created_at%22%3A%20%222018-06-20T13%3A53%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right.%20The%20comment%20is%20wrong.%20It%20is%20the%20name%20of%20the%20task%20definition.%20%5Cr%5CnThe%20nodes%2C%20where%20it%20should%20run%2C%20is%20in%20the%20note_list.%22%2C%20%22created_at%22%3A%20%222018-06-20T14%3A04%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Right%2C%20thanks%20for%20noticing%21%22%2C%20%22created_at%22%3A%20%222018-06-21T07%3A46%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A33%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL2476-2680%22%7D%2C%20%22Pull%200a13e0a2992d570d4f51ec0a38670121147728f6%20privacyidea/models.py%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196728140%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22length%20255%3F%20Is%20there%20a%20reason%20or%20just%20coincidence%3F%22%2C%20%22created_at%22%3A%20%222018-06-20T10%3A40%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20whoops%2C%20this%20is%20just%20by%20accident.%20We%20should%20probably%20review%20the%20column%20lengths%20in%20general%2C%20as%20e.g.%20%60%60name%60%60%20doesn%27t%20even%20have%20a%20specified%20length.%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-06-20T12%3A56%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A33%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL2476-2680%22%7D%2C%20%22Pull%200a13e0a2992d570d4f51ec0a38670121147728f6%20privacyidea/models.py%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196728062%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22length%20256%3F%22%2C%20%22created_at%22%3A%20%222018-06-20T10%3A40%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A33%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL2476-2680%22%7D%2C%20%22Pull%200a13e0a2992d570d4f51ec0a38670121147728f6%20privacyidea/models.py%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196728706%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Oups%2C%20I%20am%20sorry.%20We%20did%20not%20discuss%20this%20finally%2C%20yesterday.%20A%20simple%20timedelta%20could%20not%20be%20used%20to%20say%3A%20Run%20the%20job%20on%20saturday%20at%208pm.%5Cr%5Cn%5Cr%5CnI%20think%20we%20need%20to%20discuss%20this%20in%20more%20detail%20OR%20change%20this%20to%20%60%60db.Unicode%28%29%60%60%2C%20to%20be%20more%20flexible%20for%20the%20time%20spec%20here.%22%2C%20%22created_at%22%3A%20%222018-06-20T10%3A42%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20so%20should%20we%20allow%20a%20scheduling%20possibility%20similar%20to%20crontab%3F%20i.e.%20with%20minute%2C%20hour%2C%20day%20of%20month%2C%20month%2C%20day%20of%20week%3F%20If%20yes%2C%20we%20should%20discuss%20if%20we%20want%20to%20store%20this%20in%20several%20columns%2C%20or%20if%20we%20want%20to%20store%20it%20as%20a%20Unicode%20with%20a%20well-defined%20format.%22%2C%20%22created_at%22%3A%20%222018-06-20T12%3A59%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Honestly%2C%20I%20am%20not%20sure%20if%20we%20want%20to%20be%20that%20complicated%20like%20the%20crontab%20format.%20Well%2C%20maybe%20we%20want%20to%2C%20since%20some%20know%20it.%5Cr%5CnBut%20honestly%20I%20thinks%20something%20like%3A%5Cr%5Cn%5Cr%5Cn%2A%20A%20certain%20time%20of%20day%20%20%20%2811%20pm%29%5Cr%5Cn%2A%20A%20certain%20day%20of%20the%20week%20%20%28Saturday%29%5Cr%5Cn%2A%20A%20certain%20date%20of%20the%20month%20%20%2828th%20day%20in%20month%29%5Cr%5Cn%2A%20all%20X%20minutes...%5Cr%5Cn%5Cr%5CnMakes%20sense.%20And%20basically%20we%20are%20at%20the%20cron%20format.%20Well%2C%20we%20do%20not%20need%20to%20allow%20something%20like%20%5C%22%2A/4%5C%22.%20But%20bottomline%3A%20I%20would%20make%20this%20a%20%60%60unicode%60%60%20column%20and%20have%20the%20application%20apply%20the%20logic.%22%2C%20%22created_at%22%3A%20%222018-06-20T13%3A08%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20sounds%20good%21%22%2C%20%22created_at%22%3A%20%222018-06-21T07%3A45%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A33%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL2476-2680%22%7D%2C%20%22Pull%200a13e0a2992d570d4f51ec0a38670121147728f6%20privacyidea/models.py%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1106%23discussion_r196728942%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22event%20handler%5C%22%20-%3E%20%5C%22Periodic%20Task%5C%22%22%2C%20%22created_at%22%3A%20%222018-06-20T10%3A43%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-06-25T07%3A36%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL2476-2680%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cornelinux%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cornelinux'><img src='https://avatars1.githubusercontent.com/u/1908620?v=4' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1106#issuecomment-398679007'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1106?src=pr&el=h1) Report
> Merging [#1106](https://codecov.io/gh/privacyidea/privacyidea/pull/1106?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/206c5f806f7ea445d3c01ce5c1e3a4e77e7fc347?src=pr&el=desc) will **decrease** coverage by `0.03%`.
> The diff coverage is `89.89%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1106/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1106?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1106      +/-   ##
==========================================
- Coverage   95.67%   95.64%   -0.04%
==========================================
Files         132      133       +1
Lines       16418    16517      +99
==========================================
+ Hits        15708    15797      +89
- Misses        710      720      +10
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1106?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/task/base.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1106/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rhc2svYmFzZS5weQ==) | `0% <0%> (ø)` | |
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1106/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.85% <100%> (+0.08%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1106?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1106?src=pr&el=footer). Last update [206c5f8...d321a01](https://codecov.io/gh/privacyidea/privacyidea/pull/1106?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Your argumentation for naming makes totally sense!
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Thanks for the review! I incorporated the changes.
- [x] <a href='#crh-comment-Pull 0a13e0a2992d570d4f51ec0a38670121147728f6 privacyidea/lib/task/base.py 50'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1106#discussion_r196727864'>File: privacyidea/lib/task/base.py:L1-58</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The options in the event handlers are not the configuration itself. But also request specific context:
{ "g": g,
"handler_def": <handler optiones> }
So the naming of parameter ``options`` and the property ``options`` might be a bit misleading, because it is not the same. The property ``options`` returns the information, how the module can be configured. The paramter ``options`` can contain the configuration but it could also contain additional context.
We should keep this in mind. Maybe, when implementing the rest, we realize, that we should change the naming. For now, I think it is ok.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, good to know!
Yes, let's see what we'll need. I guess theoretically, we shouldn't need ``g`` because we are operating outside the request context.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Should we rename either the method ``options`` or the parameter ``options``?
(we should not spent more than 42 seconds here)
- [x] <a href='#crh-comment-Pull 0a13e0a2992d570d4f51ec0a38670121147728f6 privacyidea/models.py 24'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1106#discussion_r196728062'>File: privacyidea/models.py:L2476-2680</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> length 256?
- [x] <a href='#crh-comment-Pull 0a13e0a2992d570d4f51ec0a38670121147728f6 privacyidea/models.py 25'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1106#discussion_r196728140'>File: privacyidea/models.py:L2476-2680</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> length 255? Is there a reason or just coincidence?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah whoops, this is just by accident. We should probably review the column lengths in general, as e.g. ``name`` doesn't even have a specified length. :)
- [x] <a href='#crh-comment-Pull 0a13e0a2992d570d4f51ec0a38670121147728f6 privacyidea/models.py 23'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1106#discussion_r196728706'>File: privacyidea/models.py:L2476-2680</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Oups, I am sorry. We did not discuss this finally, yesterday. A simple timedelta could not be used to say: Run the job on saturday at 8pm.
I think we need to discuss this in more detail OR change this to ``db.Unicode()``, to be more flexible for the time spec here.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, so should we allow a scheduling possibility similar to crontab? i.e. with minute, hour, day of month, month, day of week? If yes, we should discuss if we want to store this in several columns, or if we want to store it as a Unicode with a well-defined format.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Honestly, I am not sure if we want to be that complicated like the crontab format. Well, maybe we want to, since some know it.
But honestly I thinks something like:
* A certain time of day   (11 pm)
* A certain day of the week  (Saturday)
* A certain date of the month  (28th day in month)
* all X minutes...
Makes sense. And basically we are at the cron format. Well, we do not need to allow something like "*/4". But bottomline: I would make this a ``unicode`` column and have the application apply the logic.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> OK, sounds good!
- [x] <a href='#crh-comment-Pull 0a13e0a2992d570d4f51ec0a38670121147728f6 privacyidea/models.py 54'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1106#discussion_r196728942'>File: privacyidea/models.py:L2476-2680</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> "event handler" -> "Periodic Task"
- [x] <a href='#crh-comment-Pull 0a13e0a2992d570d4f51ec0a38670121147728f6 privacyidea/models.py 35'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1106#discussion_r196787599'>File: privacyidea/models.py:L2476-2680</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> is this the `node` where the task should run?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are right. The comment is wrong. It is the name of the task definition.
The nodes, where it should run, is in the note_list.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Right, thanks for noticing!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1106?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1106?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1106?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1106'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>