### PR TITLE
get_tokens matches serial numbers exactly by default

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -1023,11 +1023,11 @@ def get_serial_by_otp_api(otp=None):
     if assigned_param:
         assigned = True
 
-    count = get_tokens(tokentype=ttype, serial="*{0!s}*".format(
+    count = get_tokens(tokentype=ttype, serial_wildcard="*{0!s}*".format(
             serial_substr), assigned=assigned, count=True)
     if not count_only:
         tokenobj_list = get_tokens(tokentype=ttype,
-                                   serial="*{0!s}*".format(serial_substr),
+                                   serial_wildcard="*{0!s}*".format(serial_substr),
                                    assigned=assigned)
         serial = get_serial_by_otp(tokenobj_list, otp=otp, window=window)
 

--- a/privacyidea/lib/decorators.py
+++ b/privacyidea/lib/decorators.py
@@ -107,8 +107,8 @@ def check_copy_serials(func):
     from privacyidea.lib.token import get_tokens
     @functools.wraps(func)
     def check_serial_wrapper(*args, **kwds):
-        tokenobject_list_from = get_tokens(serial=args[0])
-        tokenobject_list_to = get_tokens(serial=args[1])
+        tokenobject_list_from = get_tokens(serial_wildcard=args[0])
+        tokenobject_list_to = get_tokens(serial_wildcard=args[1])
         if len(tokenobject_list_from) != 1:
             log.error("not a unique token to copy from found")
             raise(TokenAdminError("No unique token to copy from found",

--- a/privacyidea/lib/decorators.py
+++ b/privacyidea/lib/decorators.py
@@ -102,13 +102,13 @@ class check_user_or_serial_in_request(object):
 def check_copy_serials(func):
     """
     Decorator to check if the serial_from and serial_to exist.
-    If the serials are not unique, we raise an error
+    If the serials are not unique or do not exist, we raise an error
     """
     from privacyidea.lib.token import get_tokens
     @functools.wraps(func)
     def check_serial_wrapper(*args, **kwds):
-        tokenobject_list_from = get_tokens(serial_wildcard=args[0])
-        tokenobject_list_to = get_tokens(serial_wildcard=args[1])
+        tokenobject_list_from = get_tokens(serial=args[0])
+        tokenobject_list_to = get_tokens(serial=args[1])
         if len(tokenobject_list_from) != 1:
             log.error("not a unique token to copy from found")
             raise(TokenAdminError("No unique token to copy from found",

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -331,6 +331,13 @@ def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
                                     revoked=revoked, locked=locked,
                                     tokeninfo=tokeninfo, maxfail=maxfail)
 
+    # Warning for unintentional exact serial matches
+    if serial is not None and "*" in serial:
+        log.info(u"Exact match on a serial containing a wildcard: {!r}".format(serial))
+    # Warning for unintentional wildcard serial matches
+    if serial_wildcard is not None and "*" not in serial_wildcard:
+        log.info(u"Wildcard match on serial without a wildcard: {!r}".format(serial_wildcard))
+
     # Decide, what we are supposed to return
     if count is True:
         ret = sql_query.count()

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -135,7 +135,7 @@ def create_tokenclass_object(db_token):
 
 
 def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
-                        serial=None, active=None, resolver=None,
+                        serial_exact=None, serial_wildcard=None, active=None, resolver=None,
                         rollout_state=None, description=None, revoked=None,
                         locked=None, userid=None, tokeninfo=None, maxfail=None):
     """
@@ -205,15 +205,15 @@ def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
         else:
             sql_query = sql_query.filter(Token.user_id == userid)
 
-    if serial is not None and serial.strip("*"):
+    if serial_wildcard is not None and serial_wildcard.strip("*"):
         # filter for serial
-        if "*" in serial:
-            # match with "like"
-            sql_query = sql_query.filter(Token.serial.like(serial.replace(
-                "*", "%")))
-        else:
-            # exact match
-            sql_query = sql_query.filter(Token.serial == serial)
+        # match with "like"
+        sql_query = sql_query.filter(Token.serial.like(serial_wildcard.replace(
+            "*", "%")))
+
+    if serial_exact is not None:
+        # exact match for serial
+        sql_query = sql_query.filter(Token.serial == serial_exact)
 
     if user is not None and not user.is_empty():
         # filter for the rest of the user.
@@ -270,7 +270,7 @@ def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
 @log_with(log)
 #@cache.memoize(10)
 def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
-               serial=None, active=None, resolver=None, rollout_state=None,
+               serial=None, serial_wildcard=None, active=None, resolver=None, rollout_state=None,
                count=False, revoked=None, locked=None, tokeninfo=None,
                maxfail=None):
     """
@@ -293,8 +293,10 @@ def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
     :type assigned: bool
     :param user: Filter for the Owner of the token
     :type user: User Object
-    :param serial: The serial number of the token
+    :param serial: The exact serial number of a token
     :type serial: basestring
+    :param serial_wildcard: A wildcard to match token serials
+    :type serial_wildcard: basestring
     :param active: Whether only active (True) or inactive (False) tokens
         should be returned
     :type active: bool
@@ -323,8 +325,8 @@ def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
     token_list = []
     sql_query = _create_token_query(tokentype=tokentype, realm=realm,
                                     assigned=assigned, user=user,
-                                    serial=serial, active=active,
-                                    resolver=resolver,
+                                    serial_exact=serial, serial_wildcard=serial_wildcard,
+                                    active=active, resolver=resolver,
                                     rollout_state=rollout_state,
                                     revoked=revoked, locked=locked,
                                     tokeninfo=tokeninfo, maxfail=maxfail)
@@ -365,7 +367,7 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
     :type assigned: bool
     :param user: The user, whose token should be displayed
     :type user: User object
-    :param serial:
+    :param serial: a pattern for matching the serial
     :param active:
     :param resolver: A resolver name, which may contain "*" for filtering.
     :type resolver: basestring
@@ -387,7 +389,7 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
     """
     sql_query = _create_token_query(tokentype=tokentype, realm=realm,
                                 assigned=assigned, user=user,
-                                serial=serial, active=active,
+                                serial_wildcard=serial, active=active,
                                 resolver=resolver,
                                 rollout_state=rollout_state,
                                 description=description, userid=userid)
@@ -545,7 +547,7 @@ def get_realms_of_token(serial, only_first_realm=False):
 @log_with(log)
 def token_exist(serial):
     """
-    returns true if the token with the given serial number exists
+    returns true if the token with the exact given serial number exists
 
     :param serial: the serial number of the token
     """
@@ -1015,7 +1017,7 @@ def remove_token(serial=None, user=None):
 
     :param user: The user, who's tokens should be deleted.
     :type user: User object
-    :param serial: The serial number of the token to delete
+    :param serial: The serial number of the token to delete (exact)
     :type serial: basestring
     :return: The number of deleted token
     :rtype: int
@@ -1054,7 +1056,7 @@ def set_realms(serial, realms=None, add=False):
 
     Thus, setting realms=[] clears all realms assignments.
 
-    :param serial: the serial number of the token
+    :param serial: the serial number of the token (exact)
     :type serial: basestring
     :param realms: A list of realm names
     :type realms: list
@@ -1084,7 +1086,7 @@ def set_realms(serial, realms=None, add=False):
 @log_with(log)
 def set_defaults(serial):
     """
-    Set the default values for the token with the given serial number
+    Set the default values for the token with the given serial number (exact)
     :param serial: token serial
     :type serial: basestring
     :return: None
@@ -1159,7 +1161,7 @@ def unassign_token(serial, user=None):
     """
     unassign the user from the token
 
-    :param serial: The serial number of the token to unassign
+    :param serial: The serial number of the token to unassign (exact)
     :return: True
     """
     tokenobject_list = get_tokens(serial=serial, user=user)
@@ -1216,7 +1218,7 @@ def resync_token(serial, otp1, otp2, options=None, user=None):
 def reset_token(serial, user=None):
     """
     Reset the failcounter
-    :param serial:
+    :param serial: serial number (exact)
     :param user:
     :return: The number of tokens, that were resetted
     :rtype: int
@@ -1243,7 +1245,7 @@ def set_pin(serial, pin, user=None, encrypt_pin=False):
     user will be set
     :type used: User object
     :param serial: If the serial is specified, the PIN for this very token
-    will be set.
+    will be set. (exact)
     :return: The number of PINs set (usually 1)
     :rtype: int
     """
@@ -1269,7 +1271,7 @@ def set_pin_user(serial, user_pin, user=None):
     This sets the user pin of a token. This just stores the information of
     the user pin for (e.g. an eTokenNG, Smartcard) in the database
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param user_pin: The user PIN
     :type user_pin: basestring
@@ -1292,7 +1294,7 @@ def set_pin_so(serial, so_pin, user=None):
     PIN of a smartcard. The SO PIN is stored in the database, so that it
     could be used for automatic processes for User PIN resetting.
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param so_pin: The Security Officer PIN
     :type so_ping: basestring
@@ -1314,7 +1316,7 @@ def revoke_token(serial, user=None):
     """
     Revoke a token.
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param enable: False is the token should be disabled
     :type enable: bool
@@ -1387,7 +1389,7 @@ def set_otplen(serial, otplen=6, user=None):
     the user.
     The OTP length is usually 6 or 8.
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param otplen: The length of the OTP value
     :type otplen: int
@@ -1412,7 +1414,7 @@ def set_hashlib(serial, hashlib="sha1", user=None):
     Set the hashlib in the tokeninfo.
     Can be something like sha1, sha256...
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param hashlib: The hashlib of the token
     :type hashlib: basestring
@@ -1445,7 +1447,7 @@ def set_count_auth(serial, count, user=None, max=False, success=False):
     :type count: int
     :param user: The user owner of the tokens tokens to modify
     :type user: User object
-    :param serial: The serial number of the one token to modifiy
+    :param serial: The serial number of the one token to modifiy (exact)
     :type serial: basestring
     :param max: True, if either count_auth_max or count_auth_success_max are
     to be modified
@@ -1534,7 +1536,7 @@ def set_validity_period_start(serial, user, start):
     """
     Set the validity period for the given token.
 
-    :param serial:
+    :param serial: serial number (exact)
     :param user:
     :param start: Timestamp in the format DD/MM/YY HH:MM
     :type start: basestring
@@ -1552,7 +1554,7 @@ def set_validity_period_end(serial, user, end):
     """
     Set the validity period for the given token.
 
-    :param serial:
+    :param serial: serial number (exact)
     :param user:
     :param end: Timestamp in the format DD/MM/YY HH:MM
     :type end: basestring
@@ -1572,7 +1574,7 @@ def set_sync_window(serial, syncwindow=1000, user=None):
     Such many OTP values are calculated ahead, to find the matching otp value
     and counter.
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param syncwindow: The size of the sync window
     :type syncwindow: int
@@ -1597,7 +1599,7 @@ def set_count_window(serial, countwindow=10, user=None):
     The count window is used during authentication to find the matching OTP
     value. This sets the count window per token.
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param countwindow: the size of the window
     :type countwindow: int
@@ -1621,7 +1623,7 @@ def set_description(serial, description, user=None):
     """
     Set the description of a token
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param description: The description for the token
     :type description: int
@@ -1645,7 +1647,7 @@ def set_failcounter(serial, counter, user=None):
     """
     Set the fail counter of a  token.
     
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :param counter: THe counter to which the fail counter should be set
     :param user: An optional user
     :return: Number of tokens, where the fail counter was set.
@@ -1666,7 +1668,7 @@ def set_max_failcount(serial, maxfail, user=None):
     Set the maximum fail counts of tokens. This is the maximum number a
     failed authentication is allowed.
 
-    :param serial: The serial number of the token
+    :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param maxfail: The maximum allowed failed authentications
     :type maxfail: int

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -523,7 +523,7 @@ def get_realms_of_token(serial, only_first_realm=False):
     """
     This function returns a list of the realms of a token
 
-    :param serial: the serial number of the token
+    :param serial: the exact serial number of the token
     :type serial: basestring
 
     :param only_first_realm: Wheather we should only return the first realm
@@ -532,6 +532,9 @@ def get_realms_of_token(serial, only_first_realm=False):
     :return: list of the realm names
     :rtype: list
     """
+    if "*" in serial:
+        return []
+
     tokenobject_list = get_tokens(serial=serial)
 
     realms = []

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1453,3 +1453,267 @@ class APITokenTestCase(MyTestCase):
             result = json.loads(res.data).get("result")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("code"), 905)
+
+
+class API00TokenPerformance(MyTestCase):
+
+    token_count = 21
+
+    def test_00_create_some_tokens(self):
+        for i in range(0,self.token_count):
+            init_token({"genkey": 1, "serial": "perf{0!s:0>3}".format(i)})
+        toks = get_tokens(serial_wildcard="perf*")
+        self.assertEqual(len(toks), self.token_count)
+
+        for i in range(0,10):
+            init_token({"genkey": 1, "serial": "TOK{0!s:0>3}".format(i)})
+        toks = get_tokens(serial_wildcard="TOK*")
+        self.assertEqual(len(toks), 10)
+
+        self.setUp_user_realms()
+
+    def test_01_number_of_tokens(self):
+        # The GET /token returns a wildcard 100 tokens
+        with self.app.test_request_context('/token/',
+                                           method='GET',
+                                           data={"serial": "perf*"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(result.get("value").get("count"), self.token_count)
+
+    def test_02_several_requests(self):
+        # Run GET challenges
+        with self.app.test_request_context('/token/challenges/*',
+                                           method='GET',
+                                           data={"serial": "perf*"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            self.assertEqual(result.get("value").get("count"), 0)
+
+        # Run POST assign with a wildcard. This shall not assign.
+        with self.app.test_request_context('/token/assign',
+                                           method='POST',
+                                           data={"user": "cornelius",
+                                                 "realm": self.realm1,
+                                                 "serial": "perf*",
+                                                 "pin": "test"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 400, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*"
+            self.assertEqual(result.get("error").get("message"), "ERR1102: no token found!")
+
+        # run POST unassign with a wildcard. This shall not unassign
+        from privacyidea.lib.token import assign_token, unassign_token
+        assign_token("perf001", User("cornelius", self.realm1))
+        with self.app.test_request_context('/token/unassign',
+                                           method='POST',
+                                           data={"serial": "perf*",
+                                                 "pin": "test"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 400, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("error").get("message"), "ERR1102: no token found!")
+
+        # Now we unassign the token anyways
+        unassign_token("perf001")
+
+        # run POST revoke with a wildcard
+        with self.app.test_request_context('/token/revoke',
+                                           method='POST',
+                                           data={"serial": "perf*",
+                                                 "pin": "test"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            # The number of revoked tokens is 0
+            self.assertEqual(result.get("value"), 0)
+
+        # run POST enable and disable with a wildcard
+        with self.app.test_request_context('/token/disable',
+                                           method='POST',
+                                           data={"serial": "perf*"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("value"), 0)
+
+        with self.app.test_request_context('/token/enable',
+                                           method='POST',
+                                           data={"serial": "perf*"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("value"), 0)
+
+        # run DELETE /token with a wildcard
+        with self.app.test_request_context('/token/perf*',
+                                           method='DELETE',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("value"), 0)
+
+        # run reset failcounter
+        with self.app.test_request_context('/token/reset/perf*',
+                                           method='POST',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("value"), 0)
+
+        # run reset failcounter
+        with self.app.test_request_context('/token/resync/perf*',
+                                           method='POST', data={"otp1": "123454",
+                                                                "otp2": "123454"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("value"), 0)
+
+        # Try to set pin
+        with self.app.test_request_context('/token/setpin/perf*',
+                                           method='POST', data={"otpppin": "123454"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("value"), 0)
+
+        # Try to set description
+        with self.app.test_request_context('/token/set/perf*',
+                                           method='POST', data={"description": "general token"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("value"), 0)
+
+        # Try to set realm
+        with self.app.test_request_context('/token/realm/perf*',
+                                           method='POST', data={"realms": self.realm1},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("value"), 0)
+
+        # Try to copy the pin
+        with self.app.test_request_context('/token/copypin',
+                                           method='POST',
+                                           data={"from": "perf*",
+                                                 "to": "perf*"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 400, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("error").get("code"), 1016)
+            self.assertEqual(result.get("error").get("message"), "ERR1016: No unique token to copy from found")
+
+        with self.app.test_request_context('/token/copypin',
+                                           method='POST',
+                                           data={"from": "perf001",
+                                                 "to": "perf*"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 400, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("error").get("code"), 1017)
+            self.assertEqual(result.get("error").get("message"), "ERR1017: No unique token to copy to found")
+
+        # Try to copy the user
+        with self.app.test_request_context('/token/copyuser',
+                                           method='POST',
+                                           data={"from": "perf*",
+                                                 "to": "perf*"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 400, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("error").get("code"), 1016)
+            self.assertEqual(result.get("error").get("message"), "ERR1016: No unique token to copy from found")
+
+        # Try to copy the user
+        with self.app.test_request_context('/token/copyuser',
+                                           method='POST',
+                                           data={"from": "perf001",
+                                                 "to": "perf*"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 400, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("error").get("code"), 1017)
+            self.assertEqual(result.get("error").get("message"), "ERR1017: No unique token to copy to found")
+
+
+
+        # Try to mark wildcard token as lost
+        # Just to be clear, all tokens are assigned to the user cornelius
+        for i in range(0,self.token_count):
+            assign_token("perf{0!s:0>3}".format(i), User("cornelius", self.realm1))
+
+        with self.app.test_request_context('/token/lost/perf*',
+                                           method='POST',
+                                           data={},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 400, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertEqual(result.get("error").get("code"), 2012)
+            self.assertEqual(result.get("error").get("message"), "ERR2012: You can only define a lost token for an assigned token.")
+
+        # unassign tokens again
+        for i in range(0,self.token_count):
+            unassign_token("perf{0!s:0>3}".format(i))
+
+        # Try to set tokeninfo
+        with self.app.test_request_context('/token/info/perf*/newkey',
+                                           method='POST',
+                                           data={"value": "newvalue"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertFalse(result.get("value"))
+
+            toks = get_tokens(tokeninfo={"newkey": "newvalue"})
+            # No token reveived this value!
+            self.assertEqual(len(toks), 0)
+
+        # Try to delete tokeninfo
+        with self.app.test_request_context('/token/info/perf*/newkey',
+                                           method='DELETE',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = json.loads(res.data).get("result")
+            # Of course there is no exact token "perf*", it does not match perf001
+            self.assertFalse(result.get("value"))

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -173,6 +173,16 @@ class TokenTestCase(MyTestCase):
                           tokeninfo={"key1": "value1",
                                      "key2": "value2"})
 
+        # wildcard matches do not work for the ``serial`` parameter
+        tokenobject_list = get_tokens(serial="hotptoke*")
+        self.assertEqual(len(tokenobject_list), 0)
+        # get tokens with a wildcard serial
+        tokenobject_list = get_tokens(serial_wildcard="SE*")
+        self.assertEqual(len(tokenobject_list), 3)
+        # get all tokens
+        tokenobject_list = get_tokens(serial_wildcard="*")
+        self.assertEqual(len(tokenobject_list), 4)
+
     def test_03_get_token_type(self):
         ttype = get_token_type("hotptoken")
         self.assertTrue(ttype == "hotp", ttype)

--- a/tools/privacyidea-get-serial
+++ b/tools/privacyidea-get-serial
@@ -70,12 +70,12 @@ def byotp(otp=None, type=None, serial="", window=10, unassigned=False,
     print
     if not assigned and not unassigned:
         assigned=None
-    count = get_tokens(tokentype=type, serial="*{0!s}*".format(
+    count = get_tokens(tokentype=type, serial_wildcard="*{0!s}*".format(
             serial), assigned=assigned, count=True)
     print("Searching in {0!s} tokens.".format(count))
 
     tokenobj_list = get_tokens(tokentype=type,
-                               serial="*{0!s}*".format(serial),
+                               serial_wildcard="*{0!s}*".format(serial),
                                assigned=assigned)
     serial = get_serial_by_otp(tokenobj_list, otp=otp, window=window)
     if serial:


### PR DESCRIPTION
This should solve a lot of performance issues,
in which a request with a wildcard serial number
loaded a list of all tokens into memory.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1240%23issuecomment-420009764%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/commit/6beaed08795b67a2bf55942d1719d3096dadfe02%23commitcomment-30454305%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1240%23issuecomment-420019284%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1240%23issuecomment-420211378%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1240%23issuecomment-420213801%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1240%23issuecomment-420009764%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231240%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.23%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/4e462f957832003a3caa583483db8bf1023d3cff%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.23%20%20%20%20%231240%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%20%20%20%20%20%2095.86%25%20%20%2095.86%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20141%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2017129%20%20%20%2017129%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2016420%20%20%20%2016420%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20709%20%20%20%20%20%20709%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5%29%20%7C%20%6098.36%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/decorators.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2RlY29yYXRvcnMucHk%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6095.26%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B4e462f9...6beaed0%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1240%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-09-10T18%3A16%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20for%20the%20sake%20of%20completeness%3A%20I%20added%20the%20early%20bailout%20to%20%60%60get_realms_of_token%60%60%20because%20the%20function%20is%20called%20by%20the%20%60%60check_base_action%60%60%20policy%20function%2C%20so%20it%20is%20called%20for%20a%20lot%20of%20requests.%22%2C%20%22created_at%22%3A%20%222018-09-10T18%3A46%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20we%20restore%20the%20wildcard%20serial%20matching%20in%20the%20case%20of%20removing%20tokens%20here%3F%20%28see%20%231225%29%5Cr%5Cni.e.%20here%20https%3A//github.com/privacyidea/privacyidea/blob/a83394b14f400a4637b81e0145a95d1788d64b98/privacyidea/lib/token.py%23L1023%22%2C%20%22created_at%22%3A%20%222018-09-11T09%3A36%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Currently%20I%20do%20not%20think%20so.%20The%20UI%20does%20not%20support%20this.%20I%20do%20not%20know%2C%20if%20anybody%20would%20use%20the%20API%20to%20delete%20tokens.%20I%20would%20rather%20recommend%20to%20delete%20tokens%20via%20the%20tokenjanitor.%5Cr%5Cn%5Cr%5CnWe%20maybe%20could%20one%20day%20think%20about%20a%20policy%2C%20that%20would%20allow%20to%20use%20wildcards%20in%20the%20UI.%22%2C%20%22created_at%22%3A%20%222018-09-11T09%3A45%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%206beaed08795b67a2bf55942d1719d3096dadfe02%20privacyidea/lib/token.py%2013%20535%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/commit/6beaed08795b67a2bf55942d1719d3096dadfe02%23commitcomment-30454305%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20should%20we%20do%20this%20failsafe%20here%2C%20if%20we%20do%20it%20nowhere%20else%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-09-10T18%3A42%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL535%20%286beaed0%29%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1240#issuecomment-420009764'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1240?src=pr&el=h1) Report
> Merging [#1240](https://codecov.io/gh/privacyidea/privacyidea/pull/1240?src=pr&el=desc) into [branch-2.23](https://codecov.io/gh/privacyidea/privacyidea/commit/4e462f957832003a3caa583483db8bf1023d3cff?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1240/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1240?src=pr&el=tree)
```diff
@@             Coverage Diff              @@
##           branch-2.23    #1240   +/-   ##
============================================
Coverage        95.86%   95.86%
============================================
Files              141      141
Lines            17129    17129
============================================
Hits             16420    16420
Misses             709      709
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1240?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1240/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5) | `98.36% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/decorators.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1240/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2RlY29yYXRvcnMucHk=) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1240/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `95.26% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1240?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1240?src=pr&el=footer). Last update [4e462f9...6beaed0](https://codecov.io/gh/privacyidea/privacyidea/pull/1240?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Just for the sake of completeness: I added the early bailout to ``get_realms_of_token`` because the function is called by the ``check_base_action`` policy function, so it is called for a lot of requests.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Should we restore the wildcard serial matching in the case of removing tokens here? (see #1225)
i.e. here https://github.com/privacyidea/privacyidea/blob/a83394b14f400a4637b81e0145a95d1788d64b98/privacyidea/lib/token.py#L1023
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Currently I do not think so. The UI does not support this. I do not know, if anybody would use the API to delete tokens. I would rather recommend to delete tokens via the tokenjanitor.
We maybe could one day think about a policy, that would allow to use wildcards in the UI.
- [ ] <a href='#crh-comment-Commit 6beaed08795b67a2bf55942d1719d3096dadfe02 privacyidea/lib/token.py 13 535'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/commit/6beaed08795b67a2bf55942d1719d3096dadfe02#commitcomment-30454305'>File: privacyidea/lib/token.py:L535 (6beaed0)</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Why should we do this failsafe here, if we do it nowhere else?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1240?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1240?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1240'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>