### PR TITLE
Allow to build python-croniter for trusty and xenial

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -31,6 +31,10 @@ CONTRIB8=pyasn1
 VERSION8=0.4.2
 URL8=https://files.pythonhosted.org/packages/eb/3d/b7d0fdf4a882e26674c68c20f40682491377c4db1439870f5b6f862f76ed/pyasn1-0.4.2.tar.gz
 
+CONTRIB9=python-croniter
+VERSION9=0.3.24
+URL9=https://files.pythonhosted.org/packages/27/69/2426b76c3647d8cc959e88aadecfb7ad96cf2c40c0ea784b6bf43a844c73/croniter-0.3.24.tar.gz
+
 ME=Cornelius Kölbel <cornelius@privacyidea.org>
 
 #series=trusty
@@ -50,6 +54,7 @@ ubuntu:
 	make flask-sqlalchemy
 	make pymysql
 	make pyasn1
+	make croniter
 
 ldap3:
 	mkdir -p $(CONTRIB3)
@@ -70,6 +75,16 @@ pyasn1:
 	(cd $(CONTRIB8)/deb_dist/pyasn1-$(VERSION8); debuild -sa -S)
 	(cd $(CONTRIB8)/deb_dist/pyasn1-$(VERSION8); debuild -b)
 	(cp $(CONTRIB8)/deb_dist/* DEBUILD || true)
+
+croniter:
+	mkdir -p $(CONTRIB9)
+	mkdir -p DEBUILD
+	(cd $(CONTRIB9); curl $(URL9) -o croniter-$(VERSION9).tar.gz)
+	(cd $(CONTRIB9); py2dsc -m '$(ME)' croniter-$(VERSION9).tar.gz)
+	(cd $(CONTRIB9)/deb_dist/croniter-$(VERSION9); dch -v $(VERSION9)-1$(series)1 --distribution $(series) -M "build for privacyidea")
+	(cd $(CONTRIB9)/deb_dist/croniter-$(VERSION9); debuild -sa -S)
+	(cd $(CONTRIB9)/deb_dist/croniter-$(VERSION9); debuild -b)
+	(cp $(CONTRIB9)/deb_dist/* DEBUILD || true)
 
 pyjwt:
 	mkdir -p $(CONTRIB2)
@@ -146,6 +161,7 @@ ppa-dev:
 	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea-dev flask-sqlalchemy_${VERSION4}-1${series}1_source.changes || true)
 	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea-dev pymysql_${VERSION5}-1${series}1_source.changes || true)
 	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea-dev pyasn1_${VERSION8}-1${series}1_source.changes || true)
+	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea-dev croniter_${VERSION9}-1${series}1_source.changes || true)
 
 ppa:
 	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea flask-cache_${VERSION1}-1${series}1_source.changes || true)
@@ -154,6 +170,7 @@ ppa:
 	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea flask-sqlalchemy_${VERSION4}-1${series}1_source.changes || true)
 	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea pymysql_${VERSION5}-1${series}1_source.changes || true)
 	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea pyasn1_${VERSION8}-1${series}1_source.changes || true)
+	(cd DEBUILD; dput -f ppa:privacyidea/privacyidea croniter_${VERSION9}-1${series}1_source.changes || true)
 
 	
 
@@ -166,5 +183,6 @@ clean:
 	rm -fr $(CONTRIB6)
 	rm -fr $(CONTRIB7)
 	rm -fr $(CONTRIB8)
+	rm -fr $(CONTRIB9)
 	rm -fr pymysql_sa
 	rm -fr DEBUILD

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ configobj==5.0.6
 cookies==2.2.1
 cov-core==1.15.0
 coverage==4.5.1
-croniter==0.3.8
+croniter==0.3.24
 defusedxml==0.5.0
 docutils==0.14
 ecdsa==0.13


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1142%23issuecomment-409110665%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1142%23issuecomment-409116817%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1142%23issuecomment-409153034%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1142%23issuecomment-409156671%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1142%23issuecomment-409110665%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20would%20close%20%231125%20%5Cr%5CnI%20think%200.3.24%20works%20as%20well%20as%20outdated%200.3.8.%22%2C%20%22created_at%22%3A%20%222018-07-31T06%3A32%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1142%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231142%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1142%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/5156a46e94b9b7c4a413719e7c887756a4ccf657%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1142/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1142%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231142%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.74%25%20%20%2095.74%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20135%20%20%20%20%20%20135%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016692%20%20%20%2016692%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2015982%20%20%20%2015982%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20710%20%20%20%20%20%20710%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1142%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1142%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B5156a46...a16e10b%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1142%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-07-31T07%3A01%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20good%20to%20me%21%20But%20could%20we%20also%20require%20the%20newer%20%60%60croniter%3D%3D0.3.24%60%60%20in%20%60%60requirements.txt%60%60%20as%20well%2C%20so%20Travis%20tests%20the%20version%20that%20is%20actually%20installed%3F%22%2C%20%22created_at%22%3A%20%222018-07-31T09%3A15%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20I%20update%20this%20in%20the%20PR%3F%5Cr%5CnI%20can%20do.%22%2C%20%22created_at%22%3A%20%222018-07-31T09%3A27%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1142#issuecomment-409110665'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This would close #1125
I think 0.3.24 works as well as outdated 0.3.8.
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1142?src=pr&el=h1) Report
> Merging [#1142](https://codecov.io/gh/privacyidea/privacyidea/pull/1142?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/5156a46e94b9b7c4a413719e7c887756a4ccf657?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1142/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1142?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master    #1142   +/-   ##
=======================================
Coverage   95.74%   95.74%
=======================================
Files         135      135
Lines       16692    16692
=======================================
Hits        15982    15982
Misses        710      710
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1142?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1142?src=pr&el=footer). Last update [5156a46...a16e10b](https://codecov.io/gh/privacyidea/privacyidea/pull/1142?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Looks good to me! But could we also require the newer ``croniter==0.3.24`` in ``requirements.txt`` as well, so Travis tests the version that is actually installed?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Should I update this in the PR?
I can do.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1142?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1142?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1142'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>