### PR TITLE
1246/clean ldap cache

### DIFF
--- a/doc/configuration/useridresolvers.rst
+++ b/doc/configuration/useridresolvers.rst
@@ -173,6 +173,10 @@ order to improve performance. This checkbox is deactivated by default
 and should only be activated after having ensured that schema information
 are unnecessary.
 
+The ``CACHE_TIMEOUT`` configures a short living per process cache for LDAP users.
+The cache is not shared between different Python processes, if you are running more processes
+in Apache or Nginx. You can set this to ``0`` to deactivate this cache.
+
 TLS certificates
 ~~~~~~~~~~~~~~~~
 

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -190,17 +190,25 @@ def cache(func):
     def cache_wrapper(self, *args, **kwds):
         # If it does not exist, create the node for this instance
         resolver_id = self.getResolverId()
+        now = datetime.datetime.now()
+        tdelta = datetime.timedelta(seconds=self.cache_timeout)
         if not resolver_id in CACHE:
             CACHE[resolver_id] = {"getUserId": {},
                                   "getUserInfo": {},
                                   "_getDN": {}}
+        else:
+            # Clean up the cache in the current resolver and the current function
+            _to_be_deleted = []
+            for user, cached_result in CACHE[resolver_id].get(func.func_name).iteritems():
+                if cached_result.get("timestamp") < now + tdelta:
+                    _to_be_deleted.append(user)
+            for user in _to_be_deleted:
+                del CACHE[resolver_id][func.func_name][user]
+            del _to_be_deleted
 
         # get the portion of the cache for this very LDAP resolver
         r_cache = CACHE.get(resolver_id).get(func.func_name)
-        if args[0] in r_cache and \
-                        datetime.datetime.now() < r_cache[args[0]][
-                    "timestamp"] + \
-                        datetime.timedelta(seconds=self.cache_timeout):
+        if args[0] in r_cache and now < r_cache[args[0]]["timestamp"] + tdelta:
             log.debug("Reading {0!r} from cache for {1!r}".format(args[0],
                                                               func.func_name))
             return r_cache[args[0]]["value"]
@@ -209,7 +217,7 @@ def cache(func):
         # now we cache the result
         CACHE[resolver_id][func.func_name][args[0]] = {
             "value": f_result,
-            "timestamp": datetime.datetime.now()}
+            "timestamp": now}
 
         return f_result
 

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -201,9 +201,14 @@ def cache(func):
             else:
                 # Clean up the cache in the current resolver and the current function
                 _to_be_deleted = []
-                for user, cached_result in CACHE[resolver_id].get(func.func_name).iteritems():
-                    if now > cached_result.get("timestamp") + tdelta:
-                        _to_be_deleted.append(user)
+                try:
+                    for user, cached_result in CACHE[resolver_id].get(func.func_name).iteritems():
+                        if now > cached_result.get("timestamp") + tdelta:
+                            _to_be_deleted.append(user)
+                except RuntimeError:
+                    # This might happen if thread A evicts an expired
+                    # cache entry while thread B looks for expired cache entries
+                    pass
                 for user in _to_be_deleted:
                     try:
                         del CACHE[resolver_id][func.func_name][user]

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -202,18 +202,21 @@ def cache(func):
                 # Clean up the cache in the current resolver and the current function
                 _to_be_deleted = []
                 for user, cached_result in CACHE[resolver_id].get(func.func_name).iteritems():
-                    if cached_result.get("timestamp") < now + tdelta:
+                    if now > cached_result.get("timestamp") + tdelta:
                         _to_be_deleted.append(user)
                 for user in _to_be_deleted:
-                    del CACHE[resolver_id][func.func_name][user]
+                    try:
+                        del CACHE[resolver_id][func.func_name][user]
+                    except KeyError:
+                        pass
                 del _to_be_deleted
 
             # get the portion of the cache for this very LDAP resolver
             r_cache = CACHE.get(resolver_id).get(func.func_name)
-            if args[0] in r_cache and now < r_cache[args[0]]["timestamp"] + tdelta:
-                log.debug("Reading {0!r} from cache for {1!r}".format(args[0],
-                                                                  func.func_name))
-                return r_cache[args[0]]["value"]
+            entry = r_cache.get(args[0])
+            if entry and now < entry.get("timestamp") + tdelta:
+                log.debug("Reading {0!r} from cache for {1!r}".format(args[0], func.func_name))
+                return entry.get("value")
 
         f_result = func(self, *args, **kwds)
 

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -15,6 +15,7 @@ from ldap3.core.exceptions import LDAPOperationResult
 from ldap3.core.results import RESULT_SIZE_LIMIT_EXCEEDED
 import mock
 import responses
+import datetime
 import uuid
 from privacyidea.lib.resolvers.LDAPIdResolver import IdResolver as LDAPResolver
 from privacyidea.lib.resolvers.SQLIdResolver import IdResolver as SQLResolver
@@ -1819,6 +1820,99 @@ class LDAPResolverTestCase(MyTestCase):
 
         info = y.getUserInfo(uid)
         self.assertEqual(info['username'], objectGUIDs[0])
+
+    @ldap3mock.activate
+    def test_32_cache_expiration(self):
+        # This test checks if the short-living cache deletes expired
+        # entries. NOTE: This does not test a multi-threaded scenario!
+        ldap3mock.setLDAPDirectory(LDAPDirectory_small)
+        cache_timeout = 120
+        y = LDAPResolver()
+        y.loadConfig({'LDAPURI': 'ldap://localhost',
+                      'LDAPBASE': 'o=test',
+                      'BINDDN': 'cn=manager,ou=example,o=test',
+                      'BINDPW': 'ldaptest',
+                      'LOGINNAMEATTRIBUTE': 'cn',
+                      'LDAPSEARCHFILTER': '(&(cn=*))', # we use this weird search filter to get a unique resolver ID
+                      'USERINFO': '{ "username": "cn",'
+                                  '"phone" : "telephoneNumber", '
+                                  '"mobile" : "mobile"'
+                                  ', "email" : "mail", '
+                                  '"surname" : "sn", '
+                                  '"givenname" : "givenName" }',
+                      'UIDTYPE': 'objectGUID',
+                      'NOREFERRALS': True,
+                      'CACHE_TIMEOUT': cache_timeout
+                      })
+        from privacyidea.lib.resolvers.LDAPIdResolver import CACHE
+        # assert that the other tests haven't left anything in the cache
+        self.assertNotIn(y.getResolverId(), CACHE)
+        bob_id = y.getUserId('bob')
+        # assert the cache contains this entry
+        self.assertEqual(CACHE[y.getResolverId()]['getUserId']['bob']['value'], bob_id)
+        # assert subsequent requests for the same data hit the cache
+        with mock.patch.object(ldap3mock.Connection, 'search') as mock_search:
+            bob_id2 = y.getUserId('bob')
+            self.assertEqual(bob_id, bob_id2)
+            mock_search.assert_not_called()
+        self.assertIn('bob', CACHE[y.getResolverId()]['getUserId'])
+        # assert requests later than CACHE_TIMEOUT seconds query the directory again
+        now = datetime.datetime.now()
+        with mock.patch('privacyidea.lib.resolvers.LDAPIdResolver.datetime.datetime',
+                        wraps=datetime.datetime) as mock_datetime:
+            # we now live CACHE_TIMEOUT + 2 seconds in the future
+            mock_datetime.now.return_value = now + datetime.timedelta(seconds=cache_timeout + 2)
+            with mock.patch.object(ldap3mock.Connection, 'search', wraps=y.l.search) as mock_search:
+                bob_id3 = y.getUserId('bob')
+                self.assertEqual(bob_id, bob_id3)
+                mock_search.assert_called_once()
+        # assert the cache contains this entry, with the updated timestamp
+        self.assertEqual(CACHE[y.getResolverId()]['getUserId']['bob'],
+                         {'value': bob_id,
+                          'timestamp': now + datetime.timedelta(seconds=cache_timeout + 2)})
+        # we now go 2 * (CACHE_TIMEOUT + 2) seconds to the future and query for someone else's user ID.
+        # This will cause bob's cache entry to be evicted.
+        with mock.patch('privacyidea.lib.resolvers.LDAPIdResolver.datetime.datetime',
+                        wraps=datetime.datetime) as mock_datetime:
+            mock_datetime.now.return_value = now + datetime.timedelta(seconds=2 * (cache_timeout + 2))
+            manager_id = y.getUserId('manager')
+        self.assertEqual(CACHE[y.getResolverId()]['getUserId'].keys(), ['manager'])
+
+    @ldap3mock.activate
+    def test_33_cache_disabled(self):
+        # This test checks if the short-living cache deletes expired
+        # entries. NOTE: This does not test a multi-threaded scenario!
+        ldap3mock.setLDAPDirectory(LDAPDirectory_small)
+        y = LDAPResolver()
+        y.loadConfig({'LDAPURI': 'ldap://localhost',
+                      'LDAPBASE': 'o=test',
+                      'BINDDN': 'cn=manager,ou=example,o=test',
+                      'BINDPW': 'ldaptest',
+                      'LOGINNAMEATTRIBUTE': 'cn',
+                      'LDAPSEARCHFILTER': '(|(cn=*))', # we use this weird search filter to get a unique resolver ID
+                      'USERINFO': '{ "username": "cn",'
+                                  '"phone" : "telephoneNumber", '
+                                  '"mobile" : "mobile"'
+                                  ', "email" : "mail", '
+                                  '"surname" : "sn", '
+                                  '"givenname" : "givenName" }',
+                      'UIDTYPE': 'objectGUID',
+                      'NOREFERRALS': True,
+                      'CACHE_TIMEOUT': 0
+                      })
+        from privacyidea.lib.resolvers.LDAPIdResolver import CACHE
+        # assert that the other tests haven't left anything in the cache
+        self.assertNotIn(y.getResolverId(), CACHE)
+        bob_id = y.getUserId('bob')
+        # assert the cache does not contain this entry
+        self.assertNotIn(y.getResolverId(), CACHE)
+        # assert subsequent requests query the directory
+        with mock.patch.object(ldap3mock.Connection, 'search', wraps=y.l.search) as mock_search:
+            bob_id2 = y.getUserId('bob')
+            self.assertEqual(bob_id, bob_id2)
+            mock_search.assert_called_once()
+
+
 
 class BaseResolverTestCase(MyTestCase):
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23issuecomment-425429117%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221246036%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221250557%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221570194%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221648807%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221652042%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221703983%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23issuecomment-426897723%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23issuecomment-425429117%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231266%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.23%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/03d180740038bfaa8c2641d79885611bd5c2610c%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6089.47%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.23%20%20%20%20%231266%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%20%20%20%20%2095.83%25%20%20%2095.85%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20141%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2017135%20%20%20%2017332%20%20%20%20%20%2B197%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2016421%20%20%20%2016613%20%20%20%20%20%2B192%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20714%20%20%20%20%20%20719%20%20%20%20%20%20%20%2B5%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6093.69%25%20%3C89.47%25%3E%20%28-0.28%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6095.5%25%20%3C0%25%3E%20%28%2B0.29%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/auditmodules/sqlaudit.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2F1ZGl0bW9kdWxlcy9zcWxhdWRpdC5weQ%3D%3D%29%20%7C%20%6095.51%25%20%3C0%25%3E%20%28%2B1.36%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B03d1807...919d86f%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1266%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-09-28T13%3A04%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20was%20thinking%3A%20Maybe%20it%20would%20be%20a%20good%20idea%20to%20add%20a%20small%20test%20for%20the%20cache%20expiration%20feature.%20I%27ll%20add%20one.%22%2C%20%22created_at%22%3A%20%222018-10-04T06%3A15%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20919d86fea0727d17cf65390c5406ef58cc4ac5a8%20privacyidea/lib/resolvers/LDAPIdResolver.py%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221648807%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20about%20some%20FIFO%20data%20structure%3F%20It%20would%20take%20care%20of%20removing%20the%20cache%20entries%20itself%20but%20i%20am%20not%20sure%20about%20the%20access%20times.%22%2C%20%22created_at%22%3A%20%222018-10-01T15%3A17%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20maybe%20a%20different%20data%20structure%20would%20be%20a%20good%20idea%20to%20keep%20the%20cache%20size%20under%20control.%20We%20could%20even%20use%20some%20module%20like%20cachetools%20which%20has%20a%20%5BTTLCache%5D%28https%3A//cachetools.readthedocs.io/en/latest/%23cachetools.TTLCache%29%20class.%20But%20maybe%20we%20should%20move%20this%20to%20the%20code%20cleanup%20milestone%3F%20I%27m%20not%20sure%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-10-01T15%3A26%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20could%20create%20our%20own%20dataclass%20or%20use%20an%20external%20module.%20But%20for%20now%20we%20can%20not%20add%20an%20additional%20dependency%20in%20the%20patch%20release%20-%20imho.%5Cr%5Cn%40plettich%20Can%20you%20please%20add%20some%20ideas%20to%20an%20issue%20for%20milestone%203%20/%20code%20cleanup%3F%22%2C%20%22created_at%22%3A%20%222018-10-01T18%3A07%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL188-228%22%7D%2C%20%22Pull%20919d86fea0727d17cf65390c5406ef58cc4ac5a8%20privacyidea/lib/resolvers/LDAPIdResolver.py%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221570194%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20if%20the%20condition%20is%20correct%20here.%20We%20want%20to%20delete%20all%20results%20which%20are%20older%20than%20%60%60CACHE_TIMEOUT%60%60%20seconds.%20Shouldn%27t%20this%20be%5Cr%5Cn%60%60cached_result.get%28%5C%22timestamp%5C%22%29%20%3C%20now%20-%20tdelta%60%60%3F%22%2C%20%22created_at%22%3A%20%222018-10-01T11%3A07%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL188-228%22%7D%2C%20%22Pull%20919d86fea0727d17cf65390c5406ef58cc4ac5a8%20privacyidea/lib/resolvers/LDAPIdResolver.py%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1266%23discussion_r221246036%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20need%20to%20be%20careful%20with%20regard%20to%20thread%20safety%20here%3A%20If%20we%20run%20this%20in%20a%20multi-threaded%20setup%2C%20two%20threads%20could%20add%20the%20same%20key%20to%20their%20%60%60_to_be_deleted%60%60%20list%2C%20so%20Thread%201%20will%20delete%20it%20from%20%60%60CACHE%60%60%20and%20the%20above%20line%20will%20fail%20in%20Thread%202.%22%2C%20%22created_at%22%3A%20%222018-09-28T13%3A08%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20we%20%60%60try%3A%60%60%20it%2C%20right.%20%28I%20thought%20you%20would%20look%20at%20it%20on%20monday%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-09-28T13%3A23%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolvers/LDAPIdResolver.py%3AL188-228%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1266#issuecomment-425429117'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1266?src=pr&el=h1) Report
> Merging [#1266](https://codecov.io/gh/privacyidea/privacyidea/pull/1266?src=pr&el=desc) into [branch-2.23](https://codecov.io/gh/privacyidea/privacyidea/commit/03d180740038bfaa8c2641d79885611bd5c2610c?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `89.47%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1266/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1266?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.23    #1266      +/-   ##
===============================================
+ Coverage        95.83%   95.85%   +0.01%
===============================================
Files              141      141
Lines            17135    17332     +197
===============================================
+ Hits             16421    16613     +192
- Misses             714      719       +5
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1266?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1266/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `93.69% <89.47%> (-0.28%)` | :arrow_down: |
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1266/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `95.5% <0%> (+0.29%)` | :arrow_up: |
| [privacyidea/lib/auditmodules/sqlaudit.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1266/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2F1ZGl0bW9kdWxlcy9zcWxhdWRpdC5weQ==) | `95.51% <0%> (+1.36%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1266?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1266?src=pr&el=footer). Last update [03d1807...919d86f](https://codecov.io/gh/privacyidea/privacyidea/pull/1266?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I was thinking: Maybe it would be a good idea to add a small test for the cache expiration feature. I'll add one.
- [ ] <a href='#crh-comment-Pull 919d86fea0727d17cf65390c5406ef58cc4ac5a8 privacyidea/lib/resolvers/LDAPIdResolver.py 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1266#discussion_r221246036'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L188-228</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> We need to be careful with regard to thread safety here: If we run this in a multi-threaded setup, two threads could add the same key to their ``_to_be_deleted`` list, so Thread 1 will delete it from ``CACHE`` and the above line will fail in Thread 2.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> So we ``try:`` it, right. (I thought you would look at it on monday ;-)
- [ ] <a href='#crh-comment-Pull 919d86fea0727d17cf65390c5406ef58cc4ac5a8 privacyidea/lib/resolvers/LDAPIdResolver.py 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1266#discussion_r221570194'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L188-228</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I'm not sure if the condition is correct here. We want to delete all results which are older than ``CACHE_TIMEOUT`` seconds. Shouldn't this be
``cached_result.get("timestamp") < now - tdelta``?
- [ ] <a href='#crh-comment-Pull 919d86fea0727d17cf65390c5406ef58cc4ac5a8 privacyidea/lib/resolvers/LDAPIdResolver.py 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1266#discussion_r221648807'>File: privacyidea/lib/resolvers/LDAPIdResolver.py:L188-228</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> what about some FIFO data structure? It would take care of removing the cache entries itself but i am not sure about the access times.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Yes, maybe a different data structure would be a good idea to keep the cache size under control. We could even use some module like cachetools which has a [TTLCache](https://cachetools.readthedocs.io/en/latest/#cachetools.TTLCache) class. But maybe we should move this to the code cleanup milestone? I'm not sure :-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We could create our own dataclass or use an external module. But for now we can not add an additional dependency in the patch release - imho.
@plettich Can you please add some ideas to an issue for milestone 3 / code cleanup?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1266?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1266?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1266'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>