### PR TITLE
Suppress warnings in privacyidea-cron

### DIFF
--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -26,6 +26,7 @@ It runs periodic tasks that are specified in the database.
 __version__ = "0.1"
 
 import sys
+import warnings
 import json
 from datetime import datetime
 
@@ -37,6 +38,8 @@ from privacyidea.lib.config import get_privacyidea_node
 from privacyidea.lib.periodictask import get_scheduled_periodic_tasks, set_periodic_task_last_run, \
     get_periodic_task_by_name, \
     execute_task, get_periodic_tasks
+
+warnings.simplefilter("ignore")
 
 app = create_app(config_name='production', silent=True)
 manager = Manager(app)


### PR DESCRIPTION
On Ubuntu 16.04, we have the following problem with the 2.23 dev packages: With the default configuration, a run of ``privacyidea-cron`` without any periodic tasks defined generates the following two warnings:
```
# privacyidea-cron run_scheduled -c
/usr/lib/python2.7/dist-packages/flask_sqlalchemy/__init__.py:800: UserWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True to suppress this warning.
  warnings.warn('SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True to suppress this warning.')
/usr/lib/python2.7/dist-packages/pymysql/cursors.py:158: Warning: '@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
  result = self._query(query)
```

These are written to stderr, and so cron tries to mail the output to the administrator. This happens every 5 minutes:

```
# cat /var/log/syslog | grep -a CRON
...
Aug 27 16:40:01 privacyidea CRON[1574]: (privacyidea) CMD (privacyidea-cron run_scheduled -c)
Aug 27 16:40:01 privacyidea CRON[1573]: (CRON) info (No MTA installed, discarding output)
Aug 27 16:45:01 privacyidea CRON[1711]: (privacyidea) CMD (privacyidea-cron run_scheduled -c)
Aug 27 16:45:02 privacyidea CRON[1710]: (CRON) info (No MTA installed, discarding output)
Aug 27 16:50:01 privacyidea CRON[1871]: (privacyidea) CMD (privacyidea-cron run_scheduled -c)
Aug 27 16:50:02 privacyidea CRON[1870]: (CRON) info (No MTA installed, discarding output)
```

(note that the CMD line is written to the syslog in any case -- the interesting line is the MTA line)

This PR generally suppresses all warnings in ``privacyidea-cron``, which admittedly isn't nice, but I think it is OK here, as privacyidea-cron is meant to be invoked periodically, and it doesn't make sense to print the same warning every five minutes.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1202%23issuecomment-416262677%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1202%23issuecomment-416262677%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1202%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231202%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1202%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/6cf051564ab965c2c476c58f9de14c85ae92379f%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1202/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1202%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231202%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.77%25%20%20%2095.77%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20141%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017119%20%20%20%2017119%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2016395%20%20%20%2016395%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20724%20%20%20%20%20%20724%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1202%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1202%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B6cf0515...9314114%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1202%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-08-27T15%3A19%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1202#issuecomment-416262677'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1202?src=pr&el=h1) Report
> Merging [#1202](https://codecov.io/gh/privacyidea/privacyidea/pull/1202?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/6cf051564ab965c2c476c58f9de14c85ae92379f?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1202/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1202?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master    #1202   +/-   ##
=======================================
Coverage   95.77%   95.77%
=======================================
Files         141      141
Lines       17119    17119
=======================================
Hits        16395    16395
Misses        724      724
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1202?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1202?src=pr&el=footer). Last update [6cf0515...9314114](https://codecov.io/gh/privacyidea/privacyidea/pull/1202?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1202?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1202?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1202'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>