### PR TITLE
1027/stats table

### DIFF
--- a/migrations/versions/19f727d285e2_.py
+++ b/migrations/versions/19f727d285e2_.py
@@ -1,0 +1,33 @@
+"""Add monitoringstats table
+
+Revision ID: 19f727d285e2
+Revises: 2c9430cfc66b
+Create Date: 2018-07-03 11:45:57.967604
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '19f727d285e2'
+down_revision = '2c9430cfc66b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    try:
+        op.create_table('monitoringstats',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), nullable=False),
+        sa.Column('stats_key', sa.Unicode(length=128), nullable=False),
+        sa.Column('stats_value', sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('timestamp', 'stats_key', name='msix_1')
+        )
+    except Exception, exx:
+        print "Could not add table for monitoring stats!"
+        print exx
+
+
+def downgrade():
+    op.drop_table('monitoringstats')

--- a/migrations/versions/19f727d285e2_.py
+++ b/migrations/versions/19f727d285e2_.py
@@ -22,7 +22,8 @@ def upgrade():
         sa.Column('stats_key', sa.Unicode(length=128), nullable=False),
         sa.Column('stats_value', sa.Integer(), nullable=False),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('timestamp', 'stats_key', name='msix_1')
+        sa.UniqueConstraint('timestamp', 'stats_key', name='msix_1'),
+        mysql_row_format='DYNAMIC'
         )
     except Exception, exx:
         print "Could not add table for monitoring stats!"

--- a/privacyidea/lib/monitoringstats.py
+++ b/privacyidea/lib/monitoringstats.py
@@ -30,7 +30,7 @@ import logging
 import traceback
 from privacyidea.lib.log import log_with
 from privacyidea.models import MonitoringStats
-from sqlalchemy import and_
+from sqlalchemy import and_, distinct
 import datetime
 log = logging.getLogger(__name__)
 
@@ -74,3 +74,15 @@ def delete_stats(stats_key, start_timestamp=None, end_timestamp=None):
         conditions.append(MonitoringStats.timestamp <= end_timestamp)
     r = MonitoringStats.query.filter(and_(*conditions)).delete()
     return r
+
+
+def get_stats_keys():
+    """
+    Return a list of all available statistics keys
+
+    :return: list of keys
+    """
+    keys = []
+    for monStat in MonitoringStats.query.with_entities(MonitoringStats.stats_key).distinct():
+        keys.append(monStat.stats_key)
+    return keys

--- a/privacyidea/lib/monitoringstats.py
+++ b/privacyidea/lib/monitoringstats.py
@@ -86,3 +86,42 @@ def get_stats_keys():
     for monStat in MonitoringStats.query.with_entities(MonitoringStats.stats_key).distinct():
         keys.append(monStat.stats_key)
     return keys
+
+
+def get_values(stats_key, start_timestamp=None, end_timestamp=None):
+    """
+    Return a list of sets of (timestamp, value)
+
+    :param stats_key: The stats key to query
+    :param start_timestamp: the start of the timespan
+    :type start_timestamp: datetime
+    :param end_timestamp: the end of the timespan
+    :type end_timestamp: datetime
+    :return: list of sets
+    """
+    values = []
+    conditions = [MonitoringStats.stats_key == stats_key]
+    if start_timestamp:
+        conditions.append(MonitoringStats.timestamp >= start_timestamp)
+    if end_timestamp:
+        conditions.append(MonitoringStats.timestamp <= end_timestamp)
+    for ms in MonitoringStats.query.filter(and_(*conditions)).\
+            order_by(MonitoringStats.timestamp.asc()):
+        values.append((ms.timestamp, ms.stats_value))
+
+    return values
+
+
+def get_last_value(stats_key):
+    """
+    Return the last value of the given key
+
+    :param stats_key:
+    :return: The value as a scalar or None
+    """
+    val = None
+    s = MonitoringStats.query.filter(MonitoringStats.stats_key == stats_key).\
+        order_by(MonitoringStats.timestamp.desc()).first()
+    if s:
+        val = s.stats_value
+    return val

--- a/privacyidea/lib/monitoringstats.py
+++ b/privacyidea/lib/monitoringstats.py
@@ -54,3 +54,23 @@ def write_stats(stats_key, stats_value, timestamp=None, reset_values=False):
         MonitoringStats.query.filter(and_(MonitoringStats.stats_key == stats_key,
                                           MonitoringStats.timestamp < timestamp)).delete()
 
+
+def delete_stats(stats_key, start_timestamp=None, end_timestamp=None):
+    """
+    Delete statistics from a given key.
+    Either delete all occurrences or only in a given time span.
+
+    :param stats_key: The name of the key to delete
+    :param start_timestamp: The start timestamp.
+    :type start_timestamp: datetime
+    :param end_timestamp: The end timestamp.
+    :type end_timestamp: datetime
+    :return: The number of deleted entries
+    """
+    conditions = [MonitoringStats.stats_key == stats_key]
+    if start_timestamp:
+        conditions.append(MonitoringStats.timestamp >= start_timestamp)
+    if end_timestamp:
+        conditions.append(MonitoringStats.timestamp <= end_timestamp)
+    r = MonitoringStats.query.filter(and_(*conditions)).delete()
+    return r

--- a/privacyidea/lib/monitoringstats.py
+++ b/privacyidea/lib/monitoringstats.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+#  2018-06-26 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             provide first interface to handle monitoring statistics
+#
+#  License:  AGPLv3
+#  contact:  http://www.privacyidea.org
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+__doc__ = """This module is used to write, read and handle data in the
+database table "monitoringstats". This can be arbitrary data for time series of
+  
+   timestamp, key, value
+
+This module is tested in tests/test_lib_monitoringstats.py
+"""
+import logging
+import traceback
+from privacyidea.lib.log import log_with
+from privacyidea.models import MonitoringStats
+from sqlalchemy import and_
+import datetime
+log = logging.getLogger(__name__)
+
+
+def write_stats(stats_key, stats_value, timestamp=None, reset_values=False):
+    """
+    Write a new statistics value to the database
+
+    :param stats_key: The key, that identifies the measurment point
+    :type stats_key: basestring
+    :param stats_value: The value to be measured
+    :type stats_value: int
+    :param timestamp: The time, when the value was measured
+    :param reset_values: Whether old entries should be deleted
+    :return: id of the database entry
+    """
+    timestamp = timestamp or datetime.datetime.now()
+    MonitoringStats(timestamp, stats_key, stats_value)
+    if reset_values:
+        # Successfully saved the new stats entry, so remove old entries
+        MonitoringStats.query.filter(and_(MonitoringStats.stats_key == stats_key,
+                                          MonitoringStats.timestamp < timestamp)).delete()
+

--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -40,7 +40,7 @@ import re
 from datetime import timedelta, datetime
 from datetime import time as dt_time
 from dateutil.parser import parse as parse_date_string
-from dateutil.tz import tzlocal
+from dateutil.tz import tzlocal, tzutc
 from netaddr import IPAddress, IPNetwork, AddrFormatError
 import hashlib
 import crypt
@@ -1093,3 +1093,13 @@ def convert_column_to_unicode(value):
         return value
     else:
         return unicode(value)
+
+
+def convert_timestamp_to_utc(timestamp):
+    """
+    Convert a timezone-aware datetime object to a naive UTC datetime.
+    :param timestamp: datetime object that should be converted
+    :type timestamp: timezone-aware datetime object
+    :return: timezone-naive datetime object
+    """
+    return timestamp.astimezone(tzutc()).replace(tzinfo=None)

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2477,6 +2477,7 @@ class AuthCache(MethodsMixin, db.Model):
         self.first_auth = first_auth
         self.last_auth = last_auth
 
+
 ### Periodic Tasks
 
 class PeriodicTask(MethodsMixin, db.Model):
@@ -2587,6 +2588,7 @@ class PeriodicTask(MethodsMixin, db.Model):
         """
         PeriodicTaskLastRun(self.id, node, timestamp)
 
+
 class PeriodicTaskOption(db.Model):
     """
     Each PeriodicTask entry can have additional options according to the
@@ -2629,6 +2631,7 @@ class PeriodicTaskOption(db.Model):
             ret = option.id
         db.session.commit()
         return ret
+
 
 class PeriodicTaskLastRun(db.Model):
     """
@@ -2677,3 +2680,37 @@ class PeriodicTaskLastRun(db.Model):
             ret = last_run.id
         db.session.commit()
         return ret
+
+
+class MonitoringStats(MethodsMixin, db.Model):
+    """
+    This is the table that stores measured, arbitrary statistic points in time.
+
+    This could be used to store time series but also to store current values,
+    by simply fetching the last value from the database.
+    """
+    __tablename__ = 'monitoringstats'
+    id = db.Column(db.Integer, Sequence("monitoringstats_seq"),
+                   primary_key=True)
+    timestamp = db.Column(db.DateTime(False), nullable=False)
+    stats_key = db.Column(db.Unicode(128), nullable=False)
+    stats_value = db.Column(db.Integer, nullable=False, default=0)
+
+    __table_args__ = (db.UniqueConstraint('timestamp',
+                                          'stats_key',
+                                          name='msix_1'), {})
+
+    def __init__(self, timestamp, key, value):
+        """
+        Create a new database entry in the monitoring stats table
+        :param timestamp: The time of the measurement point
+        :type timestamp: datetime
+        :param key: The key of the measurement
+        :type key: basestring
+        :param value: The value of the measurement
+        :type value: Int
+        """
+        self.timestamp = timestamp
+        self.stats_key = key
+        self.stats_value = value
+        self.save()

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2699,7 +2699,8 @@ class MonitoringStats(MethodsMixin, db.Model):
 
     __table_args__ = (db.UniqueConstraint('timestamp',
                                           'stats_key',
-                                          name='msix_1'), {})
+                                          name='msix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, timestamp, key, value):
         """

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2692,6 +2692,7 @@ class MonitoringStats(MethodsMixin, db.Model):
     __tablename__ = 'monitoringstats'
     id = db.Column(db.Integer, Sequence("monitoringstats_seq"),
                    primary_key=True)
+    # We store this as a naive datetime in UTC
     timestamp = db.Column(db.DateTime(False), nullable=False)
     stats_key = db.Column(db.Unicode(128), nullable=False)
     stats_value = db.Column(db.Integer, nullable=False, default=0)
@@ -2704,7 +2705,7 @@ class MonitoringStats(MethodsMixin, db.Model):
         """
         Create a new database entry in the monitoring stats table
         :param timestamp: The time of the measurement point
-        :type timestamp: datetime
+        :type timestamp: timezone-naive datetime
         :param key: The key of the measurement
         :type key: basestring
         :param value: The value of the measurement

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -15,7 +15,7 @@ from privacyidea.models import (Token,
                                 EventHandlerCondition, PrivacyIDEAServer,
                                 ClientApplication, Subscription, UserCache,
                                 EventCounter, PeriodicTask, PeriodicTaskLastRun,
-                                PeriodicTaskOption)
+                                PeriodicTaskOption, MonitoringStats)
 from .base import MyTestCase
 from datetime import datetime
 from datetime import timedelta
@@ -824,4 +824,18 @@ class TokenModelTestCase(MyTestCase):
         task2.delete()
         self.assertEqual(PeriodicTaskOption.query.count(), 0)
 
+    def test_27_monitoring_stats(self):
+        # Simple test to write data to the monitoring stats table
+        key1 = "user_count"
+        key2 = "successful_auth"
+        MonitoringStats(datetime.now(), key1, 15)
+        MonitoringStats(datetime.now(), key1, 21)
+        MonitoringStats(datetime.now(), key2, 123)
 
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 2)
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key2).count(), 1)
+
+        # Delete all entries
+        MonitoringStats.query.delete()
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 0)
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key2).count(), 0)

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -828,9 +828,10 @@ class TokenModelTestCase(MyTestCase):
         # Simple test to write data to the monitoring stats table
         key1 = "user_count"
         key2 = "successful_auth"
-        MonitoringStats(datetime.now(), key1, 15)
-        MonitoringStats(datetime.now(), key1, 21)
-        MonitoringStats(datetime.now(), key2, 123)
+        utcnow = datetime.utcnow()
+        MonitoringStats(utcnow - timedelta(seconds=1), key1, 15)
+        MonitoringStats(utcnow, key1, 21)
+        MonitoringStats(utcnow, key2, 123)
 
         self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 2)
         self.assertEqual(MonitoringStats.query.filter_by(stats_key=key2).count(), 1)

--- a/tests/test_lib_monitoringstats.py
+++ b/tests/test_lib_monitoringstats.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from privacyidea.models import MonitoringStats
-from privacyidea.lib.monitoringstats import write_stats
+from privacyidea.lib.monitoringstats import (write_stats, delete_stats)
 
 from .base import MyTestCase
 import datetime
@@ -19,3 +19,27 @@ class TokenModelTestCase(MyTestCase):
         # Now we write a new value, but with the paramter to delete old values
         write_stats(key1, 14, reset_values=True)
         self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 1)
+
+    def test_02_delete_stats(self):
+        key1 = "otherkey"
+        write_stats(key1, 12, timestamp=datetime.datetime.now() - timedelta(days=1))
+        write_stats(key1, 13, timestamp=datetime.datetime.now())
+        write_stats(key1, 14, timestamp=datetime.datetime.now() + timedelta(days=1))
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 3)
+
+        # delete the last two entries
+        r = delete_stats(key1, start_timestamp=datetime.datetime.now() - timedelta(minutes=60))
+
+        # check there is only one entry
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 1)
+        self.assertEqual(r, 2)
+
+        # Again write three entries
+        write_stats(key1, 13, timestamp=datetime.datetime.now())
+        write_stats(key1, 14, timestamp=datetime.datetime.now() + timedelta(days=1))
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 3)
+
+        # Delete the first two entries
+        r = delete_stats(key1, end_timestamp=datetime.datetime.now() + timedelta(minutes=60))
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 1)
+        self.assertEqual(r, 2)

--- a/tests/test_lib_monitoringstats.py
+++ b/tests/test_lib_monitoringstats.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from privacyidea.models import MonitoringStats
-from privacyidea.lib.monitoringstats import (write_stats, delete_stats)
+from privacyidea.lib.monitoringstats import (write_stats, delete_stats,
+                                             get_stats_keys)
 
 from .base import MyTestCase
 import datetime
@@ -43,3 +44,22 @@ class TokenModelTestCase(MyTestCase):
         r = delete_stats(key1, end_timestamp=datetime.datetime.now() + timedelta(minutes=60))
         self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 1)
         self.assertEqual(r, 2)
+
+    def test_03_get_keys(self):
+        # delete old entries
+        keys = get_stats_keys()
+        for k in keys:
+            delete_stats(k)
+
+        # write new stats entries
+        write_stats("key1", 13)
+        write_stats("key1", 13)
+        write_stats("key1", 13)
+        write_stats("key2", 12)
+        write_stats("key3", 12)
+
+        keys = get_stats_keys()
+        self.assertEqual(len(keys), 3)
+        self.assertTrue("key1" in keys)
+        self.assertTrue("key2" in keys)
+        self.assertTrue("key3" in keys)

--- a/tests/test_lib_monitoringstats.py
+++ b/tests/test_lib_monitoringstats.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+from privacyidea.models import MonitoringStats
+from privacyidea.lib.monitoringstats import write_stats
+
+from .base import MyTestCase
+import datetime
+from datetime import timedelta
+
+
+class TokenModelTestCase(MyTestCase):
+
+    def test_01_write_stats(self):
+        key1 = "some_key"
+        write_stats(key1, 12)
+        write_stats(key1, 13)
+
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 2)
+
+        # Now we write a new value, but with the paramter to delete old values
+        write_stats(key1, 14, reset_values=True)
+        self.assertEqual(MonitoringStats.query.filter_by(stats_key=key1).count(), 1)


### PR DESCRIPTION
This is the DB and library implementation for the ``monitoringstats`` table, as it is need by several Task Modules.

I'd like to merge this, so that task modules can already be developed based on this database model.

We still need to add the API endpoints.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23issuecomment-400431759%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23issuecomment-401443595%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r198808041%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r198809488%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r198809733%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r199113951%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r199251791%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r199251795%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r199252015%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23issuecomment-403156233%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23issuecomment-400431759%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231113%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/4929d4e0a7a11cbc564a88d034f7903665ba8024%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.17%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231113%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.7%25%20%20%2095.88%25%20%20%20%2B0.17%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20133%20%20%20%20%20%20134%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016540%20%20%20%2017223%20%20%20%20%20%2B683%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015830%20%20%20%2016514%20%20%20%20%20%2B684%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20710%20%20%20%20%20%20709%20%20%20%20%20%20%20-1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/monitoringstats.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21vbml0b3JpbmdzdGF0cy5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5%29%20%7C%20%6096.78%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6099.27%25%20%3C100%25%3E%20%28%2B0.42%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B4929d4e...1b704cd%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1113%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-26T19%3A19%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-06-29T18%3A55%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20migration%20script%22%2C%20%22created_at%22%3A%20%222018-07-06T21%3A55%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2051bbd329a8813cc1daa50ea6bb50ec57e19f131d%20privacyidea/lib/monitoringstats.py%2070%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r198809488%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22same%20here%20with%20%60%60start_timestamp%60%60%20and%20%60%60end_timestamp%60%60%20--%20should%20they%20be%20timezone-aware%2C%20or%20timezone-naive%20UTC%20datetimes%3F%22%2C%20%22created_at%22%3A%20%222018-06-28T11%3A38%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-06-29T18%3A56%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/monitoringstats.py%3AL1-128%22%7D%2C%20%22Pull%2051bbd329a8813cc1daa50ea6bb50ec57e19f131d%20privacyidea/lib/monitoringstats.py%20104%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r198809733%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22same%20here%20with%20start_timestamp%2C%20end_timestamp%20and%20the%20timestamp%20in%20the%20result.%22%2C%20%22created_at%22%3A%20%222018-06-28T11%3A39%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-06-29T18%3A55%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/monitoringstats.py%3AL1-128%22%7D%2C%20%22Pull%2051bbd329a8813cc1daa50ea6bb50ec57e19f131d%20privacyidea/lib/monitoringstats.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1113%23discussion_r198808041%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20we%20should%20store%20timestamps%20in%20UTC%20because%20we%20won%27t%20be%20affected%20by%20Daylight%20Saving%20Time%20then%28%5Bsee%20here%5D%28https%3A//stackoverflow.com/a/2532962%29%29%20and%20we%20are%20independent%20from%20timezone%20changes%20in%20the%20server.%20Also%2C%20we%20would%20be%20consistent%20with%20the%20%60%60PeriodicTaskLastRun%60%60%20table.%5Cr%5Cn%5Cr%5CnIf%20we%20want%20to%20do%20this%2C%20we%20need%20to%20think%20about%20the%20%60%60timezone%60%60%20parameter.%20We%20could%20require%20it%20to%20be%20a%20timezone-aware%20datetime%20object%20and%20convert%20it%20to%20UTC%20internally%2C%20or%20we%20could%20require%20a%20%5C%22naive%5C%22%20UTC%20datetime%20object%20without%20an%20attached%20timezone.%22%2C%20%22created_at%22%3A%20%222018-06-28T11%3A32%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40fredreichbier%20%20What%20do%20you%20recommend%20in%20regards%20to%20the%20timestamp%3F%5Cr%5CnWhat%20have%20you%20done%20in%20periodicTaskLastRun.%5Cr%5Cn%5Cr%5CnCan%20you%20please%20give%20a%20dedicated%20pointer%3F%20%28Currently%20I%20can%20not%20put%20my%20head%20around%20it%20and%20if%20you%20have%20the%20right%20solution%2C%20fine.%20I%20would%20like%20to%20get%20the%20merged%20in%20a%20sensible%20way%2C%20since%20this%20is%20the%20basis%20for%20further%20modules%29%22%2C%20%22created_at%22%3A%20%222018-06-29T10%3A05%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-06-29T18%3A55%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/monitoringstats.py%3AL1-128%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1113#issuecomment-400431759'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1113?src=pr&el=h1) Report
> Merging [#1113](https://codecov.io/gh/privacyidea/privacyidea/pull/1113?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/4929d4e0a7a11cbc564a88d034f7903665ba8024?src=pr&el=desc) will **increase** coverage by `0.17%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1113/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1113?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1113      +/-   ##
==========================================
+ Coverage    95.7%   95.88%   +0.17%
==========================================
Files         133      134       +1
Lines       16540    17223     +683
==========================================
+ Hits        15830    16514     +684
+ Misses        710      709       -1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1113?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/monitoringstats.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1113/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21vbml0b3JpbmdzdGF0cy5weQ==) | `100% <100%> (ø)` | |
| [privacyidea/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1113/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5) | `96.78% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1113/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `99.27% <100%> (+0.42%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1113?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1113?src=pr&el=footer). Last update [4929d4e...1b704cd](https://codecov.io/gh/privacyidea/privacyidea/pull/1113?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Thanks for the migration script
- [x] <a href='#crh-comment-Pull 51bbd329a8813cc1daa50ea6bb50ec57e19f131d privacyidea/lib/monitoringstats.py 50'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1113#discussion_r198808041'>File: privacyidea/lib/monitoringstats.py:L1-128</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Maybe we should store timestamps in UTC because we won't be affected by Daylight Saving Time then([see here](https://stackoverflow.com/a/2532962)) and we are independent from timezone changes in the server. Also, we would be consistent with the ``PeriodicTaskLastRun`` table.
If we want to do this, we need to think about the ``timezone`` parameter. We could require it to be a timezone-aware datetime object and convert it to UTC internally, or we could require a "naive" UTC datetime object without an attached timezone.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier  What do you recommend in regards to the timestamp?
What have you done in periodicTaskLastRun.
Can you please give a dedicated pointer? (Currently I can not put my head around it and if you have the right solution, fine. I would like to get the merged in a sensible way, since this is the basis for further modules)
- [x] <a href='#crh-comment-Pull 51bbd329a8813cc1daa50ea6bb50ec57e19f131d privacyidea/lib/monitoringstats.py 70'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1113#discussion_r198809488'>File: privacyidea/lib/monitoringstats.py:L1-128</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> same here with ``start_timestamp`` and ``end_timestamp`` -- should they be timezone-aware, or timezone-naive UTC datetimes?
- [x] <a href='#crh-comment-Pull 51bbd329a8813cc1daa50ea6bb50ec57e19f131d privacyidea/lib/monitoringstats.py 104'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1113#discussion_r198809733'>File: privacyidea/lib/monitoringstats.py:L1-128</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> same here with start_timestamp, end_timestamp and the timestamp in the result.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1113?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1113?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1113'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>