### PR TITLE
Allow pskc export and import of password type token

### DIFF
--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -496,7 +496,10 @@ def parsePSKCdata(xml_data,
                 enc_data = key.data.secret.encryptedvalue.ciphervalue.text
                 enc_data = enc_data.strip()
                 secret = aes_decrypt_b64(binascii.unhexlify(preshared_key_hex), enc_data)
-                token["otpkey"] = binascii.hexlify(secret)
+                if token["type"].lower() in ["hotp", "totp"]:
+                    token["otpkey"] = binascii.hexlify(secret)
+                else:
+                    token["otpkey"] = secret
         except Exception as exx:
             log.error("Failed to import tokendata: {0!s}".format(exx))
             log.debug(traceback.format_exc())
@@ -623,7 +626,10 @@ def export_pskc(tokenobj_list, psk=None):
             timedrift = 0
         otpkey = tokenobj.token.get_otpkey().getKey()
         try:
-            encrypted_otpkey = aes_encrypt_b64(psk, binascii.unhexlify(otpkey))
+            if tokenobj.type.lower() in ["totp", "hotp"]:
+                encrypted_otpkey = aes_encrypt_b64(psk, binascii.unhexlify(otpkey))
+            else:
+                encrypted_otpkey = aes_encrypt_b64(psk, otpkey)
         except TypeError:
             # Some keys might be odd string length
             continue

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -586,20 +586,24 @@ class ImportOTPTestCase(MyTestCase):
         t2 = init_token({"serial": "t2", "type": "totp", "otpkey": "123456",
                          "description": "something <with> xml!"})
         t3 = init_token({"serial": "t3", "type": "spass", "otpkey": "123456"})
-        tlist = [t1, t2, t3]
+        t4 = init_token({"serial": "t4", "type": "pw", "otpkey": "lässig",
+                         "description": "password token"})
+        tlist = [t1, t2, t3, t4]
         # export the tokens
         psk, token_num, soup = export_pskc(tlist)
         # Only 2 tokens exported, the spass token does not get exported!
-        self.assertEqual(token_num, 2)
+        self.assertEqual(token_num, 3)
         self.assertEqual(len(psk), 32)
         export = "{0!s}".format(soup)
         # remote the tokens
         remove_token("t1")
         remove_token("t2")
         remove_token("t3")
+        remove_token("t4")
+        remove_token("t5")
         # import the tokens again
         tokens = parsePSKCdata(export, preshared_key_hex=psk)
-        self.assertEqual(len(tokens), 2)
+        self.assertEqual(len(tokens), 3)
         self.assertEqual(tokens.get("t1").get("type"), "hotp")
         self.assertEqual(tokens.get("t1").get("otpkey"), "123456")
         # unicode does not get exported
@@ -607,6 +611,8 @@ class ImportOTPTestCase(MyTestCase):
         self.assertEqual(tokens.get("t2").get("type"), "totp")
         self.assertEqual(tokens.get("t2").get("timeStep"), "30")
         self.assertEqual(tokens.get("t2").get("description"), "something <with> xml!")
+        # password token
+        self.assertEqual(tokens.get("t4").get("otpkey"), "lässig")
 
 
 class GPGTestCase(MyTestCase):


### PR DESCRIPTION
The export of a password type token can fail due to the
problem that the otpkey (password) of the pw token is
not returned hexlified but as the ordinary password.

This is why we need to differentiate between hotp,totp and pw token type.

The pw token type is encrypted as is and also imported again in the
same way.

Closes #1109
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1110%23issuecomment-399905036%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1110%23discussion_r197799058%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1110%23discussion_r197799486%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1110%23issuecomment-399905036%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231110%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.22%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/a7a1e06c488364d31276a38530777d9aa3dd5db5%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26width%3D650%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.22%20%20%20%20%231110%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%20%20%20%20%2095.41%25%20%20%2095.41%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2016202%20%20%20%2016206%20%20%20%20%20%20%20%2B4%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2015459%20%20%20%2015463%20%20%20%20%20%20%20%2B4%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20743%20%20%20%20%20%20743%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/importotp.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2ltcG9ydG90cC5weQ%3D%3D%29%20%7C%20%6093.85%25%20%3C100%25%3E%20%28%2B0.08%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Ba7a1e06...1c8390a%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1110%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-25T10%3A25%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201c8390a59bb466f3f21f06fd2aaf509b10283706%20privacyidea/lib/importotp.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1110%23discussion_r197799058%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Just%20that%20I%20understand%20correctly%3A%20Export%20of%20%60%60pw%60%60%20tokens%20previously%20caused%20an%20error%20in%20this%20line%2C%20becuase%20%60%60otpkey%60%60%20was%20not%20the%20hexlified%20password%2C%20but%20the%20actual%20password%3F%22%2C%20%22created_at%22%3A%20%222018-06-25T13%3A40%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22yes.%20This%20resulted%20in%20no%20or%20very%20few%20PW%20tokens%20being%20exported.%22%2C%20%22created_at%22%3A%20%222018-06-25T13%3A41%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/importotp.py%3AL626-636%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1110#issuecomment-399905036'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1110?src=pr&el=h1) Report
> Merging [#1110](https://codecov.io/gh/privacyidea/privacyidea/pull/1110?src=pr&el=desc) into [branch-2.22](https://codecov.io/gh/privacyidea/privacyidea/commit/a7a1e06c488364d31276a38530777d9aa3dd5db5?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1110/graphs/tree.svg?token=7nHLZki60B&width=650&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1110?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.22    #1110      +/-   ##
===============================================
+ Coverage        95.41%   95.41%   +<.01%
===============================================
Files              131      131
Lines            16202    16206       +4
===============================================
+ Hits             15459    15463       +4
Misses             743      743
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1110?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/importotp.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1110/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2ltcG9ydG90cC5weQ==) | `93.85% <100%> (+0.08%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1110?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1110?src=pr&el=footer). Last update [a7a1e06...1c8390a](https://codecov.io/gh/privacyidea/privacyidea/pull/1110?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 1c8390a59bb466f3f21f06fd2aaf509b10283706 privacyidea/lib/importotp.py 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1110#discussion_r197799058'>File: privacyidea/lib/importotp.py:L626-636</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Just that I understand correctly: Export of ``pw`` tokens previously caused an error in this line, becuase ``otpkey`` was not the hexlified password, but the actual password?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> yes. This resulted in no or very few PW tokens being exported.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1110?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1110?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1110'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>