### PR TITLE
Add API layer and cron runner for periodic tasks

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -51,6 +51,7 @@ from .token import token_blueprint
 from .system import system_blueprint
 from .smtpserver import smtpserver_blueprint
 from .radiusserver import radiusserver_blueprint
+from .periodictask import periodictask_blueprint
 from .privacyideaserver import privacyideaserver_blueprint
 from .recover import recover_blueprint
 from .register import register_blueprint
@@ -89,6 +90,7 @@ def before_user_request():
 @application_blueprint.before_request
 @smtpserver_blueprint.before_request
 @eventhandling_blueprint.before_request
+@periodictask_blueprint.before_request
 @smsgateway_blueprint.before_request
 @client_blueprint.before_request
 @subscriptions_blueprint.before_request
@@ -198,6 +200,7 @@ def before_request():
 @caconnector_blueprint.after_request
 @smtpserver_blueprint.after_request
 @radiusserver_blueprint.after_request
+@periodictask_blueprint.after_request
 @privacyideaserver_blueprint.after_request
 @client_blueprint.after_request
 @subscriptions_blueprint.after_request

--- a/privacyidea/api/periodictask.py
+++ b/privacyidea/api/periodictask.py
@@ -16,8 +16,6 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-from privacyidea.api.lib.prepolicy import prepolicy, check_base_action
-from privacyidea.lib.policy import ACTION
 
 __doc__ = """These endpoints are used to create, modify and delete
 periodic tasks.
@@ -29,8 +27,10 @@ import logging
 
 from flask import Blueprint, g, request
 
+from privacyidea.api.lib.prepolicy import prepolicy, check_base_action
 from privacyidea.api.lib.utils import send_result, getParam
 from privacyidea.lib.error import ParameterError
+from privacyidea.lib.policy import ACTION
 from privacyidea.lib.log import log_with
 from privacyidea.lib.periodictask import get_periodic_tasks, set_periodic_task, delete_periodic_task, \
     enable_periodic_task

--- a/privacyidea/api/periodictask.py
+++ b/privacyidea/api/periodictask.py
@@ -16,7 +16,6 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-
 __doc__ = """These endpoints are used to create, modify and delete
 periodic tasks.
 
@@ -27,6 +26,7 @@ import logging
 
 from flask import Blueprint, g, request
 
+from privacyidea.lib.tokenclass import AUTH_DATE_FORMAT
 from privacyidea.api.lib.prepolicy import prepolicy, check_base_action
 from privacyidea.api.lib.utils import send_result, getParam
 from privacyidea.lib.error import ParameterError
@@ -48,7 +48,8 @@ def convert_datetimes_to_string(ptask):
     :return: a new periodic task dictionary
     """
     ptask = ptask.copy()
-    ptask['last_runs'] = dict((node, timestamp.isoformat()) for node, timestamp in ptask['last_runs'].items())
+    ptask['last_runs'] = dict((node, timestamp.strftime(AUTH_DATE_FORMAT))
+                              for node, timestamp in ptask['last_runs'].items())
     return ptask
 
 

--- a/privacyidea/api/periodictask.py
+++ b/privacyidea/api/periodictask.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+#  2018-07-09 Friedrich Weber <friedrich.weber@netknights.it>
+#             Initial implementation of periodic tasks
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+from privacyidea.api.lib.prepolicy import prepolicy, check_base_action
+from privacyidea.lib.policy import ACTION
+
+__doc__ = """These endpoints are used to create, modify and delete
+periodic tasks.
+
+This module is tested in tests/test_api_periodictask.py"""
+
+import json
+import logging
+
+from flask import Blueprint, g, request
+
+from privacyidea.api.lib.utils import send_result, getParam
+from privacyidea.lib.error import ParameterError
+from privacyidea.lib.log import log_with
+from privacyidea.lib.periodictask import get_periodic_tasks, set_periodic_task, delete_periodic_task, \
+    enable_periodic_task
+from privacyidea.lib.utils import is_true
+
+log = logging.getLogger(__name__)
+
+periodictask_blueprint = Blueprint('periodictask_blueprint', __name__)
+
+
+@periodictask_blueprint.route('/', methods=['GET'])
+@log_with(log)
+def list_tasks():
+    """
+    Return a list of objects of defined periodic tasks.
+    """
+    tasks = get_periodic_tasks()
+    result = dict((task["name"], task) for task in tasks)
+    g.audit_object.log({"success": True})
+    return send_result(result)
+
+
+@periodictask_blueprint.route('/', methods=['POST'])
+@prepolicy(check_base_action, request, ACTION.PERIODICTASKWRITE)
+@log_with(log)
+def set_periodic_task_api():
+    """
+    Create or replace an existing periodic task definition.
+
+    :param id: ID of an existing periodic task definition that should be updated
+    :param name: Name of the periodic task
+    :param active: true if the periodic task should be active
+    :param interval: Interval at which the periodic task should run (in cron syntax)
+    :param nodes: Comma-separated list of nodes on which the periodic task should run
+    :param taskmodule: Task module name of the task
+    :param options: A dictionary (possibly JSON) of periodic task options
+    :return: ID of the periodic task
+    """
+    param = request.all_data
+    ptask_id = getParam(param, "id", optional=True)
+    if ptask_id is not None:
+        ptask_id = int(ptask_id)
+    name = getParam(param, "name", optional=False)
+    active = is_true(getParam(param, "active", default=True))
+    interval = getParam(param, "interval", optional=False)
+    node_string = getParam(param, "nodes", optional=False)
+    node_list = [node.strip() for node in node_string.split(",")]
+    taskmodule = getParam(param, "taskmodule", optional=False)
+    options = getParam(param, "options", optional=True)
+    if options is None:
+        options = {}
+    elif not isinstance(options, dict):
+        options = json.loads(options)
+        if not isinstance(options, dict):
+            raise ParameterError(u"options: expected dictionary, got {!r}".format(options))
+    result = set_periodic_task(name, interval, node_list, taskmodule, options, active, ptask_id)
+    g.audit_object.log({"success": True, "info": result})
+    return send_result(result)
+
+
+@periodictask_blueprint.route('/enable/<ptaskid>', methods=['POST'])
+@prepolicy(check_base_action, request, ACTION.PERIODICTASKWRITE)
+@log_with(log)
+def enable_periodic_task_api(ptaskid):
+    """
+    Enable a certain periodic task.
+    :param ptaskid: ID of the periodic task
+    :return: ID of the periodic task
+    """
+    result = enable_periodic_task(int(ptaskid), True)
+    g.audit_object.log({"success": True})
+    return send_result(result)
+
+
+@periodictask_blueprint.route('/disable/<ptaskid>', methods=['POST'])
+@prepolicy(check_base_action, request, ACTION.PERIODICTASKWRITE)
+@log_with(log)
+def disable_periodic_task_api(ptaskid):
+    """
+    Disable a certain periodic task.
+    :param ptaskid: ID of the periodic task
+    :return: ID of the periodic task
+    """
+    result = enable_periodic_task(int(ptaskid), False)
+    g.audit_object.log({"success": True})
+    return send_result(result)
+
+
+@periodictask_blueprint.route('/<ptaskid>', methods=['DELETE'])
+@prepolicy(check_base_action, request, ACTION.PERIODICTASKWRITE)
+@log_with(log)
+def delete_periodic_task_api(ptaskid):
+    """
+    Delete a certain periodic task.
+    :param ptaskid: ID of the periodic task
+    :return: ID of the periodic task
+    """
+    result = delete_periodic_task(int(ptaskid))
+    g.audit_object.log({"success": True, "info": result})
+    return send_result(result)

--- a/privacyidea/api/periodictask.py
+++ b/privacyidea/api/periodictask.py
@@ -52,7 +52,7 @@ def convert_datetimes_to_string(ptask):
     return ptask
 
 
-@periodictask_blueprint.route('/taskmodules', methods=['GET'])
+@periodictask_blueprint.route('/taskmodules/', methods=['GET'])
 @log_with(log)
 def list_taskmodules():
     """

--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -47,6 +47,7 @@ from privacyidea.api.machine import machine_blueprint
 from privacyidea.api.ttype import ttype_blueprint
 from privacyidea.api.smtpserver import smtpserver_blueprint
 from privacyidea.api.radiusserver import radiusserver_blueprint
+from privacyidea.api.periodictask import periodictask_blueprint
 from privacyidea.api.privacyideaserver import privacyideaserver_blueprint
 from privacyidea.api.recover import recover_blueprint
 from privacyidea.api.event import eventhandling_blueprint
@@ -158,6 +159,7 @@ def create_app(config_name="development",
     app.register_blueprint(smtpserver_blueprint, url_prefix='/smtpserver')
     app.register_blueprint(recover_blueprint, url_prefix='/recover')
     app.register_blueprint(radiusserver_blueprint, url_prefix='/radiusserver')
+    app.register_blueprint(periodictask_blueprint, url_prefix='/periodictask')
     app.register_blueprint(privacyideaserver_blueprint,
                            url_prefix='/privacyideaserver')
     app.register_blueprint(eventhandling_blueprint, url_prefix='/event')

--- a/privacyidea/lib/periodictask.py
+++ b/privacyidea/lib/periodictask.py
@@ -267,8 +267,5 @@ def execute_task(taskmodule, params):
     :param params: dictionary mapping task option keys (unicodes) to unicodes (or None)
     :return: boolean returned by the task
     """
-    if taskmodule not in TASK_MODULES:
-        raise ParameterError("Unknown task module: {!r}".format(taskmodule))
-    cls = TASK_MODULES[taskmodule]
-    module = cls()
+    module = get_taskmodule(taskmodule)
     return module.do(params)

--- a/privacyidea/lib/periodictask.py
+++ b/privacyidea/lib/periodictask.py
@@ -88,7 +88,8 @@ def set_periodic_task(name, interval, nodes, taskmodule, options=None, active=Tr
     """
     Set a periodic task configuration. If ``id`` is None, this creates a new database entry.
     In that case, an initial "last run" is also added.
-    Otherwise, an existing entry is overwritten.
+    Otherwise, an existing entry is overwritten. We actually ensure that such
+    an entry exists and throw a ``ParameterError`` otherwise.
 
     This also checks if ``interval`` is a valid cron expression, and throws
     a ``ParameterError`` if it is not.
@@ -113,6 +114,9 @@ def set_periodic_task(name, interval, nodes, taskmodule, options=None, active=Tr
         croniter(interval)
     except ValueError as e:
         raise ParameterError("Invalid interval: {!s}".format(e))
+    if id is not None:
+        # This will throw a ParameterError if there is no such entry
+        get_periodic_task_by_id(id)
     periodic_task = PeriodicTask(name, active, interval, nodes, taskmodule, options, id)
     # If this is a new task, we actually need to add a "last" run already
     # to "kick off" the scheduling.

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -293,6 +293,7 @@ class ACTION(object):
     PRIVACYIDEASERVERWRITE = "privacyideaserver_write"
     REALMDROPDOWN = "realm_dropdown"
     EVENTHANDLINGWRITE = "eventhandling_write"
+    PERIODICTASKWRITE = "periodictask_write"
     SMSGATEWAYWRITE = "smsgateway_write"
     CHANGE_PIN_FIRST_USE = "change_pin_on_first_use"
     CHANGE_PIN_EVERY = "change_pin_every"
@@ -1326,6 +1327,11 @@ def get_static_policy_definitions(scope=None):
                                                       "write remote "
                                                       "privacyIDEA server "
                                                       "definitions."),
+                                            'mainmenu': [MAIN_MENU.CONFIG],
+                                            'group': GROUP.SYSTEM},
+            ACTION.PERIODICTASKWRITE: {'type': 'bool',
+                                       'desc': _("Admin is allowed to write "
+                                                 "periodic task definitions."),
                                             'mainmenu': [MAIN_MENU.CONFIG],
                                             'group': GROUP.SYSTEM},
             ACTION.EVENTHANDLINGWRITE: {'type': 'bool',

--- a/privacyidea/lib/task/hello.py
+++ b/privacyidea/lib/task/hello.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#  2018-08-09 Friedrich Weber <friedrich.weber@netknights.it>
+#             Hello Task
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+import logging
+from privacyidea.lib.task.base import BaseTask
+
+__doc__ = """This is a simple test task which only writes to the log."""
+
+log = logging.getLogger(__name__)
+
+class HelloTask(BaseTask):
+    identifier = "Hello"
+    description = "Write an arbitrary message to the log."
+
+    @property
+    def options(self):
+        return {
+            "message": {
+                "type": "str",
+                "description": "Message to print to the log"
+            }
+        }
+
+    def do(self, params):
+        msg = params.get("message", "Hello World!")
+        log.info(msg)
+        return True

--- a/tests/test_api_periodictask.py
+++ b/tests/test_api_periodictask.py
@@ -225,7 +225,7 @@ class APIPeriodicTasksTestCase(MyTestCase):
 
     def test_02_taskmodules(self):
         with self.mock_task_module() as taskmodule:
-            status_code, data = self.simulate_request('/periodictask/taskmodules', method='GET')
+            status_code, data = self.simulate_request('/periodictask/taskmodules/', method='GET')
             self.assertEqual(status_code, 200)
             self.assertTrue(data['result']['status'])
             self.assertEqual(data['result']['value'], ['UnitTest'])

--- a/tests/test_api_periodictask.py
+++ b/tests/test_api_periodictask.py
@@ -90,6 +90,15 @@ class APIPeriodicTasksTestCase(MyTestCase):
                 'interval': 'every day',
                 'taskmodule': 'UnitTest',
                 'options': '{"something": "123"}',
+            },
+            # invalid options
+            {
+                'name': 'some task',
+                'nodes': 'pinode1, pinode2',
+                'active': False,
+                'interval': '0 8 * * *',
+                'taskmodule': 'UnitTest',
+                'options': '[1, 2]',
             }
         ]
         # all result in ERR905
@@ -109,7 +118,6 @@ class APIPeriodicTasksTestCase(MyTestCase):
                 'active': False,
                 'interval': '0 8 * * 0',
                 'taskmodule': 'UnitTest',
-                'options': '{"something": 123, "else": true}',
             }
             status_code, data = self.simulate_request('/periodictask/', method='POST',
                                                       data=task_dict2)

--- a/tests/test_api_periodictask.py
+++ b/tests/test_api_periodictask.py
@@ -1,0 +1,240 @@
+"""
+This file contains the tests for the periodic tasks API.
+
+This tests api/periodictask.py
+"""
+import json
+from contextlib import contextmanager
+import mock
+from dateutil.parser import parse as parse_timestamp
+
+from privacyidea.lib.periodictask import TASK_MODULES
+from tests.base import MyTestCase
+
+
+class APIPeriodicTasksTestCase(MyTestCase):
+    @contextmanager
+    def mock_task_module(self):
+        """
+        Mock a UnitTest task module, use as ``with self.mock_task_module() as module:``
+        """
+        taskmodule = mock.MagicMock()
+        cls = lambda: taskmodule
+        with mock.patch.dict(TASK_MODULES, {"UnitTest": cls}, clear=True):
+            yield taskmodule
+
+    def simulate_request(self, *args, **kwargs):
+        """
+        Run test request, return a tuple (status code, decoded body)
+        If 'Authorization' is not given in the request headers, add ``self.at``.
+        """
+        headers = kwargs.get('headers', {}).copy()
+        if 'Authorization' not in headers:
+            headers['Authorization'] = self.at
+        kwargs['headers'] = headers
+        with self.app.test_request_context(*args, **kwargs):
+            res = self.app.full_dispatch_request()
+            return res.status_code, json.loads(res.data)
+
+    def test_01_crud(self):
+        # no tasks yet
+        status_code, data = self.simulate_request('/periodictask/', method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertTrue(data['result']['status'])
+        self.assertEqual(data['result']['value'], [])
+
+        # need authorization
+        status_code, data = self.simulate_request('/periodictask/', method='GET', headers={'Authorization': 'ABC'})
+        self.assertEqual(status_code, 401)
+        self.assertFalse(data['result']['status'])
+
+        # create task
+        with self.mock_task_module():
+            task_dict1 = {
+                'name': 'some task',
+                'nodes': 'pinode1, pinode2',
+                'active': False,
+                'interval': '0 8 * * *',
+                'taskmodule': 'UnitTest',
+                'options': '{"something": 123, "else": true}',
+            }
+            status_code, data = self.simulate_request('/periodictask/', method='POST', data=task_dict1)
+            self.assertEqual(status_code, 200)
+            self.assertEqual(data['result']['status'], True)
+            ptask_id1 = data['result']['value']
+
+        # some invalid tasks
+        invalid_task_dicts = [
+            # no nodes
+            {
+                'name': 'some other task',
+                'active': False,
+                'interval': '0 8 * * *',
+                'taskmodule': 'UnitTest',
+                'options': '{"something": "123", "else": true}',
+            },
+            # unknown taskmodule
+            {
+                'name': 'some other task',
+                'nodes': 'pinode1, pinode2',
+                'active': False,
+                'interval': '0 8 * * *',
+                'taskmodule': 'Unknown',
+                'options': '{"something": "123"}',
+            },
+            # invalid interval
+            {
+                'name': 'some other task',
+                'nodes': 'pinode1, pinode2',
+                'active': False,
+                'interval': 'every day',
+                'taskmodule': 'UnitTest',
+                'options': '{"something": "123"}',
+            }
+        ]
+        # all result in ERR905
+        with self.mock_task_module():
+            for invalid_task_dict in invalid_task_dicts:
+                status_code, data = self.simulate_request('/periodictask/', method='POST',
+                                                          data=invalid_task_dict)
+                self.assertEqual(status_code, 400)
+                self.assertFalse(data['result']['status'])
+                self.assertIn('ERR905', data['result']['error']['message'])
+
+        # create another task
+        with self.mock_task_module():
+            task_dict2 = {
+                'name': 'some other task',
+                'nodes': 'pinode1',
+                'active': False,
+                'interval': '0 8 * * 0',
+                'taskmodule': 'UnitTest',
+                'options': '{"something": 123, "else": true}',
+            }
+            status_code, data = self.simulate_request('/periodictask/', method='POST',
+                                                      data=task_dict2)
+
+            self.assertEqual(status_code, 200)
+            self.assertTrue(data['result']['status'])
+            ptask_id2 = data['result']['value']
+
+        # can list the periodic tasks
+        status_code, data = self.simulate_request('/periodictask/', method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertTrue(data['result']['status'])
+        self.assertEqual(len(data['result']['value']), 2)
+
+        # find first task
+        for result_dict in data['result']['value']:
+            if result_dict['id'] == ptask_id1:
+                self.assertEqual(result_dict['name'], 'some task')
+                self.assertEqual(result_dict['active'], False)
+                self.assertEqual(result_dict['interval'], '0 8 * * *')
+                self.assertEqual(result_dict['nodes'], ['pinode1', 'pinode2'])
+                self.assertEqual(set(result_dict['last_runs'].keys()), {'pinode1', 'pinode2'})
+                self.assertIsNotNone(parse_timestamp(result_dict['last_runs']['pinode1']))
+                self.assertEqual(result_dict['options'], {'something': '123', 'else': 'True'})
+                break
+        else:
+            self.fail("Could not find 'some task' in results")
+
+        # get one
+        status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id1), method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data['result']['value']['id'], ptask_id1)
+
+        # unknown ID
+        status_code, data = self.simulate_request('/periodictask/4242', method='GET')
+        self.assertEqual(status_code, 400)
+        self.assertFalse(data['result']['status'])
+
+        # update existing task
+        task_dict1['name'] = 'new name'
+        task_dict1['options'] = '{"key": "value"}'
+        task_dict1['id'] = ptask_id1
+        with self.mock_task_module():
+            status_code, data = self.simulate_request('/periodictask/', method='POST',
+                                                      data=task_dict1)
+            self.assertEqual(status_code, 200)
+            self.assertTrue(data['result']['status'])
+            self.assertEqual(data['result']['value'], ptask_id1)
+
+        # get updated task
+        status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id1), method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data['result']['value']['id'], ptask_id1)
+        self.assertEqual(data['result']['value']['name'], 'new name')
+        self.assertEqual(data['result']['value']['options'], {'key': 'value'})
+
+        # enable
+        status_code, data = self.simulate_request('/periodictask/enable/{}'.format(ptask_id1), method='POST')
+        self.assertEqual(status_code, 200)
+
+        # get updated task
+        status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id1), method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data['result']['value']['name'], 'new name')
+        self.assertEqual(data['result']['value']['active'], True)
+
+        # disable
+        status_code, data = self.simulate_request('/periodictask/disable/{}'.format(ptask_id1), method='POST')
+        self.assertEqual(status_code, 200)
+
+        # get updated task
+        status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id1), method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data['result']['value']['name'], 'new name')
+        self.assertEqual(data['result']['value']['active'], False)
+
+        # disable again without effect
+        status_code, data = self.simulate_request('/periodictask/disable/{}'.format(ptask_id1), method='POST')
+        self.assertEqual(status_code, 200)
+
+        # get updated task
+        status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id1), method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data['result']['value']['name'], 'new name')
+        self.assertEqual(data['result']['value']['active'], False)
+
+        # delete
+        status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id1), method='DELETE')
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data['result']['value'], ptask_id1)
+
+        # get updated task impossible now
+        status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id1), method='GET')
+        self.assertEqual(status_code, 400)
+        self.assertFalse(data['result']['status'], False)
+
+        # only 1 task left
+        status_code, data = self.simulate_request('/periodictask/', method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertTrue(data['result']['status'])
+        self.assertEqual(len(data['result']['value']), 1)
+
+        # delete the second task as well
+        status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id2), method='DELETE')
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data['result']['value'], ptask_id2)
+
+        # no tasks left
+        status_code, data = self.simulate_request('/periodictask/', method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertTrue(data['result']['status'])
+        self.assertEqual(data['result']['value'], [])
+
+    def test_02_taskmodules(self):
+        with self.mock_task_module() as taskmodule:
+            status_code, data = self.simulate_request('/periodictask/taskmodules', method='GET')
+            self.assertEqual(status_code, 200)
+            self.assertTrue(data['result']['status'])
+            self.assertEqual(data['result']['value'], ['UnitTest'])
+
+            options = {'key1': {'type': 'str', 'desc': 'description'},
+                       'key2': {'type': 'str', 'desc': 'other description'}}
+            taskmodule.options = options
+
+            status_code, data = self.simulate_request('/periodictask/options/UnitTest', method='GET')
+            self.assertEqual(status_code, 200)
+            self.assertTrue(data['result']['status'])
+            self.assertEqual(data['result']['value'], options)

--- a/tests/test_lib_periodictask.py
+++ b/tests/test_lib_periodictask.py
@@ -13,7 +13,7 @@ from mock import mock
 from privacyidea.lib.error import ServerError, ParameterError
 from privacyidea.lib.periodictask import calculate_next_timestamp, set_periodic_task, get_periodic_tasks, \
     enable_periodic_task, delete_periodic_task, set_periodic_task_last_run, get_scheduled_periodic_tasks, \
-    get_periodic_task, TASK_MODULES, execute_task
+    get_periodic_task_by_name, TASK_MODULES, execute_task, get_periodic_task_by_id
 from privacyidea.lib.task.base import BaseTask
 from privacyidea.models import PeriodicTask
 from .base import MyTestCase
@@ -182,9 +182,13 @@ class BasePeriodicTaskTestCase(MyTestCase):
                 "key1": 1234,
                 "key2": 5678,
             })
-        self.assertEqual(get_periodic_task("task three")["id"], task3)
+        self.assertEqual(get_periodic_task_by_name("task three")["id"], task3)
         with self.assertRaises(ParameterError):
-            get_periodic_task("task does not exist")
+            get_periodic_task_by_name("task does not exist")
+
+        self.assertEqual(get_periodic_task_by_id(task3)["name"], "task three")
+        with self.assertRaises(ParameterError):
+            get_periodic_task_by_id(1337)
 
         self.assertEqual(len(PeriodicTask.query.all()), 3)
 

--- a/tests/test_lib_periodictask.py
+++ b/tests/test_lib_periodictask.py
@@ -192,6 +192,10 @@ class BasePeriodicTaskTestCase(MyTestCase):
 
         self.assertEqual(len(PeriodicTask.query.all()), 3)
 
+        # Updating an nonexistent task fails
+        with self.assertRaises(ParameterError):
+            set_periodic_task("some task", "0 0 1 * *", ["pinode1"], "some.task.module", {}, id=123456)
+
         task1_modified = set_periodic_task("every month", "0 0 1 * *", ["pinode1"], "some.task.module", {
             "key1": 123,
             "key3": True,

--- a/tests/test_lib_periodictask.py
+++ b/tests/test_lib_periodictask.py
@@ -250,13 +250,16 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "key2": False
         })
         self.assertEqual(len(PeriodicTask.query.all()), 1)
+        task1_entry = PeriodicTask.query.filter_by(id=task1_id).one()
+
+        # We already have the initial last runs
+        self.assertEqual(len(list(task1_entry.last_runs)), 2)
+
         set_periodic_task_last_run(task1_id, "pinode1", parse_timestamp("2018-06-26 08:00+02:00"))
         set_periodic_task_last_run(task1_id, "pinode1", parse_timestamp("2018-06-26 08:05+02:00"))
 
-        task1_entry = PeriodicTask.query.filter_by(id=task1_id).one()
-
         task1 = get_periodic_tasks("task one")[0]
-        self.assertEqual(len(list(task1_entry.last_runs)), 1)
+        self.assertEqual(len(list(task1_entry.last_runs)), 2)
         self.assertEqual(task1_entry.last_runs[0].timestamp,
                          parse_timestamp("2018-06-26 06:05"))
         self.assertEqual(task1["last_runs"]["pinode1"],
@@ -295,11 +298,6 @@ class BasePeriodicTaskTestCase(MyTestCase):
         })
         # on each 1st of august at midnight
         task4 = set_periodic_task("task four", "0 0 1 8 *", ["pinode2"], "some.task.module")
-        # with invalid interval
-        task5 = set_periodic_task("task five", "obviously invalid", ["pinode1", "pinode2"], "some.task.module", {
-            "key1": 1234,
-            "key2": 5678,
-        })
 
         # we need some last runs
         set_periodic_task_last_run(task1, "pinode1", parse_timestamp("2018-06-01 00:00:05+03:00"))
@@ -383,7 +381,6 @@ class BasePeriodicTaskTestCase(MyTestCase):
         delete_periodic_task(task2)
         delete_periodic_task(task3)
         delete_periodic_task(task4)
-        delete_periodic_task(task5)
 
     def test_06_execute_task(self):
         assertEqual = self.assertEqual

--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# 2018-06-29 Friedrich Weber <friedrich.weber@netknights.it>
+#            Implement periodic task runner
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import sys
+
+__doc__ = """
+This script is meant to be invoked periodically by the system cron daemon.
+It runs periodic tasks specified in the 
+"""
+__version__ = "0.1"
+
+from datetime import datetime
+
+import dateutil
+from flask_script import Manager
+
+from privacyidea.app import create_app
+from privacyidea.lib.periodictask import get_scheduled_periodic_tasks, set_periodic_task_last_run, get_periodic_task, \
+    execute_task
+from privacyidea.lib.error import ParameterError
+
+app = create_app(config_name='production', silent=True)
+manager = Manager(app)
+
+
+def get_node_name(node):
+    """
+    Determine the node name. If no node name is given, read it from the app config.
+    Raise a ParameterError if no node name could be determined.
+    :param node: node name given by the user (can be None)
+    :return:
+    """
+    if node is None:
+        if "PI_AUDIT_SERVERNAME" in app.config:
+            return app.config["PI_AUDIT_SERVERNAME"]
+        else:
+            raise ParameterError("No PI_AUDIT_SERVERNAME specified in pi.cfg, use --node to pass a node name")
+    else:
+        return node
+
+
+def run_task_on_node(ptask, node):
+    """
+    Run a periodic task (given as a dictionary) on the given node.
+    In case of success, write the last successful run to the database. Catch any exceptions.
+    :param ptask: task as a dictionary
+    :param node: Node name
+    """
+    try:
+        result = execute_task(ptask["taskmodule"], ptask["options"])
+    except Exception as e:
+        print 'Caught exception: {!r}'.format(e)
+        result = False
+    if result:
+        current_time = datetime.now(dateutil.tz.tzlocal())
+        print 'Task {!r} on node {!r} exited successfully. Noting this in the database ...'.format(ptask["name"], node)
+        set_periodic_task_last_run(ptask["id"], node, current_time)
+    else:
+        print 'Task {!r} on node {!r} did not run successfully.'.format(ptask["name"], node)
+        print 'This unsuccessful run is not recorded in the database.'
+    return result
+
+
+@manager.option("-n", "--node",
+                help="Override the node name (read from privacyIDEA config by default)",
+                dest="node_string")
+@manager.option("-t", "--task",
+                help="Run the specified task",
+                required=True,
+                dest="task_name")
+def run_manually(node_string, task_name):
+    """
+    Manually run a periodic task.
+    BEWARE: This does not check whether the task is active, or whether it should
+    run on the given node at all.
+    """
+    node = get_node_name(node_string)
+    ptask = get_periodic_task(task_name)
+    run_task_on_node(ptask, node)
+
+
+@manager.option("-d", "--dryrun",
+                help="Do not run any tasks, only show what would be done")
+@manager.option("-n", "--node",
+                help="Override the node name (read from privacyIDEA config by default)",
+                dest="node_string")
+def run_scheduled(node_string=None, dryrun=False):
+    """
+    Execute all periodic tasks that are scheduled to run.
+    """
+    node = get_node_name(node_string)
+    current_time = datetime.now(dateutil.tz.tzlocal())
+    scheduled_tasks = get_scheduled_periodic_tasks(node, current_time)
+    if scheduled_tasks:
+        print u"The following tasks are scheduled to run on node {!s}:".format(node)
+        print
+        for ptask in scheduled_tasks:
+            print(u"  {name} ({interval!r}, {taskmodule})".format(**ptask))
+
+        print
+        if not dryrun:
+            results = []
+            for ptask in scheduled_tasks:
+                print u"Running {!r} ...".format(ptask["name"])
+                result = run_task_on_node(ptask, node)
+                results.append(result)
+            if all(results):
+                print u"All scheduled tasks executed successfully."
+            else:
+                print u"Some tasks exited with errors."
+                sys.exit(1)
+        else:
+            print u"Not running any tasks because --dryrun was passed."
+    else:
+        print u"There are no tasks scheduled on node {!s}.".format(node)
+
+manager.run()

--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -21,7 +21,7 @@ import sys
 
 __doc__ = """
 This script is meant to be invoked periodically by the system cron daemon.
-It runs periodic tasks specified in the 
+It runs periodic tasks that are specified in the database.
 """
 __version__ = "0.1"
 
@@ -63,17 +63,18 @@ def run_task_on_node(ptask, node):
     :param node: Node name
     """
     try:
+        print u"Running {!r} ...".format(ptask["name"]),
         result = execute_task(ptask["taskmodule"], ptask["options"])
     except Exception as e:
-        print 'Caught exception: {!r}'.format(e)
+        print u'Caught exception: {!r}'.format(e)
         result = False
     if result:
         current_time = datetime.now(dateutil.tz.tzlocal())
-        print 'Task {!r} on node {!r} exited successfully. Noting this in the database ...'.format(ptask["name"], node)
+        print u'Task {!r} on node {!r} exited successfully. Noting this in the database ...'.format(ptask["name"], node)
         set_periodic_task_last_run(ptask["id"], node, current_time)
     else:
-        print 'Task {!r} on node {!r} did not run successfully.'.format(ptask["name"], node)
-        print 'This unsuccessful run is not recorded in the database.'
+        print u'Task {!r} on node {!r} did not run successfully.'.format(ptask["name"], node)
+        print u'This unsuccessful run is not recorded in the database.'
     return result
 
 
@@ -117,7 +118,6 @@ def run_scheduled(node_string=None, dryrun=False):
         if not dryrun:
             results = []
             for ptask in scheduled_tasks:
-                print u"Running {!r} ...".format(ptask["name"])
                 result = run_task_on_node(ptask, node)
                 results.append(result)
             if all(results):
@@ -130,4 +130,5 @@ def run_scheduled(node_string=None, dryrun=False):
     else:
         print u"There are no tasks scheduled on node {!s}.".format(node)
 
-manager.run()
+if __name__ == '__main__':
+    manager.run()

--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -31,7 +31,7 @@ import dateutil
 from flask_script import Manager
 
 from privacyidea.app import create_app
-from privacyidea.lib.periodictask import get_scheduled_periodic_tasks, set_periodic_task_last_run, get_periodic_task, \
+from privacyidea.lib.periodictask import get_scheduled_periodic_tasks, set_periodic_task_last_run, get_periodic_task_by_name, \
     execute_task
 from privacyidea.lib.error import ParameterError
 
@@ -91,7 +91,7 @@ def run_manually(node_string, task_name):
     run on the given node at all.
     """
     node = get_node_name(node_string)
-    ptask = get_periodic_task(task_name)
+    ptask = get_periodic_task_by_name(task_name)
     run_task_on_node(ptask, node)
 
 

--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -97,6 +97,7 @@ def run_manually(node_string, task_name):
 
 
 @manager.option("-d", "--dryrun",
+                action="store_true",
                 help="Do not run any tasks, only show what would be done")
 @manager.option("-n", "--node",
                 help="Override the node name (read from privacyIDEA config by default)",

--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -26,14 +26,16 @@ It runs periodic tasks that are specified in the database.
 __version__ = "0.1"
 
 import sys
+import json
 from datetime import datetime
 
 import dateutil
 from flask_script import Manager
 
 from privacyidea.app import create_app
-from privacyidea.lib.periodictask import get_scheduled_periodic_tasks, set_periodic_task_last_run, get_periodic_task_by_name, \
-    execute_task
+from privacyidea.lib.periodictask import get_scheduled_periodic_tasks, set_periodic_task_last_run, \
+    get_periodic_task_by_name, \
+    execute_task, get_periodic_tasks
 from privacyidea.lib.error import ParameterError
 
 app = create_app(config_name='production', silent=True)
@@ -98,6 +100,27 @@ def run_manually(node_string, task_name):
     run_task_on_node(ptask, node)
 
 
+@manager.command
+def list():
+    """
+    Show a list of available tasks that could be run.
+    """
+    line_format = u'{active!s:7.7} {id:3} {name:30.30}\t{taskmodule:16}\t{node_list:20}\t{options_json}'
+    print(line_format.format(
+        active=u"Active",
+        id=u"ID",
+        name=u"Name",
+        taskmodule=u"Task Module",
+        node_list=u"Nodes",
+        options_json=u"Options",
+    ))
+    print(u"=" * 100)
+    for ptask in get_periodic_tasks():
+        print(line_format.format(node_list=u', '.join(ptask["nodes"]),
+                                 options_json=json.dumps(ptask["options"]),
+                                 **ptask))
+
+
 @manager.option("-d", "--dryrun",
                 action="store_true",
                 help="Do not run any tasks, only show what would be done")
@@ -132,6 +155,7 @@ def run_scheduled(node_string=None, dryrun=False):
             print(u"Not running any tasks because --dryrun was passed.")
     else:
         print(u"There are no tasks scheduled on node {!s}.".format(node))
+
 
 if __name__ == '__main__':
     manager.run()

--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import sys
+from __future__ import print_function
 
 __doc__ = """
 This script is meant to be invoked periodically by the system cron daemon.
@@ -25,6 +25,7 @@ It runs periodic tasks that are specified in the database.
 """
 __version__ = "0.1"
 
+import sys
 from datetime import datetime
 
 import dateutil
@@ -63,18 +64,19 @@ def run_task_on_node(ptask, node):
     :param node: Node name
     """
     try:
-        print u"Running {!r} ...".format(ptask["name"]),
+        print(u"Running {!r} ...".format(ptask["name"]), end="")
         result = execute_task(ptask["taskmodule"], ptask["options"])
     except Exception as e:
-        print u'Caught exception: {!r}'.format(e)
+        print(u'Caught exception: {!r}'.format(e))
         result = False
     if result:
         current_time = datetime.now(dateutil.tz.tzlocal())
-        print u'Task {!r} on node {!r} exited successfully. Noting this in the database ...'.format(ptask["name"], node)
+        print(u'Task {!r} on node {!r} exited successfully. Noting this in the database ...'.format(
+            ptask["name"], node))
         set_periodic_task_last_run(ptask["id"], node, current_time)
     else:
-        print u'Task {!r} on node {!r} did not run successfully.'.format(ptask["name"], node)
-        print u'This unsuccessful run is not recorded in the database.'
+        print(u'Task {!r} on node {!r} did not run successfully.'.format(ptask["name"], node))
+        print(u'This unsuccessful run is not recorded in the database.')
     return result
 
 
@@ -110,26 +112,26 @@ def run_scheduled(node_string=None, dryrun=False):
     current_time = datetime.now(dateutil.tz.tzlocal())
     scheduled_tasks = get_scheduled_periodic_tasks(node, current_time)
     if scheduled_tasks:
-        print u"The following tasks are scheduled to run on node {!s}:".format(node)
-        print
+        print(u"The following tasks are scheduled to run on node {!s}:".format(node))
+        print()
         for ptask in scheduled_tasks:
             print(u"  {name} ({interval!r}, {taskmodule})".format(**ptask))
 
-        print
+        print()
         if not dryrun:
             results = []
             for ptask in scheduled_tasks:
                 result = run_task_on_node(ptask, node)
                 results.append(result)
             if all(results):
-                print u"All scheduled tasks executed successfully."
+                print(u"All scheduled tasks executed successfully.")
             else:
-                print u"Some tasks exited with errors."
+                print(u"Some tasks exited with errors.")
                 sys.exit(1)
         else:
-            print u"Not running any tasks because --dryrun was passed."
+            print(u"Not running any tasks because --dryrun was passed.")
     else:
-        print u"There are no tasks scheduled on node {!s}.".format(node)
+        print(u"There are no tasks scheduled on node {!s}.".format(node))
 
 if __name__ == '__main__':
     manager.run()


### PR DESCRIPTION
This adds endpoints to create, modify and delete periodic tasks, as well as a ``privacyidea-cron`` script.

This also adds an exemplary task module ``Hello`` which just prints a (customizable :tada:) message to the log. We can of course delete this later on. But this already allows us to test everything:

```shell_session
# create a periodic task
$ http POST 'http://localhost:5000/periodictask/' name="my first task" interval="*/5 * * * *" nodes="pinode1" taskmodule="Hello" options='{"message": "Custom message"}' PI-Authorization:$TOKEN
# runs the cron runner every minute
$ watch -n60 python tools/privacyidea-cron run_scheduled -n pinode1
# will write Custom message to the log every five minutes.
```

I'm opening this PR to keep PRs at a reasonable size :-) Still missing is the Web UI, but I imagine it could be built similarly to the events UI (and will actually be simpler than that).

Comments are very welcome!
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23issuecomment-406033339%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r203538103%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23issuecomment-406082643%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r204649580%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r204650167%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r204650514%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r204657397%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r206454380%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r206455510%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r206456038%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r206473785%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23issuecomment-406033339%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231130%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/ff9427c80d4704bafff9fe4597f1ecffb230172d%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6095%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130/graphs/tree.svg%3Fheight%3D150%26src%3Dpr%26token%3D7nHLZki60B%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231130%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.74%25%20%20%2095.74%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20135%20%20%20%20%20%20137%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016692%20%20%20%2016823%20%20%20%20%20%2B131%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015982%20%20%20%2016107%20%20%20%20%20%2B125%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20710%20%20%20%20%20%20716%20%20%20%20%20%20%20%2B6%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/app.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBwLnB5%29%20%7C%20%6090%25%20%3C100%25%3E%20%28%2B0.16%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.39%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/before%5C%5C_after.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ%3D%3D%29%20%7C%20%6097.38%25%20%3C100%25%3E%20%28%2B0.04%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/task/hello.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rhc2svaGVsbG8ucHk%3D%29%20%7C%20%6069.23%25%20%3C69.23%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/periodictask.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BlcmlvZGljdGFzay5weQ%3D%3D%29%20%7C%20%6096%25%20%3C97.5%25%3E%20%28-1.11%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/periodictask.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3BlcmlvZGljdGFzay5weQ%3D%3D%29%20%7C%20%6097.53%25%20%3C97.53%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ%3D%3D%29%20%7C%20%6094.17%25%20%3C0%25%3E%20%28%2B1.94%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bff9427c...e2bfaff%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1130%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-07-18T18%3A40%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Would%20it%20be%20possible%20to%20increase%20the%20code%20coverage%3F%20Where%20is%20the%20miss%3F%22%2C%20%22created_at%22%3A%20%222018-07-18T21%3A38%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e2bfaff73aed5d8d9bf9af397423393d69870c6a%20tools/privacyidea-cron%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r203538103%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Nice%20idea%20to%20allow%20to%20run%20tasks%20manually.%5Cr%5CnIn%20this%20case%20it%20would%20be%20good%2C%20to%20also%20have%20a%20command%20to%20list%20the%20configured%20tasks%2C%20so%20that%20the%20admin%20can%20list%20the%20tasks%20and%20choose%20which%20one%20to%20run.%22%2C%20%22created_at%22%3A%20%222018-07-18T21%3A37%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/privacyidea-cron%3AL1-136%22%7D%2C%20%22Pull%20e2bfaff73aed5d8d9bf9af397423393d69870c6a%20privacyidea/api/periodictask.py%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r204649580%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20just%20remembered%20why%20I%20didn%27t%20implement%20this%20in%20the%20PeriodicTask%20class%20%3A-%29%20With%20the%20current%20implementation%2C%20the%20API%20layer%20does%20not%20have%20to%20deal%20with%20%60%60PeriodicTask%60%60%20objects%20at%20all%2C%20only%20with%20periodic%20task%20dictionaries%20%28that%20are%20also%20serializable%29.%20In%20other%20words%2C%20the%20lib%20layer%20only%20takes%20and%20returns%20periodic%20task%20dictionaries%2C%20so%20%60%60PeriodicTask%60%60%20objects%20do%20not%20leak%20to%20any%20upper%20layers.%20I%20find%20this%20pretty%20nice%20because%20it%20lowers%20complexity.%5Cr%5Cn%5Cr%5CnBut%20I%27m%20now%20thinking%20if%20we%20shouldn%27t%20just%20remove%20the%20function%20above%20and%20pass%20the%20datetimes%20to%20%60%60send_result%60%60.%20Because%20then%2C%20flask%20automatically%20converts%20them%20to%20RFC1123%20strings%20%28i.e.%20%60%60Wdy%2C%20DD%20Mon%20YYYY%20HH%3AMM%3ASS%20GMT%60%60%29.%20Are%20there%20any%20other%20places%20where%20we%20return%20datetimes%20in%20the%20API%3F%22%2C%20%22created_at%22%3A%20%222018-07-24T07%3A27%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK.%20I%20think%20I%20understand%20why.%5Cr%5Cn%5Cr%5CnThere%20are%20other%20datetimes%20in%20the%20API%20like%20in%20the%20tokendetails%2C%20the%20vaild_from%20and%20valid_to%20fields%20of%20a%20token.%22%2C%20%22created_at%22%3A%20%222018-07-31T09%3A20%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20changed%20this%20to%20use%20AUTH_DATE_FORMAT.%22%2C%20%22created_at%22%3A%20%222018-07-31T10%3A24%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/periodictask.py%3AL1-183%22%7D%2C%20%22Pull%20e2bfaff73aed5d8d9bf9af397423393d69870c6a%20privacyidea/api/periodictask.py%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r204650167%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%27re%20right%2C%20%60%60/taskmodules%60%60%20is%20there%20because%20I%20imitated%20the%20events%20API%20%3A-%29%20Honestly%20I%20have%20no%20idea%20what%20the%20best%20practice%20would%20be%20here%20--%20I%27ll%20read%20a%20bit%20about%20REST%20and%20get%20back%20to%20this.%22%2C%20%22created_at%22%3A%20%222018-07-24T07%3A29%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20it%20seems%20like%20people%20have%20very%20different%20opinions%20about%20trailing%20slashes%20%3A-%29%5Cr%5Cn%5Cr%5Cn%5BThis%20page%5D%28https%3A//restfulapi.net/resource-naming/%29%20%28point%202%20of%20%5C%22Consistency%20is%20the%20key%5C%22%29%20says%20we%20should%20not%20use%20trailing%20slashes%2C%20and%20the%20first%20comment%20already%20says%20we%20should%20always%20use%20trailing%20slashes.%20%5BHere%5D%28https%3A//apievangelist.com/2015/08/04/how-do-we-handle-that-trailing-slash-in-our-api-endpoints/%29%20are%20some%20more%20opinions.%5Cr%5Cn%5Cr%5CnPersonally%20I%20think%20adding%20a%20slash%20makes%20sense%2C%20because%20we%20return%20a%20collection%20of%20task%20modules.%5Cr%5Cn%5Cr%5CnBut%20thinking%20about%20the%20RESTfulness%20of%20the%20API%3A%5Cr%5Cn%2A%20Shouldn%27t%20%60%60/options/%3Ctaskmodule%3E%60%60%20rather%20be%20%60%60/taskmodules/%3Ctaskmodule%3E/options%60%60%20then%3F%20Because%20%60%60/options/%60%60%20doesn%27t%20identify%20a%20resource.%5Cr%5Cn%2A%20Aren%27t%20%60%60/enable/%3Cptaskid%3E%60%60%20and%20%60%60/disable/%3Cptaskid%3E%60%60%20not%20really%20RESTful%20either%3F%20%60%60/enable/%60%60%20and%20%60%60/disable/%60%60%20do%20not%20identify%20resources%20either%20%3A-/%5Cr%5Cn%5Cr%5Cn...%20complex%20topic%21%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-07-24T07%3A56%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20totally%20right.%20Probably%20they%20should%20have%20been%20named%20%60%60/%3Cptaskid%3E/enable%60%60%20and%20%60%60/%3Cptaskid%3E/disable%60%60%20is%20this%20was%20possible.%5Cr%5Cn%5Cr%5CnMaybe%20we%20should%20add%20this%20one%20day.%5Cr%5CnThe%20nice%20thing%2C%20is%20that%20we%20can%20have%20several%20route%20decorators...%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-07-31T09%3A24%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/periodictask.py%3AL1-183%22%7D%2C%20%22Pull%20e2bfaff73aed5d8d9bf9af397423393d69870c6a%20privacyidea/lib/periodictask.py%20114%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1130%23discussion_r204650514%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hm%2C%20there%20hopefully%20shouldn%27t%20be%2C%20because%20we%20have%20a%20%60%60unique%3DTrue%60%60%20constraint%20on%20the%20%60%60name%60%60%20field.%22%2C%20%22created_at%22%3A%20%222018-07-24T07%3A30%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20the%20name%20is%20unique%2C%20then%20the%20if%20statement%20will%20be%20%60%60%3C1%60%60%20and%20not%20%60%60%21%3D1%60%60.%5Cr%5CnSo%20the%20code%20was%20misleading%20to%20me.%5Cr%5CnBut%20if%20the%20name%20is%20always%20unique%2C%20then%20the%20message%20is%20right.%5Cr%5CnLeave%20it%20this%20way%21%20%22%2C%20%22created_at%22%3A%20%222018-07-31T09%3A26%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/periodictask.py%3AL175-216%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1130#issuecomment-406033339'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1130?src=pr&el=h1) Report
> Merging [#1130](https://codecov.io/gh/privacyidea/privacyidea/pull/1130?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/ff9427c80d4704bafff9fe4597f1ecffb230172d?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `95%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1130/graphs/tree.svg?height=150&src=pr&token=7nHLZki60B&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/1130?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1130      +/-   ##
==========================================
- Coverage   95.74%   95.74%   -0.01%
==========================================
Files         135      137       +2
Lines       16692    16823     +131
==========================================
+ Hits        15982    16107     +125
- Misses        710      716       +6
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1130?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/app.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1130/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBwLnB5) | `90% <100%> (+0.16%)` | :arrow_up: |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1130/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.39% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/before\_after.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1130/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ==) | `97.38% <100%> (+0.04%)` | :arrow_up: |
| [privacyidea/lib/task/hello.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1130/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rhc2svaGVsbG8ucHk=) | `69.23% <69.23%> (ø)` | |
| [privacyidea/lib/periodictask.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1130/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BlcmlvZGljdGFzay5weQ==) | `96% <97.5%> (-1.11%)` | :arrow_down: |
| [privacyidea/api/periodictask.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1130/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3BlcmlvZGljdGFzay5weQ==) | `97.53% <97.53%> (ø)` | |
| [privacyidea/api/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1130/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi91dGlscy5weQ==) | `94.17% <0%> (+1.94%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1130?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1130?src=pr&el=footer). Last update [ff9427c...e2bfaff](https://codecov.io/gh/privacyidea/privacyidea/pull/1130?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Would it be possible to increase the code coverage? Where is the miss?
- [x] <a href='#crh-comment-Pull e2bfaff73aed5d8d9bf9af397423393d69870c6a tools/privacyidea-cron 88'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1130#discussion_r203538103'>File: tools/privacyidea-cron:L1-136</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Nice idea to allow to run tasks manually.
In this case it would be good, to also have a command to list the configured tasks, so that the admin can list the tasks and choose which one to run.
- [x] <a href='#crh-comment-Pull e2bfaff73aed5d8d9bf9af397423393d69870c6a privacyidea/api/periodictask.py 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1130#discussion_r204649580'>File: privacyidea/api/periodictask.py:L1-183</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I just remembered why I didn't implement this in the PeriodicTask class :-) With the current implementation, the API layer does not have to deal with ``PeriodicTask`` objects at all, only with periodic task dictionaries (that are also serializable). In other words, the lib layer only takes and returns periodic task dictionaries, so ``PeriodicTask`` objects do not leak to any upper layers. I find this pretty nice because it lowers complexity.
But I'm now thinking if we shouldn't just remove the function above and pass the datetimes to ``send_result``. Because then, flask automatically converts them to RFC1123 strings (i.e. ``Wdy, DD Mon YYYY HH:MM:SS GMT``). Are there any other places where we return datetimes in the API?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK. I think I understand why.
There are other datetimes in the API like in the tokendetails, the vaild_from and valid_to fields of a token.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I changed this to use AUTH_DATE_FORMAT.
- [x] <a href='#crh-comment-Pull e2bfaff73aed5d8d9bf9af397423393d69870c6a privacyidea/api/periodictask.py 55'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1130#discussion_r204650167'>File: privacyidea/api/periodictask.py:L1-183</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> You're right, ``/taskmodules`` is there because I imitated the events API :-) Honestly I have no idea what the best practice would be here -- I'll read a bit about REST and get back to this.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, it seems like people have very different opinions about trailing slashes :-)
[This page](https://restfulapi.net/resource-naming/) (point 2 of "Consistency is the key") says we should not use trailing slashes, and the first comment already says we should always use trailing slashes. [Here](https://apievangelist.com/2015/08/04/how-do-we-handle-that-trailing-slash-in-our-api-endpoints/) are some more opinions.
Personally I think adding a slash makes sense, because we return a collection of task modules.
But thinking about the RESTfulness of the API:
* Shouldn't ``/options/<taskmodule>`` rather be ``/taskmodules/<taskmodule>/options`` then? Because ``/options/`` doesn't identify a resource.
* Aren't ``/enable/<ptaskid>`` and ``/disable/<ptaskid>`` not really RESTful either? ``/enable/`` and ``/disable/`` do not identify resources either :-/
... complex topic! :-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are totally right. Probably they should have been named ``/<ptaskid>/enable`` and ``/<ptaskid>/disable`` is this was possible.
Maybe we should add this one day.
The nice thing, is that we can have several route decorators...
- [x] <a href='#crh-comment-Pull e2bfaff73aed5d8d9bf9af397423393d69870c6a privacyidea/lib/periodictask.py 114'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1130#discussion_r204650514'>File: privacyidea/lib/periodictask.py:L175-216</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, there hopefully shouldn't be, because we have a ``unique=True`` constraint on the ``name`` field.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> If the name is unique, then the if statement will be ``<1`` and not ``!=1``.
So the code was misleading to me.
But if the name is always unique, then the message is right.
Leave it this way!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1130?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1130?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1130'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>