### PR TITLE
Fix editable installs by avoiding UTF-8 in shell scripts

### DIFF
--- a/tools/privacyidea-diag
+++ b/tools/privacyidea-diag
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# 2018-07-31 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+# 2018-07-31 Cornelius Koelbel <cornelius.koelbel@netknights.it>
 #
-# Copyright (c) 2018, Cornelius Kölbel
+# Copyright (c) 2018, Cornelius Koelbel
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I noticed editable installs break with our new privacyidea-diag script :-)
Normal installs do not seem to be affected.

Reproducible with:

```shell
$ pip install -e git+https://github.com/privacyidea/privacyidea#egg=privacyidea 
<snip>
    Installing privacyidea-diag script to /tmp/venv/bin
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/venv/src/privacyidea/setup.py", line 167, in <module>
        long_description=get_file_contents('README.rst')
      File "/tmp/venv/lib/python2.7/site-packages/setuptools/__init__.py", line 131, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib64/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/usr/lib64/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/usr/lib64/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/tmp/venv/lib/python2.7/site-packages/setuptools/command/develop.py", line 38, in run
        self.install_for_development()
      File "/tmp/venv/lib/python2.7/site-packages/setuptools/command/develop.py", line 154, in install_for_development
        self.process_distribution(None, self.dist, not self.no_deps)
      File "/tmp/venv/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 729, in process_distribution
        self.install_egg_scripts(dist)
      File "/tmp/venv/lib/python2.7/site-packages/setuptools/command/develop.py", line 190, in install_egg_scripts
        self.install_script(dist, script_name, script_text, script_path)
      File "/tmp/venv/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 808, in install_script
        self.write_script(script_name, _to_ascii(script_text), 'b')
      File "/tmp/venv/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 842, in write_script
        f.write(contents)
    UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 38: ordinal not in range(128)
```

... this is because of the "ö"s in the copyright notice of ``privacyidea-diag``.

Just to be clear -- this appears to be a bug in pip/easy_install, but maybe we could just replace ö with oe as a workaround :-)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1166%23discussion_r208486033%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1166%23discussion_r208487362%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1166%23discussion_r208490930%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20f755275fc7a89f5f5330d610047a0041f6d3f2a1%20tools/privacyidea-diag%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1166%23discussion_r208486033%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Isn%27t%20there%20a%20way%20to%20use%20utf8%20anyways%20-%20like%20adding%20a%20header%20like%20in%20a%20python%20script%3F%5Cr%5CnI%20like%20my%20name%21%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-08-08T07%3A48%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Doesn%27t%20seem%20so%20%3A-%28%20But%20I%20just%20found%20https%3A//github.com/pypa/setuptools/pull/1389%20which%20is%20super-fresh%20and%20seems%20to%20fix%20this%21%20So%20maybe%20we%20can%20also%20just%20wait%20for%20the%20next%20pip%20version%20...%22%2C%20%22created_at%22%3A%20%222018-08-08T07%3A53%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Waiting%20is%20lame%20%3A-/%22%2C%20%22created_at%22%3A%20%222018-08-08T08%3A06%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/privacyidea-diag%3AL1-9%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f755275fc7a89f5f5330d610047a0041f6d3f2a1 tools/privacyidea-diag 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1166#discussion_r208486033'>File: tools/privacyidea-diag:L1-9</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Isn't there a way to use utf8 anyways - like adding a header like in a python script?
I like my name! ;-)
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Doesn't seem so :-( But I just found https://github.com/pypa/setuptools/pull/1389 which is super-fresh and seems to fix this! So maybe we can also just wait for the next pip version ...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Waiting is lame :-/


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1166?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1166?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1166'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>