### PR TITLE
Limit the number of tokens fetched by ``get_token_type``

### DIFF
--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -131,6 +131,12 @@ class TokenTestCase(MyTestCase):
         # get tokens of type TOTP
         tokenobject_list = get_tokens(tokentype="totp")
         self.assertTrue(len(tokenobject_list) > 0, tokenobject_list)
+        # get tokens of type TOTP with a limit
+        tokenobject_list = get_tokens(tokentype="totp", limit=1)
+        self.assertEqual(len(tokenobject_list), 1)
+        # get tokens of type TOTP with a limit
+        tokenobject_list = get_tokens(tokentype="totp", limit=2)
+        self.assertEqual(len(tokenobject_list), 2)
 
         # Search for tokens in realm
         db_token = Token("hotptoken",
@@ -176,6 +182,12 @@ class TokenTestCase(MyTestCase):
     def test_03_get_token_type(self):
         ttype = get_token_type("hotptoken")
         self.assertTrue(ttype == "hotp", ttype)
+
+        # test correct behavior with wildcards
+        self.assertEqual(get_token_type("SE1"), "totp")
+        self.assertEqual(get_token_type("SE*"), "")
+        self.assertEqual(get_token_type("*1"), "totp")
+        self.assertEqual(get_token_type("hotptoke*"), "hotp")
 
     def test_04_check_serial(self):
         r, nserial = check_serial("hotptoken")
@@ -299,6 +311,9 @@ class TokenTestCase(MyTestCase):
     def test_15_init_token(self):
         count = get_tokens(count=True)
         self.assertTrue(count == 4, count)
+        # Tets with limit
+        count = get_tokens(count=True, limit=2)
+        self.assertEqual(count, 2)
         tokenobject = init_token({"serial": "NEW001", "type": "hotp",
                                   "otpkey": "1234567890123456"},
                                  user=User(login="cornelius",


### PR DESCRIPTION
Working on #1123 

I made this patch against branch-2.22, in case we want to do another bugfix release of 2.22. If not, we could also base it on against master.

This slightly changes behavior: Before, ``get_token_type(serial)`` with a serial containing wildcards returned the token type of the *last matching* token. Now, it only returns a token type if a unique token could be determined.

In my opinion, this is the more predictable behavior, as the order of tokens returned by ``get_tokens`` is essentially arbitrary. However, this change may break existing policies which matched on the token type parameter (e.g. in an environment in which all tokens are of the same type). We should look into that before merging this.

As an alternative, we could 
1) implement the old behavior more efficiently (by using ``SELECT ... FROM token ORDER BY id DESC LIMIT 1``) or
2) modify ``get_token_type`` such that it selects the distinct token types of all matching tokens, and returns it if all matching tokens have the same token type.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1124%23issuecomment-404530857%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1124%23issuecomment-407336897%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1124%23issuecomment-404530857%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231124%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.22%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/be18284e7cd023813ef1c0c6e039e1906ff594dd%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.22%20%20%20%20%231124%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%20%20%20%20%2095.41%25%20%20%2095.41%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20131%20%20%20%20%20%20131%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2016206%20%20%20%2016207%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2015463%20%20%20%2015464%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20743%20%20%20%20%20%20743%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6094.5%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bbe18284...0d4b86a%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1124%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-07-12T14%3A25%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20had%20another%20look%20at%20this%3A%20%60%60get_token_type%60%60%20is%20actually%20%2Aonly%2A%20used%20in%20%60%60before_request%60%60%2C%20and%20%60%60before_request%60%60%20passes%20its%20result%20only%20to%20%60%60g.audit_object.log%28%29%60%60.%20%20This%20would%20mean%20that%20the%20modified%20behavior%20would%20only%20affect%20audit%20log%20entries.%20Shouldn%27t%20this%20mean%20that%20it%20cannot%20have%20any%20influence%20on%20policies%3F%5Cr%5Cn%5Cr%5CnIn%20my%20opinion%2C%20the%20modified%20behavior%20makes%20more%20sense%3A%20if%20we%20search%20for%20%5C%22P%2A%5C%22%2C%20and%20there%20are%20HOTP%20as%20well%20as%20TOTP%20tokens%20with%20that%20prefix%2C%20I%20think%20it%20makes%20most%20sense%20that%20the%20corresponding%20audit%20log%20entry%20is%20left%20blank.%22%2C%20%22created_at%22%3A%20%222018-07-24T09%3A09%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1124#issuecomment-404530857'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1124?src=pr&el=h1) Report
> Merging [#1124](https://codecov.io/gh/privacyidea/privacyidea/pull/1124?src=pr&el=desc) into [branch-2.22](https://codecov.io/gh/privacyidea/privacyidea/commit/be18284e7cd023813ef1c0c6e039e1906ff594dd?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1124/graphs/tree.svg?token=7nHLZki60B&src=pr&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1124?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.22    #1124      +/-   ##
===============================================
+ Coverage        95.41%   95.41%   +<.01%
===============================================
Files              131      131
Lines            16206    16207       +1
===============================================
+ Hits             15463    15464       +1
Misses             743      743
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1124?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1124/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `94.5% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1124?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1124?src=pr&el=footer). Last update [be18284...0d4b86a](https://codecov.io/gh/privacyidea/privacyidea/pull/1124?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I've had another look at this: ``get_token_type`` is actually *only* used in ``before_request``, and ``before_request`` passes its result only to ``g.audit_object.log()``.  This would mean that the modified behavior would only affect audit log entries. Shouldn't this mean that it cannot have any influence on policies?
In my opinion, the modified behavior makes more sense: if we search for "P*", and there are HOTP as well as TOTP tokens with that prefix, I think it makes most sense that the corresponding audit log entry is left blank.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1124?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1124?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1124'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>