### PR TITLE
Rebase to 2.23: Allow deletion in chunks to avoid deadlocks

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -61,6 +61,7 @@ import contextlib
 
 import flask
 
+from privacyidea.lib.sqlutils import delete_matching_rows
 from privacyidea.lib.security.default import DefaultSecurityModule
 from privacyidea.lib.crypto import geturandom
 from privacyidea.lib.auth import (create_db_admin, list_db_admin,
@@ -566,6 +567,8 @@ except TypeError:
 @manager.option('--config', help="Read config from the specified yaml file.")
 @manager.option('--dryrun', help="Do not actually delete, only show "
                                  "what would be done.", action="store_true")
+@manager.option('--chunksize', help="Delete entries in chunks of the given size "
+                                    "to avoid deadlocks")
 @audit_manager.option('--highwatermark', '--hw', help="If entries exceed this value, "
                                                 "old entries are deleted.")
 @audit_manager.option('--lowwatermark', '--lw', help="Keep this number of entries.")
@@ -574,8 +577,10 @@ except TypeError:
 @audit_manager.option('--config', help="Read config from the specified yaml file.")
 @audit_manager.option('--dryrun', help="Do not actually delete, only show "
                                  "what would be done.", action="store_true")
+@audit_manager.option('--chunksize', help="Delete entries in chunks of the given size "
+                                          "to avoid deadlocks")
 def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
-                 dryrun=False):
+                 dryrun=False, chunksize=None):
     """
     Clean the SQL audit log.
 
@@ -599,6 +604,8 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
     metadata = MetaData()
     highwatermark = int(highwatermark or 10000)
     lowwatermark = int(lowwatermark or 5000)
+    if chunksize is not None:
+        chunksize = int(chunksize)
 
     default_module = "privacyidea.lib.auditmodules.sqlaudit"
     token_db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
@@ -662,19 +669,17 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
             print("If you only would let me I would clean up {0!s} entries!".format(len(delete_list)))
         else:
             print("Cleaning up {0!s} entries.".format(len(delete_list)))
-            engine.execute(LogEntry.__table__.delete().where(LogEntry.id.in_(delete_list)))
-            session.commit()
-
+            delete_matching_rows(session, LogEntry.__table__, LogEntry.id.in_(delete_list), chunksize)
     elif age:
         now = datetime.datetime.now() - datetime.timedelta(days=age)
         print("Deleting entries older than {0!s}".format(now))
-        sqlquery = session.query(LogEntry.date).filter(LogEntry.date < now)
+        criterion = LogEntry.date < now
         if dryrun:
-            r = len(sqlquery.all())
+            r = LogEntry.query.filter(criterion).count()
+            print("Would delete {0!s} entries.".format(r))
         else:
-            r = session.query(LogEntry.date).filter(LogEntry.date < now).delete()
-            session.commit()
-        print("{0!s} entries deleted.".format(r))
+            r = delete_matching_rows(session, LogEntry.__table__, criterion, chunksize)
+            print("{0!s} entries deleted.".format(r))
     else:
         count = session.query(LogEntry.id).count()
         for l in session.query(LogEntry.id).order_by(desc(LogEntry.id)).limit(1):
@@ -687,12 +692,11 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
             cut_id = last_id - lowwatermark
             # delete all entries less than cut_id
             print("Deleting entries smaller than %i" % cut_id)
-            sqlquery = session.query(LogEntry.id).filter(LogEntry.id < cut_id)
+            criterion = LogEntry.id < cut_id
             if dryrun:
-                r = len(sqlquery.all())
+                r = LogEntry.query.filter(criterion).count()
             else:
-                r = session.query(LogEntry.id).filter(LogEntry.id < cut_id).delete()
-                session.commit()
+                r = delete_matching_rows(session, LogEntry.__table__, criterion, chunksize)
             print("{0!s} entries deleted.".format(r))
 
 

--- a/privacyidea/lib/sqlutils.py
+++ b/privacyidea/lib/sqlutils.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+#  2018-10-02 Friedrich Weber <friedrich.weber@netknights.it>
+#             Add chunked deletions
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import ClauseElement, Delete
+
+
+class DeleteLimit(Delete, ClauseElement):
+    """
+    A modified DELETE clause element that allows to specify a limit
+    for the number of rows that should be deleted.
+
+    Deleting a large number of rows via just one SQL statement
+    may cause deadlocks in a replicated setup. This clause can
+    be used to split the one big DELETE statement into multiple
+    smaller statements ("chunks") which reduces the probability
+    of deadlocks.
+
+    A dedicated clause element is needed because different
+    databases use different notation for limits on DELETE statements.
+    """
+    def __init__(self, table, filter, limit=1000):
+        Delete.__init__(self, table)
+        self.table = table
+        self.filter = filter
+        if not isinstance(limit, int):
+            raise RuntimeError('limit must be an integer')
+        if limit <= 0:
+            raise RuntimeError('limit must be positive')
+        self.limit = limit
+
+
+@compiles(DeleteLimit)
+def visit_delete_limit(element, compiler, **kw):
+    """
+    Default compiler for the DeleteLimit clause element.
+    This compiles to a DELETE statement with a SELECT subquery which
+    has a limit set::
+
+        DELETE FROM ... WHERE id IN
+        (SELECT id FROM ... WHERE ... LIMIT ...)
+
+    However, this syntax is not supported by MySQL.
+    """
+    select_stmt = select([element.table.c.id]).where(element.filter).limit(element.limit)
+    delete_stmt = element.table.delete().where(element.table.c.id.in_(select_stmt))
+    return compiler.process(delete_stmt)
+
+
+@compiles(DeleteLimit, 'mysql')
+def visit_delete_limit_mysql(element, compiler, **kw):
+    """
+    Special compiler for the DeleteLimit clause element
+    for MySQL dialects. This compiles to a DELETE element
+    with a LIMIT::
+
+        DELETE FROM pidea_audit WHERE ... LIMIT ...
+    """
+    return 'DELETE FROM {} WHERE {} LIMIT {:d}'.format(
+        compiler.process(element.table, asfrom=True),
+        compiler.process(element.filter), element.limit)
+
+
+def delete_chunked(session, table, filter, limit=1000):
+    """
+    Delete all rows matching a given filter criterion from a table,
+    but only delete *limit* rows at a time. Commit after each DELETE.
+
+    :param session: SQLAlchemy session object
+    :param table: SQLAlchemy table object (e.g. ``LogEntry.__table__``)
+    :param filter: A filter criterion (e.g. ``LogEntry.age < now``)
+    :param limit: Number of rows to delete in one chunk
+    :return: total number of deleted rows
+    """
+    deleted = 0
+    statement = DeleteLimit(table, filter, limit)
+    while True:
+        result = session.execute(statement)
+        deleted += result.rowcount
+        session.commit()
+        if result.rowcount < limit:
+            return deleted
+
+
+def delete_matching_rows(session, table, filter, chunksize=None):
+    """
+    Delete all rows matching a given filter criterion from a table,
+    using chunked deletes if *chunksize* is not None.
+
+    :param session: session object
+    :param table: table object
+    :param filter: filter criterion
+    :param chunksize: An integer (a chunksize), or None.
+    :return: total number of deleted rows
+    """
+    if chunksize is None:
+        result = session.execute(table.delete().where(filter))
+        session.commit()
+        return result.rowcount
+    else:
+        return delete_chunked(session, table, filter, chunksize)

--- a/tests/test_lib_sqlutils.py
+++ b/tests/test_lib_sqlutils.py
@@ -1,0 +1,80 @@
+"""
+This file contains the tests for lib/sqlutils.py
+"""
+from datetime import datetime
+
+from mock import MagicMock
+from sqlalchemy.orm import Session
+from sqlalchemy.testing import AssertsCompiledSQL, AssertsExecutionResults
+from sqlalchemy.testing.assertsql import CompiledSQL
+
+from privacyidea.lib.sqlutils import DeleteLimit, delete_matching_rows
+from privacyidea.models import Audit as LogEntry
+from .base import MyTestCase
+
+
+class SQLUtilsCompilationTestCase(MyTestCase, AssertsCompiledSQL):
+    def test_01_delete_limit(self):
+        stmt = DeleteLimit(LogEntry.__table__, LogEntry.id < 100)
+        self.assertEqual(stmt.limit, 1000)
+        stmt = DeleteLimit(LogEntry.__table__, LogEntry.id < 100, 1234)
+        self.assertEqual(stmt.limit, 1234)
+        with self.assertRaises(RuntimeError):
+            DeleteLimit(LogEntry.__table__, LogEntry.id < 100, None)
+        with self.assertRaises(RuntimeError):
+            DeleteLimit(LogEntry.__table__, LogEntry.id < 100, "not an integer")
+        with self.assertRaises(RuntimeError):
+            DeleteLimit(LogEntry.__table__, LogEntry.id < 100, 0)
+        with self.assertRaises(RuntimeError):
+            DeleteLimit(LogEntry.__table__, LogEntry.id < 100, -10)
+
+    def test_02_compile_delete_limit(self):
+        now = datetime.now()
+        stmt_age = DeleteLimit(LogEntry.__table__, LogEntry.date < now)
+        self.assert_compile(stmt_age,
+                            "DELETE FROM pidea_audit WHERE pidea_audit.id IN "
+                            "(SELECT pidea_audit.id FROM pidea_audit WHERE pidea_audit.date < :date_1 LIMIT :param_1)",
+                            checkparams={"date_1": now, "param_1": 1000},
+                            dialect='default')
+        self.assert_compile(stmt_age,
+                            "DELETE FROM pidea_audit WHERE pidea_audit.date < %s LIMIT 1000",
+                            checkpositional=(now,),
+                            dialect='mysql')
+
+        stmt_id = DeleteLimit(LogEntry.__table__, LogEntry.id < 1000, 1234)
+        self.assert_compile(stmt_id,
+                            "DELETE FROM pidea_audit WHERE pidea_audit.id IN "
+                            "(SELECT pidea_audit.id FROM pidea_audit WHERE pidea_audit.id < :id_1 LIMIT :param_1)",
+                            checkparams={"id_1": 1000, "param_1": 1234},
+                            dialect='default')
+        self.assert_compile(stmt_id,
+                            "DELETE FROM pidea_audit WHERE pidea_audit.id < %s LIMIT 1234",
+                            checkpositional=(1000,),
+                            dialect='mysql')
+
+    def test_03_delete(self):
+        session = MagicMock()
+
+        fake_results = [1000, 1000, 500]
+        def fake_execute_delete1(stmt):
+            result = MagicMock()
+            result.rowcount = fake_results.pop(0)
+            return result
+
+        session.execute.side_effect = fake_execute_delete1
+        # delete chunked
+        result = delete_matching_rows(session, LogEntry.__table__, LogEntry.id < 1234, 1000)
+        # was called three times to delete 2500 entries
+        self.assertEqual(len(session.execute.mock_calls), 3)
+        self.assertEqual(result, 2500)
+
+        session.execute.reset_mock()
+        def fake_execute_delete2(stmt):
+            result = MagicMock()
+            result.rowcount = 2500
+            return result
+        session.execute.side_effect = fake_execute_delete2
+        # delete in one statement
+        result = delete_matching_rows(session, LogEntry.__table__, LogEntry.id < 1234)
+        self.assertEqual(len(session.execute.mock_calls), 1)
+        self.assertEqual(result, 2500)


### PR DESCRIPTION
This is exactly #1269, but rebased to ``branch-2.23``.

Closes #1239
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1274%23issuecomment-429794312%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1274%23discussion_r225116406%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1274%23discussion_r225143952%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1274%23discussion_r225156176%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1274%23issuecomment-429794312%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231274%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.23%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/1f1e61b6e5394b53aa5d573152d8e8466f299f0b%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.23%20%20%20%20%231274%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%20%20%20%20%2095.81%25%20%20%2095.82%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20142%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2017167%20%20%20%2017201%20%20%20%20%20%20%2B34%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2016449%20%20%20%2016483%20%20%20%20%20%20%2B34%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20718%20%20%20%20%20%20718%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/sqlutils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NxbHV0aWxzLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B1f1e61b...c21e1e4%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1274%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-10-15T10%3A30%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c21e1e4d3006e29634944d3e80c6dbb7302cca9b%20privacyidea/lib/sqlutils.py%2098%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1274%23discussion_r225116406%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20does%20%5C%22result.rowcount%5C%22%20contain%3F%5Cr%5Cn%5Cr%5CnI%20need%20to%20delete%201500%20entries%20with%20a%20chungsize%20of%201000.%5Cr%5CnWould%20this%20mean%2C%20first%201000%20entries%20would%20be%20deleted%20and%20then%20500%3F%20The%20rowcount%20would%20be%20smaller%20the%20%60%60limit%60%60%20-%3E%20exit.%5Cr%5CnWhat%20would%20happen%20if%20there%20are%20exacty%202000%20entries%3F%5Cr%5Cn%5Cr%5CnThere%20would%20be%20a%20final%20run%20with%20the%20attempt%20to%20delete%20up%20to%201000%20entries%2C%20but%20no%20entires%20available.%5Cr%5CnWould%20this%20do%20any%20harm%3F%22%2C%20%22created_at%22%3A%20%222018-10-15T10%3A37%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20at%20least%20in%20the%20case%20of%20SQLite%20and%20MySQL%2C%20%60%60rowcount%60%60%20contains%20the%20number%20of%20actually%20deleted%20entries.%20However%2C%20the%20exact%20implementation%20%5Bseems%20to%20depend%5D%28https%3A//docs.sqlalchemy.org/en/latest/core/connections.html%23sqlalchemy.engine.ResultProxy.rowcount%29%20on%20the%20dialect%20implementation.%5Cr%5Cn%5Cr%5CnI%20think%20in%20the%20case%20you%20describe%20with%202000%20entries%20and%20%60%60chunksize%20%3D%201000%60%60%20we%20would%20indeed%20have%20a%20final%20attempt%20to%20delete%20more%20entries%2C%20but%20there%20won%27t%20be%20any%20rows%20matching%20the%20condition%2C%20so%20%60%60result.rowcount%60%60%20will%20be%200.%5Cr%5Cn%5Cr%5CnI%20was%20also%20wondering%20if%20an%20infinite%20loop%20would%20be%20possible%2C%20but%20I%20think%20in%20case%20of%20SQLite%20and%20MySQL%20this%20shouldn%27t%20happen.%20%22%2C%20%22created_at%22%3A%20%222018-10-15T12%3A22%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20fine.%20I%20merge%20it%20%22%2C%20%22created_at%22%3A%20%222018-10-15T13%3A02%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/sqlutils.py%3AL1-119%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1274#issuecomment-429794312'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1274?src=pr&el=h1) Report
> Merging [#1274](https://codecov.io/gh/privacyidea/privacyidea/pull/1274?src=pr&el=desc) into [branch-2.23](https://codecov.io/gh/privacyidea/privacyidea/commit/1f1e61b6e5394b53aa5d573152d8e8466f299f0b?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1274/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1274?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.23    #1274      +/-   ##
===============================================
+ Coverage        95.81%   95.82%   +<.01%
===============================================
Files              141      142       +1
Lines            17167    17201      +34
===============================================
+ Hits             16449    16483      +34
Misses             718      718
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1274?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/sqlutils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1274/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NxbHV0aWxzLnB5) | `100% <100%> (ø)` | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1274?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1274?src=pr&el=footer). Last update [1f1e61b...c21e1e4](https://codecov.io/gh/privacyidea/privacyidea/pull/1274?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull c21e1e4d3006e29634944d3e80c6dbb7302cca9b privacyidea/lib/sqlutils.py 98'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1274#discussion_r225116406'>File: privacyidea/lib/sqlutils.py:L1-119</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What does "result.rowcount" contain?
I need to delete 1500 entries with a chungsize of 1000.
Would this mean, first 1000 entries would be deleted and then 500? The rowcount would be smaller the ``limit`` -> exit.
What would happen if there are exacty 2000 entries?
There would be a final run with the attempt to delete up to 1000 entries, but no entires available.
Would this do any harm?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think at least in the case of SQLite and MySQL, ``rowcount`` contains the number of actually deleted entries. However, the exact implementation [seems to depend](https://docs.sqlalchemy.org/en/latest/core/connections.html#sqlalchemy.engine.ResultProxy.rowcount) on the dialect implementation.
I think in the case you describe with 2000 entries and ``chunksize = 1000`` we would indeed have a final attempt to delete more entries, but there won't be any rows matching the condition, so ``result.rowcount`` will be 0.
I was also wondering if an infinite loop would be possible, but I think in case of SQLite and MySQL this shouldn't happen.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> It is fine. I merge it


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1274?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1274?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1274'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>