### PR TITLE
Fix issues with max key length in mariadb

### DIFF
--- a/deploy/debian-ubuntu/privacyidea-apache2.postinst
+++ b/deploy/debian-ubuntu/privacyidea-apache2.postinst
@@ -83,10 +83,13 @@ adapt_pi_cfg() {
 }
 
 create_database() {
+    printf "[mariadb]\ninnodb_large_prefix=on\ninnodb_file_format=Barracuda\n" > /etc/mysql/conf.d/pi-maxkeylengthfix.cnf
+    invoke-rc.d mysql restart
+
 	# create the MYSQL database
 	if [ !$(grep "^SQLALCHEMY_DATABASE_URI" /etc/privacyidea/pi.cfg || true) ]; then
-	    USER="debian-sys-maint"
-	    PASSWORD=$(grep "^password" /etc/mysql/debian.cnf | sort -u | cut -d " " -f3)
+	    USER=$(grep "^user" /etc/mysql/debian.cnf | sort -u | awk '{print $3}')
+	    PASSWORD=$(grep "^password" /etc/mysql/debian.cnf | sort -u | awk '{print $3}')
 	    NPW="$(tr -dc A-Za-z0-9_ </dev/urandom | head -c12)"
 	    mysql -u $USER --password=$PASSWORD -e "create database pi;" || true
 	    mysql -u $USER --password=$PASSWORD -e "grant all privileges on pi.* to 'pi'@'localhost' identified by '$NPW';"

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -125,6 +125,7 @@ class Token(MethodsMixin, db.Model):
     to the tokentype.
     """
     __tablename__ = 'token'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("token_seq"),
                    primary_key=True,
                    nullable=False)
@@ -631,7 +632,8 @@ class TokenInfo(MethodsMixin, db.Model):
                             backref='info_list')
     __table_args__ = (db.UniqueConstraint('token_id',
                                           'Key',
-                                          name='tiix_2'), {})
+                                          name='tiix_2'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, token_id, Key, Value,
                  Type= None,
@@ -683,6 +685,7 @@ class Admin(db.Model):
     :type email: basestring
     """
     __tablename__ = "admin"
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     username = db.Column(db.Unicode(120),
                          primary_key=True,
                          nullable=False)
@@ -722,6 +725,7 @@ class Config(TimestampMethodsMixin, db.Model):
     stored in specific tables.
     """
     __tablename__ = "config"
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     Key = db.Column(db.Unicode(255),
                     primary_key=True,
                     nullable=False)
@@ -760,6 +764,7 @@ class Realm(TimestampMethodsMixin, db.Model):
     the realms. The linking to resolvers is stored in the table "resolverrealm".
     """
     __tablename__ = 'realm'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("realm_seq"), primary_key=True,
                    nullable=False)
     name = db.Column(db.Unicode(255), default=u'',
@@ -795,6 +800,7 @@ class CAConnector(MethodsMixin, db.Model):
     stored in the table "caconnectorconfig".
     """
     __tablename__ = 'caconnector'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("caconnector_seq"), primary_key=True,
                    nullable=False)
     name = db.Column(db.Unicode(255), default=u"",
@@ -844,7 +850,8 @@ class CAConnectorConfig(db.Model):
                             backref='config_list')
     __table_args__ = (db.UniqueConstraint('caconnector_id',
                                           'Key',
-                                          name='ccix_2'), {})
+                                          name='ccix_2'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, caconnector_id=None,
                  Key=None, Value=None,
@@ -890,6 +897,7 @@ class Resolver(TimestampMethodsMixin, db.Model):
     configuration of the resolvers is stored in the table "resolverconfig".
     """
     __tablename__ = 'resolver'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("resolver_seq"), primary_key=True,
                    nullable=False)
     name = db.Column(db.Unicode(255), default=u"",
@@ -939,8 +947,9 @@ class ResolverConfig(TimestampMethodsMixin, db.Model):
                            backref='config_list')
     __table_args__ = (db.UniqueConstraint('resolver_id',
                                           'Key',
-                                          name='rcix_2'), {})
-    
+                                          name='rcix_2'),
+                      {'mysql_row_format': 'DYNAMIC'})
+
     def __init__(self, resolver_id=None,
                  Key=None, Value=None,
                  resolver=None,
@@ -1003,8 +1012,9 @@ class ResolverRealm(TimestampMethodsMixin, db.Model):
                             backref="resolver_list")
     __table_args__ = (db.UniqueConstraint('resolver_id',
                                           'realm_id',
-                                          name='rrix_2'), {})
-    
+                                          name='rrix_2'),
+                      {'mysql_row_format': 'DYNAMIC'})
+
     def __init__(self, resolver_id=None, realm_id=None,
                  resolver_name=None,
                  realm_name=None,
@@ -1048,8 +1058,9 @@ class TokenRealm(MethodsMixin, db.Model):
                             backref='token_list')
     __table_args__ = (db.UniqueConstraint('token_id',
                                           'realm_id',
-                                          name='trix_2'), {})
-                                      
+                                          name='trix_2'),
+                      {'mysql_row_format': 'DYNAMIC'})
+
     def __init__(self, realm_id=0, token_id=0, realmname=None):
         """
         Create a new TokenRealm entry.
@@ -1095,6 +1106,7 @@ class PasswordReset(MethodsMixin, db.Model):
     Optional: The email to which the recoverycode was sent, can be stored.
     """
     __tablename__ = "passwordreset"
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer(), Sequence("pwreset_seq"), primary_key=True,
                    nullable=False)
     recoverycode = db.Column(db.Unicode(255), nullable=False)
@@ -1124,6 +1136,7 @@ class Challenge(MethodsMixin, db.Model):
     Table for handling of the generic challenges.
     """
     __tablename__ = "challenge"
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer(), Sequence("challenge_seq"), primary_key=True,
                    nullable=False)
     transaction_id = db.Column(db.Unicode(64), nullable=False, index=True)
@@ -1275,6 +1288,7 @@ class Policy(TimestampMethodsMixin, db.Model):
      * user actions
     """
     __tablename__ = "policy"
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("policy_seq"), primary_key=True)
     active = db.Column(db.Boolean, default=True)
     check_all_resolvers = db.Column(db.Boolean, default=False)
@@ -1379,6 +1393,7 @@ class MachineToken(MethodsMixin, db.Model):
     This can be an n:m mapping.
     """
     __tablename__ = 'machinetoken'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer(), Sequence("machinetoken_seq"),
                    primary_key=True, nullable=False)
     token_id = db.Column(db.Integer(),
@@ -1479,6 +1494,7 @@ class MachineTokenOptions(db.Model):
     options.
     """
     __tablename__ = 'machinetokenoptions'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer(), Sequence("machtokenopt_seq"),
                    primary_key=True, nullable=False)
     machinetoken_id = db.Column(db.Integer(),
@@ -1549,6 +1565,7 @@ class EventHandler(MethodsMixin, db.Model):
     condition and action.
     """
     __tablename__ = 'eventhandler'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("eventhandler_seq"), primary_key=True,
                    nullable=False)
     # in fact the name is a description
@@ -1676,7 +1693,8 @@ class EventHandlerCondition(db.Model):
                             backref='condition_list')
     __table_args__ = (db.UniqueConstraint('eventhandler_id',
                                           'Key',
-                                          name='ehcix_1'), {})
+                                          name='ehcix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, eventhandler_id, Key, Value, comparator="equal"):
         self.eventhandler_id = eventhandler_id
@@ -1723,7 +1741,8 @@ class EventHandlerOption(db.Model):
                             backref='option_list')
     __table_args__ = (db.UniqueConstraint('eventhandler_id',
                                           'Key',
-                                          name='ehoix_1'), {})
+                                          name='ehoix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, eventhandler_id, Key, Value, Type="", Description=""):
         self.eventhandler_id = eventhandler_id
@@ -1763,6 +1782,7 @@ class MachineResolver(MethodsMixin, db.Model):
     its config
     """
     __tablename__ = 'machineresolver'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("machineresolver_seq"),
                    primary_key=True, nullable=False)
     name = db.Column(db.Unicode(255), default=u"",
@@ -1807,7 +1827,8 @@ class MachineResolverConfig(db.Model):
                            backref='config_list')
     __table_args__ = (db.UniqueConstraint('resolver_id',
                                           'Key',
-                                          name='mrcix_2'), {})
+                                          name='mrcix_2'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, resolver_id=None, Key=None, Value=None, resolver=None,
                  Type="", Description=""):
@@ -1910,6 +1931,7 @@ class SMSGateway(MethodsMixin, db.Model):
     All options and parameters are saved in other tables.
     """
     __tablename__ = 'smsgateway'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("smsgateway_seq"), primary_key=True)
     identifier = db.Column(db.Unicode(255), nullable=False, unique=True)
     description = db.Column(db.Unicode(1024), default=u"")
@@ -2014,7 +2036,8 @@ class SMSGatewayOption(MethodsMixin, db.Model):
                             backref='ref_option_list')
     __table_args__ = (db.UniqueConstraint('gateway_id',
                                           'Key',
-                                          name='sgix_1'), {})
+                                          name='sgix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, gateway_id, Key, Value, Type=None):
 
@@ -2052,6 +2075,7 @@ class PrivacyIDEAServer(MethodsMixin, db.Model):
     This table can store remote privacyIDEA server definitions
     """
     __tablename__ = 'privacyideaserver'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("privacyideaserver_seq"),
                    primary_key=True)
     # This is a name to refer to
@@ -2101,6 +2125,7 @@ class RADIUSServer(MethodsMixin, db.Model):
     radius passthru policy.
     """
     __tablename__ = 'radiusserver'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("radiusserver_seq"), primary_key=True)
     # This is a name to refer to
     identifier = db.Column(db.Unicode(255), nullable=False, unique=True)
@@ -2158,6 +2183,7 @@ class SMTPServer(MethodsMixin, db.Model):
     The config entries are referenced by the id of the machine resolver
     """
     __tablename__ = 'smtpserver'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("smtpserver_seq"),primary_key=True)
     # This is a name to refer to
     identifier = db.Column(db.Unicode(255), nullable=False)
@@ -2217,7 +2243,8 @@ class ClientApplication(MethodsMixin, db.Model):
     lastseen = db.Column(db.DateTime)
     __table_args__ = (db.UniqueConstraint('ip',
                                           'clienttype',
-                                          name='caix'), {})
+                                          name='caix'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def save(self):
         clientapp = ClientApplication.query.filter(
@@ -2250,6 +2277,7 @@ class Subscription(MethodsMixin, db.Model):
     This table stores the imported subscription files.
     """
     __tablename__ = 'subscription'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("subscription_seq"), primary_key=True)
     application = db.Column(db.Unicode(80), index=True)
     for_name = db.Column(db.Unicode(80), nullable=False)
@@ -2309,6 +2337,7 @@ class EventCounter(db.Model):
     This table stores counters of the event handler "Counter".
     """
     __tablename__ = 'eventcounter'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     counter_name = db.Column(db.Unicode(80), nullable=False, primary_key=True)
     counter_value = db.Column(db.Integer, default=0)
 
@@ -2382,6 +2411,7 @@ class Audit(MethodsMixin, db.Model):
     This class stores the Audit entries
     """
     __tablename__ = AUDIT_TABLE_NAME
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("audit_seq"), primary_key=True)
     date = db.Column(db.DateTime)
     signature = db.Column(db.String(audit_column_length.get("signature")))
@@ -2437,10 +2467,12 @@ class Audit(MethodsMixin, db.Model):
         self.loglevel = convert_column_to_unicode(loglevel)
         self.clearance_level = convert_column_to_unicode(clearance_level)
 
+
 ### User Cache
 
 class UserCache(MethodsMixin, db.Model):
     __tablename__ = 'usercache'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("usercache_seq"), primary_key=True)
     username = db.Column(db.Unicode(64), default=u"", index=True)
     resolver = db.Column(db.Unicode(120), default=u'')
@@ -2456,6 +2488,7 @@ class UserCache(MethodsMixin, db.Model):
 
 class AuthCache(MethodsMixin, db.Model):
     __tablename__ = 'authcache'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("usercache_seq"), primary_key=True)
     first_auth = db.Column(db.DateTime)
     last_auth = db.Column(db.DateTime)
@@ -2477,6 +2510,7 @@ class AuthCache(MethodsMixin, db.Model):
         self.first_auth = first_auth
         self.last_auth = last_auth
 
+
 ### Periodic Tasks
 
 class PeriodicTask(MethodsMixin, db.Model):
@@ -2484,6 +2518,7 @@ class PeriodicTask(MethodsMixin, db.Model):
     This class stores tasks that should be run periodically.
     """
     __tablename__ = 'periodictask'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("periodictask_seq"), primary_key=True)
     name = db.Column(db.Unicode(64), unique=True, nullable=False)
     active = db.Column(db.Boolean, default=True, nullable=False)
@@ -2587,6 +2622,7 @@ class PeriodicTask(MethodsMixin, db.Model):
         """
         PeriodicTaskLastRun(self.id, node, timestamp)
 
+
 class PeriodicTaskOption(db.Model):
     """
     Each PeriodicTask entry can have additional options according to the
@@ -2601,7 +2637,8 @@ class PeriodicTaskOption(db.Model):
 
     __table_args__ = (db.UniqueConstraint('periodictask_id',
                                           'key',
-                                          name='ptoix_1'), {})
+                                          name='ptoix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, periodictask_id, key, value):
         self.periodictask_id = periodictask_id
@@ -2630,6 +2667,7 @@ class PeriodicTaskOption(db.Model):
         db.session.commit()
         return ret
 
+
 class PeriodicTaskLastRun(db.Model):
     """
     Each PeriodicTask entry stores, for each node, the timestamp of the last successful run.
@@ -2643,7 +2681,8 @@ class PeriodicTaskLastRun(db.Model):
 
     __table_args__ = (db.UniqueConstraint('periodictask_id',
                                           'node',
-                                          name='ptlrix_1'), {})
+                                          name='ptlrix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, periodictask_id, node, timestamp):
         """


### PR DESCRIPTION
Using privacyIDEA with mariadb (i.e. on Debian 9.4) resulted in a warning
about a key being to long.
The max key length in mariadb (v10.1) is 767 bytes thus limiting unique
varchar columns to 190 characters (with standard utf8 @ 4bytes encoding).
To avoid this limitation, some steps must be taken:
- mariadb must be started with innodb_large_prefix=on and
  innodb_file_format=Barracuda, which is default in mariadb v10.2.2
- tables must be created with row format DYNAMIC

And to simplify installation on Debian, the database user name will be
taken from the configuration as well.

Fixes #967
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1112%23issuecomment-400310272%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1112%23issuecomment-400316827%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1112%23issuecomment-400310272%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22mariadb%20knows%20a%20configuration%20to%20set%20the%20default%20row%20format%20in%20innodb%2C%20unfortunately%20only%20since%20v10.2.2.%5Cr%5CnIn%20newer%20mariadb%20versions%2C%20these%20settings%20are%20the%20default%2C%20as%20well%20as%20in%20mysql%20%28since%205.6.3%29%20so%20this%20pull%20should%20not%20change%20the%20behavior.%22%2C%20%22created_at%22%3A%20%222018-06-26T13%3A34%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231112%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/4929d4e0a7a11cbc564a88d034f7903665ba8024%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26width%3D650%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231112%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.7%25%20%20%2095.71%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20133%20%20%20%20%20%20133%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016540%20%20%20%2016563%20%20%20%20%20%20%2B23%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015830%20%20%20%2015853%20%20%20%20%20%20%2B23%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20710%20%20%20%20%20%20710%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.87%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B4929d4e...51b6566%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1112%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-26T13%3A52%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1112#issuecomment-400310272'>General Comment</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> mariadb knows a configuration to set the default row format in innodb, unfortunately only since v10.2.2.
In newer mariadb versions, these settings are the default, as well as in mysql (since 5.6.3) so this pull should not change the behavior.
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1112?src=pr&el=h1) Report
> Merging [#1112](https://codecov.io/gh/privacyidea/privacyidea/pull/1112?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/4929d4e0a7a11cbc564a88d034f7903665ba8024?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1112/graphs/tree.svg?token=7nHLZki60B&width=650&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1112?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1112      +/-   ##
==========================================
+ Coverage    95.7%   95.71%   +<.01%
==========================================
Files         133      133
Lines       16540    16563      +23
==========================================
+ Hits        15830    15853      +23
Misses        710      710
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1112?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1112/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.87% <100%> (+0.01%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1112?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1112?src=pr&el=footer). Last update [4929d4e...51b6566](https://codecov.io/gh/privacyidea/privacyidea/pull/1112?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1112?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1112?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1112'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>