### PR TITLE
Only show limited assign-err message for user

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -422,7 +422,12 @@ def assign_api():
     serial = getParam(request.all_data, "serial", required, allow_empty=False)
     pin = getParam(request.all_data, "pin")
     encrypt_pin = getParam(request.all_data, "encryptpin")
-    res = assign_token(serial, user, pin=pin, encrypt_pin=encrypt_pin)
+    if g.logged_in_user.get("role") == "user":
+        err_message = "Token already assigned to another user."
+    else:
+        err_message = None
+    res = assign_token(serial, user, pin=pin, encrypt_pin=encrypt_pin,
+                       err_message=err_message)
     g.audit_object.log({"success": True})
     return send_result(res)
 

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1102,7 +1102,7 @@ def set_defaults(serial):
 
 
 @log_with(log)
-def assign_token(serial, user, pin=None, encrypt_pin=False):
+def assign_token(serial, user, pin=None, encrypt_pin=False, err_message=None):
     """
     Assign token to a user.
     If the PIN is given, the PIN is reset.
@@ -1115,6 +1115,8 @@ def assign_token(serial, user, pin=None, encrypt_pin=False):
     :type pin: basestring
     :param encrypt_pin: Whether the PIN should be stored in an encrypted way
     :type encrypt_pin: bool
+    :param err_message: The error message, that is displayed in case the token is already assigned
+    :type err_message: basestring
 
     :return: True if the token was assigned, in case of an error an exception
     is thrown
@@ -1132,8 +1134,8 @@ def assign_token(serial, user, pin=None, encrypt_pin=False):
     old_user = tokenobject.user
     if old_user:
         log.warning("token already assigned to user: {0!r}".format(old_user))
-        raise TokenAdminError("Token already assigned to user {0!r}".format(
-                              old_user), id=1103)
+        err_message = err_message or "Token already assigned to user {0!r}".format(old_user)
+        raise TokenAdminError(err_message, id=1103)
 
     tokenobject.set_user(user)
     if pin is not None:


### PR DESCRIPTION
If user assigns a token and the token already
belongs to another user, only a limited error
message is displayed. It does not tell to whom
this token is already assigned.

Closes #1232