### PR TITLE
Make audit log more verbose

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -248,13 +248,9 @@ def after_request(response):
 def auth_error(error):
     if "audit_object" in g:
         message = ''
-        description = ''
 
         if hasattr(error, 'message'):
             message = error.message
-
-        if hasattr(error, 'description'):
-            message = u'{}|{}'.format(message, error.description)
 
         if hasattr(error, 'details'):
             if error.details:

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -250,13 +250,16 @@ def auth_error(error):
         message = ''
         description = ''
         
+        if hasattr(error, 'message'):
+            message = error.message
+            
         if hasattr(error, 'description'):
-            description = error.description
+            message = "{}|{}".format(message, error.description)
 
         if hasattr(error, 'details'):
             if error.details:
                 if 'message' in error.details:
-                    message = "{}|{}".format(description, error.details['message'])
+                    message = "{}|{}".format(message, error.details['message'])
 
         g.audit_object.log({"info": message})
         g.audit_object.finalize_log()

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -249,17 +249,17 @@ def auth_error(error):
     if "audit_object" in g:
         message = ''
         description = ''
-        
+
         if hasattr(error, 'message'):
             message = error.message
-            
+
         if hasattr(error, 'description'):
-            message = "{}|{}".format(message, error.description)
+            message = u'{}|{}'.format(message, error.description)
 
         if hasattr(error, 'details'):
             if error.details:
                 if 'message' in error.details:
-                    message = "{}|{}".format(message, error.details['message'])
+                    message = u'{}|{}'.format(message, error.details['message'])
 
         g.audit_object.log({"info": message})
         g.audit_object.finalize_log()

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -247,7 +247,13 @@ def after_request(response):
 @postrequest(sign_response, request=request)
 def auth_error(error):
     if "audit_object" in g:
-        g.audit_object.log({"info": error.message})
+        message = error.description
+
+        if hasattr(error, 'details'):
+            if 'message' in error.details:
+                message = "{}|{}".format(error.description, error.details['message'])
+
+        g.audit_object.log({"info": message})
         g.audit_object.finalize_log()
     return send_error(error.message,
                       error_code=error.id,

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -247,12 +247,16 @@ def after_request(response):
 @postrequest(sign_response, request=request)
 def auth_error(error):
     if "audit_object" in g:
-        message = error.description
+        message = ''
+        description = ''
+        
+        if hasattr(error, 'description'):
+            description = error.description
 
         if hasattr(error, 'details'):
             if error.details:
                 if 'message' in error.details:
-                    message = "{}|{}".format(error.description, error.details['message'])
+                    message = "{}|{}".format(description, error.details['message'])
 
         g.audit_object.log({"info": message})
         g.audit_object.finalize_log()

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -250,8 +250,9 @@ def auth_error(error):
         message = error.description
 
         if hasattr(error, 'details'):
-            if 'message' in error.details:
-                message = "{}|{}".format(error.description, error.details['message'])
+            if error.details:
+                if 'message' in error.details:
+                    message = "{}|{}".format(error.description, error.details['message'])
 
         g.audit_object.log({"info": message})
         g.audit_object.finalize_log()


### PR DESCRIPTION
https://github.com/privacyidea/privacyidea/issues/1192
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r212838105%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23issuecomment-417382455%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23issuecomment-436277214%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23issuecomment-437106711%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r232975713%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r233122185%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r233123561%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r251738241%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r251742134%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23issuecomment-417382455%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231197%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/6cf051564ab965c2c476c58f9de14c85ae92379f%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6055.55%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231197%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2095.77%25%20%20%2095.74%25%20%20%20-0.03%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20141%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017119%20%20%20%2017128%20%20%20%20%20%20%20%2B9%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016395%20%20%20%2016400%20%20%20%20%20%20%20%2B5%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20724%20%20%20%20%20%20728%20%20%20%20%20%20%20%2B4%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/before%5C%5C_after.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ%3D%3D%29%20%7C%20%6095.75%25%20%3C55.55%25%3E%20%28-1.8%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6093.97%25%20%3C0%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B6cf0515...50f8145%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1197%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-08-30T16%3A30%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20should%20do%20something%20about%20the%20test%20coverage%21%5Cr%5Cn%40fredreichbier%20%40plettich%20any%20idea%3F%20Create%20some%20error%20tests.%22%2C%20%22created_at%22%3A%20%222018-11-06T14%3A45%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20We%20should%20do%20something%20about%20the%20test%20coverage%21%5Cr%5Cn%3E%20%40fredreichbier%20%40plettich%20any%20idea%3F%20Create%20some%20error%20tests.%5Cr%5Cn%5Cr%5CnI%20think%20it%20wouldn%27t%20hurt%20to%20test%20the%20errors.%5Cr%5CnBut%20in%20this%20case%20we%20need%20to%20trigger%20the%20errors%20in%20the%20request%20if%20understand%20this%20correctly.%22%2C%20%22created_at%22%3A%20%222018-11-08T18%3A30%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f1cf1d539aebb6aa2ad18ff4ce6079a1070f4f94%20privacyidea/api/before_after.py%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r212838105%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20a%20nice%20idea.%5Cr%5CnBut%20please%20note%2C%20that%20e.g.%20%60%60AuthError%60%60%20has%20not%20%60%60description%60%60.%5Cr%5CnSee%20the%20failing%20tests%20at%20travis-ci.%20you%20can%20also%20run%20the%20tests%20in%20your%20virtualenv%5Cr%5Cn%5Cr%5Cn%20%20%20%20py.test%20tests/%5Cr%5Cn%5Cr%5CnSo%20your%20code%20should%20check%2C%20if%20actually%20%60%60error%60%60%20has%20the%20attribute%20%60%60description%60%60.%22%2C%20%22created_at%22%3A%20%222018-08-26T20%3A33%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/before_after.py%3AL266-279%22%7D%2C%20%22Pull%208d801a9ddbdc81cd26d1253e816e62f33431377b%20privacyidea/api/before_after.py%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r233123561%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20change%20this%20to%20u%60%60%5C%22%7B%7D%7C%7B%7D%5C%22%60%60%3F%20I%20think%20%60%60error.details%60%60%20is%20a%20unicode%20string%20and%20could%20contain%20non-ASCII%20characters%2C%20which%20would%20break%20without%20the%20%60%60u%60%60%20prefix%20to%20the%20format%20string%20literal.%22%2C%20%22created_at%22%3A%20%222018-11-13T16%3A36%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197/files%23diff-522d037024042d4c2a1037c637df32d9R262%22%2C%20%22created_at%22%3A%20%222019-01-29T09%3A02%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5985348%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/p53%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/before_after.py%3AL266-287%22%7D%2C%20%22Pull%208d801a9ddbdc81cd26d1253e816e62f33431377b%20privacyidea/api/before_after.py%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1197%23discussion_r232975713%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20if%20I%20understand%20correctly%20%60%60auth_error%60%60%20is%20only%20called%20for%20errors%20that%20are%20instances%20of%20%60%60AuthError%60%60.%20But%20it%20seems%20that%20%60%60AuthError%60%60%20have%20no%20%60%60description%60%60%20or%20%60%60details%60%60%20attributes%2C%20only%20%60%60message%60%60.%20Wouldn%27t%20this%20mean%20that%20the%20first%20%60%60if%60%60%20branch%20would%20be%20enough%3F%22%2C%20%22created_at%22%3A%20%222018-11-13T10%3A20%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%20%40p53%2C%20I%20was%20mistaken%2C%20%60%60AuthError%60%60%20does%20have%20a%20%60%60details%60%60%20attribute.%20%3A-%29%20But%20%28unless%20I%27m%20mistaken%20again%29%20it%20does%20not%20have%20a%20%60%60description%60%60%20attribute%3F%22%2C%20%22created_at%22%3A%20%222018-11-13T16%3A33%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22according%20to%20this%20code%20it%20has%20description%20attribute%20https%3A//github.com/privacyidea/privacyidea/blob/3cf3d05b8245e79bf7e3f330d955cffed345911b/privacyidea/lib/error.py%23L111%22%2C%20%22created_at%22%3A%20%222019-01-29T08%3A50%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5985348%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/p53%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/before_after.py%3AL266-287%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull f1cf1d539aebb6aa2ad18ff4ce6079a1070f4f94 privacyidea/api/before_after.py 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1197#discussion_r212838105'>File: privacyidea/api/before_after.py:L266-279</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This is a nice idea.
But please note, that e.g. ``AuthError`` has not ``description``.
See the failing tests at travis-ci. you can also run the tests in your virtualenv
py.test tests/
So your code should check, if actually ``error`` has the attribute ``description``.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1197#issuecomment-417382455'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1197?src=pr&el=h1) Report
> Merging [#1197](https://codecov.io/gh/privacyidea/privacyidea/pull/1197?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/6cf051564ab965c2c476c58f9de14c85ae92379f?src=pr&el=desc) will **decrease** coverage by `0.02%`.
> The diff coverage is `55.55%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1197/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1197?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1197      +/-   ##
==========================================
- Coverage   95.77%   95.74%   -0.03%
==========================================
Files         141      141
Lines       17119    17128       +9
==========================================
+ Hits        16395    16400       +5
- Misses        724      728       +4
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1197?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/before\_after.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1197/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2JlZm9yZV9hZnRlci5weQ==) | `95.75% <55.55%> (-1.8%)` | :arrow_down: |
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1197/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `93.97% <0%> (+0.01%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1197?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1197?src=pr&el=footer). Last update [6cf0515...50f8145](https://codecov.io/gh/privacyidea/privacyidea/pull/1197?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We should do something about the test coverage!
@fredreichbier @plettich any idea? Create some error tests.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> > We should do something about the test coverage!
> @fredreichbier @plettich any idea? Create some error tests.
I think it wouldn't hurt to test the errors.
But in this case we need to trigger the errors in the request if understand this correctly.
- [ ] <a href='#crh-comment-Pull 8d801a9ddbdc81cd26d1253e816e62f33431377b privacyidea/api/before_after.py 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1197#discussion_r232975713'>File: privacyidea/api/before_after.py:L266-287</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, if I understand correctly ``auth_error`` is only called for errors that are instances of ``AuthError``. But it seems that ``AuthError`` have no ``description`` or ``details`` attributes, only ``message``. Wouldn't this mean that the first ``if`` branch would be enough?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Sorry @p53, I was mistaken, ``AuthError`` does have a ``details`` attribute. :-) But (unless I'm mistaken again) it does not have a ``description`` attribute?
- <a href='https://github.com/p53'><img border=0 src='https://avatars1.githubusercontent.com/u/5985348?v=4' height=16 width=16></a> according to this code it has description attribute https://github.com/privacyidea/privacyidea/blob/3cf3d05b8245e79bf7e3f330d955cffed345911b/privacyidea/lib/error.py#L111
- [ ] <a href='#crh-comment-Pull 8d801a9ddbdc81cd26d1253e816e62f33431377b privacyidea/api/before_after.py 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1197#discussion_r233123561'>File: privacyidea/api/before_after.py:L266-287</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Could you change this to u``"{}|{}"``? I think ``error.details`` is a unicode string and could contain non-ASCII characters, which would break without the ``u`` prefix to the format string literal.
- <a href='https://github.com/p53'><img border=0 src='https://avatars1.githubusercontent.com/u/5985348?v=4' height=16 width=16></a> https://github.com/privacyidea/privacyidea/pull/1197/files#diff-522d037024042d4c2a1037c637df32d9R262


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1197?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1197?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1197'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>