### PR TITLE
Avoid reload of static configuration

### DIFF
--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -44,8 +44,7 @@ webservice!
 
 import logging
 from log import log_with
-from config import (get_resolver_types,
-                     get_resolver_class_dict)
+from config import (get_resolver_types, get_resolver_classes)
 from privacyidea.lib.usercache import delete_user_cache
 from ..models import (Resolver,
                       ResolverConfig)
@@ -293,21 +292,18 @@ def get_resolver_config_description(resolver_type):
 
 #@cache.memoize(10)
 def get_resolver_class(resolver_type):
-    '''
+    """
     return the class object for a resolver type
     :param resolver_type: string specifying the resolver
                           fully qualified or abreviated
     :return: resolver object class
-    '''
+    """
     ret = None
-    
-    (resolver_clazzes, resolver_types) = get_resolver_class_dict()
-
-    if resolver_type in resolver_types.values():
-        for k, v in resolver_types.items():
-            if v == resolver_type:
-                ret = resolver_clazzes.get(k)
-                break
+    resolver_clazzes = get_resolver_classes()
+    for k in resolver_clazzes:
+        if k.getResolverClassType() == resolver_type:
+            ret = k
+            break
     return ret
 
 

--- a/tests/test_lib_config.py
+++ b/tests/test_lib_config.py
@@ -19,8 +19,8 @@ from privacyidea.lib.config import (get_resolver_list,
                                     get_token_types,
                                     get_token_classes, get_token_prefix,
                                     get_machine_resolver_class_dict,
-                                    get_privacyidea_node, get_privacyidea_nodes
-                                    )
+                                    get_privacyidea_node, get_privacyidea_nodes,
+                                    this)
 from privacyidea.lib.resolvers.PasswdIdResolver import IdResolver as PWResolver
 from privacyidea.lib.tokens.hotptoken import HotpTokenClass
 from privacyidea.lib.tokens.totptoken import TotpTokenClass
@@ -79,16 +79,12 @@ class ConfigTestCase(MyTestCase):
 
         self.assertTrue(module in mlist, mlist)
 
-        # At the beginning the resolver classes are not cached.
-        self.assertFalse("pi_resolver_classes" in current_app.config,
-                                current_app.config)
+        # resolver classes are not cached at this point
+        self.assertFalse("pi_resolver_classes" in this.config, this.config)
         r = get_resolver_classes()
         self.assertTrue(PWResolver in r, r)
-        # Now the resolver classes are cached
-        self.assertTrue("pi_resolver_classes" in current_app.config,
-                                current_app.config)
-        r = get_resolver_classes()
-        self.assertTrue(PWResolver in r, r)
+        # resolver classes should be available here
+        self.assertTrue("pi_resolver_classes" in this.config, this.config)
 
         # Class dict
         (classes, types) = get_resolver_class_dict()
@@ -102,15 +98,9 @@ class ConfigTestCase(MyTestCase):
         self.assertTrue(types.get('privacyidea.lib.resolvers.PasswdIdResolver'
                         '.IdResolver') == "passwdresolver", types)
 
-        # At the start the resolvers are not stored in the current_app.config
-        self.assertFalse("pi_resolver_types" in current_app.config,
-                         current_app.config)
+        # With calling 'get_resolver_classes()' the resolver types will also be cached
+        self.assertTrue("pi_resolver_types" in this.config, this.config)
         # When the resolvers are determined, they are stored
-        types = get_resolver_types()
-        self.assertTrue("passwdresolver" in types, types)
-        # Now the resolver types are contained.
-        self.assertTrue("pi_resolver_types" in current_app.config,
-                         current_app.config)
         types = get_resolver_types()
         self.assertTrue("passwdresolver" in types, types)
 
@@ -151,25 +141,14 @@ class ConfigTestCase(MyTestCase):
         self.assertTrue(types.get('privacyidea.lib.tokens.totptoken'
                                   '.TotpTokenClass') == "totp", types)
 
-        types = get_token_types()
-        self.assertTrue("totp" in types, types)
-        self.assertTrue("hotp" in types, types)
-        # Now the resolver types are contained.
-        self.assertTrue("pi_token_types" in current_app.config,
-                        current_app.config)
+        # token types should be cached here because of calling 'get_token_module_list()'
+        self.assertTrue("pi_token_types" in this.config, this.config)
         types = get_token_types()
         self.assertTrue("totp" in types, types)
         self.assertTrue("hotp" in types, types)
 
-        # At the beginning the token classes are not cached.
-        self.assertFalse("pi_token_classes" in current_app.config,
-                         current_app.config)
-        r = get_token_classes()
-        self.assertTrue(TotpTokenClass in r, r)
-        self.assertTrue(HotpTokenClass in r, r)
-        # Now the token classes are cached
-        self.assertTrue("pi_token_classes" in current_app.config,
-                        current_app.config)
+        # token classes are cached with calling 'get_token_types()'
+        self.assertTrue("pi_token_classes" in this.config, this.config)
         r = get_token_classes()
         self.assertTrue(TotpTokenClass in r, r)
         self.assertTrue(HotpTokenClass in r, r)


### PR DESCRIPTION
The pretty static configuration of available Token/Resolver classes and
types was reloaded every time which lead to a performance degradation when
called for a lot of tokens.
Caching the configuration on a module level solves this.
In addition this reduces the dependency on flask in the libs (See #331).

Fixes #1253 