### PR TITLE
Allow pi-manage to create AES keys on an HSM

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -102,6 +102,7 @@ event_manager = Manager(usage='Manage events')
 api_manager = Manager(usage="Manage API keys")
 ca_manager = Manager(usage="Manage Certificate Authorities")
 audit_manager = Manager(usage="Manage Audit log")
+hsm_manager = Manager(usage="Manage HSM")
 manager.add_command('db', MigrateCommand)
 manager.add_command('admin', admin_manager)
 manager.add_command('backup', backup_manager)
@@ -112,6 +113,35 @@ manager.add_command('event', event_manager)
 manager.add_command('api', api_manager)
 manager.add_command('ca', ca_manager)
 manager.add_command('audit', audit_manager)
+manager.add_command('hsm', hsm_manager)
+
+
+@hsm_manager.command
+def create_keys():
+    """
+    Create new encryption keys on the HSM. Be sure to first setup the HSM module, the PKCS11
+    module and the slot/password for the given HSM in your pi.cfg.
+    Set the variables PI_HSM_MODULE, PI_HSM_MODULE_MODULE, PI_HSM_MODULE_SLOT, PI_HSM_MODULE_PASSWORD.
+    """
+
+    hsm_module_name = app.config.get("PI_HSM_MODULE",
+                                     "privacyidea.lib.security.default.DefaultSecurityModule")
+    module_parts = hsm_module_name.split(".")
+    package_name = ".".join(module_parts[:-1])
+    class_name = module_parts[-1]
+    mod = __import__(package_name, globals(), locals(), [class_name])
+    hsm_class = getattr(mod, class_name)
+    hsm_parameters = {}
+    for key in app.config.keys():
+        if key.startswith("PI_HSM_MODULE_"):
+            param = key[len("PI_HSM_MODULE_"):].lower()
+            hsm_parameters[param] = app.config.get(key)
+    hsm_object = hsm_class(hsm_parameters)
+    r = hsm_object.create_keys()
+    print("Please add the following to your pi.cfg:")
+    print("PI_HSM_MODULE_KEY_LABEL_TOKEN = '{0}'".format(r.get("token")))
+    print("PI_HSM_MODULE_KEY_LABEL_CONFIG = '{0}'".format(r.get("token")))
+    print("PI_HSM_MODULE_KEY_LABEL_VALUE = '{0}'".format(r.get("token")))
 
 
 @ca_manager.command

--- a/pi-manage
+++ b/pi-manage
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
+# 2018-08-07 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#            Allow creation of HSM keys
 # 2017-10-08 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #            Allow cleaning up different actions with different
 #            retention times.
@@ -83,6 +85,7 @@ from sqlalchemy.orm import sessionmaker
 from privacyidea.lib.auditmodules.sqlaudit import LogEntry
 from privacyidea.lib.audit import getAudit
 from privacyidea.lib.utils import parse_timedelta
+from privacyidea.lib.crypto import create_hsm_object
 from Crypto.PublicKey import RSA
 import jwt
 import ast
@@ -123,20 +126,7 @@ def create_keys():
     module and the slot/password for the given HSM in your pi.cfg.
     Set the variables PI_HSM_MODULE, PI_HSM_MODULE_MODULE, PI_HSM_MODULE_SLOT, PI_HSM_MODULE_PASSWORD.
     """
-
-    hsm_module_name = app.config.get("PI_HSM_MODULE",
-                                     "privacyidea.lib.security.default.DefaultSecurityModule")
-    module_parts = hsm_module_name.split(".")
-    package_name = ".".join(module_parts[:-1])
-    class_name = module_parts[-1]
-    mod = __import__(package_name, globals(), locals(), [class_name])
-    hsm_class = getattr(mod, class_name)
-    hsm_parameters = {}
-    for key in app.config.keys():
-        if key.startswith("PI_HSM_MODULE_"):
-            param = key[len("PI_HSM_MODULE_"):].lower()
-            hsm_parameters[param] = app.config.get(key)
-    hsm_object = hsm_class(hsm_parameters)
+    hsm_object = create_hsm_object(app.config)
     r = hsm_object.create_keys()
     print("Please add the following to your pi.cfg:")
     print("PI_HSM_MODULE_KEY_LABEL_TOKEN = '{0}'".format(r.get("token")))
@@ -545,6 +535,7 @@ class CommandOutsideRequestContext(Command):
     def __call__(self, app=None, *args, **kwargs):
         return self.run(*args, **kwargs)
 
+
 def profile(length=30, profile_dir=None):
     """
     Start the application in profiling mode.
@@ -568,14 +559,21 @@ except TypeError:
 
 
 @manager.option('--highwatermark', '--hw', help="If entries exceed this value, "
-                                        "old entries are deleted.")
+                                                "old entries are deleted.")
 @manager.option('--lowwatermark', '--lw', help="Keep this number of entries.")
 @manager.option('--age', help="Delete audit entries older than these number "
                               "of days.")
 @manager.option('--config', help="Read config from the specified yaml file.")
 @manager.option('--dryrun', help="Do not actually delete, only show "
                                  "what would be done.", action="store_true")
-@audit_manager.command
+@audit_manager.option('--highwatermark', '--hw', help="If entries exceed this value, "
+                                                "old entries are deleted.")
+@audit_manager.option('--lowwatermark', '--lw', help="Keep this number of entries.")
+@audit_manager.option('--age', help="Delete audit entries older than these number "
+                              "of days.")
+@audit_manager.option('--config', help="Read config from the specified yaml file.")
+@audit_manager.option('--dryrun', help="Do not actually delete, only show "
+                                 "what would be done.", action="store_true")
 def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
                  dryrun=False):
     """

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -295,35 +295,7 @@ def init_hsm():
     """
     config = current_app.config
     if "pi_hsm" not in config or not isinstance(config["pi_hsm"], dict):
-        hsm_module_name = config.get("PI_HSM_MODULE",
-                                     "privacyidea.lib.security.default.DefaultSecurityModule")
-        module_parts = hsm_module_name.split(".")
-        package_name = ".".join(module_parts[:-1])
-        class_name = module_parts[-1]
-        mod = __import__(package_name, globals(), locals(), [class_name])
-        hsm_class = getattr(mod, class_name)
-        log.info("initializing HSM class: {0!s}".format(hsm_class))
-        if not hasattr(hsm_class, "setup_module"):  # pragma: no cover
-            raise NameError("Security Module AttributeError: " + package_name + "." +
-                            class_name+ " instance has no attribute 'setup_module'")
-
-        hsm_parameters = {}
-        if class_name == "DefaultSecurityModule":
-            hsm_parameters = {"file": config.get("PI_ENCFILE")}
-        else:
-            # get all parameters by splitting every config entry starting with PI_HSM_MODULE_
-            # and pass this as a config object to hsm_class.
-            hsm_parameters = {}
-            for key in config.keys():
-                if key.startswith("PI_HSM_MODULE_"):
-                    param = key[len("PI_HSM_MODULE_"):].lower()
-                    hsm_parameters[param] = config.get(key)
-            logging_params = dict(hsm_parameters)
-            if "password" in logging_params:
-                logging_params["password"] = "XXXX"
-            log.info("calling HSM module with parameters {0}".format(logging_params))
-
-        HSM_config = {"obj": hsm_class(hsm_parameters)}
+        HSM_config = {"obj": create_hsm_object(config)}
         current_app.config["pi_hsm"] = HSM_config
         log.info("Initialized HSM object {0}".format(HSM_config))
     hsm = current_app.config.get("pi_hsm").get('obj')
@@ -739,3 +711,45 @@ class Sign(object):
             log.error("Failed to verify signature: {0!r}".format(s))
             log.debug("{0!s}".format(traceback.format_exc()))
         return r
+
+
+def create_hsm_object(config):
+    """
+    This creates an HSM object from the given config dictionary.
+    The config dictionary are the values that appear in pi.cfg.
+
+    It is needed PI_HSM_MODULE and all other values
+    PI_HSM_MODULE_* depending on the module implementation.
+
+    :param config: A configuration dictionary
+    :return: A HSM object
+    """
+    hsm_module_name = config.get("PI_HSM_MODULE",
+                                 "privacyidea.lib.security.default.DefaultSecurityModule")
+    module_parts = hsm_module_name.split(".")
+    package_name = ".".join(module_parts[:-1])
+    class_name = module_parts[-1]
+    mod = __import__(package_name, globals(), locals(), [class_name])
+    hsm_class = getattr(mod, class_name)
+    log.info("initializing HSM class: {0!s}".format(hsm_class))
+    if not hasattr(hsm_class, "setup_module"):  # pragma: no cover
+        raise NameError("Security Module AttributeError: " + package_name + "." +
+                        class_name + " instance has no attribute 'setup_module'")
+
+    hsm_parameters = {}
+    if class_name == "DefaultSecurityModule":
+        hsm_parameters = {"file": config.get("PI_ENCFILE")}
+    else:
+        # get all parameters by splitting every config entry starting with PI_HSM_MODULE_
+        # and pass this as a config object to hsm_class.
+        hsm_parameters = {}
+        for key in config.keys():
+            if key.startswith("PI_HSM_MODULE_"):
+                param = key[len("PI_HSM_MODULE_"):].lower()
+                hsm_parameters[param] = config.get(key)
+        logging_params = dict(hsm_parameters)
+        if "password" in logging_params:
+            logging_params["password"] = "XXXX"
+        log.info("calling HSM module with parameters {0}".format(logging_params))
+
+    return hsm_class(hsm_parameters)

--- a/privacyidea/lib/security/default.py
+++ b/privacyidea/lib/security/default.py
@@ -130,6 +130,14 @@ class SecurityModule(object):
                   "the method : %s " % (fname,))
         raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
+    def create_keys(self):
+        """
+        This can be used to create the encryption keys
+        :return: Module dependent
+        """
+        fname = "create_keys"
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
+
 
 class DefaultSecurityModule(SecurityModule):
 


### PR DESCRIPTION
Closes #1159
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23issuecomment-410736882%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23discussion_r207964455%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23discussion_r207971144%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23discussion_r207971585%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23discussion_r208116690%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23discussion_r208125633%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23discussion_r208261752%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23issuecomment-410736882%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231161%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/f518d4a9475385db2584e17765e036790d125305%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6050%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161/graphs/tree.svg%3Ftoken%3D7nHLZki60B%26height%3D150%26src%3Dpr%26width%3D650%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231161%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.77%25%20%20%2095.79%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20139%20%20%20%20%20%20139%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2016930%20%20%20%2017083%20%20%20%20%20%2B153%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016215%20%20%20%2016365%20%20%20%20%20%2B150%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20715%20%20%20%20%20%20718%20%20%20%20%20%20%20%2B3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/security/aeshsm.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2Flc2hzbS5weQ%3D%3D%29%20%7C%20%6036.58%25%20%3C100%25%3E%20%28%2B1.58%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/security/default.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2RlZmF1bHQucHk%3D%29%20%7C%20%6098.38%25%20%3C33.33%25%3E%20%28-1.07%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6094.16%25%20%3C0%25%3E%20%28-1.67%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/prepolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wcmVwb2xpY3kucHk%3D%29%20%7C%20%6097.53%25%20%3C0%25%3E%20%28%2B0.93%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bf518d4a...a639e73%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1161%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-08-06T14%3A56%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a639e73bfbba6824a07ac108efbd6e8a7d28bf86%20pi-manage%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23discussion_r207964455%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Couldn%27t%20we%20just%20import%20%60%60init_hsm%60%60%20from%20%60%60privacyidea.lib.crypto%60%60%20and%20replace%20all%20the%20code%20above%20with%20%60%60hsm_object%20%3D%20init_hsm%28%29%60%60%3F%22%2C%20%22created_at%22%3A%20%222018-08-06T17%3A08%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20already%20checked%20this.%20We%20rould%20run%20outside%20of%20an%20application%20context%2C%20since%20%60%60init_hsm%60%60%20uses%20%60%60current_app%60%60%21%5Cr%5Cn%5Cr%5CnSo%3A%20No.%22%2C%20%22created_at%22%3A%20%222018-08-06T17%3A32%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20I%20thought%20this%20could%20work%20because%20flask-script%20would%20push%20an%20application%20context%20before%20handling%20the%20command%20%3A-/%5Cr%5CnAnyway%2C%20I%27m%20not%20so%20happy%20about%20the%20code%20duplication%20with%20%60%60init_hsm%60%60%20--%20especially%20because%20this%20is%20quite%20complex%20code%20and%20it%20might%20happen%20that%20we%20change%20it%20at%20one%20place%2C%20but%20forget%20to%20change%20it%20at%20the%20other%20place.%20Also%2C%20we%20might%20add%20more%20%60%60hsm%60%60%20commands%20in%20the%20future.%5Cr%5CnMaybe%20we%20can%20split%20%60%60init_hsm%60%60%20into%20two%20functions%2C%20%60%60import_hsm%28config%29%60%60%20%28which%20works%20without%20an%20application%20context%29%20and%20%60%60init_hsm%28%29%60%60%20which%20needs%20the%20application%20context%20and%20invokes%20%60%60import_hsm%60%60%3F%22%2C%20%22created_at%22%3A%20%222018-08-07T06%3A52%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Will%20do%20so.%20Can%20you%20please%20mark%20this%20as%20required%20change%20in%20the%20review%3F%22%2C%20%22created_at%22%3A%20%222018-08-07T07%3A32%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pi-manage%3AL113-148%22%7D%2C%20%22Pull%20a639e73bfbba6824a07ac108efbd6e8a7d28bf86%20privacyidea/lib/security/aeshsm.py%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1161%23discussion_r207971585%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%2C%20since%20the%20session%20that%20is%20already%20open%20is%20not%20a%20%60%60RW%60%60%20session.%20I%20am%20not%20sure%2C%20if%20we%20can%20actually%20%60%60WRITE%60%60%20new%20keys.%20The%20existing%20session%20is%20only%20opened%20to%20sign/decrypt%20things.%5Cr%5Cn%5Cr%5CnSee%20%60%60CKF_RW_SESSION%60%60%20%28which%20is%20not%20the%20default%29%22%2C%20%22created_at%22%3A%20%222018-08-06T17%3A33%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-08-07T14%3A48%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/security/aeshsm.py%3AL315-355%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1161#issuecomment-410736882'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1161?src=pr&el=h1) Report
> Merging [#1161](https://codecov.io/gh/privacyidea/privacyidea/pull/1161?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/f518d4a9475385db2584e17765e036790d125305?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `50%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1161/graphs/tree.svg?token=7nHLZki60B&height=150&src=pr&width=650)](https://codecov.io/gh/privacyidea/privacyidea/pull/1161?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1161      +/-   ##
==========================================
+ Coverage   95.77%   95.79%   +0.02%
==========================================
Files         139      139
Lines       16930    17083     +153
==========================================
+ Hits        16215    16365     +150
- Misses        715      718       +3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1161?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/security/aeshsm.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1161/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2Flc2hzbS5weQ==) | `36.58% <100%> (+1.58%)` | :arrow_up: |
| [privacyidea/lib/security/default.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1161/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2RlZmF1bHQucHk=) | `98.38% <33.33%> (-1.07%)` | :arrow_down: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1161/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `94.16% <0%> (-1.67%)` | :arrow_down: |
| [privacyidea/api/lib/prepolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1161/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wcmVwb2xpY3kucHk=) | `97.53% <0%> (+0.93%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1161?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1161?src=pr&el=footer). Last update [f518d4a...a639e73](https://codecov.io/gh/privacyidea/privacyidea/pull/1161?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull a639e73bfbba6824a07ac108efbd6e8a7d28bf86 pi-manage 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1161#discussion_r207964455'>File: pi-manage:L113-148</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Couldn't we just import ``init_hsm`` from ``privacyidea.lib.crypto`` and replace all the code above with ``hsm_object = init_hsm()``?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I already checked this. We rould run outside of an application context, since ``init_hsm`` uses ``current_app``!
So: No.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, I thought this could work because flask-script would push an application context before handling the command :-/
Anyway, I'm not so happy about the code duplication with ``init_hsm`` -- especially because this is quite complex code and it might happen that we change it at one place, but forget to change it at the other place. Also, we might add more ``hsm`` commands in the future.
Maybe we can split ``init_hsm`` into two functions, ``import_hsm(config)`` (which works without an application context) and ``init_hsm()`` which needs the application context and invokes ``import_hsm``?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Will do so. Can you please mark this as required change in the review?
- [x] <a href='#crh-comment-Pull a639e73bfbba6824a07ac108efbd6e8a7d28bf86 privacyidea/lib/security/aeshsm.py 22'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1161#discussion_r207971585'>File: privacyidea/lib/security/aeshsm.py:L315-355</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> No, since the session that is already open is not a ``RW`` session. I am not sure, if we can actually ``WRITE`` new keys. The existing session is only opened to sign/decrypt things.
See ``CKF_RW_SESSION`` (which is not the default)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1161?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1161?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1161'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>