### PR TITLE
Add API for retrieving and deleting statistics

### DIFF
--- a/doc/modules/api/monitoring.rst
+++ b/doc/modules/api/monitoring.rst
@@ -1,0 +1,13 @@
+.. _rest_monitoring:
+
+Event monitoring
+................
+
+.. automodule:: privacyidea.api.monitoring
+
+.. autoflask:: privacyidea.app:create_app()
+   :endpoints:
+   :blueprints: monitoring_blueprint
+
+   :include-empty-docstring:
+

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -59,6 +59,7 @@ from .event import eventhandling_blueprint
 from .smsgateway import smsgateway_blueprint
 from .clienttype import client_blueprint
 from .subscriptions import subscriptions_blueprint
+from .monitoring import monitoring_blueprint
 from privacyidea.api.lib.postpolicy import postrequest, sign_response
 from ..lib.error import (privacyIDEAError,
                          AuthError, UserError,
@@ -94,6 +95,7 @@ def before_user_request():
 @smsgateway_blueprint.before_request
 @client_blueprint.before_request
 @subscriptions_blueprint.before_request
+@monitoring_blueprint.before_request
 @admin_required
 def before_admin_request():
     before_request()
@@ -204,6 +206,7 @@ def before_request():
 @privacyideaserver_blueprint.after_request
 @client_blueprint.after_request
 @subscriptions_blueprint.after_request
+@monitoring_blueprint.after_request
 @postrequest(sign_response, request=request)
 def after_request(response):
     """
@@ -231,6 +234,7 @@ def after_request(response):
 @application_blueprint.app_errorhandler(AuthError)
 @smtpserver_blueprint.app_errorhandler(AuthError)
 @subscriptions_blueprint.app_errorhandler(AuthError)
+@monitoring_blueprint.app_errorhandler(AuthError)
 @postrequest(sign_response, request=request)
 def auth_error(error):
     if "audit_object" in g:
@@ -253,6 +257,7 @@ def auth_error(error):
 @register_blueprint.app_errorhandler(PolicyError)
 @recover_blueprint.app_errorhandler(PolicyError)
 @subscriptions_blueprint.app_errorhandler(PolicyError)
+@monitoring_blueprint.app_errorhandler(PolicyError)
 @postrequest(sign_response, request=request)
 def policy_error(error):
     if "audit_object" in g:
@@ -274,6 +279,7 @@ def policy_error(error):
 @register_blueprint.app_errorhandler(privacyIDEAError)
 @recover_blueprint.app_errorhandler(privacyIDEAError)
 @subscriptions_blueprint.app_errorhandler(privacyIDEAError)
+@monitoring_blueprint.app_errorhandler(privacyIDEAError)
 @postrequest(sign_response, request=request)
 def privacyidea_error(error):
     """
@@ -300,6 +306,7 @@ def privacyidea_error(error):
 @register_blueprint.app_errorhandler(500)
 @recover_blueprint.app_errorhandler(500)
 @subscriptions_blueprint.app_errorhandler(500)
+@monitoring_blueprint.app_errorhandler(500)
 @postrequest(sign_response, request=request)
 def internal_error(error):
     """

--- a/privacyidea/api/monitoring.py
+++ b/privacyidea/api/monitoring.py
@@ -67,7 +67,8 @@ def get_statistics(stats_key=None):
         end = getParam(param, "end")
         if end:
             end = parse_legacy_time(end, return_date=True)
-        values = get_values(stats_key=stats_key, start_timestamp=start, end_timestamp=end)
+        values = get_values(stats_key=stats_key, start_timestamp=start, end_timestamp=end,
+                            date_strings=True)
         g.audit_object.log({"success": True})
         return send_result(values)
 

--- a/privacyidea/api/monitoring.py
+++ b/privacyidea/api/monitoring.py
@@ -77,7 +77,15 @@ def get_statistics(stats_key=None):
 @prepolicy(check_base_action, request, ACTION.STATISTICSDELETE)
 def delete_statistics(stats_key, start, end):
     """
-    Delete the statistics data of a certain stats_key
+    Delete the statistics data of a certain stats_key.
+
+    You can specify the start date and the end date when to delete the
+    monitoring data.
+    You should specify the dates including the timezone. Otherwise your client
+    could send its local time and the server would interpret it as its own local
+    time which would result in deleting unexpected entries.
+
+    You can specify the dates like 2010-12-31 22:00+0200
     """
     start = parse_legacy_time(start, return_date=True)
     end = parse_legacy_time(end, return_date=True)

--- a/privacyidea/api/monitoring.py
+++ b/privacyidea/api/monitoring.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# http://www.privacyidea.org
+#
+# 2018-08-01 Cornelius Kölbel, <cornelius.koelbel@netknights.it>
+#            Initial writeup
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+This endpoint is used fetch monitoring/statistics data
+
+The code of this module is tested in tests/test_api_monitoring.py
+"""
+from flask import (Blueprint,
+                   request)
+from .lib.utils import getParam, send_result
+from ..lib.utils import parse_legacy_time
+from ..lib.log import log_with
+from ..lib.monitoringstats import (get_stats_keys, get_values,
+                                   get_last_value, delete_stats)
+from flask import g
+import logging
+from ..api.lib.prepolicy import prepolicy, check_base_action
+from ..lib.policy import ACTION
+
+
+log = logging.getLogger(__name__)
+
+
+monitoring_blueprint = Blueprint('monitoring_blueprint', __name__)
+
+
+@monitoring_blueprint.route('/', methods=['GET'])
+@monitoring_blueprint.route('/<stats_key>', methods=['GET'])
+@log_with(log)
+@prepolicy(check_base_action, request, ACTION.STATISTICSREAD)
+def get_statistics(stats_key=None):
+    """
+    return a list of all available statistics keys in the database if no *stats_key*
+    is specified.
+
+    If a stats_key is specified it returns the data of this key.
+    The parameters "start" and "end" can be used to specify a time window,
+    from which the statistics data should be fetched.
+    """
+    if stats_key is None:
+        stats_keys = get_stats_keys()
+        g.audit_object.log({"success": True})
+        return send_result(stats_keys)
+    else:
+        param = request.all_data
+        start = getParam(param, "start")
+        if start:
+            start = parse_legacy_time(start, return_date=True)
+        end = getParam(param, "end")
+        if end:
+            end = parse_legacy_time(end, return_date=True)
+        values = get_values(stats_key=stats_key, start_timestamp=start, end_timestamp=end)
+        g.audit_object.log({"success": True})
+        return send_result(values)
+
+
+@monitoring_blueprint.route('/<stats_key>/<start>/<end>', methods=['DELETE'])
+@log_with(log)
+@prepolicy(check_base_action, request, ACTION.STATISTICSDELETE)
+def delete_statistics(stats_key, start, end):
+    """
+    Delete the statistics data of a certain stats_key
+    """
+    start = parse_legacy_time(start, return_date=True)
+    end = parse_legacy_time(end, return_date=True)
+    r = delete_stats(stats_key, start, end)
+    g.audit_object.log({"success": True})
+    return send_result(r)
+
+
+@monitoring_blueprint.route('/<stats_key>/last', methods=['GET'])
+@log_with(log)
+@prepolicy(check_base_action, request, ACTION.STATISTICSREAD)
+def get_statistics_last(stats_key):
+    """
+    Get the last value of the stats key
+    """
+    last_value = get_last_value(stats_key)
+    g.audit_object.log({"success": True})
+    return send_result(last_value)
+

--- a/privacyidea/api/monitoring.py
+++ b/privacyidea/api/monitoring.py
@@ -73,10 +73,10 @@ def get_statistics(stats_key=None):
         return send_result(values)
 
 
-@monitoring_blueprint.route('/<stats_key>/<start>/<end>', methods=['DELETE'])
+@monitoring_blueprint.route('/<stats_key>', methods=['DELETE'])
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.STATISTICSDELETE)
-def delete_statistics(stats_key, start, end):
+def delete_statistics(stats_key):
     """
     Delete the statistics data of a certain stats_key.
 
@@ -88,8 +88,13 @@ def delete_statistics(stats_key, start, end):
 
     You can specify the dates like 2010-12-31 22:00+0200
     """
-    start = parse_legacy_time(start, return_date=True)
-    end = parse_legacy_time(end, return_date=True)
+    param = request.all_data
+    start = getParam(param, "start")
+    if start:
+        start = parse_legacy_time(start, return_date=True)
+    end = getParam(param, "end")
+    if end:
+        end = parse_legacy_time(end, return_date=True)
     r = delete_stats(stats_key, start, end)
     g.audit_object.log({"success": True})
     return send_result(r)

--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -54,6 +54,7 @@ from privacyidea.api.event import eventhandling_blueprint
 from privacyidea.api.smsgateway import smsgateway_blueprint
 from privacyidea.api.clienttype import client_blueprint
 from privacyidea.api.subscriptions import subscriptions_blueprint
+from privacyidea.api.monitoring import monitoring_blueprint
 from privacyidea.lib.log import DEFAULT_LOGGING_CONFIG
 from privacyidea.config import config
 from privacyidea.models import db
@@ -166,6 +167,7 @@ def create_app(config_name="development",
     app.register_blueprint(smsgateway_blueprint, url_prefix='/smsgateway')
     app.register_blueprint(client_blueprint, url_prefix='/client')
     app.register_blueprint(subscriptions_blueprint, url_prefix='/subscriptions')
+    app.register_blueprint(monitoring_blueprint, url_prefix='/monitoring')
     db.init_app(app)
     migrate = Migrate(app, db)
 

--- a/privacyidea/lib/monitoringstats.py
+++ b/privacyidea/lib/monitoringstats.py
@@ -41,7 +41,7 @@ def write_stats(stats_key, stats_value, timestamp=None, reset_values=False):
     """
     Write a new statistics value to the database
 
-    :param stats_key: The key, that identifies the measurment point
+    :param stats_key: The key, that identifies the measurement point
     :type stats_key: basestring
     :param stats_value: The value to be measured
     :type stats_value: int

--- a/privacyidea/lib/monitoringstats.py
+++ b/privacyidea/lib/monitoringstats.py
@@ -33,7 +33,9 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.utils import convert_timestamp_to_utc
 from privacyidea.models import MonitoringStats
 from sqlalchemy import and_, distinct
+from privacyidea.lib.tokenclass import AUTH_DATE_FORMAT
 import datetime
+
 log = logging.getLogger(__name__)
 
 
@@ -95,7 +97,7 @@ def get_stats_keys():
     return keys
 
 
-def get_values(stats_key, start_timestamp=None, end_timestamp=None):
+def get_values(stats_key, start_timestamp=None, end_timestamp=None, date_strings=False):
     """
     Return a list of sets of (timestamp, value), ordered by timestamps in ascending order
 
@@ -104,6 +106,7 @@ def get_values(stats_key, start_timestamp=None, end_timestamp=None):
     :type start_timestamp: timezone-aware datetime object
     :param end_timestamp: the end of the timespan, inclusive
     :type end_timestamp: timezone-aware datetime object
+    :param date_strings: Return dates as strings formatted as AUTH_DATE_FORMAT
     :return: list of sets, with timestamps being timezone-aware UTC datetime objects
     """
     values = []
@@ -117,6 +120,8 @@ def get_values(stats_key, start_timestamp=None, end_timestamp=None):
     for ms in MonitoringStats.query.filter(and_(*conditions)).\
             order_by(MonitoringStats.timestamp.asc()):
         aware_timestamp = ms.timestamp.replace(tzinfo=tzutc())
+        if date_strings:
+            aware_timestamp = aware_timestamp.strftime(AUTH_DATE_FORMAT)
         values.append((aware_timestamp, ms.stats_value))
 
     return values

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -308,6 +308,8 @@ class ACTION(object):
     HIDE_WELCOME = "hide_welcome_info"
     CUSTOM_MENU = "custom_menu"
     CUSTOM_BASELINE = "custom_baseline"
+    STATISTICSREAD = "statistics_read"
+    STATISTICSDELETE = "statistics_delete"
 
 
 class GROUP(object):
@@ -1334,6 +1336,12 @@ def get_static_policy_definitions(scope=None):
                                                  "periodic task definitions."),
                                             'mainmenu': [MAIN_MENU.CONFIG],
                                             'group': GROUP.SYSTEM},
+            ACTION.STATISTICSREAD: {'type': 'bool',
+                                    'desc': _("Admin is allowed to read statistics data."),
+                                    'group': GROUP.SYSTEM},
+            ACTION.STATISTICSDELETE: {'type': 'bool',
+                                    'desc': _("Admin is allowed to delete statistics data."),
+                                    'group': GROUP.SYSTEM},
             ACTION.EVENTHANDLINGWRITE: {'type': 'bool',
                                         'desc': _("Admin is allowed to write "
                                                   "and modify the event "

--- a/tests/test_api_monitoring.py
+++ b/tests/test_api_monitoring.py
@@ -47,7 +47,7 @@ class APIMonitoringTestCase(MyTestCase):
 
         # check values of key1, with a start value in the past
         with self.app.test_request_context('/monitoring/key1',
-                                           data={"start": "2010-01-01"},
+                                           data={"start": "2010-01-01 10:00+0200"},
                                            method='GET',
                                            headers={'Authorization': self.at}):
 

--- a/tests/test_api_monitoring.py
+++ b/tests/test_api_monitoring.py
@@ -1,0 +1,114 @@
+import json
+from .base import MyTestCase
+from privacyidea.lib.monitoringstats import write_stats
+import datetime
+
+
+class APIMonitoringTestCase(MyTestCase):
+
+    def test_01_get_stats(self):
+
+        # create some statistics
+
+        write_stats("key1", 1)
+        write_stats("key2", "A")
+        write_stats("key1", 2)
+        ts = datetime.datetime.now().isoformat()
+
+        write_stats("key2", "B")
+        write_stats("key1", 3)
+        write_stats("key2", "A")
+        write_stats("key1", 4)
+
+        # get available stats keys
+        with self.app.test_request_context('/monitoring/',
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertTrue("key1" in result.get("value"))
+            self.assertTrue("key2" in result.get("value"))
+
+        # check values of key1
+        with self.app.test_request_context('/monitoring/key1',
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(len(result.get("value")), 4)
+            self.assertEqual(result.get("value")[0][1], 1)
+            self.assertEqual(result.get("value")[1][1], 2)
+            self.assertEqual(result.get("value")[2][1], 3)
+            self.assertEqual(result.get("value")[3][1], 4)
+
+        # check values of key1, with a start value in the past
+        with self.app.test_request_context('/monitoring/key1',
+                                           data={"start": "2010-01-01"},
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(len(result.get("value")), 4)
+
+        # End value in the past will return no data.
+        with self.app.test_request_context('/monitoring/key1',
+                                           data={"end": "2010-01-01"},
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(len(result.get("value")), 0)
+
+        # check with start timestamp after the 2nd value.
+        # This should return the 3rd and 4th.
+        with self.app.test_request_context('/monitoring/key1',
+                                           data={"start": ts},
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(len(result.get("value")), 2)
+            self.assertEqual(result.get("value")[0][1], 3)
+            self.assertEqual(result.get("value")[1][1], 4)
+
+        # check the last value of key1
+        with self.app.test_request_context('/monitoring/key1/last',
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(result.get("value"), 4)
+
+    def test_02_delete_stats(self):
+
+        # Now we delete some keys
+        with self.app.test_request_context('/monitoring/key2/2010-01-01/2100-01-01',
+                                           method='DELETE',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Number of deleted values
+            self.assertEqual(result.get("value"), 3)
+
+        # ..and check if there are still keys
+        with self.app.test_request_context('/monitoring/key2',
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Number of remaining values
+            self.assertEqual(len(result.get("value")), 0)


### PR DESCRIPTION
We can now retrieve all statistics keys
and all values of statistics data.

This statistics can be retrieved for
certain time windows.

Statistics can be deleted in different
time windows.

Closes #1027
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23issuecomment-409542745%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206936902%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206955677%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206956386%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206956549%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206965270%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206966690%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206969362%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206969440%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206973134%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206973180%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23issuecomment-409542745%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231147%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/d612000bdea07247917ef72a172afd5a1e3f7039%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147/graphs/tree.svg%3Fsrc%3Dpr%26token%3D7nHLZki60B%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231147%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.76%25%20%20%2095.77%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20137%20%20%20%20%20%20138%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016834%20%20%20%2016890%20%20%20%20%20%20%2B56%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016121%20%20%20%2016177%20%20%20%20%20%20%2B56%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20713%20%20%20%20%20%20713%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/monitoringstats.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21vbml0b3JpbmdzdGF0cy5weQ%3D%3D%29%20%7C%20%60100%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.39%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/monitoring.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL21vbml0b3JpbmcucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/api/before%5C%5C_after.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ%3D%3D%29%20%7C%20%6097.47%25%20%3C100%25%3E%20%28%2B0.09%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/app.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBwLnB5%29%20%7C%20%6090.16%25%20%3C100%25%3E%20%28%2B0.16%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bd612000...d704b09%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1147%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-08-01T11%3A25%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20d704b09dac0037c42ccf5452efc51a15edbcd84e%20privacyidea/api/monitoring.py%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206956386%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20%2A%2Athought%2A%2A%20the%20DELETE%20method%20would%20not%20allow%20any%20parameters%21%3F%5Cr%5CnThis%20is%20why%20I%20added%20it%20this%20way.%5Cr%5Cn%5Cr%5CnAlso%3A%20If%20you%20think%20of%20%2Aeach%2A%20single%20monitoring%20point%2C%20the%20resource%20would%20address%20different%20resources%2C%5Cr%5Cn%5Cr%5Cni.e.%20%60%60/counter1/2018-10-1/2018-10-10%60%60%20%20are%20different%20resources%20than%20%60%60/counter1/2018-11-1/2018-11-30%60%60.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-08-01T16%3A57%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20good%20question.%20e.g.%20%5BThis%20page%5D%28https%3A//apihandyman.io/api-design-tips-and-tricks-getting-creating-updating-or-deleting-multiple-resources-in-one-api-call/%23get-or-delete-multiple-resources%29%20sounds%20like%20query%20parameters%20are%20possible%20for%20DELETE%20requests.%20I%20think%20this%20would%20be%20especially%20nice%20because%20we%20could%20use%20the%20exact%20same%20URL%20to%20get%20and%20delete%20monitoring%20points%3A%20%60%60GET%20/counter1%3Fstart%3D...%26end%3D...%60%60%20and%20%60%60DELETE%20/counter1%3Fstart%3D...%26end%3D...%60%60.%5Cr%5Cn%5Cr%5Cnregarding%20your%20second%20paragraph%3A%20That%27s%20true%2C%20but%20I%20still%20think%20that%20the%20analogy%20between%20paths%20and%20resources%20is%20not%20so%20nice%20here%20then.%20%20Assume%20e.g.%20that%20there%20are%20no%20measurements%20on%202018-10-9.%20Then%2C%20%60%60/counter1/2018-10-1/2018-10-9%60%60%20and%20%60%60/counter1/2018-10-1/2018-10-10%60%60%20are%20different%20URLs%2C%20but%20denote%20the%20same%20resources.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-08-01T17%3A29%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20all%20other%20DELETE%20requests%20in%20privacyIDEA%20did%20not%20take%20any%20parameter%20yet%2C%20since%20they%20did%20not%20need%20one.%5Cr%5CnWe%20do%20not%20delete%20audit%20logs.%5Cr%5CnWe%20delete%20tokens%2C%20but%20this%20is%20%60%60DELETE%20/token/%3Cserial%3E%60%60.%5Cr%5Cn%5Cr%5CnAnd%20I%20also%20%2Athink%2A%20to%20remember%2C%20that%20%60%60self.app.test_request_context%60%60%20does%20not%20accept%20%60%60data%60%60%20or%20%60%60params%60%60%20in%20case%20the%20method%20is%20DELETE.%5Cr%5Cn%5Cr%5Cn%28Honestly%20I%20am%20not%20so%20convinced%20by%20the%20URL%20format%20either%2C%20but%20I%20%2Athink%2A%20it%20will%20not%20work%20in%20another%20way%29%22%2C%20%22created_at%22%3A%20%222018-08-01T17%3A38%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/monitoring.py%3AL1-100%22%7D%2C%20%22Pull%20d704b09dac0037c42ccf5452efc51a15edbcd84e%20privacyidea/api/monitoring.py%2056%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206936902%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%60start%60%60%20and%20%60%60end%60%60%20are%20parsed%20using%20%60%60parse_legacy_time%60%60.%20If%20the%20string%20does%20not%20specify%20a%20timezone%2C%20this%20interprets%20the%20string%20in%20the%20local%20timezone%20of%20the%20server%20%28not%20the%20client%21%29.%20Maybe%20we%20should%20add%20a%20sentence%20to%20explain%20that%3F%5Cr%5CnOr%2C%20alternatively%2C%20say%20that%20%60%60start%60%60%20and%20%60%60end%60%60%20should%20include%20the%20timezone%20offset%3F%22%2C%20%22created_at%22%3A%20%222018-08-01T15%3A59%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20%2A%2Athink%2A%2A%20a%20timezone%20would%20be%20interpreted%20in%20the%20correct%20way%3F%5Cr%5Cn%5Cr%5CnI%20think%20adding%20a%20comment%20to%20the%20API%20is%20sufficient.%20I%20think%20in%20the%20end%20we%20will%20use%20the%20API%20from%20within%20the%20Web%20SPA.%22%2C%20%22created_at%22%3A%20%222018-08-01T16%3A55%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%20agree%20that%20the%20code%20is%20totally%20correct%20here%2C%20but%20we%20should%20add%20a%20comment%20to%20the%20API%20documentation.%20e.g.%20if%20the%20client%20is%20in%20GMT%2B2%2C%20but%20the%20server%27s%20timezone%20is%20set%20to%20UTC%2C%20passing%20timestamps%20without%20timezone%20information%20would%20have%20surprising%20results.%22%2C%20%22created_at%22%3A%20%222018-08-01T17%3A24%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Will%20add%20a%20comment%20in%20the%20API.%22%2C%20%22created_at%22%3A%20%222018-08-01T17%3A38%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222018-08-01T17%3A50%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/monitoring.py%3AL1-100%22%7D%2C%20%22Pull%20d704b09dac0037c42ccf5452efc51a15edbcd84e%20privacyidea/api/monitoring.py%2072%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1147%23discussion_r206956549%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Will%20do%21%22%2C%20%22created_at%22%3A%20%222018-08-01T16%3A58%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222018-08-01T17%3A50%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/monitoring.py%3AL1-100%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1147#issuecomment-409542745'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1147?src=pr&el=h1) Report
> Merging [#1147](https://codecov.io/gh/privacyidea/privacyidea/pull/1147?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/d612000bdea07247917ef72a172afd5a1e3f7039?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1147/graphs/tree.svg?src=pr&token=7nHLZki60B&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1147?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1147      +/-   ##
==========================================
+ Coverage   95.76%   95.77%   +0.01%
==========================================
Files         137      138       +1
Lines       16834    16890      +56
==========================================
+ Hits        16121    16177      +56
Misses        713      713
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1147?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/monitoringstats.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1147/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21vbml0b3JpbmdzdGF0cy5weQ==) | `100% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1147/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.39% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/monitoring.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1147/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL21vbml0b3JpbmcucHk=) | `100% <100%> (ø)` | |
| [privacyidea/api/before\_after.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1147/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ==) | `97.47% <100%> (+0.09%)` | :arrow_up: |
| [privacyidea/app.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1147/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBwLnB5) | `90.16% <100%> (+0.16%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1147?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1147?src=pr&el=footer). Last update [d612000...d704b09](https://codecov.io/gh/privacyidea/privacyidea/pull/1147?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull d704b09dac0037c42ccf5452efc51a15edbcd84e privacyidea/api/monitoring.py 56'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1147#discussion_r206936902'>File: privacyidea/api/monitoring.py:L1-100</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> ``start`` and ``end`` are parsed using ``parse_legacy_time``. If the string does not specify a timezone, this interprets the string in the local timezone of the server (not the client!). Maybe we should add a sentence to explain that?
Or, alternatively, say that ``start`` and ``end`` should include the timezone offset?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I **think** a timezone would be interpreted in the correct way?
I think adding a comment to the API is sufficient. I think in the end we will use the API from within the Web SPA.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Yes, I agree that the code is totally correct here, but we should add a comment to the API documentation. e.g. if the client is in GMT+2, but the server's timezone is set to UTC, passing timestamps without timezone information would have surprising results.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Will add a comment in the API.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done
- [ ] <a href='#crh-comment-Pull d704b09dac0037c42ccf5452efc51a15edbcd84e privacyidea/api/monitoring.py 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1147#discussion_r206956386'>File: privacyidea/api/monitoring.py:L1-100</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I **thought** the DELETE method would not allow any parameters!?
This is why I added it this way.
Also: If you think of *each* single monitoring point, the resource would address different resources,
i.e. ``/counter1/2018-10-1/2018-10-10``  are different resources than ``/counter1/2018-11-1/2018-11-30``.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, good question. e.g. [This page](https://apihandyman.io/api-design-tips-and-tricks-getting-creating-updating-or-deleting-multiple-resources-in-one-api-call/#get-or-delete-multiple-resources) sounds like query parameters are possible for DELETE requests. I think this would be especially nice because we could use the exact same URL to get and delete monitoring points: ``GET /counter1?start=...&end=...`` and ``DELETE /counter1?start=...&end=...``.
regarding your second paragraph: That's true, but I still think that the analogy between paths and resources is not so nice here then.  Assume e.g. that there are no measurements on 2018-10-9. Then, ``/counter1/2018-10-1/2018-10-9`` and ``/counter1/2018-10-1/2018-10-10`` are different URLs, but denote the same resources.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think all other DELETE requests in privacyIDEA did not take any parameter yet, since they did not need one.
We do not delete audit logs.
We delete tokens, but this is ``DELETE /token/<serial>``.
And I also *think* to remember, that ``self.app.test_request_context`` does not accept ``data`` or ``params`` in case the method is DELETE.
(Honestly I am not so convinced by the URL format either, but I *think* it will not work in another way)
- [ ] <a href='#crh-comment-Pull d704b09dac0037c42ccf5452efc51a15edbcd84e privacyidea/api/monitoring.py 72'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1147#discussion_r206956549'>File: privacyidea/api/monitoring.py:L1-100</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Will do!
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1147?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1147?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1147'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>