### PR TITLE
fix max_token_per_user enroll policy

### DIFF
--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -30,6 +30,10 @@ This is the maximum allowed number of tokens in the specified realm.
    imported a pool of hardware tokens you can thus limit the
    consumed hardware tokens per realm.
 
+.. note:: If there are multiple matching policies, the *highest* maximum
+   allowed number of tokens among the matching policies is enforced.
+   Policy priorities are ignored.
+
 max_token_per_user
 ~~~~~~~~~~~~~~~~~~
 
@@ -40,6 +44,9 @@ Limit the maximum number of tokens per user in this realm.
 .. note:: If you do not set this action, a user may have
    unlimited tokens assigned.
 
+.. note:: If there are multiple matching policies, the *highest* maximum
+   allowed number of tokens among the matching policies is enforced.
+   Policy priorities are ignored.
 
 tokenissuer
 ~~~~~~~~~~~

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -614,6 +614,7 @@ def twostep_enrollment_parameters(request=None, action=None):
             if action_values:
                 request.all_data[parameter] = action_values[0]
 
+
 def check_max_token_user(request=None, action=None):
     """
     Pre Policy
@@ -642,7 +643,7 @@ def check_max_token_user(request=None, action=None):
             # we need to check how many tokens the user already has assigned!
             tokenobject_list = get_tokens(user=user_object)
             already_assigned_tokens = len(tokenobject_list)
-            if already_assigned_tokens >= int(max(limit_list)):
+            if already_assigned_tokens >= max([int(x) for x in limit_list]):
                 raise PolicyError(ERROR)
     return True
 
@@ -679,10 +680,10 @@ def check_max_token_realm(request=None, action=None):
                                                      realm=realm,
                                                      client=g.client_ip)
         if limit_list:
-            # we need to check how many tokens the user already has assigned!
+            # we need to check how many tokens the realm already has assigned!
             tokenobject_list = get_tokens(realm=realm)
             already_assigned_tokens = len(tokenobject_list)
-            if already_assigned_tokens >= int(max(limit_list)):
+            if already_assigned_tokens >= max([int(x) for x in limit_list]):
                 raise PolicyError(ERROR)
     return True
 

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -296,6 +296,17 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         self.assertRaises(PolicyError,
                           check_max_token_user, req)
 
+        # Now we set another policy for the user max_token = 12.
+        # This way, the user should be allowed to enroll tokens again, since there
+        # are two policies matching for the user and the maximum is 12.
+        set_policy(name="pol_max_12",
+                   scope=SCOPE.ENROLL,
+                   action="{0!s}={1!s}".format(ACTION.MAXTOKENUSER, 12))
+        g.policy_object = PolicyClass()
+        # new check_max_token_user should not raise an error!
+        self.assertTrue(check_max_token_user(req))
+        delete_policy("pol_max_12")
+        g.policy_object = PolicyClass()
 
         # The check for a token, that has no username in it, must not
         # succeed. I.e. in the realm new tokens must be enrollable.


### PR DESCRIPTION
The string max_token values are converted to int
_before_ we determine the max()

Fixes #1117
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1118%23issuecomment-401457459%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1118%23issuecomment-402075952%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1118%23issuecomment-403155664%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1118%23issuecomment-401457459%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231118%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/f9c2fbb1138d73e05da0c48f75b99d1e734659e0%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.16%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26width%3D650%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231118%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.7%25%20%20%2095.86%25%20%20%20%2B0.16%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20133%20%20%20%20%20%20133%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016563%20%20%20%2017155%20%20%20%20%20%2B592%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015851%20%20%20%2016446%20%20%20%20%20%2B595%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20712%20%20%20%20%20%20709%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/lib/prepolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wcmVwb2xpY3kucHk%3D%29%20%7C%20%6096.57%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6099.27%25%20%3C0%25%3E%20%28%2B0.39%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bf9c2fbb...bd46e21%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1118%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-29T19%3A53%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20also%20think%20the%20change%20itself%20looks%20good%21%5Cr%5Cn%5Cr%5CnI%20have%20one%20question%20though%3A%20The%20implemented%20behavior%20is%20that%20if%20we%20have%20multiple%20matching%20max_token_per_user%20policies%2C%20the%20policy%20with%20the%20%2Ahighest%2A%20number%20of%20allowed%20tokens%20takes%20precedence.%20Intuitively%2C%20I%20wouldn%27t%20expect%20that%3A%20I%20would%20expect%20that%20the%20%5C%22most%20constrained%5C%22%20policy%20takes%20precedence%2C%20e.g.%3A%20If%20I%20have%20one%20policy%20that%20allows%204%20tokens%20and%20one%20that%20allows%208%20tokens%2C%20I%20would%20expect%20that%20I%20can%20only%20enroll%204%20tokens.%5Cr%5Cn%5Cr%5CnI%20understand%20that%20we%20shouldn%27t%20just%20change%20the%20behavior%20of%20the%20policy%20%28due%20to%20backwards-compatibility%29%2C%20but%20maybe%20we%20should%20add%20an%20explaining%20sentence%20to%20the%20documentation.%5Cr%5Cn%5Cr%5CnWhat%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-07-03T09%3A28%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20note.%20So%20I%20will%20merge.%22%2C%20%22created_at%22%3A%20%222018-07-06T21%3A51%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1118#issuecomment-401457459'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1118?src=pr&el=h1) Report
> Merging [#1118](https://codecov.io/gh/privacyidea/privacyidea/pull/1118?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/f9c2fbb1138d73e05da0c48f75b99d1e734659e0?src=pr&el=desc) will **increase** coverage by `0.16%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1118/graphs/tree.svg?token=7nHLZki60B&width=650&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1118?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1118      +/-   ##
==========================================
+ Coverage    95.7%   95.86%   +0.16%
==========================================
Files         133      133
Lines       16563    17155     +592
==========================================
+ Hits        15851    16446     +595
+ Misses        712      709       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1118?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/lib/prepolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1118/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wcmVwb2xpY3kucHk=) | `96.57% <100%> (ø)` | :arrow_up: |
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1118/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `99.27% <0%> (+0.39%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1118/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1118?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1118?src=pr&el=footer). Last update [f9c2fbb...bd46e21](https://codecov.io/gh/privacyidea/privacyidea/pull/1118?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I also think the change itself looks good!
I have one question though: The implemented behavior is that if we have multiple matching max_token_per_user policies, the policy with the *highest* number of allowed tokens takes precedence. Intuitively, I wouldn't expect that: I would expect that the "most constrained" policy takes precedence, e.g.: If I have one policy that allows 4 tokens and one that allows 8 tokens, I would expect that I can only enroll 4 tokens.
I understand that we shouldn't just change the behavior of the policy (due to backwards-compatibility), but maybe we should add an explaining sentence to the documentation.
What do you think?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Thanks for the note. So I will merge.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1118?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1118?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1118'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>