### PR TITLE
Add basic Web UI for Periodic Tasks

### DIFF
--- a/migrations/versions/2c9430cfc66b_.py
+++ b/migrations/versions/2c9430cfc66b_.py
@@ -23,6 +23,8 @@ def upgrade():
         sa.Column('interval', sa.Unicode(length=256), nullable=False),
         sa.Column('nodes', sa.Unicode(length=256), nullable=False),
         sa.Column('taskmodule', sa.Unicode(length=256), nullable=False),
+        sa.Column('ordering', sa.Integer(), nullable=False),
+        sa.Column('last_update', sa.DateTime(), nullable=False),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('name'),
         mysql_row_format='DYNAMIC'

--- a/privacyidea/api/periodictask.py
+++ b/privacyidea/api/periodictask.py
@@ -141,7 +141,7 @@ def set_periodic_task_api():
     if node_string.strip():
         node_list = [node.strip() for node in node_string.split(",")]
     else:
-        raise ParameterError(u"nodes: expected at least one node, got {!r}".format(node_string))
+        raise ParameterError(u"nodes: expected at least one node")
     taskmodule = getParam(param, "taskmodule", optional=False)
     if taskmodule not in get_available_taskmodules():
         raise ParameterError("Unknown task module: {!r}".format(taskmodule))

--- a/privacyidea/api/periodictask.py
+++ b/privacyidea/api/periodictask.py
@@ -44,11 +44,12 @@ periodictask_blueprint = Blueprint('periodictask_blueprint', __name__)
 
 def convert_datetimes_to_string(ptask):
     """
-    Convert the ``last_runs`` timestamps to ISO 8601 strings and return a copy of ``ptask``.
+    Convert the ``last_update`` and ``last_runs`` timestamps to ISO 8601 strings and return a copy of ``ptask``.
     :param ptask: periodic task dictionary
     :return: a new periodic task dictionary
     """
     ptask = ptask.copy()
+    ptask['last_update'] = ptask['last_update'].strftime(AUTH_DATE_FORMAT)
     ptask['last_runs'] = dict((node, timestamp.strftime(AUTH_DATE_FORMAT))
                               for node, timestamp in ptask['last_runs'].items())
     return ptask

--- a/privacyidea/api/periodictask.py
+++ b/privacyidea/api/periodictask.py
@@ -127,6 +127,7 @@ def set_periodic_task_api():
     :param interval: Interval at which the periodic task should run (in cron syntax)
     :param nodes: Comma-separated list of nodes on which the periodic task should run
     :param taskmodule: Task module name of the task
+    :param ordering: Ordering of the task, must be a number >= 0.
     :param options: A dictionary (possibly JSON) of periodic task options, mapping unicodes to unicodes
     :return: ID of the periodic task
     """
@@ -145,6 +146,7 @@ def set_periodic_task_api():
     taskmodule = getParam(param, "taskmodule", optional=False)
     if taskmodule not in get_available_taskmodules():
         raise ParameterError("Unknown task module: {!r}".format(taskmodule))
+    ordering = int(getParam(param, "ordering", optional=False))
     options = getParam(param, "options", optional=True)
     if options is None:
         options = {}
@@ -152,7 +154,7 @@ def set_periodic_task_api():
         options = json.loads(options)
         if not isinstance(options, dict):
             raise ParameterError(u"options: expected dictionary, got {!r}".format(options))
-    result = set_periodic_task(name, interval, node_list, taskmodule, options, active, ptask_id)
+    result = set_periodic_task(name, interval, node_list, taskmodule, ordering, options, active, ptask_id)
     g.audit_object.log({"success": True, "info": result})
     return send_result(result)
 

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2527,6 +2527,7 @@ class PeriodicTask(MethodsMixin, db.Model):
     interval = db.Column(db.Unicode(256), nullable=False)
     nodes = db.Column(db.Unicode(256), nullable=False)
     taskmodule = db.Column(db.Unicode(256), nullable=False)
+    ordering = db.Column(db.Integer, nullable=False, default=0)
     last_update = db.Column(db.DateTime(False), nullable=False)
     options = db.relationship('PeriodicTaskOption',
                               lazy='dynamic',
@@ -2535,7 +2536,7 @@ class PeriodicTask(MethodsMixin, db.Model):
                                 lazy='dynamic',
                                 backref='periodictask')
 
-    def __init__(self, name, active, interval, node_list, taskmodule, options=None, id=None):
+    def __init__(self, name, active, interval, node_list, taskmodule, ordering, options=None, id=None):
         """
         :param name: Unique name of the periodic task as unicode
         :param active: a boolean
@@ -2544,6 +2545,7 @@ class PeriodicTask(MethodsMixin, db.Model):
                           If we update an existing PeriodicTask entry, PeriodicTaskLastRun entries
                           referring to nodes that are not present in ``node_list`` any more will be deleted.
         :param taskmodule: a unicode
+        :param ordering: an integer. Lower tasks are executed first.
         :param options: a dictionary of options, mapping unicode keys to values. Values will be converted to unicode.
                         If we update an existing PeriodicTask entry, all options that have been set previously
                         but are not present in ``options`` will be deleted.
@@ -2555,6 +2557,7 @@ class PeriodicTask(MethodsMixin, db.Model):
         self.interval = interval
         self.nodes = u", ".join(node_list)
         self.taskmodule = taskmodule
+        self.ordering = ordering
         self.save()
         # add the options to the periodic task
         options = options or {}
@@ -2593,6 +2596,7 @@ class PeriodicTask(MethodsMixin, db.Model):
                 "nodes": [node.strip() for node in self.nodes.split(",")],
                 "taskmodule": self.taskmodule,
                 "last_update": self.aware_last_update,
+                "ordering": self.ordering,
                 "options": dict((option.key, option.value) for option in self.options),
                 "last_runs": dict((last_run.node, last_run.aware_timestamp) for last_run in self.last_runs)}
 
@@ -2614,6 +2618,7 @@ class PeriodicTask(MethodsMixin, db.Model):
                 "interval": self.interval,
                 "nodes": self.nodes,
                 "taskmodule": self.taskmodule,
+                "ordering": self.ordering,
                 "last_update": self.last_update,
             })
         db.session.commit()

--- a/privacyidea/static/app.js
+++ b/privacyidea/static/app.js
@@ -61,6 +61,7 @@ myApp.constant("machineUrl", backendUrl + instance + "/machine");
 myApp.constant("applicationUrl", backendUrl + instance + "/application");
 myApp.constant("realmUrl", backendUrl + instance + "/realm");
 myApp.constant("eventUrl", backendUrl + instance + "/event");
+myApp.constant("periodicTaskUrl", backendUrl + instance + "/periodictask");
 myApp.constant("smsgatewayUrl", backendUrl + instance + "/smsgateway");
 myApp.constant("defaultRealmUrl", backendUrl + instance + "/defaultrealm");
 myApp.constant("validateUrl", backendUrl + instance + "/validate");

--- a/privacyidea/static/components/config/controllers/periodicTaskController.js
+++ b/privacyidea/static/components/config/controllers/periodicTaskController.js
@@ -49,6 +49,21 @@ myApp.controller("periodicTaskController", function($scope, $stateParams, $state
             $scope.getPeriodicTasks();
         });
     };
+    $scope.orderChanged = function (ptask) {
+        // we cannot directly pass ``ptask`` because we need to join the nodes list
+        var params = {
+            "id": ptask.id,
+            "interval": ptask.interval,
+            "name": ptask.name,
+            "taskmodule": ptask.taskmodule,
+            "nodes": ptask.nodes.join(", "),
+            "ordering": ptask.ordering,
+            "options": ptask.options,
+        };
+        ConfigFactory.setPeriodicTask(params, function() {
+            $scope.getPeriodicTasks();
+        });
+    };
 
     // Get all tasks
     $scope.getPeriodicTasks();
@@ -59,12 +74,14 @@ myApp.controller("periodicTaskController", function($scope, $stateParams, $state
 
 myApp.controller("periodicTaskDetailController", function($scope, $stateParams, ConfigFactory, $state) {
     // init
-    $scope.form = {};
+    $scope.form = {
+        "ordering": 0
+    };
     $scope.ptaskid = $stateParams.ptaskid;
     $scope.opts = {};
     $('html,body').scrollTop(0);
 
-    $scope.getAvailableNodes = function () {
+    $scope.getAvailableNodes = function (cb) {
         ConfigFactory.getNodes(function(response) {
             // prepare the input model for the multi-select box
             $scope.availableNodes = [];
@@ -74,6 +91,7 @@ myApp.controller("periodicTaskDetailController", function($scope, $stateParams, 
                     "ticked": false,
                 });
             });
+            cb();
         });
     }
 
@@ -126,6 +144,7 @@ myApp.controller("periodicTaskDetailController", function($scope, $stateParams, 
             "name": $scope.form.name,
             "taskmodule": $scope.form.taskmodule,
             "nodes": nodes.join(", "),
+            "ordering": $scope.form.ordering,
             "options": options,
         };
         if ($scope.ptaskid) {
@@ -150,9 +169,10 @@ myApp.controller("periodicTaskDetailController", function($scope, $stateParams, 
     };
 
     $scope.getTaskModules();
-    $scope.getAvailableNodes();
-    if ($scope.ptaskid) {
-        $scope.getPeriodicTask();
-    }
-
+    // ensure that the nodes are available before we fetch the task
+    $scope.getAvailableNodes(function () {
+        if ($scope.ptaskid) {
+            $scope.getPeriodicTask();
+        }
+    });
 });

--- a/privacyidea/static/components/config/controllers/periodicTaskController.js
+++ b/privacyidea/static/components/config/controllers/periodicTaskController.js
@@ -96,6 +96,7 @@ myApp.controller("periodicTaskDetailController", function($scope, $stateParams, 
             angular.forEach($scope.availableNodes, function (row) {
                 row["ticked"] = ptask.nodes.indexOf(row.name) >= 0;
             });
+            $scope.noLastRuns = angular.equals($scope.form.last_runs, {});
             $scope.getTaskmoduleOptions();
         });
     };

--- a/privacyidea/static/components/config/controllers/periodicTaskController.js
+++ b/privacyidea/static/components/config/controllers/periodicTaskController.js
@@ -1,0 +1,150 @@
+/**
+ * http://www.privacyidea.org
+ * (c) cornelius kölbel, cornelius@privacyidea.org
+ *
+ * 2018-07-31 Friedrich Weber, <friedrich.weber@netknights.it>
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+myApp.controller("periodicTaskController", function($scope, $stateParams, $state,
+                                             $location, ConfigFactory) {
+    if ($location.path() === "/config/periodictasks") {
+        $location.path("/config/periodictasks/list");
+    }
+    $('html,body').scrollTop(0);
+
+    $scope.getPeriodicTasks = function () {
+        ConfigFactory.getPeriodicTasks(function(data) {
+            $scope.periodictasks = data.result.value;
+        });
+    };
+
+    $scope.delPeriodicTask = function (ptaskid) {
+        ConfigFactory.delPeriodicTask(ptaskid, function(data) {
+            $scope.getPeriodicTasks();
+            $state.go("config.periodictasks.list");
+        });
+    };
+
+    $scope.enablePeriodicTask = function (ptaskid) {
+        ConfigFactory.enablePeriodicTask(ptaskid, function () {
+            $scope.getPeriodicTasks();
+        });
+    };
+
+    $scope.disablePeriodicTask = function (ptaskid) {
+        ConfigFactory.disablePeriodicTask(ptaskid, function () {
+            $scope.getPeriodicTasks();
+        });
+    };
+
+    // Get all tasks
+    $scope.getPeriodicTasks();
+
+    // listen to the reload broadcast
+    $scope.$on("piReload", $scope.getPeriodicTasks);
+});
+
+myApp.controller("periodicTaskDetailController", function($scope, $stateParams, ConfigFactory, $state) {
+    // init
+    $scope.form = {};
+    $scope.ptaskid = $stateParams.ptaskid;
+    $scope.opts = {};
+    $('html,body').scrollTop(0);
+
+    $scope.getAvailableNodes = function () {
+        ConfigFactory.getNodes(function(response) {
+            // prepare the input model for the multi-select box
+            $scope.availableNodes = [];
+            angular.forEach(response.result.value, function (node) {
+                $scope.availableNodes.push({
+                    "name": node,
+                    "ticked": false,
+                });
+            });
+        });
+    }
+
+    $scope.taskmoduleChanged = function () {
+        $scope.getTaskmoduleOptions();
+    }
+
+    $scope.getTaskmoduleOptions = function () {
+        ConfigFactory.getPeriodicTaskmoduleOptions($scope.form.taskmodule, function(response) {
+            var taskmoduleOptions = response.result.value;
+            $scope.taskmoduleOptions = taskmoduleOptions;
+        });
+    }
+
+    $scope.getPeriodicTask = function () {
+        ConfigFactory.getPeriodicTask($scope.ptaskid, function(response1) {
+            var ptask = response1.result.value;
+            $scope.form = ptask;
+            // tick the appropriate nodes
+            angular.forEach($scope.availableNodes, function (row) {
+                row["ticked"] = ptask.nodes.indexOf(row.name) >= 0;
+            });
+            $scope.getTaskmoduleOptions();
+        });
+    };
+    $scope.getTaskModules = function () {
+        ConfigFactory.getPeriodicTaskmodules(function(data) {
+            $scope.taskmodules = data.result.value;
+        });
+    };
+
+    $scope.createPeriodicTask = function () {
+        // get list of nodes from multi-select box
+        var nodes = [];
+        angular.forEach($scope.selectedNodes, function(node) {
+            if (node.ticked) {
+                nodes.push(node.name);
+            };
+        });
+        var params = {
+            "interval": $scope.form.interval,
+            "name": $scope.form.name,
+            "taskmodule": $scope.form.taskmodule,
+            "nodes": nodes.join(", "),
+            "options": $scope.form.options,
+        };
+        if($scope.ptaskid) {
+            params["id"] = $scope.ptaskid;
+        }
+        ConfigFactory.setPeriodicTask(params, function() {
+            $state.go("config.periodictasks.list");
+        });
+        $('html,body').scrollTop(0);
+    };
+
+    $scope.enablePeriodicTask = function (ptaskid) {
+        ConfigFactory.enablePeriodicTask(ptaskid, function () {
+            $scope.getPeriodicTask();
+        });
+    };
+
+    $scope.disablePeriodicTask = function (ptaskid) {
+        ConfigFactory.disablePeriodicTask(ptaskid, function () {
+            $scope.getPeriodicTask();
+        });
+    };
+
+    $scope.getTaskModules();
+    $scope.getAvailableNodes();
+    if ($scope.ptaskid) {
+        $scope.getPeriodicTask();
+    }
+
+});

--- a/privacyidea/static/components/config/controllers/periodicTaskController.js
+++ b/privacyidea/static/components/config/controllers/periodicTaskController.js
@@ -113,14 +113,21 @@ myApp.controller("periodicTaskDetailController", function($scope, $stateParams, 
                 nodes.push(node.name);
             };
         });
+        // filter options to only contain the current task module's options
+        var options = {};
+        angular.forEach($scope.form.options, function(value, key) {
+            if ($scope.taskmoduleOptions.hasOwnProperty(key)) {
+                options[key] = value;
+            }
+        });
         var params = {
             "interval": $scope.form.interval,
             "name": $scope.form.name,
             "taskmodule": $scope.form.taskmodule,
             "nodes": nodes.join(", "),
-            "options": $scope.form.options,
+            "options": options,
         };
-        if($scope.ptaskid) {
+        if ($scope.ptaskid) {
             params["id"] = $scope.ptaskid;
         }
         ConfigFactory.setPeriodicTask(params, function() {

--- a/privacyidea/static/components/config/factories/config.js
+++ b/privacyidea/static/components/config/factories/config.js
@@ -54,6 +54,7 @@ myApp.factory("ConfigFactory", function (AuthFactory, $http, $state, $rootScope,
                                          policyUrl, eventUrl, smtpServerUrl,
                                          radiusServerUrl, smsgatewayUrl,
                                          defaultRealmUrl, systemUrl,
+                                         periodicTaskUrl,
                                          privacyideaServerUrl,
                                          CAConnectorUrl, inform) {
     /**
@@ -145,6 +146,61 @@ myApp.factory("ConfigFactory", function (AuthFactory, $http, $state, $rootScope,
         },
         getHandlerConditions: function(handlername, callback) {
             $http.get(eventUrl + "/conditions/" + handlername, {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken()}
+            }).success(callback
+            ).error(error_func);
+        },
+        delPeriodicTask: function (ptaskid, callback) {
+            $http.delete(periodicTaskUrl + "/" + ptaskid, {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken()}}
+            ).success(callback
+            ).error(error_func);
+        },
+        getPeriodicTasks: function(callback) {
+            $http.get(periodicTaskUrl + "/", {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken()}
+            }).success(callback
+            ).error(error_func);
+        },
+        getPeriodicTaskmodules: function(callback) {
+            $http.get(periodicTaskUrl + "/taskmodules/", {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken()}
+            }).success(callback
+            ).error(error_func);
+        },
+        getPeriodicTaskmoduleOptions: function(taskmodule, callback) {
+            $http.get(periodicTaskUrl + "/options/" + taskmodule, {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken()}
+            }).success(callback
+            ).error(error_func);
+        },
+        getPeriodicTask: function(ptaskid, callback) {
+            $http.get(periodicTaskUrl + "/" + ptaskid, {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken()}
+            }).success(callback
+            ).error(error_func);
+        },
+        setPeriodicTask: function(params, callback) {
+            $http.post(periodicTaskUrl + "/", params, {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken(),
+                          'Content-Type': 'application/json'}
+            }).success(callback
+            ).error(error_func);
+        },
+        enablePeriodicTask: function(ptaskid, callback) {
+            $http.post(periodicTaskUrl + "/enable/" + ptaskid, {},
+                { headers: {'PI-Authorization': AuthFactory.getAuthToken()} }
+            ).success(callback
+            ).error(error_func);
+        },
+        disablePeriodicTask: function(ptaskid, callback) {
+            $http.post(periodicTaskUrl + "/disable/" + ptaskid, {},
+                { headers: {'PI-Authorization': AuthFactory.getAuthToken()} }
+            ).success(callback
+            ).error(error_func);
+        },
+        getNodes: function(callback) {
+            $http.get(periodicTaskUrl + "/nodes/", {
                 headers: {'PI-Authorization': AuthFactory.getAuthToken()}
             }).success(callback
             ).error(error_func);

--- a/privacyidea/static/components/config/states/states.js
+++ b/privacyidea/static/components/config/states/states.js
@@ -236,5 +236,20 @@ angular.module('privacyideaApp.configStates', ['ui.router']).config(
                     templateUrl: configpath + "config.events.list.html",
                     controller: "eventController"
                 })
+                .state('config.periodictasks', {
+                    url: "/periodictasks",
+                    templateUrl: configpath + "config.periodictasks.html",
+                    controller: "periodicTaskController"
+                })
+                .state('config.periodictasks.list', {
+                    url: "/list",
+                    templateUrl: configpath + "config.periodictasks.list.html",
+                    controller: "periodicTaskController"
+                })
+                .state('config.periodictasks.details', {
+                    url: "/details/{ptaskid:.*}",
+                    templateUrl: configpath + "config.periodictasks.details.html",
+                    controller: "periodicTaskDetailController"
+                })
             ;
         }]);

--- a/privacyidea/static/components/config/views/config.events.details.html
+++ b/privacyidea/static/components/config/views/config.events.details.html
@@ -74,7 +74,7 @@
             Order</label>
         <div class="col-sm-6">
             <input type="number" ng-model="form.ordering"
-                           class="form-control" min="0" />
+                           class="form-control" min="0" max="999" />
         </div>
     </div>
 

--- a/privacyidea/static/components/config/views/config.events.details.html
+++ b/privacyidea/static/components/config/views/config.events.details.html
@@ -74,7 +74,7 @@
             Order</label>
         <div class="col-sm-6">
             <input type="number" ng-model="form.ordering"
-                           class="form-control" min="0" max="999" />
+                           class="form-control" min="0" />
         </div>
     </div>
 

--- a/privacyidea/static/components/config/views/config.html
+++ b/privacyidea/static/components/config/views/config.html
@@ -28,6 +28,11 @@
                     <span class="glyphicon glyphicon-flag"
                           aria-hidden="true"></span>
                     <span translate>Events</span></a></li>
+                <li ng-class="{active: $state.includes('config.periodictasks')}">
+                    <a ui-sref="config.periodictasks">
+                        <span class="glyphicon glyphicon-calendar"
+                          aria-hidden="true"></span>
+                        <span translate>Periodic Tasks</span></a></li>
                 <li ng-class="{active: $state.includes('config.tokens')}">
                     <a ui-sref="config.tokens">
                     <span class="glyphicon glyphicon-phone"
@@ -59,13 +64,6 @@
                         <span class="glyphicon glyphicon-bookmark"
                           aria-hidden="true"></span>
                         <span translate>CAs</span>
-                    </a>
-                </li>
-                <li ng-class="{active: $state.includes('config.periodictasks')}">
-                    <a ui-sref="config.periodictasks">
-                        <span class="glyphicon glyphicon-calendar"
-                          aria-hidden="true"></span>
-                        <span translate>Periodic Tasks</span>
                     </a>
                 </li>
             </ul>

--- a/privacyidea/static/components/config/views/config.html
+++ b/privacyidea/static/components/config/views/config.html
@@ -61,6 +61,13 @@
                         <span translate>CAs</span>
                     </a>
                 </li>
+                <li ng-class="{active: $state.includes('config.periodictasks')}">
+                    <a ui-sref="config.periodictasks">
+                        <span class="glyphicon glyphicon-calendar"
+                          aria-hidden="true"></span>
+                        <span translate>Periodic Tasks</span>
+                    </a>
+                </li>
             </ul>
 
         </div>

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -69,11 +69,11 @@
     </div>
 
     <div class="form-group">
-        <label for="nodes" class="col-sm-3 control-label"
+        <label for="last_runs" class="col-sm-3 control-label"
         translate>Recorded Last Runs</label>
 
         <div class="col-sm-6">
-            <table class="table table-hover">
+            <table id="last_runs" class="table table-hover">
                 <tr ng-repeat="(timestamp, node) in form.last_runs">
                     <td>{{ timestamp }}</td>
                     <td>{{ node }}</td>
@@ -83,6 +83,13 @@
         </div>
     </div>
 
+    <div class="form-group">
+        <label for="last_update" class="col-sm-3 control-label"
+        translate>Last Definition Update</label>
+        <div class="col-sm-6" id="last_update">
+            {{ form.last_update }}
+        </div>
+    </div>
 
     <div class="form-group">
         <label for="taskmodule" class="col-sm-3 control-label" translate>

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -92,6 +92,15 @@
     </div>
 
     <div class="form-group">
+        <label for="ordering" class="col-sm-3 control-label" translate>
+            Order</label>
+        <div class="col-sm-6">
+            <input id="ordering" type="number" ng-model="form.ordering"
+                   class="form-control" min="0" />
+        </div>
+    </div>
+
+    <div class="form-group">
         <label for="taskmodule" class="col-sm-3 control-label" translate>
             Taskmodule</label>
         <div class="col-sm-6">

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -1,0 +1,129 @@
+<h2 class="form-signin-heading"
+    ng-show="ptaskid">
+    <translate>Edit Periodic Task {{ ptaskid }}</translate>
+
+    <span ng-show="checkRight('periodictask_write')">
+    <button class="btn btn-danger"
+            ng-click="disablePeriodicTask(ptaskid)"
+            ng-show="form.active" translate>
+        Disable
+    </button>
+    <button class="btn btn-success"
+            ng-click="enablePeriodicTask(ptaskid)"
+            ng-show="!form.active" translate>
+        Enable
+    </button>
+    <button class="btn btn-danger"
+        ng-click="delPeriodicTask(ptaskid)">
+        <span class="glyphicon glyphicon-trash"></span>
+        <span translate>Delete</span>
+    </button>
+    </span>
+</h2>
+
+<h2 class="form-signin-heading"
+        ng-hide="ptaskid" translate>Create a new Periodic Task</h2>
+
+<form name="formPeriodicTaskAdd" role="form" validate
+      class="form-horizontal">
+
+    <div class="form-group">
+        <label for="name" class="col-sm-3 control-label" translate>
+            Description</label>
+        <div class="col-sm-6">
+            <input id="name" class="form-control"
+                   ng-model="form.name"
+                   placeholder="Name"
+                   required/>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="interval" class="col-sm-3 control-label" translate>
+            Interval</label>
+        <div class="col-sm-6">
+            <input id="interval" class="form-control"
+                   ng-model="form.interval"
+                   placeholder="Interval"
+                   required/>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="nodes" class="col-sm-3 control-label"
+        translate>Nodes</label>
+
+        <div class="col-sm-9">
+            <div isteven-multi-select
+                 required
+                 input-model="availableNodes"
+                 output-model="selectedNodes"
+                 button-label="icon name"
+                 item-label="icon name maker"
+                 tick-property="ticked"
+                 id="nodes">
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <label for="taskmodule" class="col-sm-3 control-label" translate>
+            Taskmodule</label>
+        <div class="col-sm-6">
+            <select class="form-control"
+                    id="taskmodule"
+                    ng-model="form.taskmodule" required
+                    ng-options="module for module in taskmodules"
+                    ng-change="taskmoduleChanged()"
+                    >
+            </select>
+        </div>
+    </div>
+
+    <!-- options -->
+    <h4 translate>Options</h4>
+    <table class="table table-hover">
+        <tr ng-repeat="(optionname, option) in taskmoduleOptions">
+            <td>
+                <b>{{ optionname }}</b>
+            </td>
+            <td>
+                <select class="form-control"
+                        ng-if="option.value"
+                        ng-required="option.required && option.value"
+                        ng-model="form.options[optionname]"
+                        ng-options="value for value in option.value">
+                </select>
+                <textarea type="text" rows="6"
+                          ng-required="option.required && !option.value"
+                          ng-if="option.type==='text' && !option.value"
+                          class="form-control"
+                          ng-model="form.options[optionname]">
+                </textarea>
+                <input class="form-control"
+                       ng-required="option.required && !option.value"
+                       ng-model="form.options[optionname]"
+                       ng-if="option.type==='str' && !option.value">
+
+                <input type="checkbox"
+                       ng-model="form.options[optionname]"
+                       ng-if="option.type==='bool' && !option.value">
+                <p class="help help-block">
+                    {{ option.description }}
+                </p>
+            </td>
+        </tr>
+    </table>
+
+
+    <!-- button -->
+    <div class="text-center"
+         ng-show="checkRight('periodictask_write')">
+        <button ng-click="createPeriodicTask()"
+                id="createPeriodicTaskButton"
+                ng-disabled="formPeriodicTaskAdd.$invalid"
+                class="btn btn-primary">
+            <span class="glyphicon glyphicon-plus"></span>
+            <span translate>Create Periodic Task Definition</span>
+        </button>
+    </div>
+
+</form>

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -47,9 +47,17 @@
                    required/>
             <p class="help help-block" translate>
                 Please use crontab notation to specify the times at which the periodic task
-                should be run. Examples: "5 10 * * *" runs the task every day at 10:05,
-                and "*/10 * * * *" runs the task every ten minutes.
+                should be run.
             </p>
+            <accordion>
+                <accordion-group heading="{{ 'Examples'|translate}}">
+                    <ul translate>
+                        <li><b>"5 10 * * *"</b> runs the task every day at 10:05 am.</li>
+                        <li><b>"*/10 * * * *"</b> runs the task every ten minutes.</li>
+                        <li><b>"1 23 * * 7"</b> runs the task at 11:01pm on Sundays.</li>
+                    </ul>
+                </accordion-group>
+            </accordion>
         </div>
     </div>
     <div class="form-group">

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -47,7 +47,8 @@
                    required/>
             <p class="help help-block" translate>
                 Please use crontab notation to specify the times at which the periodic task
-                should be run. Example: "5 10 * * *" runs the task every day at 10:05.
+                should be run. Examples: "5 10 * * *" runs the task every day at 10:05,
+                and "*/10 * * * *" runs the task every ten minutes.
             </p>
         </div>
     </div>
@@ -96,7 +97,7 @@
             Order</label>
         <div class="col-sm-6">
             <input id="ordering" type="number" ng-model="form.ordering"
-                   class="form-control" min="0" />
+                   class="form-control" min="0" max="999" />
         </div>
     </div>
 

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -68,22 +68,22 @@
         </div>
     </div>
 
-    <div class="form-group">
+    <div class="form-group" ng-show="ptaskid">
         <label for="last_runs" class="col-sm-3 control-label"
         translate>Recorded Last Runs</label>
 
         <div class="col-sm-6">
-            <table id="last_runs" class="table table-hover">
+            <table id="last_runs" class="table table-hover" ng-show="!noLastRuns">
                 <tr ng-repeat="(timestamp, node) in form.last_runs">
                     <td>{{ timestamp }}</td>
                     <td>{{ node }}</td>
                 </tr>
             </table>
-
+            <span ng-show="noLastRuns" translate>(none)</span>
         </div>
     </div>
 
-    <div class="form-group">
+    <div class="form-group" ng-show="ptaskid">
         <label for="last_update" class="col-sm-3 control-label"
         translate>Last Definition Update</label>
         <div class="col-sm-6" id="last_update">

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -45,6 +45,10 @@
                    ng-model="form.interval"
                    placeholder="Interval"
                    required/>
+            <p class="help help-block" translate>
+                Please use crontab notation to specify the times at which the periodic task
+                should be run. Example: "5 10 * * *" runs the task every day at 10:05.
+            </p>
         </div>
     </div>
     <div class="form-group">
@@ -63,6 +67,22 @@
             </div>
         </div>
     </div>
+
+    <div class="form-group">
+        <label for="nodes" class="col-sm-3 control-label"
+        translate>Recorded Last Runs</label>
+
+        <div class="col-sm-6">
+            <table class="table table-hover">
+                <tr ng-repeat="(timestamp, node) in form.last_runs">
+                    <td>{{ timestamp }}</td>
+                    <td>{{ node }}</td>
+                </tr>
+            </table>
+
+        </div>
+    </div>
+
 
     <div class="form-group">
         <label for="taskmodule" class="col-sm-3 control-label" translate>

--- a/privacyidea/static/components/config/views/config.periodictasks.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.html
@@ -1,0 +1,20 @@
+<div class="row">
+    <div class="col-lg-3">
+        <div class="pa-sidebar panel">
+            <ul class="nav nav-pills nav-stacked">
+                <li role="presentation"
+                    ng-class="{ active: $state.includes('config.periodictasks.list')}">
+                    <a ui-sref="config.periodictasks.list" translate>
+                        All Periodic Tasks</a></li>
+                <li role="presentation"
+                    ng-show="checkRight('periodictask_write')"
+                    ng-class="{ active: $state.includes('config.periodictasks.details')}">
+                    <a ui-sref="config.periodictasks.details"
+                       translate>Create new Periodic Task</a></li>
+            </ul>
+        </div>
+
+    </div>
+    <div ui-view class="col-lg-9 slide panel">
+    </div>
+</div>

--- a/privacyidea/static/components/config/views/config.periodictasks.list.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.list.html
@@ -2,6 +2,7 @@
     <table class="table table-bordered table-responsive table-striped">
         <thead>
         <tr>
+            <th translate>Order</th>
             <th translate>Active</th>
             <!--<th translate>Id</th>-->
             <th translate>Description</th>
@@ -13,6 +14,11 @@
         </thead>
         <tbody>
         <tr ng-repeat="ptask in periodictasks">
+            <td>
+                <input type="number" ng-model="ptask.ordering"
+                       class="form-control" min="0"
+                       ng-change="orderChanged(ptask)" />
+            </td>
             <td>
                 <span ng-show="ptask.active"
                       class="glyphicon glyphicon-ok"

--- a/privacyidea/static/components/config/views/config.periodictasks.list.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.list.html
@@ -1,0 +1,55 @@
+<div class="table-responsive">
+    <table class="table table-bordered table-responsive table-striped">
+        <thead>
+        <tr>
+            <th translate>Active</th>
+            <!--<th translate>Id</th>-->
+            <th translate>Description</th>
+            <th translate>Interval</th>
+            <th translate>Taskmodule</th>
+            <th translate>Nodes</th>
+            <th translate>Options</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr ng-repeat="ptask in periodictasks">
+            <td>
+                <span ng-show="ptask.active"
+                      class="glyphicon glyphicon-ok"
+                      ng-click="disablePeriodicTask(ptask.id)">
+                </span>
+                <span ng-hide="ptask.active"
+                      class="glyphicon glyphicon-minus"
+                      ng-click="enablePeriodicTask(ptask.id)">
+                </span>
+            </td>
+            <td>
+                <a ui-sref="config.periodictasks.details({ptaskid: ptask.id})">
+                    {{ ptask.name }}
+                </a>
+            </td>
+            <td>
+                {{ ptask.interval }}
+            </td>
+            <td>
+                {{ ptask.taskmodule }}
+            </td>
+            <td>
+                {{ ptask.nodes }}
+            </td>
+            <td>
+                {{ ptask.options | json }}
+            </td>
+            <td>
+                <button class="btn btn-danger"
+                        ng-show="checkRight('periodictask_write')"
+                        ng-click="delPeriodicTask(ptask.id)">
+                        <span class="glyphicon glyphicon-trash"></span>
+                        <span translate>Delete</span>
+                </button>
+            </td>
+        </tr>
+
+        </tbody>
+    </table>
+</div>

--- a/privacyidea/static/templates/footer.html
+++ b/privacyidea/static/templates/footer.html
@@ -54,6 +54,7 @@
 <script src="{{ instance }}/static/components/config/states/states.js"></script>
 <script src="{{ instance }}/static/components/config/controllers/configControllers.js"></script>
 <script src="{{ instance }}/static/components/config/controllers/eventController.js"></script>
+<script src="{{ instance }}/static/components/config/controllers/periodicTaskController.js"></script>
 <script src="{{ instance }}/static/components/config/controllers/ldapMachineResolverController.js"></script>
 <script src="{{ instance }}/static/components/config/controllers/smtpServerController.js"></script>
 <script src="{{ instance }}/static/components/config/controllers/radiusServerController.js"></script>

--- a/tests/test_api_periodictask.py
+++ b/tests/test_api_periodictask.py
@@ -73,6 +73,15 @@ class APIPeriodicTasksTestCase(MyTestCase):
                 'taskmodule': 'UnitTest',
                 'options': '{"something": "123", "else": true}',
             },
+            # empty nodes
+            {
+                'name': 'some other task',
+                'active': False,
+                'interval': '0 8 * * *',
+                'nodes': '    ',
+                'taskmodule': 'UnitTest',
+                'options': '{"something": "123", "else": true}',
+            },
             # unknown taskmodule
             {
                 'name': 'some other task',
@@ -255,3 +264,9 @@ class APIPeriodicTasksTestCase(MyTestCase):
             self.assertEqual(status_code, 200)
             self.assertTrue(data['result']['status'])
             self.assertEqual(data['result']['value'], options)
+
+    def test_03_nodes(self):
+        status_code, data = self.simulate_request('/periodictask/nodes/', method='GET')
+        self.assertEqual(status_code, 200)
+        self.assertTrue(data['result']['status'])
+        self.assertEqual(data['result']['value'], ['Node2', 'Node1'])

--- a/tests/test_api_periodictask.py
+++ b/tests/test_api_periodictask.py
@@ -139,8 +139,9 @@ class APIPeriodicTasksTestCase(MyTestCase):
                 self.assertEqual(result_dict['active'], False)
                 self.assertEqual(result_dict['interval'], '0 8 * * *')
                 self.assertEqual(result_dict['nodes'], ['pinode1', 'pinode2'])
-                self.assertEqual(set(result_dict['last_runs'].keys()), {'pinode1', 'pinode2'})
-                self.assertIsNotNone(parse_timestamp(result_dict['last_runs']['pinode1']))
+                self.assertEqual(result_dict['last_runs'], {})
+                last_update = parse_timestamp(result_dict['last_update'])
+                self.assertIsNotNone(last_update)
                 self.assertEqual(result_dict['options'], {'something': '123', 'else': 'True'})
                 break
         else:
@@ -173,6 +174,9 @@ class APIPeriodicTasksTestCase(MyTestCase):
         self.assertEqual(data['result']['value']['id'], ptask_id1)
         self.assertEqual(data['result']['value']['name'], 'new name')
         self.assertEqual(data['result']['value']['options'], {'key': 'value'})
+        self.assertGreater(parse_timestamp(data['result']['value']['last_update']),
+                           last_update)
+        last_update = parse_timestamp(data['result']['value']['last_update'])
 
         # enable
         status_code, data = self.simulate_request('/periodictask/enable/{}'.format(ptask_id1), method='POST')
@@ -183,6 +187,9 @@ class APIPeriodicTasksTestCase(MyTestCase):
         self.assertEqual(status_code, 200)
         self.assertEqual(data['result']['value']['name'], 'new name')
         self.assertEqual(data['result']['value']['active'], True)
+        self.assertGreater(parse_timestamp(data['result']['value']['last_update']),
+                           last_update)
+        last_update = parse_timestamp(data['result']['value']['last_update'])
 
         # disable
         status_code, data = self.simulate_request('/periodictask/disable/{}'.format(ptask_id1), method='POST')
@@ -193,6 +200,8 @@ class APIPeriodicTasksTestCase(MyTestCase):
         self.assertEqual(status_code, 200)
         self.assertEqual(data['result']['value']['name'], 'new name')
         self.assertEqual(data['result']['value']['active'], False)
+        self.assertGreater(parse_timestamp(data['result']['value']['last_update']),
+                           last_update)
 
         # disable again without effect
         status_code, data = self.simulate_request('/periodictask/disable/{}'.format(ptask_id1), method='POST')

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -745,12 +745,12 @@ class TokenModelTestCase(MyTestCase):
         with mock.patch('privacyidea.models.datetime') as mock_dt:
             mock_dt.utcnow.return_value = current_utc_time
 
-            task1 = PeriodicTask("task1", False, "0 5 * * *", ["localhost"], "some.module", {
+            task1 = PeriodicTask("task1", False, "0 5 * * *", ["localhost"], "some.module", 2, {
                 "key1": "value2",
                 "KEY2": True,
                 "key3": u"öfføff",
             })
-            task2 = PeriodicTask("some other task", True, "0 6 * * *", ["localhost"], "some.other.module", {
+            task2 = PeriodicTask("some other task", True, "0 6 * * *", ["localhost"], "some.other.module", 1, {
                 "foo": "bar"
             })
 
@@ -768,6 +768,7 @@ class TokenModelTestCase(MyTestCase):
             "last_update": current_utc_time.replace(tzinfo=tzutc()),
             "nodes": ["localhost"],
             "taskmodule": "some.module",
+            "ordering": 2,
             "options": {
                 "key1": "value2",
                 "KEY2": "True",
@@ -782,7 +783,7 @@ class TokenModelTestCase(MyTestCase):
         later_utc_time = current_utc_time + timedelta(seconds=1)
         with mock.patch('privacyidea.models.datetime') as mock_dt:
             mock_dt.utcnow.return_value = later_utc_time
-            PeriodicTask("task one", True, "0 8 * * *", ["localhost", "otherhost"], "some.module", {
+            PeriodicTask("task one", True, "0 8 * * *", ["localhost", "otherhost"], "some.module", 3, {
                 "KEY2": "value number 2",
                 "key 4": 1234
             }, id=task1.id)
@@ -798,6 +799,7 @@ class TokenModelTestCase(MyTestCase):
                              "last_update": later_utc_time.replace(tzinfo=tzutc()),
                              "nodes": ["localhost", "otherhost"],
                              "taskmodule": "some.module",
+                             "ordering": 3,
                              "options": {"KEY2": "value number 2",
                                          "key 4": "1234"},
                              "last_runs": {
@@ -819,6 +821,7 @@ class TokenModelTestCase(MyTestCase):
                              "last_update": later_utc_time.replace(tzinfo=tzutc()),
                              "nodes": ["localhost", "otherhost"],
                              "taskmodule": "some.module",
+                             "ordering": 3,
                              "options": {"KEY2": "value number 2",
                                          "key 4": "1234"},
                              "last_runs": {
@@ -828,7 +831,7 @@ class TokenModelTestCase(MyTestCase):
                          })
 
         # remove "localhost", assert the last run is removed
-        PeriodicTask("task one", True, "0 8 * * *", ["otherhost"], "some.module", {"foo": "bar"}, id=task1.id)
+        PeriodicTask("task one", True, "0 8 * * *", ["otherhost"], "some.module", 4, {"foo": "bar"}, id=task1.id)
         self.assertEqual(PeriodicTaskOption.query.filter_by(periodictask_id=task1.id).count(), 1)
         self.assertEqual(PeriodicTaskLastRun.query.filter_by(periodictask_id=task1.id).one().node, "otherhost")
         # naive timestamp in the database

--- a/tests/test_lib_periodictask.py
+++ b/tests/test_lib_periodictask.py
@@ -30,7 +30,8 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "active": True,
             "name": "task one",
             "interval": "0 8 * * *",
-            "nodes": ["foo", "bar"],
+            "last_update": parse_timestamp("2018-06-23 07:55:00 UTC"),
+            "nodes": ["foo", "bar", "baz"],
             "taskmodule": "some.module",
             "options": {"KEY2": "value number 2",
                         "key 4": "1234"},
@@ -44,8 +45,36 @@ class BasePeriodicTaskTestCase(MyTestCase):
                          parse_timestamp("2018-06-26 08:00 UTC"))
         self.assertEqual(calculate_next_timestamp(task1, "bar", tzinfo),
                          parse_timestamp("2018-06-24 08:00 UTC"))
-        with self.assertRaises(ServerError):
-            calculate_next_timestamp(task1, "baz")
+        # the next run of baz is calculated based on last_update
+        self.assertEqual(calculate_next_timestamp(task1, "baz", tzinfo),
+                         parse_timestamp("2018-06-23 08:00 UTC"))
+
+        # no last run recorded
+        task1b = {
+            "id": 1,
+            "active": True,
+            "name": "task one",
+            "interval": "0 8 * * *",
+            "last_update": parse_timestamp("2018-06-24 07:55:00 UTC"),
+            "nodes": ["foo", "bar"],
+            "taskmodule": "some.module",
+            "options": {"KEY2": "value number 2",
+                        "key 4": "1234"},
+            "last_runs": {}
+        }
+
+        self.assertEqual(calculate_next_timestamp(task1b, "foo", tzinfo),
+                         parse_timestamp("2018-06-24 08:00 UTC"))
+        self.assertEqual(calculate_next_timestamp(task1b, "bar", tzinfo),
+                         parse_timestamp("2018-06-24 08:00 UTC"))
+
+        # now, "foo" has a last run!
+        task1b["last_runs"]["foo"] = parse_timestamp("2018-06-24 08:00 UTC")
+        self.assertEqual(calculate_next_timestamp(task1b, "foo", tzinfo),
+                         parse_timestamp("2018-06-25 08:00 UTC"))
+        # ... bar has still not run
+        self.assertEqual(calculate_next_timestamp(task1b, "bar", tzinfo),
+                         parse_timestamp("2018-06-24 08:00 UTC"))
 
         # every weekday
         task2 = {
@@ -53,6 +82,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "active": True,
             "name": "task two",
             "interval": "0 0 * * 1-5",
+            "last_update": parse_timestamp("2018-06-24 08:00:00 UTC"),
             "nodes": ["foo", "bar"],
             "taskmodule": "some.module",
             "options": {"KEY2": "value number 2",
@@ -70,6 +100,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "active": True,
             "name": "task two",
             "interval": "5 0 * 8 *",
+            "last_update": parse_timestamp("2018-06-24 08:00:00 UTC"),
             "nodes": ["foo", "bar"],
             "taskmodule": "some.module",
             "options": {"KEY2": "value number 2",
@@ -87,6 +118,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "active": True,
             "name": "task two",
             "interval": "every two days",
+            "last_update": parse_timestamp("2018-06-24 08:00:00 UTC"),
             "nodes": ["foo", "bar"],
             "taskmodule": "some.module",
             "options": {"KEY2": "value number 2",
@@ -106,16 +138,22 @@ class BasePeriodicTaskTestCase(MyTestCase):
         # every day at 08:00
         task = {
             "interval": "0 8 * * *",
+            "last_update": parse_timestamp("2018-06-24 02:30 UTC"),
             "last_runs": {
                 "foo": parse_timestamp("2018-06-25 05:04:30 UTC"),
             }
         }
         self.assertEqual(calculate_next_timestamp(task, "foo", tzinfo),
                          parse_timestamp("2018-06-26 05:00 UTC"))
+        self.assertEqual(calculate_next_timestamp(task, "bar", tzinfo),
+                         parse_timestamp("2018-06-24 05:00 UTC"))
+        self.assertEqual(calculate_next_timestamp(task, "this_node_does_not_exist", tzinfo),
+                         parse_timestamp("2018-06-24 05:00 UTC"))
 
         # every day at 08:00
         task = {
             "interval": "0 8 * * *",
+            "last_update": parse_timestamp("2018-06-24 02:30 UTC"),
             "last_runs": {
                 "foo": parse_timestamp("2018-06-25 04:04:30 UTC"),
             }
@@ -126,6 +164,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
         # every day at midnight
         task = {
             "interval": "0 0 * * *",
+            "last_update": parse_timestamp("2018-06-24 02:30 UTC"),
             "last_runs": {
                 "foo": parse_timestamp("2018-06-25 21:01 UTC"),
             }
@@ -136,6 +175,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
         # every wednesday at midnight
         task = {
             "interval": "0 0 * * 3",
+            "last_update": parse_timestamp("2018-06-24 02:30 UTC"),
             "last_runs": {
                 "foo": parse_timestamp("2018-06-24 21:00 UTC"),  # this is actually monday 00:00 in russia
             }
@@ -146,6 +186,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
         # every 15th at 01:00
         task = {
             "interval": "0 1 15 * *",
+            "last_update": parse_timestamp("2018-06-24 02:30 UTC"),
             "last_runs": {
                 "foo": parse_timestamp("2018-05-15 00:00 UTC"),
             }
@@ -156,6 +197,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
         # every 15th at 01:00
         task = {
             "interval": "0 1 15 * *",
+            "last_update": parse_timestamp("2018-06-24 02:30 UTC"),
             "last_runs": {
                 "foo": parse_timestamp("2018-05-14 21:59 UTC"),
             }
@@ -182,6 +224,9 @@ class BasePeriodicTaskTestCase(MyTestCase):
                 "key1": 1234,
                 "key2": 5678,
             })
+
+        task1_last_update = get_periodic_task_by_id(task1)["last_update"]
+
         self.assertEqual(get_periodic_task_by_name("task three")["id"], task3)
         with self.assertRaises(ParameterError):
             get_periodic_task_by_name("task does not exist")
@@ -203,6 +248,8 @@ class BasePeriodicTaskTestCase(MyTestCase):
 
         self.assertEqual(len(PeriodicTask.query.all()), 3)
         self.assertEqual(task1, task1_modified)
+        # we have updated the task definition
+        self.assertGreater(get_periodic_task_by_id(task1)["last_update"], task1_last_update)
         self.assertEqual(get_periodic_tasks(name="every month")[0]["options"],
                          {"key1": "123", "key3": "True"})
 
@@ -260,14 +307,14 @@ class BasePeriodicTaskTestCase(MyTestCase):
         self.assertEqual(len(PeriodicTask.query.all()), 1)
         task1_entry = PeriodicTask.query.filter_by(id=task1_id).one()
 
-        # We already have the initial last runs
-        self.assertEqual(len(list(task1_entry.last_runs)), 2)
+        # We have no initial last runs
+        self.assertEqual(len(list(task1_entry.last_runs)), 0)
 
         set_periodic_task_last_run(task1_id, "pinode1", parse_timestamp("2018-06-26 08:00+02:00"))
         set_periodic_task_last_run(task1_id, "pinode1", parse_timestamp("2018-06-26 08:05+02:00"))
 
         task1 = get_periodic_tasks("task one")[0]
-        self.assertEqual(len(list(task1_entry.last_runs)), 2)
+        self.assertEqual(len(list(task1_entry.last_runs)), 1)
         self.assertEqual(task1_entry.last_runs[0].timestamp,
                          parse_timestamp("2018-06-26 06:05"))
         self.assertEqual(task1["last_runs"]["pinode1"],
@@ -295,10 +342,17 @@ class BasePeriodicTaskTestCase(MyTestCase):
             "key2": False
         })
         # at 08:00 on wednesdays
-        task2 = set_periodic_task("task two", "0 8 * * WED", ["pinode2"], "some.task.module", {
-            "key1": "value",
-            "key2": "foo"
-        }, active=False)
+        current_utc_time = parse_timestamp("2018-05-31 05:08:00")
+        with mock.patch('privacyidea.models.datetime') as mock_dt:
+            mock_dt.utcnow.return_value = current_utc_time
+            task2 = set_periodic_task("task two", "0 8 * * WED", ["pinode2", "pinode3"], "some.task.module", {
+                "key1": "value",
+                "key2": "foo"
+            }, active=False)
+        self.assertEqual(get_periodic_task_by_id(task2)["last_update"],
+                         parse_timestamp("2018-05-31 08:08:00+03:00"))
+        self.assertEqual(get_periodic_task_by_id(task2)["last_runs"], {})
+
         # every 30 minutes, on Tuesdays
         task3 = set_periodic_task("task three", "*/30 * * * 2", ["pinode1", "pinode2"], "some.task.module", {
             "key1": 1234,
@@ -310,6 +364,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
         # we need some last runs
         set_periodic_task_last_run(task1, "pinode1", parse_timestamp("2018-06-01 00:00:05+03:00"))
 
+        # no last run for pinode3 here!
         set_periodic_task_last_run(task2, "pinode2", parse_timestamp("2018-06-20 08:00:05+03:00"))
 
         set_periodic_task_last_run(task3, "pinode1", parse_timestamp("2018-06-26 11:36:37+03:00"))
@@ -365,8 +420,10 @@ class BasePeriodicTaskTestCase(MyTestCase):
         scheduled = get_scheduled_periodic_tasks("pinode2", current_timestamp, tzinfo)
         self.assertEqual([task["name"] for task in scheduled], ["task four"])
 
-        # Enable task2, now we also have to run it on pinode2
-        enable_periodic_task(task2)
+        # Enable task2, now we also have to run it on pinode2 and pinode3
+        with mock.patch('privacyidea.models.datetime') as mock_dt:
+            mock_dt.utcnow.return_value = current_utc_time
+            enable_periodic_task(task2)
 
         scheduled = get_scheduled_periodic_tasks("pinode1", current_timestamp, tzinfo)
         self.assertEqual([task["name"] for task in scheduled], ["task one"])
@@ -374,9 +431,13 @@ class BasePeriodicTaskTestCase(MyTestCase):
         scheduled = get_scheduled_periodic_tasks("pinode2", current_timestamp, tzinfo)
         self.assertEqual([task["name"] for task in scheduled], ["task two", "task four"])
 
+        scheduled = get_scheduled_periodic_tasks("pinode3", current_timestamp, tzinfo)
+        self.assertEqual([task["name"] for task in scheduled], ["task two"])
+
         # Simulate runs
         set_periodic_task_last_run(task1, "pinode1", current_timestamp)
         set_periodic_task_last_run(task2, "pinode2", current_timestamp)
+        set_periodic_task_last_run(task2, "pinode3", current_timestamp)
         set_periodic_task_last_run(task4, "pinode2", current_timestamp)
 
         # Now, we don't have to run anything

--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -33,10 +33,10 @@ import dateutil
 from flask_script import Manager
 
 from privacyidea.app import create_app
+from privacyidea.lib.config import get_privacyidea_node
 from privacyidea.lib.periodictask import get_scheduled_periodic_tasks, set_periodic_task_last_run, \
     get_periodic_task_by_name, \
     execute_task, get_periodic_tasks
-from privacyidea.lib.error import ParameterError
 
 app = create_app(config_name='production', silent=True)
 manager = Manager(app)
@@ -45,17 +45,13 @@ manager = Manager(app)
 def get_node_name(node):
     """
     Determine the node name. If no node name is given, read it from the app config.
-    Raise a ParameterError if no node name could be determined.
     :param node: node name given by the user (can be None)
     :return:
     """
-    if node is None:
-        if "PI_AUDIT_SERVERNAME" in app.config:
-            return app.config["PI_AUDIT_SERVERNAME"]
-        else:
-            raise ParameterError("No PI_AUDIT_SERVERNAME specified in pi.cfg, use --node to pass a node name")
-    else:
+    if node is not None:
         return node
+    else:
+        return get_privacyidea_node()
 
 
 def run_task_on_node(ptask, node):


### PR DESCRIPTION
This adds a web UI for periodic tasks. I'm very happy about any comments and suggestions :-)

Working on #1107 

Some ideas for further improvements:
* We could have some predefined interval expressions for users who are not fluent with crontab notation (e.g. "every hour", "every day" ...)
* We could display when each task is scheduled to run next on each node. But this would require API changes, and we cannot be sure if the tasks will *really* be run on the respective node, because we don't know the interval at which ``privacyidea-cron`` is invoked.

~~Before we merge this, I would like to update the translations.~~
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23issuecomment-409691803%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23issuecomment-409904479%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23issuecomment-409908821%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23issuecomment-409938813%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23issuecomment-409960997%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207002794%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207153440%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207205826%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207238941%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207239093%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207830933%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207830937%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23issuecomment-410650843%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207936611%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207937186%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23issuecomment-410771230%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23issuecomment-409691803%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231150%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/63265afc7ab4134632a176ea782bea50c2fc7975%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26src%3Dpr%26width%3D650%26height%3D150%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231150%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.75%25%20%20%2095.79%25%20%20%20%2B0.03%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20138%20%20%20%20%20%20139%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016863%20%20%20%2017170%20%20%20%20%20%2B307%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016148%20%20%20%2016448%20%20%20%20%20%2B300%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20715%20%20%20%20%20%20722%20%20%20%20%20%20%20%2B7%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/periodictask.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BlcmlvZGljdGFzay5weQ%3D%3D%29%20%7C%20%6096.8%25%20%3C100%25%3E%20%28-0.14%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.89%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/periodictask.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3BlcmlvZGljdGFzay5weQ%3D%3D%29%20%7C%20%6098.91%25%20%3C100%25%3E%20%28-1.09%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.33%25%20%3C0%25%3E%20%28-2.5%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/before%5C%5C_after.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ%3D%3D%29%20%7C%20%6096.28%25%20%3C0%25%3E%20%28-1.11%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/error.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5%29%20%7C%20%6090.81%25%20%3C0%25%3E%20%28-1.03%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/monitoringstats.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21vbml0b3JpbmdzdGF0cy5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/monitoring.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL21vbml0b3JpbmcucHk%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.69%25%20%3C0%25%3E%20%28%2B0.29%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/app.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBwLnB5%29%20%7C%20%6092.36%25%20%3C0%25%3E%20%28%2B2.36%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B63265af...cec8889%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1150%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-08-01T19%3A21%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20regards%20to%20translation%3A%20We%20have%20some%20other%20PRs%20that%20where%20merged%20earlier.%20I%20think%20we%20should%20wait%20for%20the%20translation%20till%20all%20PRs%20are%20merged.%20Then%20add%20a%20translation%20PR.%22%2C%20%22created_at%22%3A%20%222018-08-02T12%3A10%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Some%20notes%20from%20looking%20at%20the%20UI%2C%20not%20the%20code%3A%5Cr%5Cn%5Cr%5Cn1.%20The%20%5C%22recorded%20last%20run%5C%22%20should%20not%20be%20visable%20during%20creation%20of%20the%20periodic%20task%5Cr%5Cn2.%20list%20could%20contain%20an%20%5C%22order%5C%22%20like%20the%20event%20handler.%20%28OK%2C%20we%20probably%20need%20to%20enhance%20the%20DB%20model%29%5Cr%5Cn3.%20In%20regards%20to%20the%20example%20crontab%20notation%3A%20We%20could%20make%20a%20popup/slideup/accordeon%2C%20that%20gives%20some%20examples%20about%20%5Cr%5Cn%20%20%20%20%20%2A%20a%20specific%20time%5Cr%5Cn%20%20%20%20%20%2A%20all%20x%20minutes%5Cr%5Cn%20%20%20%20%20%2A%20a%20certain%20day%20of%20week...%5Cr%5Cn%20%20%20%20I%20think%20this%20should%20be%20enough.%22%2C%20%22created_at%22%3A%20%222018-08-02T12%3A27%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20suggestions%21%20I%20fixed%20%281%29%20and%20will%20fix%20%282%29%20and%20%283%29%20in%20subsequent%20commits.%5Cr%5Cn%5Cr%5CnI%27ll%20also%20update%20the%20migration%20script%20once%20the%20model%20is%20stable.%22%2C%20%22created_at%22%3A%20%222018-08-02T14%3A07%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20the%20ordering%20of%20periodic%20tasks.%5Cr%5CnTODOs%20left%20here%3A%5Cr%5Cn%2A%20crontab%20syntax%20examples%20in%20the%20Web%20UI%5Cr%5Cn%2A%20add%20ordering%2C%20last_update%20columns%20to%20the%20migration%20script%22%2C%20%22created_at%22%3A%20%222018-08-02T15%3A09%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%200%206%20%2A%20%2A%20%2A%5Cr%5Cn%3E%20%2A/2%20%2A%20%2A%20%2A%20%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-08-06T09%3A43%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20like%20both%20suggestions%20and%20implemented%20them%20both%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-08-06T16%3A39%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207bfab5b4382dadf6987355a03f4b2de0781b9ca3%20privacyidea/static/components/config/views/config.periodictasks.details.html%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207936611%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20do%20you%20think%20of%20this%3A%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Ehtml%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%3Cp%20class%3D%5C%22help%20help-block%5C%22%20translate%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Please%20use%20crontab%20notation%20to%20specify%20the%20times%20at%20which%20the%20periodic%20task%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20should%20be%20run.%3C/p%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%3Caccordion%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Caccordion-group%20heading%3D%5C%22%7B%7B%20%27Examples%27%7Ctranslate%7D%7D%5C%22%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cul%20translate%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cli%3E%3Cb%3E%5C%225%2010%20%2A%20%2A%20%2A%5C%22%3C/b%3E%20runs%20the%20task%20every%20day%20at%2010%3A05%20am.%3C/li%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cli%3E%3Cb%3E%5C%22%2A/10%20%2A%20%2A%20%2A%20%2A%5C%22%3C/b%3E%20runs%20the%20task%20every%20ten%20minutes.%3C/li%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cli%3E%3Cb%3E%5C%221%2023%20%2A%20%2A%207%3C/b%3Eruns%20the%20task%20at%2011%3A01pm%20on%20Sundays.%3C/li%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C/ul%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C/accordion-group%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%3C/accordion%3E%5Cr%5Cn%7E%7E%7E%7E%5Cr%5CnThis%20way%20the%20user%20gets%20more%20information%20and%20can%20hide%20or%20show%20it.%22%2C%20%22created_at%22%3A%20%222018-08-06T15%3A36%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/config/views/config.periodictasks.details.html%3AL1-167%22%7D%2C%20%22Pull%207bfab5b4382dadf6987355a03f4b2de0781b9ca3%20privacyidea/static/components/config/views/config.html%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207937186%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20move%20this%20menu%20entry%20after%20events.%20I%20think%20it%20is%20more%20logical%20there%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20policies%2C%20events%2C%20tasks%2C%20....%22%2C%20%22created_at%22%3A%20%222018-08-06T15%3A38%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/config/views/config.html%3AL61-74%22%7D%2C%20%22Pull%204cf4f16692c1f9b69743276b8ecd5c4725f04cf8%20privacyidea/api/periodictask.py%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207153440%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22isn%27t%20%60node_string%60%20empty%20in%20the%20%60else%60%20case%3F%22%2C%20%22created_at%22%3A%20%222018-08-02T09%3A07%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%27re%20right%2C%20this%20doesn%27t%20make%20much%20sense.%20Will%20change%20the%20error%20message%21%22%2C%20%22created_at%22%3A%20%222018-08-02T12%3A24%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed%20this%20in%20cb40d19%20%22%2C%20%22created_at%22%3A%20%222018-08-02T14%3A07%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-08-06T09%3A42%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/periodictask.py%3AL137-147%22%7D%2C%20%22Pull%204cf4f16692c1f9b69743276b8ecd5c4725f04cf8%20privacyidea/api/periodictask.py%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1150%23discussion_r207002794%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Oh%2C%20I%20forgot%20to%20add%20a%20test%20for%20this.%20Will%20do%20that.%5Cr%5Cn%5Cr%5Cn...%20but%20maybe%20this%20should%20be%20a%20more%20central%20API%20request%3F%20Because%20the%20nodes%20are%20not%20only%20useful%20for%20periodic%20tasks.%22%2C%20%22created_at%22%3A%20%222018-08-01T19%3A24%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20a%20test%20for%20this.%22%2C%20%22created_at%22%3A%20%222018-08-02T14%3A06%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-08-06T09%3A42%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/periodictask.py%3AL65-82%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1150#issuecomment-409691803'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1150?src=pr&el=h1) Report
> Merging [#1150](https://codecov.io/gh/privacyidea/privacyidea/pull/1150?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/63265afc7ab4134632a176ea782bea50c2fc7975?src=pr&el=desc) will **increase** coverage by `0.03%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/graphs/tree.svg?token=7nHLZki60B&src=pr&width=650&height=150)](https://codecov.io/gh/privacyidea/privacyidea/pull/1150?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1150      +/-   ##
==========================================
+ Coverage   95.75%   95.79%   +0.03%
==========================================
Files         138      139       +1
Lines       16863    17170     +307
==========================================
+ Hits        16148    16448     +300
- Misses        715      722       +7
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1150?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/periodictask.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BlcmlvZGljdGFzay5weQ==) | `96.8% <100%> (-0.14%)` | :arrow_down: |
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.89% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/periodictask.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3BlcmlvZGljdGFzay5weQ==) | `98.91% <100%> (-1.09%)` | :arrow_down: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.33% <0%> (-2.5%)` | :arrow_down: |
| [privacyidea/api/before\_after.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ==) | `96.28% <0%> (-1.11%)` | :arrow_down: |
| [privacyidea/lib/error.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5) | `90.81% <0%> (-1.03%)` | :arrow_down: |
| [privacyidea/lib/monitoringstats.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21vbml0b3JpbmdzdGF0cy5weQ==) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/api/monitoring.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL21vbml0b3JpbmcucHk=) | `100% <0%> (ø)` | |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.69% <0%> (+0.29%)` | :arrow_up: |
| [privacyidea/app.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1150/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBwLnB5) | `92.36% <0%> (+2.36%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1150?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1150?src=pr&el=footer). Last update [63265af...cec8889](https://codecov.io/gh/privacyidea/privacyidea/pull/1150?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> In regards to translation: We have some other PRs that where merged earlier. I think we should wait for the translation till all PRs are merged. Then add a translation PR.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Some notes from looking at the UI, not the code:
1. The "recorded last run" should not be visable during creation of the periodic task
2. list could contain an "order" like the event handler. (OK, we probably need to enhance the DB model)
3. In regards to the example crontab notation: We could make a popup/slideup/accordeon, that gives some examples about
* a specific time
* all x minutes
* a certain day of week...
I think this should be enough.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Thanks for the suggestions! I fixed (1) and will fix (2) and (3) in subsequent commits.
I'll also update the migration script once the model is stable.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I've added the ordering of periodic tasks.
TODOs left here:
* crontab syntax examples in the Web UI
* add ordering, last_update columns to the migration script
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> > 0 6 * * *
> */2 * * *
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I like both suggestions and implemented them both :-)
- [ ] <a href='#crh-comment-Pull 7bfab5b4382dadf6987355a03f4b2de0781b9ca3 privacyidea/static/components/config/views/config.periodictasks.details.html 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1150#discussion_r207936611'>File: privacyidea/static/components/config/views/config.periodictasks.details.html:L1-167</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What do you think of this:
~~~~html
<p class="help help-block" translate>
Please use crontab notation to specify the times at which the periodic task
should be run.</p>
<accordion>
<accordion-group heading="{{ 'Examples'|translate}}">
<ul translate>
<li><b>"5 10 * * *"</b> runs the task every day at 10:05 am.</li>
<li><b>"*/10 * * * *"</b> runs the task every ten minutes.</li>
<li><b>"1 23 * * 7</b>runs the task at 11:01pm on Sundays.</li>
</ul>
</accordion-group>
</accordion>
~~~~
This way the user gets more information and can hide or show it.
- [ ] <a href='#crh-comment-Pull 7bfab5b4382dadf6987355a03f4b2de0781b9ca3 privacyidea/static/components/config/views/config.html 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1150#discussion_r207937186'>File: privacyidea/static/components/config/views/config.html:L61-74</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Please move this menu entry after events. I think it is more logical there:
policies, events, tasks, ....
- [x] <a href='#crh-comment-Pull 4cf4f16692c1f9b69743276b8ecd5c4725f04cf8 privacyidea/api/periodictask.py 20'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1150#discussion_r207002794'>File: privacyidea/api/periodictask.py:L65-82</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Oh, I forgot to add a test for this. Will do that.
... but maybe this should be a more central API request? Because the nodes are not only useful for periodic tasks.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I've added a test for this.
- [x] <a href='#crh-comment-Pull 4cf4f16692c1f9b69743276b8ecd5c4725f04cf8 privacyidea/api/periodictask.py 34'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1150#discussion_r207153440'>File: privacyidea/api/periodictask.py:L137-147</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> isn't `node_string` empty in the `else` case?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> You're right, this doesn't make much sense. Will change the error message!
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Changed this in cb40d19


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1150?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1150?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1150'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>