### PR TITLE
Audit rotation: Allow deletion in chunks to avoid deadlocks

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -61,6 +61,7 @@ import contextlib
 
 import flask
 
+from privacyidea.lib.sqlutils import delete_matching_rows
 from privacyidea.lib.security.default import DefaultSecurityModule
 from privacyidea.lib.crypto import geturandom
 from privacyidea.lib.auth import (create_db_admin, list_db_admin,
@@ -566,6 +567,8 @@ except TypeError:
 @manager.option('--config', help="Read config from the specified yaml file.")
 @manager.option('--dryrun', help="Do not actually delete, only show "
                                  "what would be done.", action="store_true")
+@manager.option('--chunksize', help="Delete entries in chunks of the given size "
+                                    "to avoid deadlocks")
 @audit_manager.option('--highwatermark', '--hw', help="If entries exceed this value, "
                                                 "old entries are deleted.")
 @audit_manager.option('--lowwatermark', '--lw', help="Keep this number of entries.")
@@ -574,8 +577,10 @@ except TypeError:
 @audit_manager.option('--config', help="Read config from the specified yaml file.")
 @audit_manager.option('--dryrun', help="Do not actually delete, only show "
                                  "what would be done.", action="store_true")
+@audit_manager.option('--chunksize', help="Delete entries in chunks of the given size "
+                                          "to avoid deadlocks")
 def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
-                 dryrun=False):
+                 dryrun=False, chunksize=None):
     """
     Clean the SQL audit log.
 
@@ -599,6 +604,8 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
     metadata = MetaData()
     highwatermark = int(highwatermark or 10000)
     lowwatermark = int(lowwatermark or 5000)
+    if chunksize is not None:
+        chunksize = int(chunksize)
 
     default_module = "privacyidea.lib.auditmodules.sqlaudit"
     token_db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
@@ -662,19 +669,17 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
             print("If you only would let me I would clean up {0!s} entries!".format(len(delete_list)))
         else:
             print("Cleaning up {0!s} entries.".format(len(delete_list)))
-            engine.execute(LogEntry.__table__.delete().where(LogEntry.id.in_(delete_list)))
-            session.commit()
-
+            delete_matching_rows(session, LogEntry.__table__, LogEntry.id.in_(delete_list), chunksize)
     elif age:
         now = datetime.datetime.now() - datetime.timedelta(days=age)
         print("Deleting entries older than {0!s}".format(now))
-        sqlquery = session.query(LogEntry.date).filter(LogEntry.date < now)
+        criterion = LogEntry.date < now
         if dryrun:
-            r = len(sqlquery.all())
+            r = LogEntry.query.filter(criterion).count()
+            print("Would delete {0!s} entries.".format(r))
         else:
-            r = session.query(LogEntry.date).filter(LogEntry.date < now).delete()
-            session.commit()
-        print("{0!s} entries deleted.".format(r))
+            r = delete_matching_rows(session, LogEntry.__table__, criterion, chunksize)
+            print("{0!s} entries deleted.".format(r))
     else:
         count = session.query(LogEntry.id).count()
         for l in session.query(LogEntry.id).order_by(desc(LogEntry.id)).limit(1):
@@ -687,12 +692,11 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
             cut_id = last_id - lowwatermark
             # delete all entries less than cut_id
             print("Deleting entries smaller than %i" % cut_id)
-            sqlquery = session.query(LogEntry.id).filter(LogEntry.id < cut_id)
+            criterion = LogEntry.id < cut_id
             if dryrun:
-                r = len(sqlquery.all())
+                r = LogEntry.query.filter(criterion).count()
             else:
-                r = session.query(LogEntry.id).filter(LogEntry.id < cut_id).delete()
-                session.commit()
+                r = delete_matching_rows(session, LogEntry.__table__, criterion, chunksize)
             print("{0!s} entries deleted.".format(r))
 
 

--- a/privacyidea/lib/sqlutils.py
+++ b/privacyidea/lib/sqlutils.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+#  2018-10-02 Friedrich Weber <friedrich.weber@netknights.it>
+#             Add chunked deletions
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import ClauseElement, Delete
+
+
+class DeleteLimit(Delete, ClauseElement):
+    """
+    A modified DELETE clause element that allows to specify a limit
+    for the number of rows that should be deleted.
+
+    Deleting a large number of rows via just one SQL statement
+    may cause deadlocks in a replicated setup. This clause can
+    be used to split the one big DELETE statement into multiple
+    smaller statements ("chunks") which reduces the probability
+    of deadlocks.
+
+    A dedicated clause element is needed because different
+    databases use different notation for limits on DELETE statements.
+    """
+    def __init__(self, table, filter, limit=1000):
+        Delete.__init__(self, table)
+        self.table = table
+        self.filter = filter
+        if not isinstance(limit, int):
+            raise RuntimeError('limit must be an integer')
+        if limit <= 0:
+            raise RuntimeError('limit must be positive')
+        self.limit = limit
+
+
+@compiles(DeleteLimit)
+def visit_delete_limit(element, compiler, **kw):
+    """
+    Default compiler for the DeleteLimit clause element.
+    This compiles to a DELETE statement with a SELECT subquery which
+    has a limit set::
+
+        DELETE FROM ... WHERE id IN
+        (SELECT id FROM ... WHERE ... LIMIT ...)
+
+    However, this syntax is not supported by MySQL.
+    """
+    select_stmt = select([element.table.c.id]).where(element.filter).limit(element.limit)
+    delete_stmt = element.table.delete().where(element.table.c.id.in_(select_stmt))
+    return compiler.process(delete_stmt)
+
+
+@compiles(DeleteLimit, 'mysql')
+def visit_delete_limit_mysql(element, compiler, **kw):
+    """
+    Special compiler for the DeleteLimit clause element
+    for MySQL dialects. This compiles to a DELETE element
+    with a LIMIT::
+
+        DELETE FROM pidea_audit WHERE ... LIMIT ...
+    """
+    return 'DELETE FROM {} WHERE {} LIMIT {:d}'.format(
+        compiler.process(element.table, asfrom=True),
+        compiler.process(element.filter), element.limit)
+
+
+def delete_chunked(session, table, filter, limit=1000):
+    """
+    Delete all rows matching a given filter criterion from a table,
+    but only delete *limit* rows at a time. Commit after each DELETE.
+
+    :param session: SQLAlchemy session object
+    :param table: SQLAlchemy table object (e.g. ``LogEntry.__table__``)
+    :param filter: A filter criterion (e.g. ``LogEntry.age < now``)
+    :param limit: Number of rows to delete in one chunk
+    :return: total number of deleted rows
+    """
+    deleted = 0
+    statement = DeleteLimit(table, filter, limit)
+    while True:
+        result = session.execute(statement)
+        deleted += result.rowcount
+        session.commit()
+        if result.rowcount < limit:
+            return deleted
+
+
+def delete_matching_rows(session, table, filter, chunksize=None):
+    """
+    Delete all rows matching a given filter criterion from a table,
+    using chunked deletes if *chunksize* is not None.
+
+    :param session: session object
+    :param table: table object
+    :param filter: filter criterion
+    :param chunksize: An integer (a chunksize), or None.
+    :return: total number of deleted rows
+    """
+    if chunksize is None:
+        result = session.execute(table.delete().where(filter))
+        session.commit()
+        return result.rowcount
+    else:
+        return delete_chunked(session, table, filter, chunksize)

--- a/tests/test_lib_sqlutils.py
+++ b/tests/test_lib_sqlutils.py
@@ -1,0 +1,80 @@
+"""
+This file contains the tests for lib/sqlutils.py
+"""
+from datetime import datetime
+
+from mock import MagicMock
+from sqlalchemy.orm import Session
+from sqlalchemy.testing import AssertsCompiledSQL, AssertsExecutionResults
+from sqlalchemy.testing.assertsql import CompiledSQL
+
+from privacyidea.lib.sqlutils import DeleteLimit, delete_matching_rows
+from privacyidea.models import Audit as LogEntry
+from .base import MyTestCase
+
+
+class SQLUtilsCompilationTestCase(MyTestCase, AssertsCompiledSQL):
+    def test_01_delete_limit(self):
+        stmt = DeleteLimit(LogEntry.__table__, LogEntry.id < 100)
+        self.assertEqual(stmt.limit, 1000)
+        stmt = DeleteLimit(LogEntry.__table__, LogEntry.id < 100, 1234)
+        self.assertEqual(stmt.limit, 1234)
+        with self.assertRaises(RuntimeError):
+            DeleteLimit(LogEntry.__table__, LogEntry.id < 100, None)
+        with self.assertRaises(RuntimeError):
+            DeleteLimit(LogEntry.__table__, LogEntry.id < 100, "not an integer")
+        with self.assertRaises(RuntimeError):
+            DeleteLimit(LogEntry.__table__, LogEntry.id < 100, 0)
+        with self.assertRaises(RuntimeError):
+            DeleteLimit(LogEntry.__table__, LogEntry.id < 100, -10)
+
+    def test_02_compile_delete_limit(self):
+        now = datetime.now()
+        stmt_age = DeleteLimit(LogEntry.__table__, LogEntry.date < now)
+        self.assert_compile(stmt_age,
+                            "DELETE FROM pidea_audit WHERE pidea_audit.id IN "
+                            "(SELECT pidea_audit.id FROM pidea_audit WHERE pidea_audit.date < :date_1 LIMIT :param_1)",
+                            checkparams={"date_1": now, "param_1": 1000},
+                            dialect='default')
+        self.assert_compile(stmt_age,
+                            "DELETE FROM pidea_audit WHERE pidea_audit.date < %s LIMIT 1000",
+                            checkpositional=(now,),
+                            dialect='mysql')
+
+        stmt_id = DeleteLimit(LogEntry.__table__, LogEntry.id < 1000, 1234)
+        self.assert_compile(stmt_id,
+                            "DELETE FROM pidea_audit WHERE pidea_audit.id IN "
+                            "(SELECT pidea_audit.id FROM pidea_audit WHERE pidea_audit.id < :id_1 LIMIT :param_1)",
+                            checkparams={"id_1": 1000, "param_1": 1234},
+                            dialect='default')
+        self.assert_compile(stmt_id,
+                            "DELETE FROM pidea_audit WHERE pidea_audit.id < %s LIMIT 1234",
+                            checkpositional=(1000,),
+                            dialect='mysql')
+
+    def test_03_delete(self):
+        session = MagicMock()
+
+        fake_results = [1000, 1000, 500]
+        def fake_execute_delete1(stmt):
+            result = MagicMock()
+            result.rowcount = fake_results.pop(0)
+            return result
+
+        session.execute.side_effect = fake_execute_delete1
+        # delete chunked
+        result = delete_matching_rows(session, LogEntry.__table__, LogEntry.id < 1234, 1000)
+        # was called three times to delete 2500 entries
+        self.assertEqual(len(session.execute.mock_calls), 3)
+        self.assertEqual(result, 2500)
+
+        session.execute.reset_mock()
+        def fake_execute_delete2(stmt):
+            result = MagicMock()
+            result.rowcount = 2500
+            return result
+        session.execute.side_effect = fake_execute_delete2
+        # delete in one statement
+        result = delete_matching_rows(session, LogEntry.__table__, LogEntry.id < 1234)
+        self.assertEqual(len(session.execute.mock_calls), 1)
+        self.assertEqual(result, 2500)


### PR DESCRIPTION
This adds a ``--chunksize`` option to ``rotate_audit`` to allow deletion in chunks. This keeps individual transactions small and reduces the risk of deadlocks in Galera setups.

The somewhat complicated custom clause element ``DeleteLimit`` is necessary because, e.g., SQLite does not support the ``DELETE ... LIMIT`` syntax, while MySQL does not support the ``DELETE ... WHERE id in (SELECT ... LIMIT)`` syntax. We would need to test other dialects to see which syntax they support. Because of that, ``rotate_audit`` still executes one big DELETE statement by default.

I guess we'll need to do a bit testing before committing this to make sure this does what we want :-)

Closes #1239
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1269%23issuecomment-426244353%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1269%23issuecomment-429784931%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1269%23issuecomment-426244353%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231269%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/7a18294290e25aca98acf59c6e5064fa61c9d85f%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.02%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231269%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.8%25%20%20%2095.83%25%20%20%20%2B0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20142%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017150%20%20%20%2017184%20%20%20%20%20%20%2B34%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016431%20%20%20%2016468%20%20%20%20%20%20%2B37%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20719%20%20%20%20%20%20716%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/sqlutils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NxbHV0aWxzLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B2.5%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B7a18294...bdd54f9%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1269%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-10-02T11%3A49%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20tested%20that%5Cr%5Cn%2A%20this%20doesn%27t%20change%20behavior%20if%20no%20%60%60--chunksize%60%60%20option%20is%20given%20and%5Cr%5Cn%2A%20this%20deletes%20in%20chunks%20if%20%60%60--chunksize%60%60%20is%20given%5Cr%5Cnon%5Cr%5Cn%2A%20SQLite%5Cr%5Cn%2A%20MariaDB%205.5.56%5Cr%5Cn%5Cr%5CnI%20haven%27t%20tested%20this%20on%20other%20databases%20such%20as%20Postgres%2C%20but%20behavior%20should%20also%20be%20unchanged%20if%20no%20%60%60--chunksize%60%60%20is%20given.%22%2C%20%22created_at%22%3A%20%222018-10-15T10%3A03%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1269#issuecomment-426244353'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1269?src=pr&el=h1) Report
> Merging [#1269](https://codecov.io/gh/privacyidea/privacyidea/pull/1269?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/7a18294290e25aca98acf59c6e5064fa61c9d85f?src=pr&el=desc) will **increase** coverage by `0.02%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1269/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1269?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1269      +/-   ##
==========================================
+ Coverage    95.8%   95.83%   +0.02%
==========================================
Files         141      142       +1
Lines       17150    17184      +34
==========================================
+ Hits        16431    16468      +37
+ Misses        719      716       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1269?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/sqlutils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1269/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NxbHV0aWxzLnB5) | `100% <100%> (ø)` | |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1269/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+2.5%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1269?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1269?src=pr&el=footer). Last update [7a18294...bdd54f9](https://codecov.io/gh/privacyidea/privacyidea/pull/1269?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I've tested that
* this doesn't change behavior if no ``--chunksize`` option is given and
* this deletes in chunks if ``--chunksize`` is given
on
* SQLite
* MariaDB 5.5.56
I haven't tested this on other databases such as Postgres, but behavior should also be unchanged if no ``--chunksize`` is given.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1269?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1269?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1269'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>