### PR TITLE
Add lib functions for periodic tasks

### DIFF
--- a/deploy/debian-ubuntu/control
+++ b/deploy/debian-ubuntu/control
@@ -9,7 +9,7 @@ Package: python-privacyidea
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-flask-migrate, python-qrcode, python-netaddr,
  python-pyrad, python-yaml, python-configobj, python-bs4, python-pandas, python-matplotlib, python-ecdsa, python-gnupg, python-openssl,
- python-dateutil
+ python-dateutil, python-croniter
 Replaces: privacyidea (<< 2.0)
 Breaks: privacyidea (<< 2.0)
 X-Python-Version: >= 2.7

--- a/migrations/versions/2c9430cfc66b_.py
+++ b/migrations/versions/2c9430cfc66b_.py
@@ -24,7 +24,8 @@ def upgrade():
         sa.Column('nodes', sa.Unicode(length=256), nullable=False),
         sa.Column('taskmodule', sa.Unicode(length=256), nullable=False),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('name')
+        sa.UniqueConstraint('name'),
+        mysql_row_format='DYNAMIC'
         )
         op.create_table('periodictasklastrun',
         sa.Column('id', sa.Integer(), nullable=False),
@@ -33,7 +34,8 @@ def upgrade():
         sa.Column('timestamp', sa.DateTime(), nullable=False),
         sa.ForeignKeyConstraint(['periodictask_id'], ['periodictask.id'], ),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('periodictask_id', 'node', name='ptlrix_1')
+        sa.UniqueConstraint('periodictask_id', 'node', name='ptlrix_1'),
+        mysql_row_format='DYNAMIC'
         )
         op.create_table('periodictaskoption',
         sa.Column('id', sa.Integer(), nullable=False),
@@ -42,7 +44,8 @@ def upgrade():
         sa.Column('value', sa.Unicode(length=2000), nullable=True),
         sa.ForeignKeyConstraint(['periodictask_id'], ['periodictask.id'], ),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('periodictask_id', 'key', name='ptoix_1')
+        sa.UniqueConstraint('periodictask_id', 'key', name='ptoix_1'),
+        mysql_row_format='DYNAMIC'
         )
     except Exception, exx:
         print "Could not add tables for periodic tasks!"

--- a/privacyidea/lib/periodictask.py
+++ b/privacyidea/lib/periodictask.py
@@ -167,6 +167,8 @@ def get_scheduled_periodic_tasks(node, current_timestamp=None, interval_tzinfo=N
     active_ptasks = get_periodic_tasks(node=node, active=True)
     if current_timestamp is None:
         current_timestamp = datetime.now(tzutc())
+    if current_timestamp.tzinfo is None:
+        raise ParameterError(u"expected timezone-aware datetime, got {!r}".format(current_timestamp))
     scheduled_ptasks = []
     log.debug(u"Collecting periodic tasks to run at {!s}".format(current_timestamp.isoformat()))
     for ptask in active_ptasks:

--- a/privacyidea/lib/periodictask.py
+++ b/privacyidea/lib/periodictask.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#  2018-06-25 Friedrich Weber <friedrich.weber@netknights.it>
+#             Initial implementation of periodic tasks
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+__doc__ = """This module provides functions to manage periodic tasks in the database,
+to determine their next scheduled running time and to run them."""
+
+from datetime import datetime
+
+from croniter import croniter
+from dateutil.tz import tzutc
+
+from privacyidea.lib.error import ServerError
+
+
+def calculate_next_timestamp(ptask, node):
+    """
+    Calculate the timestamp of the next scheduled run of task ``ptask`` on node ``node``.
+    We do not check if the task is even scheduled to run on the specified node.
+    If the periodic task has no prior run recorded on the specified node, a
+    ``ServerError`` is thrown. Malformed cron expressions may throw a
+    ``ValueError``.
+
+    :param ptask: Dictionary describing the periodic task, as from ``PeriodicTask.get()``
+    :param node: Node on which the periodic task is scheduled
+    :type node: unicode
+    :return: a timezone-aware (UTC) datetime object
+    """
+    if node not in ptask["last_runs"]:
+        raise ServerError("No last run on node {!r} recorded for task {!r}".format(node, ptask["name"]))
+    # This will be a UTC timestamp
+    assert ptask["last_runs"][node].tzinfo is None
+    iterator = croniter(ptask["interval"], ptask["last_runs"][node])
+    next_timestamp = iterator.get_next(datetime)
+    # This will again be a UTC timestamp, but we return a timezone-aware UTC timestamp
+    return next_timestamp.replace(tzinfo=tzutc())

--- a/privacyidea/lib/periodictask.py
+++ b/privacyidea/lib/periodictask.py
@@ -19,15 +19,19 @@
 __doc__ = """This module provides functions to manage periodic tasks in the database,
 to determine their next scheduled running time and to run them."""
 
+import logging
 from datetime import datetime
 
 from croniter import croniter
-from dateutil.tz import tzutc
+from dateutil.tz import tzutc, tzlocal
 
-from privacyidea.lib.error import ServerError
+from privacyidea.lib.error import ServerError, ParameterError
+from privacyidea.models import PeriodicTask
+
+log = logging.getLogger(__name__)
 
 
-def calculate_next_timestamp(ptask, node):
+def calculate_next_timestamp(ptask, node, interval_tzinfo=None):
     """
     Calculate the timestamp of the next scheduled run of task ``ptask`` on node ``node``.
     We do not check if the task is even scheduled to run on the specified node.
@@ -38,13 +42,137 @@ def calculate_next_timestamp(ptask, node):
     :param ptask: Dictionary describing the periodic task, as from ``PeriodicTask.get()``
     :param node: Node on which the periodic task is scheduled
     :type node: unicode
+    :param interval_tzinfo: Timezone in which the cron expression should be interpreted. Defaults to local time.
+    :type interval_tzinfo: tzinfo
     :return: a timezone-aware (UTC) datetime object
     """
+    if interval_tzinfo is None:
+        interval_tzinfo = tzlocal()
     if node not in ptask["last_runs"]:
         raise ServerError("No last run on node {!r} recorded for task {!r}".format(node, ptask["name"]))
-    # This will be a UTC timestamp
-    assert ptask["last_runs"][node].tzinfo is None
-    iterator = croniter(ptask["interval"], ptask["last_runs"][node])
+    timestamp = ptask["last_runs"][node]
+    local_timestamp = timestamp.astimezone(interval_tzinfo)
+    iterator = croniter(ptask["interval"], local_timestamp)
     next_timestamp = iterator.get_next(datetime)
-    # This will again be a UTC timestamp, but we return a timezone-aware UTC timestamp
-    return next_timestamp.replace(tzinfo=tzutc())
+    # This will again be a timezone-aware datetime, but we return a timezone-aware UTC timestamp
+    return next_timestamp.astimezone(tzutc())
+
+
+def set_periodic_task(name, interval, nodes, taskmodule, options=None, active=True, id=None):
+    """
+    Set a periodic task configuration. If ``id`` is None, this creates a new database entry.
+    Otherwise, an existing entry is overwritten.
+    :param name: Unique name of the periodic task
+    :type name: unicode
+    :param interval: Periodicity as a string in crontab format
+    :type interval: unicode
+    :param nodes: List of nodes on which this task should be run
+    :type nodes: list of unicode
+    :param taskmodule: Name of the task module
+    :type taskmodule: unicode
+    :param options: Additional options for the task module
+    :type options: Dictionary mapping unicodes to values that can be converted to unicode or None
+    :param active: Flag determining whether the periodic task is active
+    :type active: bool
+    :param id: ID of the existing entry, or None
+    :type id: int or None
+    :return: ID of the entry
+    """
+    periodic_task = PeriodicTask(name, active, interval, nodes, taskmodule, options, id)
+    return periodic_task.id
+
+
+def delete_periodic_task(ptask_id):
+    """
+    Delete an existing periodic task. If ``ptask_id`` refers to an unknown entry, a ParameterError is raised.
+    :param ptask_id: ID of the database entry
+    :return: ID of the deleted entry
+    """
+    periodic_task = PeriodicTask.query.filter_by(id=ptask_id).first()
+    if periodic_task is None:
+        raise ParameterError("The periodic task with id {!r} does not exist".format(ptask_id))
+    return periodic_task.delete()
+
+
+def enable_periodic_task(ptask_id, enable=True):
+    """
+    Set the ``active`` flag of an existing periodic task to ``enable``.
+    If ``ptask_id`` refers to an unknown entry, a ParameterError is raised.
+    :param ptask_id: ID of the database entry
+    :param enable: New value of the ``active`` flag
+    :return: ID of the database entry
+    """
+    periodic_task = PeriodicTask.query.filter_by(id=ptask_id).first()
+    if periodic_task is None:
+        raise ParameterError("The periodic task with id {!r} does not exist".format(ptask_id))
+    periodic_task.active = enable
+    return periodic_task.save()
+
+
+def get_periodic_tasks(name=None, node=None, active=None):
+    """
+    Get a list of all periodic tasks, or of all tasks satisfying a filter criterion.
+    :param name: Name of the periodic task
+    :type name: unicode
+    :param node: Node for which periodic tasks should be collected. This only includes
+                 periodic tasks which are scheduled to run on ``node``.
+    :type node: unicode
+    :param active: This can be used to filter for active or inactive tasks only
+    :return: A (possibly empty) list of periodic task dictionaries
+    """
+    query = PeriodicTask.query
+    if name is not None:
+        query = query.filter_by(name=name)
+    if active is not None:
+        query = query.filter_by(active=active)
+    entries = query.all()
+    result = []
+    for entry in entries:
+        ptask = entry.get()
+        if node is None or node in ptask["nodes"]:
+            result.append(ptask)
+    return result
+
+
+def set_periodic_task_last_run(ptask_id, node, last_run_timestamp):
+    """
+    Write to the database the information that the specified
+    periodic task has been run on a node at a given time.
+    :param ptask_id: ID of the periodic task. Raises ParameterError if unknown.
+    :type ptask_id: int
+    :param node: Node name. It is not checked whether the task is scheduled to run on that node!
+    :type node: unioode
+    :param last_run_timestamp: Timestamp of the last run
+    :type last_run_timestamp: timezone-aware datetime object
+    """
+    periodic_task = PeriodicTask.query.filter_by(id=ptask_id).first()
+    if periodic_task is None:
+        raise ParameterError("The periodic task with id {!r} does not exist".format(ptask_id))
+    utc_last_run = last_run_timestamp.astimezone(tzutc()).replace(tzinfo=None)
+    periodic_task.set_last_run(node, utc_last_run)
+
+
+def get_scheduled_periodic_tasks(node, current_timestamp=None, interval_tzinfo=None):
+    """
+    Collect all periodic tasks that should be run on a specific node.
+
+    :param node: Node name
+    :type node: unicode
+    :param current_timestamp: The current timestamp, defaults to the current time
+    :type current_timestamp: timezone-aware datetime
+    :param interval_tzinfo: timezone in which the crontab expression should be interpreted
+    :type interval_tzinfo: tzinfo, defaults to local time
+    :return: List of periodic task dictionaries
+    """
+    active_ptasks = get_periodic_tasks(node=node, active=True)
+    if current_timestamp is None:
+        current_timestamp = datetime.now(tzutc())
+    scheduled_ptasks = []
+    for ptask in active_ptasks:
+        try:
+            next_timestamp = calculate_next_timestamp(ptask, node, interval_tzinfo)
+            if next_timestamp <= current_timestamp:
+                scheduled_ptasks.append(ptask)
+        except Exception as e:
+            log.warning(u"Ignoring periodic task {!s}: {!r}".format(ptask["name"], e))
+    return scheduled_ptasks

--- a/privacyidea/lib/periodictask.py
+++ b/privacyidea/lib/periodictask.py
@@ -156,6 +156,9 @@ def get_scheduled_periodic_tasks(node, current_timestamp=None, interval_tzinfo=N
     """
     Collect all periodic tasks that should be run on a specific node.
 
+    This function is usually called by the local cron runner which is aware of the
+    current local node name.
+
     :param node: Node name
     :type node: unicode
     :param current_timestamp: The current timestamp, defaults to the current time

--- a/privacyidea/lib/periodictask.py
+++ b/privacyidea/lib/periodictask.py
@@ -168,11 +168,14 @@ def get_scheduled_periodic_tasks(node, current_timestamp=None, interval_tzinfo=N
     if current_timestamp is None:
         current_timestamp = datetime.now(tzutc())
     scheduled_ptasks = []
+    log.debug(u"Collecting periodic tasks to run at {!s}".format(current_timestamp.isoformat()))
     for ptask in active_ptasks:
         try:
             next_timestamp = calculate_next_timestamp(ptask, node, interval_tzinfo)
+            log.debug(u"Next scheduled run of {!r}: {!s}".format(ptask["name"], next_timestamp.isoformat()))
             if next_timestamp <= current_timestamp:
+                log.debug(u"Scheduling periodic task {!r}".format(ptask["name"]))
                 scheduled_ptasks.append(ptask)
         except Exception as e:
-            log.warning(u"Ignoring periodic task {!s}: {!r}".format(ptask["name"], e))
+            log.warning(u"Ignoring periodic task {!r}: {!r}".format(ptask["name"], e))
     return scheduled_ptasks

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2486,6 +2486,7 @@ class PeriodicTask(MethodsMixin, db.Model):
     This class stores tasks that should be run periodically.
     """
     __tablename__ = 'periodictask'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("periodictask_seq"), primary_key=True)
     name = db.Column(db.Unicode(64), unique=True, nullable=False)
     active = db.Column(db.Boolean, default=True, nullable=False)
@@ -2604,7 +2605,8 @@ class PeriodicTaskOption(db.Model):
 
     __table_args__ = (db.UniqueConstraint('periodictask_id',
                                           'key',
-                                          name='ptoix_1'), {})
+                                          name='ptoix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, periodictask_id, key, value):
         self.periodictask_id = periodictask_id
@@ -2646,7 +2648,8 @@ class PeriodicTaskLastRun(db.Model):
 
     __table_args__ = (db.UniqueConstraint('periodictask_id',
                                           'node',
-                                          name='ptlrix_1'), {})
+                                          name='ptlrix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
 
     def __init__(self, periodictask_id, node, timestamp):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ configobj==5.0.6
 cookies==2.2.1
 cov-core==1.15.0
 coverage==4.5.1
-croniter==0.3.4
+croniter==0.3.8
 defusedxml==0.5.0
 docutils==0.14
 ecdsa==0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ configobj==5.0.6
 cookies==2.2.1
 cov-core==1.15.0
 coverage==4.5.1
+croniter==0.3.4
 defusedxml==0.5.0
 docutils==0.14
 ecdsa==0.13

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ install_requires = ["Flask>=0.10.1",
                     "lxml>=3.3",
                     "python-gnupg>=0.3.8",
                     "defusedxml>=0.4.1",
-                    "flask-babel>=0.9"
+                    "flask-babel>=0.9",
+                    "croniter>=0.3.4"
                     ]
 
 # For python 2.6 we need additional dependency importlib

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ install_requires = ["Flask>=0.10.1",
                     "python-gnupg>=0.3.8",
                     "defusedxml>=0.4.1",
                     "flask-babel>=0.9",
-                    "croniter>=0.3.4"
+                    "croniter>=0.3.8"
                     ]
 
 # For python 2.6 we need additional dependency importlib

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -17,6 +17,7 @@ from privacyidea.models import (Token,
                                 EventCounter, PeriodicTask, PeriodicTaskLastRun,
                                 PeriodicTaskOption)
 from .base import MyTestCase
+from dateutil.tz import tzutc
 from datetime import datetime
 from datetime import timedelta
 
@@ -787,8 +788,8 @@ class TokenModelTestCase(MyTestCase):
                              "options": {"KEY2": "value number 2",
                                          "key 4": "1234"},
                              "last_runs": {
-                                 "localhost": datetime(2018, 3, 4, 5, 6, 7),
-                                 "otherhost": datetime(2018, 8, 9, 10, 11, 12),
+                                 "localhost": datetime(2018, 3, 4, 5, 6, 7, tzinfo=tzutc()),
+                                 "otherhost": datetime(2018, 8, 9, 10, 11, 12, tzinfo=tzutc()),
                              }
                          })
         # assert all old options are removed
@@ -807,8 +808,8 @@ class TokenModelTestCase(MyTestCase):
                              "options": {"KEY2": "value number 2",
                                          "key 4": "1234"},
                              "last_runs": {
-                                 "localhost": datetime(2018, 3, 4, 5, 6, 8),
-                                 "otherhost": datetime(2018, 8, 9, 10, 11, 12),
+                                 "localhost": datetime(2018, 3, 4, 5, 6, 8, tzinfo=tzutc()),
+                                 "otherhost": datetime(2018, 8, 9, 10, 11, 12, tzinfo=tzutc()),
                              }
                          })
 
@@ -816,6 +817,11 @@ class TokenModelTestCase(MyTestCase):
         PeriodicTask("task one", True, "0 8 * * *", ["otherhost"], "some.module", {"foo": "bar"}, id=task1.id)
         self.assertEqual(PeriodicTaskOption.query.filter_by(periodictask_id=task1.id).count(), 1)
         self.assertEqual(PeriodicTaskLastRun.query.filter_by(periodictask_id=task1.id).one().node, "otherhost")
+        # naive timestamp in the database
+        self.assertEqual(PeriodicTaskLastRun.query.filter_by(periodictask_id=task1.id).one().timestamp,
+                         datetime(2018, 8, 9, 10, 11, 12, tzinfo=None))
+        self.assertEqual(PeriodicTaskLastRun.query.filter_by(periodictask_id=task1.id).one().aware_timestamp,
+                         datetime(2018, 8, 9, 10, 11, 12, tzinfo=tzutc()))
 
         # remove the tasks, everything is removed
         task1.delete()

--- a/tests/test_lib_periodictask.py
+++ b/tests/test_lib_periodictask.py
@@ -4,15 +4,23 @@ This file contains the tests for periodic tasks.
 In particular, this tests
 lib/periodictask.py
 """
-from dateutil.parser import parse as parse_timestamp
+from datetime import datetime, timedelta
 
-from privacyidea.lib.error import ServerError
-from privacyidea.lib.periodictask import calculate_next_timestamp
+from dateutil.parser import parse as parse_timestamp
+from dateutil.tz import gettz, tzutc
+
+from privacyidea.lib.error import ServerError, ParameterError
+from privacyidea.lib.periodictask import calculate_next_timestamp, set_periodic_task, get_periodic_tasks, \
+    enable_periodic_task, delete_periodic_task, set_periodic_task_last_run, get_scheduled_periodic_tasks
+from privacyidea.models import PeriodicTask
 from .base import MyTestCase
 
 
 class BasePeriodicTaskTestCase(MyTestCase):
-    def test_01_calculate_next_timestamp(self):
+    def test_01_calculate_next_timestamp_utc(self):
+        # The easy case: calculate everything in UTC
+        tzinfo = tzutc()
+
         # every day at 08:00
         task1 = {
             "id": 1,
@@ -24,14 +32,14 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "options": {"KEY2": "value number 2",
                         "key 4": "1234"},
             "last_runs": {
-                "foo": parse_timestamp("2018-06-25 08:04:30"),
-                "bar": parse_timestamp("2018-06-24 07:05:37"),
+                "foo": parse_timestamp("2018-06-25 08:04:30 UTC"),
+                "bar": parse_timestamp("2018-06-24 07:05:37 UTC"),
             }
         }
 
-        self.assertEqual(calculate_next_timestamp(task1, "foo"),
+        self.assertEqual(calculate_next_timestamp(task1, "foo", tzinfo),
                          parse_timestamp("2018-06-26 08:00 UTC"))
-        self.assertEqual(calculate_next_timestamp(task1, "bar"),
+        self.assertEqual(calculate_next_timestamp(task1, "bar", tzinfo),
                          parse_timestamp("2018-06-24 08:00 UTC"))
         with self.assertRaises(ServerError):
             calculate_next_timestamp(task1, "baz")
@@ -47,10 +55,10 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "options": {"KEY2": "value number 2",
                         "key 4": "1234"},
             "last_runs": {
-                "localhost": parse_timestamp("2018-06-29 00:00"),
+                "localhost": parse_timestamp("2018-06-29 00:00 UTC"),
             }
         }
-        self.assertEqual(calculate_next_timestamp(task2, "localhost"),
+        self.assertEqual(calculate_next_timestamp(task2, "localhost", tzinfo),
                          parse_timestamp("2018-07-02 00:00 UTC"))
 
         # at 00:05 in August
@@ -64,10 +72,10 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "options": {"KEY2": "value number 2",
                         "key 4": "1234"},
             "last_runs": {
-                "localhost": parse_timestamp("2017-08-31 00:06"),
+                "localhost": parse_timestamp("2017-08-31 00:06 UTC"),
             }
         }
-        self.assertEqual(calculate_next_timestamp(task3, "localhost"),
+        self.assertEqual(calculate_next_timestamp(task3, "localhost", tzinfo),
                          parse_timestamp("2018-08-01 00:05 UTC"))
 
         # malformed
@@ -81,8 +89,282 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "options": {"KEY2": "value number 2",
                         "key 4": "1234"},
             "last_runs": {
-                "localhost": parse_timestamp("2017-08-31 00:06"),
+                "localhost": parse_timestamp("2017-08-31 00:06 UTC"),
             }
         }
         with self.assertRaises(ValueError):
             calculate_next_timestamp(task4, "localhost")
+
+    def test_02_calculate_next_timestamp_localtime(self):
+        # The harder case: Calculate everything in a local timezone
+        # There is no DST in russia, so we operate in +03:00
+        tzinfo = gettz("Europe/Moscow")
+
+        # every day at 08:00
+        task = {
+            "interval": "0 8 * * *",
+            "last_runs": {
+                "foo": parse_timestamp("2018-06-25 05:04:30 UTC"),
+            }
+        }
+        self.assertEqual(calculate_next_timestamp(task, "foo", tzinfo),
+                         parse_timestamp("2018-06-26 05:00 UTC"))
+
+        # every day at 08:00
+        task = {
+            "interval": "0 8 * * *",
+            "last_runs": {
+                "foo": parse_timestamp("2018-06-25 04:04:30 UTC"),
+            }
+        }
+        self.assertEqual(calculate_next_timestamp(task, "foo", tzinfo),
+                         parse_timestamp("2018-06-25 05:00 UTC"))
+
+        # every day at midnight
+        task = {
+            "interval": "0 0 * * *",
+            "last_runs": {
+                "foo": parse_timestamp("2018-06-25 21:01 UTC"),
+            }
+        }
+        self.assertEqual(calculate_next_timestamp(task, "foo", tzinfo),
+                         parse_timestamp("2018-06-26 21:00 UTC"))
+
+        # every wednesday at midnight
+        task = {
+            "interval": "0 0 * * 3",
+            "last_runs": {
+                "foo": parse_timestamp("2018-06-24 21:00 UTC"),  # this is actually monday 00:00 in russia
+            }
+        }
+        self.assertEqual(calculate_next_timestamp(task, "foo", tzinfo),
+                         parse_timestamp("2018-06-26 21:00 UTC"))
+
+        # every 15th at 01:00
+        task = {
+            "interval": "0 1 15 * *",
+            "last_runs": {
+                "foo": parse_timestamp("2018-05-15 00:00 UTC"),
+            }
+        }
+        self.assertEqual(calculate_next_timestamp(task, "foo", tzinfo),
+                         parse_timestamp("2018-06-14 22:00 UTC"))
+
+        # every 15th at 01:00
+        task = {
+            "interval": "0 1 15 * *",
+            "last_runs": {
+                "foo": parse_timestamp("2018-05-14 21:59 UTC"),
+            }
+        }
+        self.assertEqual(calculate_next_timestamp(task, "foo", tzinfo),
+                         parse_timestamp("2018-05-14 22:00 UTC"))
+
+    def test_03_crud(self):
+        task1 = set_periodic_task("task one", "0 0 1 * *", ["pinode1"], "some.task.module", {
+            "key1": 1,
+            "key2": False
+        })
+        task2 = set_periodic_task("task two", "0 0 * * WED", ["pinode2"], "some.task.module", {
+            "key1": "value",
+            "key2": "foo"
+        }, active=False)
+        task3 = set_periodic_task("task three", "30 * * * *", ["pinode1", "pinode2"], "some.task.module", {
+            "key1": 1234,
+            "key2": 5678,
+        })
+
+        self.assertEqual(len(PeriodicTask.query.all()), 3)
+
+        task1_modified = set_periodic_task("every month", "0 0 1 * *", ["pinode1"], "some.task.module", {
+            "key1": 123,
+            "key3": True,
+        }, id=task1)
+
+        self.assertEqual(len(PeriodicTask.query.all()), 3)
+        self.assertEqual(task1, task1_modified)
+        self.assertEqual(get_periodic_tasks(name="every month")[0]["options"],
+                         {"key1": "123", "key3": "True"})
+
+        all_tasks = get_periodic_tasks()
+        self.assertEqual(len(all_tasks), 3)
+        self.assertEqual(all_tasks[0]["name"], "every month")
+
+        active_tasks = get_periodic_tasks(active=True)
+        self.assertEqual(len(active_tasks), 2)
+        self.assertEqual([task["name"] for task in active_tasks], ["every month", "task three"])
+
+        active_tasks_on_pinode2 = get_periodic_tasks(active=True, node="pinode2")
+        self.assertEqual(len(active_tasks_on_pinode2), 1)
+        self.assertEqual(active_tasks_on_pinode2[0]["name"], "task three")
+
+        enable_periodic_task(task2)
+
+        active_tasks_on_pinode2 = get_periodic_tasks(active=True, node="pinode2")
+        self.assertEqual(len(active_tasks_on_pinode2), 2)
+        self.assertEqual([task["name"] for task in active_tasks_on_pinode2],
+                         ["task two", "task three"])
+
+        active_tasks_on_pinode1 = get_periodic_tasks(active=True, node="pinode1")
+        self.assertEqual(len(active_tasks_on_pinode1), 2)
+        self.assertEqual([task["name"] for task in active_tasks_on_pinode1],
+                         ["every month", "task three"])
+
+        active_tasks_on_pinode3 = get_periodic_tasks(active=True, node="pinode3")
+        self.assertEqual(active_tasks_on_pinode3, [])
+
+        enable_periodic_task(task1, False)
+        delete_periodic_task(task3)
+        with self.assertRaises(ParameterError):
+            enable_periodic_task(task3)
+
+        active_tasks_on_pinode1 = get_periodic_tasks(active=True, node="pinode1")
+        self.assertEqual(active_tasks_on_pinode1, [])
+
+        tasks_on_pinode1 = get_periodic_tasks(node="pinode1")
+        self.assertEqual(len(tasks_on_pinode1), 1)
+        self.assertEqual(tasks_on_pinode1[0]["name"], "every month")
+
+        delete_periodic_task(task1)
+        delete_periodic_task(task2)
+        with self.assertRaises(ParameterError):
+            delete_periodic_task(task2)
+
+        self.assertEqual(get_periodic_tasks(), [])
+
+    def test_04_last_run(self):
+        task1_id = set_periodic_task("task one", "*/5 * * * *", ["pinode1", "pinode2"], "some.task.module", {
+            "key1": 1,
+            "key2": False
+        })
+        self.assertEqual(len(PeriodicTask.query.all()), 1)
+        set_periodic_task_last_run(task1_id, "pinode1", parse_timestamp("2018-06-26 08:00+02:00"))
+        set_periodic_task_last_run(task1_id, "pinode1", parse_timestamp("2018-06-26 08:05+02:00"))
+
+        task1_entry = PeriodicTask.query.filter_by(id=task1_id).one()
+
+        task1 = get_periodic_tasks("task one")[0]
+        self.assertEqual(len(list(task1_entry.last_runs)), 1)
+        self.assertEqual(task1_entry.last_runs[0].timestamp,
+                         parse_timestamp("2018-06-26 06:05"))
+        self.assertEqual(task1["last_runs"]["pinode1"],
+                         parse_timestamp("2018-06-26 06:05 UTC"))
+
+        set_periodic_task_last_run(task1_id, "pinode2", parse_timestamp("2018-06-26 08:10+01:00"))
+        set_periodic_task_last_run(task1_id, "pinode3", parse_timestamp("2018-06-26 08:10-08:00"))
+        task1 = get_periodic_tasks("task one")[0]
+        self.assertEqual(task1["last_runs"]["pinode1"],
+                         parse_timestamp("2018-06-26 06:05 UTC"))
+        self.assertEqual(task1["last_runs"]["pinode2"],
+                         parse_timestamp("2018-06-26 07:10 UTC"))
+        self.assertEqual(task1["last_runs"]["pinode3"],
+                         parse_timestamp("2018-06-26 16:10 UTC"))
+
+        delete_periodic_task(task1_id)
+
+    def test_05_scheduling(self):
+        # this unit test operates in russian time
+        tzinfo = gettz("Europe/Moscow")
+
+        # at midnight on each 1st
+        task1 = set_periodic_task("task one", "0 0 1 * *", ["pinode1"], "some.task.module", {
+            "key1": 1,
+            "key2": False
+        })
+        # at 08:00 on wednesdays
+        task2 = set_periodic_task("task two", "0 8 * * WED", ["pinode2"], "some.task.module", {
+            "key1": "value",
+            "key2": "foo"
+        }, active=False)
+        # every 30 minutes, on Tuesdays
+        task3 = set_periodic_task("task three", "*/30 * * * 2", ["pinode1", "pinode2"], "some.task.module", {
+            "key1": 1234,
+            "key2": 5678,
+        })
+        # on each 1st of august at midnight
+        task4 = set_periodic_task("task four", "0 0 1 8 *", ["pinode2"], "some.task.module")
+        # with invalid interval
+        task5 = set_periodic_task("task five", "obviously invalid", ["pinode1", "pinode2"], "some.task.module", {
+            "key1": 1234,
+            "key2": 5678,
+        })
+
+        # we need some last runs
+        set_periodic_task_last_run(task1, "pinode1", parse_timestamp("2018-06-01 00:00:05+03:00"))
+
+        set_periodic_task_last_run(task2, "pinode2", parse_timestamp("2018-06-20 08:00:05+03:00"))
+
+        set_periodic_task_last_run(task3, "pinode1", parse_timestamp("2018-06-26 11:36:37+03:00"))
+        set_periodic_task_last_run(task3, "pinode2", parse_timestamp("2018-06-26 11:30:33+03:00"))
+
+        set_periodic_task_last_run(task4, "pinode2", parse_timestamp("2017-08-01 00:00:43+03:00"))
+
+        # On pinode1:
+        # task1 at midnight on each 1st
+        # task3 every 30 minutes on tuesdays
+
+        # On pinode2:
+        # task2 on 08:00 on wednesdays, but it is inactive
+        # task3 every 30 minutes on tuesdays
+        # task4 on each 1st August at midnight
+
+        # 26th June (Tuesday), 11:59
+        # No tasks on both nodes
+        current_timestamp = parse_timestamp("2018-06-26 11:59+03:00")
+
+        scheduled = get_scheduled_periodic_tasks("pinode1", current_timestamp, tzinfo)
+        self.assertEqual(scheduled, [])
+
+        scheduled = get_scheduled_periodic_tasks("pinode2", current_timestamp, tzinfo)
+        self.assertEqual(scheduled, [])
+
+        # 26th June (Tuesday), 12:00
+        # Run task3 on both nodes
+        current_timestamp = parse_timestamp("2018-06-26 12:00+03:00")
+
+        scheduled = get_scheduled_periodic_tasks("pinode1", current_timestamp, tzinfo)
+        self.assertEqual([task["name"] for task in scheduled], ["task three"])
+
+        scheduled = get_scheduled_periodic_tasks("pinode2", current_timestamp, tzinfo)
+        self.assertEqual([task["name"] for task in scheduled], ["task three"])
+
+        # 1th August (Wednesday), 13:57
+        # Assume task3 has been run successfully on 30th July (Tuesday)
+        set_periodic_task_last_run(task3, "pinode1", parse_timestamp("2018-08-01 00:00+03:00"))
+        set_periodic_task_last_run(task3, "pinode2", parse_timestamp("2018-08-01 00:00+03:00"))
+
+        # On pinode1, run task1
+        # On pinode2, run task4
+        current_timestamp = parse_timestamp("2018-08-01 11:59+03:00")
+
+        scheduled = get_scheduled_periodic_tasks("pinode1", current_timestamp, tzinfo)
+        self.assertEqual([task["name"] for task in scheduled], ["task one"])
+
+        scheduled = get_scheduled_periodic_tasks("pinode2", current_timestamp, tzinfo)
+        self.assertEqual([task["name"] for task in scheduled], ["task four"])
+
+        # Enable task2, now we also have to run it on pinode2
+        enable_periodic_task(task2)
+
+        scheduled = get_scheduled_periodic_tasks("pinode1", current_timestamp, tzinfo)
+        self.assertEqual([task["name"] for task in scheduled], ["task one"])
+
+        scheduled = get_scheduled_periodic_tasks("pinode2", current_timestamp, tzinfo)
+        self.assertEqual([task["name"] for task in scheduled], ["task two", "task four"])
+
+        # Simulate runs
+        set_periodic_task_last_run(task1, "pinode1", current_timestamp)
+        set_periodic_task_last_run(task2, "pinode2", current_timestamp)
+        set_periodic_task_last_run(task4, "pinode2", current_timestamp)
+
+        # Now, we don't have to run anything
+        current_timestamp += timedelta(seconds=1)
+
+        self.assertEqual(get_scheduled_periodic_tasks("pinode1", current_timestamp, tzinfo), [])
+        self.assertEqual(get_scheduled_periodic_tasks("pinode2", current_timestamp, tzinfo), [])
+
+        delete_periodic_task(task1)
+        delete_periodic_task(task2)
+        delete_periodic_task(task3)
+        delete_periodic_task(task4)
+        delete_periodic_task(task5)

--- a/tests/test_lib_periodictask.py
+++ b/tests/test_lib_periodictask.py
@@ -299,6 +299,10 @@ class BasePeriodicTaskTestCase(MyTestCase):
 
         set_periodic_task_last_run(task4, "pinode2", parse_timestamp("2017-08-01 00:00:43+03:00"))
 
+        # Invalid timestamp
+        with self.assertRaises(ParameterError):
+            get_scheduled_periodic_tasks("pinode1", parse_timestamp("2017-08-01 00:00:00"), tzinfo)
+
         # On pinode1:
         # task1 at midnight on each 1st
         # task3 every 30 minutes on tuesdays

--- a/tests/test_lib_periodictask.py
+++ b/tests/test_lib_periodictask.py
@@ -1,0 +1,88 @@
+"""
+This file contains the tests for periodic tasks.
+
+In particular, this tests
+lib/periodictask.py
+"""
+from dateutil.parser import parse as parse_timestamp
+
+from privacyidea.lib.error import ServerError
+from privacyidea.lib.periodictask import calculate_next_timestamp
+from .base import MyTestCase
+
+
+class BasePeriodicTaskTestCase(MyTestCase):
+    def test_01_calculate_next_timestamp(self):
+        # every day at 08:00
+        task1 = {
+            "id": 1,
+            "active": True,
+            "name": "task one",
+            "interval": "0 8 * * *",
+            "nodes": ["foo", "bar"],
+            "taskmodule": "some.module",
+            "options": {"KEY2": "value number 2",
+                        "key 4": "1234"},
+            "last_runs": {
+                "foo": parse_timestamp("2018-06-25 08:04:30"),
+                "bar": parse_timestamp("2018-06-24 07:05:37"),
+            }
+        }
+
+        self.assertEqual(calculate_next_timestamp(task1, "foo"),
+                         parse_timestamp("2018-06-26 08:00 UTC"))
+        self.assertEqual(calculate_next_timestamp(task1, "bar"),
+                         parse_timestamp("2018-06-24 08:00 UTC"))
+        with self.assertRaises(ServerError):
+            calculate_next_timestamp(task1, "baz")
+
+        # every weekday
+        task2 = {
+            "id": 2,
+            "active": True,
+            "name": "task two",
+            "interval": "0 0 * * 1-5",
+            "nodes": ["foo", "bar"],
+            "taskmodule": "some.module",
+            "options": {"KEY2": "value number 2",
+                        "key 4": "1234"},
+            "last_runs": {
+                "localhost": parse_timestamp("2018-06-29 00:00"),
+            }
+        }
+        self.assertEqual(calculate_next_timestamp(task2, "localhost"),
+                         parse_timestamp("2018-07-02 00:00 UTC"))
+
+        # at 00:05 in August
+        task3 = {
+            "id": 3,
+            "active": True,
+            "name": "task two",
+            "interval": "5 0 * 8 *",
+            "nodes": ["foo", "bar"],
+            "taskmodule": "some.module",
+            "options": {"KEY2": "value number 2",
+                        "key 4": "1234"},
+            "last_runs": {
+                "localhost": parse_timestamp("2017-08-31 00:06"),
+            }
+        }
+        self.assertEqual(calculate_next_timestamp(task3, "localhost"),
+                         parse_timestamp("2018-08-01 00:05 UTC"))
+
+        # malformed
+        task4 = {
+            "id": 3,
+            "active": True,
+            "name": "task two",
+            "interval": "every two days",
+            "nodes": ["foo", "bar"],
+            "taskmodule": "some.module",
+            "options": {"KEY2": "value number 2",
+                        "key 4": "1234"},
+            "last_runs": {
+                "localhost": parse_timestamp("2017-08-31 00:06"),
+            }
+        }
+        with self.assertRaises(ValueError):
+            calculate_next_timestamp(task4, "localhost")


### PR DESCRIPTION
This implements some library functions for periodic tasks.

Some issues with this:
* Ubuntu 14.04 only has croniter 0.3.4, which causes some problems. We could possibly add a workaround for that. Ubuntu 16.04 has croniter 0.3.8, which is fine.
* I'm not 100% sure about the timezone handling. I decided to store timestamps without timezone information in the database because apparently, not all database backends support it. So I decided to always store UTC timestamps.

I'm happy about any comments and suggestions :-)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23issuecomment-401340878%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23issuecomment-405482131%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23issuecomment-405483244%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23issuecomment-405483943%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23issuecomment-405485954%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202909346%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202910121%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202910521%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202911706%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202911709%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202912648%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202914031%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202917323%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23issuecomment-401340878%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231116%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/4929d4e0a7a11cbc564a88d034f7903665ba8024%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.15%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6097.43%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116/graphs/tree.svg%3Fheight%3D150%26width%3D650%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231116%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.7%25%20%20%2095.85%25%20%20%20%2B0.15%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20133%20%20%20%20%20%20134%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016540%20%20%20%2017264%20%20%20%20%20%2B724%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015830%20%20%20%2016549%20%20%20%20%20%2B719%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20710%20%20%20%20%20%20715%20%20%20%20%20%20%20%2B5%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6099.27%25%20%3C100%25%3E%20%28%2B0.41%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/periodictask.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BlcmlvZGljdGFzay5weQ%3D%3D%29%20%7C%20%6097.1%25%20%3C97.1%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.33%25%20%3C0%25%3E%20%28-2.5%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/importotp.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2ltcG9ydG90cC5weQ%3D%3D%29%20%7C%20%6093.14%25%20%3C0%25%3E%20%28-0.08%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6094.61%25%20%3C0%25%3E%20%28%2B0.06%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/error.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5%29%20%7C%20%6091.83%25%20%3C0%25%3E%20%28%2B1.02%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B4929d4e...87a8fd4%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1116%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-29T12%3A34%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20yes%2C%20I%20think%20I%20missed%20this%20up%20until%20now.%20Right%20now%2C%20I%20don%27t%20know%20how%20a%20node%20could%20know%20the%20names%20of%20other%20privacyIDEA%20nodes%20--%20because%20a%20privacyIDEA%20node%20itself%20does%20not%20know%20if%20it%20is%20running%20in%20a%20redundant%20setup%20or%20not%3F%5Cr%5Cn%5Cr%5CnHm%2C%20personally%20I%20would%20prefer%20to%20postpone%20this%20issue%20because%20it%20doesn%27t%20interfere%20with%20the%20actual%20functionality.%20In%20a%20first%20step%2C%20we%20could%20let%20the%20user%20manually%20enter%20the%20nodes%20on%20which%20a%20task%20should%20run.%22%2C%20%22created_at%22%3A%20%222018-07-17T07%3A08%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22privacyIDEA%20does%20actually%20not%20know%20this%21%20The%20database%20config%20knows%20it.%5Cr%5CnBut%20as%20mentioned%2C%20we%20probably%20should%20put%20the%20node%20discussion%20into%20another%20issue.%5Cr%5CnI%20am%20not%20sure%2C%20if%20we%20should%20save%20the%20available%20nodes%20in%20the%20database%20-%20so%20that%20all%20PI%20nodes%20have%20the%20same%20node%20list.%5Cr%5CnOr%20if%20a%20PI%20node%20should%20somehow%20%5C%22register%5C%22%20in%20such%20database%20table%2C%20so%20that%20the%20PI%20node%20can%20take%20the%20information%20%5Cr%5Cn%2A%20what%20node%20am%20I%5Cr%5Cn%2A%20what%20nodes%20are%20available%20%5Cr%5Cnfrom%20the%20database%20or%20from%20pi.cfg.%20Should%20a%20node%20be%20renamable%3F%5Cr%5CnWe%20skip%20it%20here%20and%20please%20open%20an%20issue%20accordingly.%5Cr%5Cn%5Cr%5CnSo%20I%20think%20we%20can%20merge%20this%20PR%20here.%22%2C%20%22created_at%22%3A%20%222018-07-17T07%3A13%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20the%20comment%20to%20%60%60get_scheduled_periodic_tasks%60%60.%5Cr%5Cn%5Cr%5CnI%20agree%20that%20having%20a%20list%20of%20nodes%20to%20choose%20from%20would%20be%20very%20nice.%20I%27ll%20open%20another%20issue%20for%20that.%22%2C%20%22created_at%22%3A%20%222018-07-17T07%3A16%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-07-17T07%3A24%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203538ec92f68bc116406f344d9e663d27d01aa3ac%20privacyidea/lib/periodictask.py%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202909346%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22At%20one%20point%20a%20task%20has%20to%20run%20for%20the%20first%20time.%5Cr%5Cncould%20this%20cause%20problems%20to%20throw%20an%20exception%2C%20if%20the%20task%20did%20not%20run%20before%20%28first-runner%29%22%2C%20%22created_at%22%3A%20%222018-07-17T06%3A46%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%27re%20right%2C%20I%20forgot%20to%20mention%20this%3A%20In%20order%20to%20calculate%20the%20timestamp%20of%20the%20next%20run%2C%20we%20always%20need%20the%20last%20run%20as%20a%20reference%20point.%5Cr%5CnMy%20current%20approach%20%28I%20have%20implemented%20this%20locally%20already%29%20is%20to%20add%20a%20%60%60last_run%60%60%20when%20a%20new%20periodic%20task%20is%20created%20whose%20time%20is%20the%20time%20of%20the%20task%20creation.%20This%20is%20not%20so%20nice%2C%20because%20the%20task%20has%20not%20actually%20run%20at%20that%20time%20--%20but%20calculating%20the%20next%20scheduled%20run%20works%20fine%20then.%22%2C%20%22created_at%22%3A%20%222018-07-17T06%3A50%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-07-17T06%3A59%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/periodictask.py%3AL1-184%22%7D%2C%20%22Pull%203538ec92f68bc116406f344d9e663d27d01aa3ac%20privacyidea/lib/periodictask.py%20155%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202910521%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20a%20way%20of%20getting%20the%20list%20of%20available%20nodes%3F%5Cr%5Cn%5Cr%5CnOtherwise%20we%20might%20want%20to%20make%20the%20%60%60node%60%60%20parameter%20optional.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-07-17T06%3A53%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hah%20you%27re%20right%2C%20currently%20there%20is%20no%20way%20to%20obtain%20the%20available%20nodes.%20And%20I%27m%20currently%20not%20sure%20how%20we%20would%20obtain%20such%20a%20list%3F%5Cr%5Cn%5Cr%5CnHowever%2C%20the%20%60%60get_scheduled_periodic_tasks%60%60%20function%20is%20intended%20to%20be%20called%20by%20the%20local%20cron%20runner%20to%20find%20out%20which%20tasks%20are%20scheduled%20to%20run%20on%20the%20local%20node.%20And%20at%20this%20point%2C%20the%20cron%20runner%20should%20know%20its%20local%20node%20name%2C%20and%20the%20other%20node%20names%20are%20not%20relevant%20then.%22%2C%20%22created_at%22%3A%20%222018-07-17T07%3A03%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20we%20leave%20it%20to%20the%20cron%20runner%20to%20determine%20the%20name%20of%20the%20node.%5Cr%5Cn%5Cr%5CnCan%20you%20please%20add%20something%20to%20the%20docstring%20like%20%5C%22This%20method%20is%20usually%20called%20by%20the%20local%20cron%20runner%2C%20who%20is%20aware%20of%20his%20local%20node%20name%5C%22.%5Cr%5Cn%5Cr%5CnSo%20the%20tasks%20are%20self%20contained%20and%20maybe%20we%20would%20add%20a%20node%20handling%20later.%5Cr%5Cn%5Cr%5CnI%20think%20for%20the%20UI%20it%20would%20be%20quite%20helpfull%20to%20have%20a%20lib%20function%20that%20returns%20the%20available%20node%20names%20so%20that%20the%20admin%20can%20choose%20accordingly%20and%20do%20not%20create%20a%20misspelling.%20%28renaming%20nodes%29%20Maybe%20we%20should%20put%20the%20node%20thingy%20into%20another%20issue%21%22%2C%20%22created_at%22%3A%20%222018-07-17T07%3A10%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-07-17T07%3A24%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/periodictask.py%3AL1-184%22%7D%2C%20%22Pull%203538ec92f68bc116406f344d9e663d27d01aa3ac%20privacyidea/lib/periodictask.py%2085%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1116%23discussion_r202911709%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-07-17T06%3A59%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/periodictask.py%3AL1-184%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1116#issuecomment-401340878'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1116?src=pr&el=h1) Report
> Merging [#1116](https://codecov.io/gh/privacyidea/privacyidea/pull/1116?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/4929d4e0a7a11cbc564a88d034f7903665ba8024?src=pr&el=desc) will **increase** coverage by `0.15%`.
> The diff coverage is `97.43%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1116/graphs/tree.svg?height=150&width=650&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1116?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1116      +/-   ##
==========================================
+ Coverage    95.7%   95.85%   +0.15%
==========================================
Files         133      134       +1
Lines       16540    17264     +724
==========================================
+ Hits        15830    16549     +719
- Misses        710      715       +5
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1116?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1116/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `99.27% <100%> (+0.41%)` | :arrow_up: |
| [privacyidea/lib/periodictask.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1116/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BlcmlvZGljdGFzay5weQ==) | `97.1% <97.1%> (ø)` | |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1116/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.33% <0%> (-2.5%)` | :arrow_down: |
| [privacyidea/lib/importotp.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1116/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2ltcG9ydG90cC5weQ==) | `93.14% <0%> (-0.08%)` | :arrow_down: |
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1116/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `94.61% <0%> (+0.06%)` | :arrow_up: |
| [privacyidea/lib/error.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1116/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5) | `91.83% <0%> (+1.02%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1116?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1116?src=pr&el=footer). Last update [4929d4e...87a8fd4](https://codecov.io/gh/privacyidea/privacyidea/pull/1116?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Oh yes, I think I missed this up until now. Right now, I don't know how a node could know the names of other privacyIDEA nodes -- because a privacyIDEA node itself does not know if it is running in a redundant setup or not?
Hm, personally I would prefer to postpone this issue because it doesn't interfere with the actual functionality. In a first step, we could let the user manually enter the nodes on which a task should run.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> privacyIDEA does actually not know this! The database config knows it.
But as mentioned, we probably should put the node discussion into another issue.
I am not sure, if we should save the available nodes in the database - so that all PI nodes have the same node list.
Or if a PI node should somehow "register" in such database table, so that the PI node can take the information
* what node am I
* what nodes are available
from the database or from pi.cfg. Should a node be renamable?
We skip it here and please open an issue accordingly.
So I think we can merge this PR here.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I've added the comment to ``get_scheduled_periodic_tasks``.
I agree that having a list of nodes to choose from would be very nice. I'll open another issue for that.
- [x] <a href='#crh-comment-Pull 3538ec92f68bc116406f344d9e663d27d01aa3ac privacyidea/lib/periodictask.py 52'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1116#discussion_r202909346'>File: privacyidea/lib/periodictask.py:L1-184</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> At one point a task has to run for the first time.
could this cause problems to throw an exception, if the task did not run before (first-runner)
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> You're right, I forgot to mention this: In order to calculate the timestamp of the next run, we always need the last run as a reference point.
My current approach (I have implemented this locally already) is to add a ``last_run`` when a new periodic task is created whose time is the time of the task creation. This is not so nice, because the task has not actually run at that time -- but calculating the next scheduled run works fine then.
- [x] <a href='#crh-comment-Pull 3538ec92f68bc116406f344d9e663d27d01aa3ac privacyidea/lib/periodictask.py 155'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1116#discussion_r202910521'>File: privacyidea/lib/periodictask.py:L1-184</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Is there a way of getting the list of available nodes?
Otherwise we might want to make the ``node`` parameter optional.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hah you're right, currently there is no way to obtain the available nodes. And I'm currently not sure how we would obtain such a list?
However, the ``get_scheduled_periodic_tasks`` function is intended to be called by the local cron runner to find out which tasks are scheduled to run on the local node. And at this point, the cron runner should know its local node name, and the other node names are not relevant then.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> So we leave it to the cron runner to determine the name of the node.
Can you please add something to the docstring like "This method is usually called by the local cron runner, who is aware of his local node name".
So the tasks are self contained and maybe we would add a node handling later.
I think for the UI it would be quite helpfull to have a lib function that returns the available node names so that the admin can choose accordingly and do not create a misspelling. (renaming nodes) Maybe we should put the node thingy into another issue!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1116?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1116?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1116'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>