### PR TITLE
Add nodes to pi.cfg

### DIFF
--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -102,3 +102,12 @@ In certain cases when you experiencing problems you may use the parameters
 ``PI_AUDIT_POOL_SIZE`` and ``PI_AUDIT_POOL_RECYCLE``.
 
 
+
+privacyIDEA Nodes
+-----------------
+
+privacyIDEA can run in a redundant setup. For statistics and monitoring purposes you
+can give these different nodes, dedicated names.
+
+``PI_NODE`` is a string with the name of this very node. ``PI_NODES`` is a list of
+all available nodes in the cluster.

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -111,3 +111,6 @@ can give these different nodes, dedicated names.
 
 ``PI_NODE`` is a string with the name of this very node. ``PI_NODES`` is a list of
 all available nodes in the cluster.
+
+If ``PI_NODE`` is not set, then ``PI_AUDIT_SERVERNAME`` is used as node name.
+If this is also not set, the node name is returned as "localnode".

--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -48,6 +48,8 @@ class TestingConfig(Config):
     PI_GNUPG_HOME = "tests/testdata/gpg"
     CACHE_TYPE = "None"
     PI_SCRIPT_HANDLER_DIRECTORY = "tests/testdata/scripts/"
+    PI_NODE = "Node1"
+    PI_NODES = ["Node2"]
 
 
 class ProductionConfig(Config):

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -861,3 +861,27 @@ def return_saml_attributes_on_fail():
     r = get_from_config(key="ReturnSamlAttributesOnFail", default=False,
                         return_bool=True)
     return r
+
+
+def get_privacyidea_node():
+    """
+    This returns the node name of the privacyIDEA node as found in the pi.cfg
+    file in PI_NODE.
+    If it does not exist, the PI_AUDIT_SERVERNAME is used.
+    :return:
+    """
+    node_name = current_app.config.get("PI_NODE",
+                                       current_app.config.get("PI_AUDIT_SERVERNAME", ""))
+    return node_name
+
+
+def get_privacyidea_nodes():
+    """
+    This returns the list of the nodes.
+    :return:
+    """
+    own_node_name = get_privacyidea_node()
+    nodes = current_app.config.get("PI_NODES") or []
+    if own_node_name not in nodes:
+        nodes.append(own_node_name)
+    return nodes

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -868,20 +868,21 @@ def get_privacyidea_node():
     This returns the node name of the privacyIDEA node as found in the pi.cfg
     file in PI_NODE.
     If it does not exist, the PI_AUDIT_SERVERNAME is used.
-    :return:
+    :return: the destinct node name
     """
     node_name = current_app.config.get("PI_NODE",
-                                       current_app.config.get("PI_AUDIT_SERVERNAME", ""))
+                                       current_app.config.get("PI_AUDIT_SERVERNAME",
+                                                              "localnode"))
     return node_name
 
 
 def get_privacyidea_nodes():
     """
-    This returns the list of the nodes.
-    :return:
+    This returns the list of the nodes, including the own local node name
+    :return: list of nodes
     """
     own_node_name = get_privacyidea_node()
-    nodes = current_app.config.get("PI_NODES") or []
+    nodes = current_app.config.get("PI_NODES", [])[:]
     if own_node_name not in nodes:
         nodes.append(own_node_name)
     return nodes

--- a/tests/test_lib_config.py
+++ b/tests/test_lib_config.py
@@ -18,7 +18,8 @@ from privacyidea.lib.config import (get_resolver_list,
                                     get_token_class_dict,
                                     get_token_types,
                                     get_token_classes, get_token_prefix,
-                                    get_machine_resolver_class_dict
+                                    get_machine_resolver_class_dict,
+                                    get_privacyidea_node, get_privacyidea_nodes
                                     )
 from privacyidea.lib.resolvers.PasswdIdResolver import IdResolver as PWResolver
 from privacyidea.lib.tokens.hotptoken import HotpTokenClass
@@ -228,3 +229,10 @@ class ConfigTestCase(MyTestCase):
         self.assertTrue("secretInfo1" not in a)
         a = get_from_config("secretInfo1", role="public")
         self.assertEqual(a, None)
+
+    def test_07_node_names(self):
+        node = get_privacyidea_node()
+        self.assertEqual(node, "Node1")
+        nodes = get_privacyidea_nodes()
+        self.assertTrue("Node1" in nodes)
+        self.assertTrue("Node2" in nodes)


### PR DESCRIPTION
PI_NODE specifies the node name of this very node, while
PI_NODES provides the list of available nodes.

Closes #1126
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1143%23issuecomment-409123106%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1143%23discussion_r206420430%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1143%23discussion_r206452351%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1143%23discussion_r206452615%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1143%23issuecomment-409123106%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231143%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/5156a46e94b9b7c4a413719e7c887756a4ccf657%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143/graphs/tree.svg%3Fwidth%3D650%26height%3D150%26src%3Dpr%26token%3D7nHLZki60B%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231143%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.74%25%20%20%2095.74%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20135%20%20%20%20%20%20135%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016692%20%20%20%2016703%20%20%20%20%20%20%2B11%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2015982%20%20%20%2015993%20%20%20%20%20%20%2B11%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20710%20%20%20%20%20%20710%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/config.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ%3D%3D%29%20%7C%20%6096.52%25%20%3C100%25%3E%20%28%2B0.08%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/config.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvY29uZmlnLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B5156a46...bb5ba9b%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1143%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-07-31T07%3A27%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20bb5ba9b0c5eaeba8becd2f56cccb01266d5055c5%20doc/installation/system/inifile.rst%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1143%23discussion_r206420430%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20add%20a%20note%20that%20%60%60PI_NODE%60%60%20defaults%20to%20%60%60PI_AUDIT_SERVERNAME%60%60%20and%20explain%20what%20happens%20if%20neither%20are%20specified%20%28see%20below%29.%22%2C%20%22created_at%22%3A%20%222018-07-31T07%3A29%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/installation/system/inifile.rst%3AL102-114%22%7D%2C%20%22Pull%20bb5ba9b0c5eaeba8becd2f56cccb01266d5055c5%20privacyidea/lib/config.py%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1143%23discussion_r206452351%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20choose%20a%20very%20nasty%20node%20name%2C%20so%20that%20users%20are%20encourage%20to%20change%20it%21%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-07-31T09%3A14%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5C%22nnn%5C%22%20%3D%20Nasty%20Node%20Name%20%3B-%29%5Cr%5Cn%5Cr%5Cn...ok%2C%20I%20go%20with%20%5C%22localnode%5C%22.%22%2C%20%22created_at%22%3A%20%222018-07-31T09%3A15%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/config.py%3AL861-888%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1143#issuecomment-409123106'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1143?src=pr&el=h1) Report
> Merging [#1143](https://codecov.io/gh/privacyidea/privacyidea/pull/1143?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/5156a46e94b9b7c4a413719e7c887756a4ccf657?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1143/graphs/tree.svg?width=650&height=150&src=pr&token=7nHLZki60B)](https://codecov.io/gh/privacyidea/privacyidea/pull/1143?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1143      +/-   ##
==========================================
+ Coverage   95.74%   95.74%   +<.01%
==========================================
Files         135      135
Lines       16692    16703      +11
==========================================
+ Hits        15982    15993      +11
Misses        710      710
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1143?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/config.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1143/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ==) | `96.52% <100%> (+0.08%)` | :arrow_up: |
| [privacyidea/config.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1143/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvY29uZmlnLnB5) | `100% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1143?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1143?src=pr&el=footer). Last update [5156a46...bb5ba9b](https://codecov.io/gh/privacyidea/privacyidea/pull/1143?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull bb5ba9b0c5eaeba8becd2f56cccb01266d5055c5 doc/installation/system/inifile.rst 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1143#discussion_r206420430'>File: doc/installation/system/inifile.rst:L102-114</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> We should add a note that ``PI_NODE`` defaults to ``PI_AUDIT_SERVERNAME`` and explain what happens if neither are specified (see below).
- [ ] <a href='#crh-comment-Pull bb5ba9b0c5eaeba8becd2f56cccb01266d5055c5 privacyidea/lib/config.py 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1143#discussion_r206452351'>File: privacyidea/lib/config.py:L861-888</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We should choose a very nasty node name, so that users are encourage to change it!
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> "nnn" = Nasty Node Name ;-)
...ok, I go with "localnode".


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1143?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1143?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1143'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>