### PR TITLE
Somewhat better vasco library error handling and log output

### DIFF
--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -157,9 +157,13 @@ class VascoTokenClass(TokenClass):
                 # wrong OTP value, no log message
                 pass
             elif result == 201:
-                log.warning("A previous OTP value was used again!")
+                log.warning("VASCO token failed to authenticate, code replay attempt, previous OTP value was used again!")
             elif result == 202:
                 log.warning("Token-internal fail counter reached its maximum!")
+            elif result == -202:
+                log.warning("VASCO token failed to authenticate, response too small, user did not type his complete OTP!")
+            elif result == -205:
+                log.warning("VASCO token failed to authenticate, response not decimal!")
             else:
                 log.warning("VASCO token failed to authenticate, result: {!r}".format(result))
             return -1


### PR DESCRIPTION
According to https://www.vasco.com/large_download/kbpdf/kb_100034.pdf
the vasco library has errorlevels -202 on otp response to small and -205 on otp response not decimal.

Added those errorcodes to have more information in the logging.
I've tested this while i was playing around with that bug today.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1231%23discussion_r216018360%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1231%23issuecomment-419501172%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1231%23discussion_r216029074%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1231%23discussion_r216038481%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1231%23issuecomment-419501172%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231231%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/a3edc09beffa2104f357fe24971ea3211ce40751%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6060%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231231%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.84%25%20%20%2095.85%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20141%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017129%20%20%20%2017133%20%20%20%20%20%20%20%2B4%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016418%20%20%20%2016422%20%20%20%20%20%20%20%2B4%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20711%20%20%20%20%20%20711%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/vascotoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjb3Rva2VuLnB5%29%20%7C%20%6093.54%25%20%3C60%25%3E%20%28-3.01%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Ba3edc09...fb204b6%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1231%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-09-07T16%3A53%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20fb204b66c92ea062bd45374b2137dd49c9256714%20privacyidea/lib/tokens/vascotoken.py%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1231%23discussion_r216018360%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20it%20really%20%60%60-202%60%60%3F%20It%20was%20%60%60202%60%60%20before%21%5Cr%5CnThe%20%60%60result%60%60%20is%20returned%20from%20our%20%60%60vasco_otp_check%60%60.%20Is%20the%20minus%20maybe%20dropped%3F%22%2C%20%22created_at%22%3A%20%222018-09-07T16%3A37%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20according%20to%20the%20vasco%20documentation%2C%20and%20to%20the%20current%20privacyidea.log%20output%20we%20are%20having%20entries%20like%20this%3A%5Cr%5Cn%5Cr%5Cn%5BWARNING%5D%5Bprivacyidea.lib.tokens.vascotoken%3A164%5D%20VASCO%20token%20failed%20to%20authenticate%2C%20result%3A%20-205%5Cr%5Cn%5BWARNING%5D%5Bprivacyidea.lib.tokens.vascotoken%3A164%5D%20VASCO%20token%20failed%20to%20authenticate%2C%20result%3A%20-202%5Cr%5Cn%5Cr%5CnI%27m%20actually%20not%20sure%20what%20the%20positive%20202%20error%20is.%20Can%27t%20find%20this%20in%20the%20documentation.%5Cr%5CnAnd%20also%20can%27t%20find%20any%20log%20output%20with%3A%20%5C%22Token-internal%20fail%20counter%20reached%20its%20maximum%5C%22%20in%20our%20logs.%22%2C%20%22created_at%22%3A%20%222018-09-07T17%3A17%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1587083%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/renini%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20ok%2C%20you%20are%20not%20touching%20it%20anyway.%5Cr%5CnIt%20helps%20to%20be%20able%20to%20read%20the%20diff%20view%21%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-09-07T17%3A51%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/tokens/vascotoken.py%3AL157-170%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull fb204b66c92ea062bd45374b2137dd49c9256714 privacyidea/lib/tokens/vascotoken.py 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1231#discussion_r216018360'>File: privacyidea/lib/tokens/vascotoken.py:L157-170</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Is it really ``-202``? It was ``202`` before!
The ``result`` is returned from our ``vasco_otp_check``. Is the minus maybe dropped?
- <a href='https://github.com/renini'><img border=0 src='https://avatars3.githubusercontent.com/u/1587083?v=4' height=16 width=16></a> Yes according to the vasco documentation, and to the current privacyidea.log output we are having entries like this:
[WARNING][privacyidea.lib.tokens.vascotoken:164] VASCO token failed to authenticate, result: -205
[WARNING][privacyidea.lib.tokens.vascotoken:164] VASCO token failed to authenticate, result: -202
I'm actually not sure what the positive 202 error is. Can't find this in the documentation.
And also can't find any log output with: "Token-internal fail counter reached its maximum" in our logs.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Ah, ok, you are not touching it anyway.
It helps to be able to read the diff view! :-)
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1231#issuecomment-419501172'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1231?src=pr&el=h1) Report
> Merging [#1231](https://codecov.io/gh/privacyidea/privacyidea/pull/1231?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/a3edc09beffa2104f357fe24971ea3211ce40751?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `60%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1231/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1231?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1231      +/-   ##
==========================================
+ Coverage   95.84%   95.85%   +<.01%
==========================================
Files         141      141
Lines       17129    17133       +4
==========================================
+ Hits        16418    16422       +4
Misses        711      711
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1231?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/vascotoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1231/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjb3Rva2VuLnB5) | `93.54% <60%> (-3.01%)` | :arrow_down: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1231/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1231?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1231?src=pr&el=footer). Last update [a3edc09...fb204b6](https://codecov.io/gh/privacyidea/privacyidea/pull/1231?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1231?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1231?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1231'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>