### PR TITLE
Fix loading of event handler detail view

### DIFF
--- a/privacyidea/static/components/config/controllers/eventController.js
+++ b/privacyidea/static/components/config/controllers/eventController.js
@@ -154,6 +154,9 @@ myApp.controller("eventDetailController", function($scope, $stateParams,
             //debug: console.log("getting handlermodules");
             $scope.handlermodules = data.result.value;
             //debug: console.log($scope.handlermodules );
+            if ($scope.eventid) {
+               $scope.getEvent();
+            }
         });
     };
 
@@ -255,8 +258,5 @@ myApp.controller("eventDetailController", function($scope, $stateParams,
 
     $scope.getAvailableEvents();
     $scope.getHandlerModules();
-    if ($scope.eventid) {
-        $scope.getEvent();
-    }
 
 });

--- a/privacyidea/static/components/config/views/config.events.details.html
+++ b/privacyidea/static/components/config/views/config.events.details.html
@@ -62,7 +62,7 @@
             <select class="form-control"
                     id="handlermodule"
                     ng-model="form.handlermodule" required
-                    ng-options="module for module in handlermodules"
+                    ng-options="handlermodule as handlermodule for handlermodule in handlermodules"
                     ng-change="handlerModuleChanged()"
                     >
             </select>


### PR DESCRIPTION
Fix #1210
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1211%23issuecomment-418260233%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1211%23issuecomment-418260903%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1211%23issuecomment-418260233%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1211%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231211%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1211%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.23%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/0b1fbd949398e7bc58e64460439c74224f6014f9%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1211/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1211%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.23%20%20%20%20%231211%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%20%20%20%20%20%2095.81%25%20%20%2095.81%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20141%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2017120%20%20%20%2017120%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2016403%20%20%20%2016403%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20717%20%20%20%20%20%20717%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1211%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1211%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B0b1fbd9...71e360a%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1211%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-09-04T06%3A52%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20move%20the%20loading%20of%20the%20event%20from%20behind%20the%20%60%60getHandlerModules%60%60-call%20%2Ainto%2A%20the%20%60%60getHandlermodules%60%60-call%2C%20because%20the%20%60%60getHandlerModules%60%60%20can%20return%20before%20the%20API%20response%20is%20received%20and%20then%20there%20is%20no%20%60%60form.handlermodules%60%60%20list.%20The%20%60%60select%60%60%20does%20not%20like%20this.%22%2C%20%22created_at%22%3A%20%222018-09-04T06%3A56%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1211#issuecomment-418260233'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1211?src=pr&el=h1) Report
> Merging [#1211](https://codecov.io/gh/privacyidea/privacyidea/pull/1211?src=pr&el=desc) into [branch-2.23](https://codecov.io/gh/privacyidea/privacyidea/commit/0b1fbd949398e7bc58e64460439c74224f6014f9?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1211/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1211?src=pr&el=tree)
```diff
@@             Coverage Diff              @@
##           branch-2.23    #1211   +/-   ##
============================================
Coverage        95.81%   95.81%
============================================
Files              141      141
Lines            17120    17120
============================================
Hits             16403    16403
Misses             717      717
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1211?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1211?src=pr&el=footer). Last update [0b1fbd9...71e360a](https://codecov.io/gh/privacyidea/privacyidea/pull/1211?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We move the loading of the event from behind the ``getHandlerModules``-call *into* the ``getHandlermodules``-call, because the ``getHandlerModules`` can return before the API response is received and then there is no ``form.handlermodules`` list. The ``select`` does not like this.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1211?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1211?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1211'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>