### PR TITLE
Add functionality to dump audit log into csv file

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -82,6 +82,7 @@ from sqlalchemy import create_engine, desc, MetaData
 from sqlalchemy.orm import sessionmaker
 from privacyidea.lib.auditmodules.sqlaudit import LogEntry
 from privacyidea.lib.audit import getAudit
+from privacyidea.lib.utils import parse_timedelta
 from Crypto.PublicKey import RSA
 import jwt
 import ast
@@ -681,20 +682,18 @@ def smartopen(filename):
             fh.close()
 
 
-@audit_manager.command
-def dump(filename):
-    """Dump the audit log into a csv file."""
-    default_module = "privacyidea.lib.auditmodules.sqlaudit"
-    token_db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
-    audit_db_uri = app.config.get("PI_AUDIT_SQL_URI", token_db_uri)
-    audit_module = app.config.get("PI_AUDIT_MODULE", default_module)
-    if audit_module != default_module:
-        raise Exception("Currently only the SQL audit module is supported. You are using %s" %
-                        audit_module)
-
+@audit_manager.option('--timelimit', '-t', help="Limit the dumped audit entries to a certain "
+                                                "period (i.e. '5d' or '3h' for the entries from "
+                                                "the last five days or three hours. By default "
+                                                "all audit entries will be dumped.")
+@audit_manager.option('--filename', '-f', help="Name of the 'csv' file to dump the audit entries "
+                                               "into. By default write to stdout.", default='-')
+def dump(filename, timelimit=None):
+    """Dump the audit log in csv format."""
     audit = getAudit(app.config)
+    tl = parse_timedelta(timelimit) if timelimit else None
     with smartopen(filename) as fh:
-        for line in audit.csv_generator():
+        for line in audit.csv_generator(timelimit=tl):
             fh.write(line)
 
 

--- a/pi-manage
+++ b/pi-manage
@@ -55,6 +55,7 @@ from subprocess import call, Popen, PIPE
 from getpass import getpass
 import gnupg
 import yaml
+import contextlib
 
 import flask
 
@@ -80,6 +81,7 @@ from privacyidea.models import Audit
 from sqlalchemy import create_engine, desc, MetaData
 from sqlalchemy.orm import sessionmaker
 from privacyidea.lib.auditmodules.sqlaudit import LogEntry
+from privacyidea.lib.audit import getAudit
 from Crypto.PublicKey import RSA
 import jwt
 import ast
@@ -98,6 +100,7 @@ policy_manager = Manager(usage='Manage policies')
 event_manager = Manager(usage='Manage events')
 api_manager = Manager(usage="Manage API keys")
 ca_manager = Manager(usage="Manage Certificate Authorities")
+audit_manager = Manager(usage="Manage Audit log")
 manager.add_command('db', MigrateCommand)
 manager.add_command('admin', admin_manager)
 manager.add_command('backup', backup_manager)
@@ -107,6 +110,7 @@ manager.add_command('policy', policy_manager)
 manager.add_command('event', event_manager)
 manager.add_command('api', api_manager)
 manager.add_command('ca', ca_manager)
+manager.add_command('audit', audit_manager)
 
 
 @ca_manager.command
@@ -540,6 +544,7 @@ except TypeError:
 @manager.option('--config', help="Read config from the specified yaml file.")
 @manager.option('--dryrun', help="Do not actually delete, only show "
                                  "what would be done.", action="store_true")
+@audit_manager.command
 def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
                  dryrun=False):
     """
@@ -570,7 +575,6 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
     token_db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
     audit_db_uri = app.config.get("PI_AUDIT_SQL_URI", token_db_uri)
     audit_module = app.config.get("PI_AUDIT_MODULE", default_module)
-    actions = []
     if audit_module != default_module:
         raise Exception("We only rotate SQL audit module. You are using %s" %
                         audit_module)
@@ -661,6 +665,37 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
                 r = session.query(LogEntry.id).filter(LogEntry.id < cut_id).delete()
                 session.commit()
             print("{0!s} entries deleted.".format(r))
+
+
+@contextlib.contextmanager
+def smartopen(filename):
+    if filename and filename != '-':
+        fh = open(filename, 'w')
+    else:
+        fh = sys.stdout
+
+    try:
+        yield fh
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
+
+
+@audit_manager.command
+def dump(filename):
+    """Dump the audit log into a csv file."""
+    default_module = "privacyidea.lib.auditmodules.sqlaudit"
+    token_db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
+    audit_db_uri = app.config.get("PI_AUDIT_SQL_URI", token_db_uri)
+    audit_module = app.config.get("PI_AUDIT_MODULE", default_module)
+    if audit_module != default_module:
+        raise Exception("Currently only the SQL audit module is supported. You are using %s" %
+                        audit_module)
+
+    audit = getAudit(app.config)
+    with smartopen(filename) as fh:
+        for line in audit.csv_generator():
+            fh.write(line)
 
 
 @resolver_manager.command

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -353,8 +353,8 @@ class Audit(AuditBase):
     def csv_generator(self, param=None, user=None, timelimit=None):
         """
         Returns the audit log as csv file.
-        :param config: The current flask app configuration
-        :type config: dict
+        :param timelimit: Limit the number of dumped entries by time
+        :type timelimit: datetime.timedelta
         :param param: The request parameters
         :type param: dict
         :param user: The user, who issued the request


### PR DESCRIPTION
Added a sub-manager for audit based tasks.
The `dump` task outputs the audit-log data in `csv` format by reusing the
`csv_generator` from `sqlaudit.py`.
The `rotate_audit` task is available in the `audit` sub-manager as well as
in the main manager for backward compatibility.

This fixes #1120
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1145%23issuecomment-409245899%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1145%23issuecomment-409250114%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1145%23discussion_r206783603%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1145%23discussion_r206820447%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1145%23issuecomment-409245899%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Due%20to%20the%20fact%20that%20flask-script%20is%20deprecated%20%28see%20%231121%29%20this%20is%20just%20a%20minor%20fix%20for%20%60pi-manage%60%20for%202.23.%5Cr%5CnWe%20need%20to%20do%20some%20more%20work%20for%20the%20next%20release%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-07-31T14%3A41%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1145%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231145%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1145%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/e68564ecec3fa68d5205eb8b7da680e202bebc50%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1145/graphs/tree.svg%3Fheight%3D150%26token%3D7nHLZki60B%26src%3Dpr%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1145%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231145%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.76%25%20%20%2095.76%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20137%20%20%20%20%20%20137%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016834%20%20%20%2016834%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2016121%20%20%20%2016121%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20713%20%20%20%20%20%20713%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1145%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1145%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Be68564e...84c6f75%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1145%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-07-31T14%3A53%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200dc1a64e6ab74e4beaacf1e75a3d26ba24a5fa9d%20privacyidea/lib/auditmodules/sqlaudit.py%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1145%23discussion_r206820447%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22thx%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-08-01T09%3A56%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/auditmodules/sqlaudit.py%3AL353-361%22%7D%2C%20%22Pull%2084c6f75d5476b888ed936d2712c9ea113ba54302%20pi-manage%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1145%23discussion_r206783603%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20add%20a%20parameter%20to%20only%20dump%20the%20last%20%60%60x%60%60%20days.%20Since%20we%20want%20to%20use%20this%20function%20also%20for%20support%20cases%2C%20it%20makes%20sense%20to%20only%20receive%20some%20days.%5Cr%5Cn%5Cr%5CnYou%20can%20use%20the%20parameter%20%60%60timelimit%60%60%20%20in%20the%20%60%60csv_generator%60%60%2C%20which%20takes%20a%20%60%60Timedelta%60%60%2C%20I%20think.%5Cr%5Cn%5Cr%5CnSomething%20like%20%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Epython%5Cr%5Cn%40audit_manager.command%5Cr%5Cndef%20dump%28filename%2C%20days%29%3A%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cncould%20do%20the%20trick%20or%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Epython%5Cr%5Cn%40audit_manager.option%28%27-f%27%2C%20%27--fiilename%27%2C%20default%3D%27-%27%29%5Cr%5Cn%40audit_manager.option%28%27-d%27%2C%20%27--days%27%2C%20default%3D%277%27%29%5Cr%5Cndef%20dump%28filename%2C%20days%29%3A%5Cr%5Cn%7E%7E%7E%7E%22%2C%20%22created_at%22%3A%20%222018-08-01T07%3A48%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL667-704%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1145#issuecomment-409245899'>General Comment</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Due to the fact that flask-script is deprecated (see #1121) this is just a minor fix for `pi-manage` for 2.23.
We need to do some more work for the next release :-)
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1145?src=pr&el=h1) Report
> Merging [#1145](https://codecov.io/gh/privacyidea/privacyidea/pull/1145?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/e68564ecec3fa68d5205eb8b7da680e202bebc50?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1145/graphs/tree.svg?height=150&token=7nHLZki60B&src=pr&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/1145?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master    #1145   +/-   ##
=======================================
Coverage   95.76%   95.76%
=======================================
Files         137      137
Lines       16834    16834
=======================================
Hits        16121    16121
Misses        713      713
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1145?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1145?src=pr&el=footer). Last update [e68564e...84c6f75](https://codecov.io/gh/privacyidea/privacyidea/pull/1145?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 84c6f75d5476b888ed936d2712c9ea113ba54302 pi-manage 67'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1145#discussion_r206783603'>File: pi-manage:L667-704</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Please add a parameter to only dump the last ``x`` days. Since we want to use this function also for support cases, it makes sense to only receive some days.
You can use the parameter ``timelimit``  in the ``csv_generator``, which takes a ``Timedelta``, I think.
Something like
~~~~python
@audit_manager.command
def dump(filename, days):
~~~~
could do the trick or
~~~~python
@audit_manager.option('-f', '--fiilename', default='-')
@audit_manager.option('-d', '--days', default='7')
def dump(filename, days):
~~~~
- [ ] <a href='#crh-comment-Pull 0dc1a64e6ab74e4beaacf1e75a3d26ba24a5fa9d privacyidea/lib/auditmodules/sqlaudit.py 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1145#discussion_r206820447'>File: privacyidea/lib/auditmodules/sqlaudit.py:L353-361</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> thx :-)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1145?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1145?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1145'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>