### PR TITLE
Fixes cast of userid from int to string

### DIFF
--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -221,7 +221,7 @@ def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
             sql_query = sql_query.filter(Token.resolver == user.resolver)
         (uid, _rtype, _resolver) = user.get_user_identifiers()
         if uid:
-            sql_query = sql_query.filter(Token.user_id == uid)
+            sql_query = sql_query.filter(Token.user_id == str(uid))
 
     if active is not None:
         # Filter active or inactive tokens

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -221,7 +221,8 @@ def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
             sql_query = sql_query.filter(Token.resolver == user.resolver)
         (uid, _rtype, _resolver) = user.get_user_identifiers()
         if uid:
-            uid = str(uid) if type(uid) == int else uid
+            if type(uid) == int:
+                uid = str(uid)
             sql_query = sql_query.filter(Token.user_id == uid)
 
     if active is not None:

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -221,7 +221,8 @@ def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
             sql_query = sql_query.filter(Token.resolver == user.resolver)
         (uid, _rtype, _resolver) = user.get_user_identifiers()
         if uid:
-            sql_query = sql_query.filter(Token.user_id == str(uid))
+            uid = str(uid) if type(uid) == int else uid
+            sql_query = sql_query.filter(Token.user_id == uid)
 
     if active is not None:
         # Filter active or inactive tokens


### PR DESCRIPTION
Postgres does not implicitly cast integer values to string. To avoid an
error when using a SQLIdResolver (which returns the uid as an integer), the
uid is cast to string before submitting the db-query.

Fixes #1272
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23issuecomment-429814715%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23issuecomment-429843194%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23issuecomment-429923919%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23discussion_r225130897%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23discussion_r225144873%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23discussion_r225146377%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23discussion_r225155206%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23discussion_r225164815%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23discussion_r225205313%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23issuecomment-429814715%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231276%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.23%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/1f1e61b6e5394b53aa5d573152d8e8466f299f0b%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6050%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.23%20%20%20%231276%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%20%20%20%20%20%2095.81%25%20%20%2095.8%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20141%20%20%20%20%20142%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2017167%20%20%2017203%20%20%20%20%20%20%2B36%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2016449%20%20%2016482%20%20%20%20%20%20%2B33%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20718%20%20%20%20%20721%20%20%20%20%20%20%20%2B3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6095.18%25%20%3C50%25%3E%20%28-0.11%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6094.16%25%20%3C0%25%3E%20%28-1.67%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/sqlutils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NxbHV0aWxzLnB5%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B1f1e61b...0971a4e%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1276%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-10-15T11%3A29%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20can%27t%20test%20this%20with%20a%20real%20PostgreSQL%20database%2C%20but%20it%20looks%20good%20to%20me%21%5Cr%5Cn%5Cr%5CnBut%20might%20there%20be%20other%20places%20where%20we%20need%20a%20cast%20to%20string%20to%20make%20internal%20resolvers%20work%20with%20PostgreSQL%3F%22%2C%20%22created_at%22%3A%20%222018-10-15T12%3A58%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-10-15T16%3A33%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c3bc4cc29bf27289106d72db00eacb29bcdeca88%20privacyidea/lib/token.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23discussion_r225155206%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20find%20this%20harder%20to%20read%20than%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Epython%5Cr%5Cnif%20type%28uid%29%20%3D%3D%20int%3A%5Cr%5Cn%20%20%20%20uid%20%3D%20str%28uid%29%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cn%5Cr%5CnEspecially%20since%20we%20do%20not%20need%20the%20else%20branch.%5Cr%5CnIs%20there%20any%20performance%20consideration%20or%20is%20it%20just%20style%3F%22%2C%20%22created_at%22%3A%20%222018-10-15T12%3A58%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20yeah%2C%20now%20that%20you%20mention%20it%2C%20I%20also%20find%20the%20two-liner%20easier%20to%20read%20%3A-%29%20I%20don%27t%20think%20this%20makes%20any%20noticeable%20performance%20difference.%22%2C%20%22created_at%22%3A%20%222018-10-15T13%3A29%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20i%20have%20to%20admit%2C%20i%20just%20wanted%20it%20to%20look%20fancy%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-10-15T15%3A15%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL221-229%22%7D%2C%20%22Pull%20e19a411996fb29d42d7143fe4cf9ba24f0b62176%20privacyidea/lib/token.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1276%23discussion_r225130897%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20there%20be%20any%20scenario%2C%20where%20we%20could%20run%20into%20an%20encoding%20error%2C%20when%20we%20use%20%60%60str%60%60%20-%20with%20cool%20uid%27s%20like%20%5C%22k%5Cu00f6lbel%5C%22%20or%20u%5C%22k%5Cu00f6lbel%5C%22%3F%5Cr%5Cn%5Cr%5CnMaybe%20we%20should%20only%20cast%2C%20if%20the%20%60%60type%28uid%29%60%60%20is%20%60%60int%60%60%20or%20is%20not%20%60%60str%60%60%20or%20%60%60unicode%60%60.%22%2C%20%22created_at%22%3A%20%222018-10-15T11%3A33%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20there%20%2Acould%2A%20be%20a%20scenario...%20but%20according%20to%20the%20documentation%20of%20%5BgetUserId%28%29%5D%28https%3A//github.com/privacyidea/privacyidea/blob/7a18294290e25aca98acf59c6e5064fa61c9d85f/privacyidea/lib/resolvers/UserIdResolver.py%23L119%29%20it%20should%20only%20return%20%60int%60%20or%20%60str%60.%5Cr%5CnI%27ll%20add%20a%20check%20and%20cast%20for%20%60int%60%20and%20pass%20all%20other%20values%20as%20is.%22%2C%20%22created_at%22%3A%20%222018-10-15T12%3A24%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20there%20might%20indeed%20be%20a%20problem%20with%20%60%60uidtype%3Ddn%60%60%20and%20a%20unicode%20username%2C%20because%20the%20result%20of%20%60%60getUserId%60%60%20will%20be%20unicode%20then%20%3A-/%20The%20%60%60getUserId%60%60%20documentation%20is%20not%20really%20correct.%5Cr%5Cn...%20one%20more%20reason%20for%20Python%203%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-10-15T12%3A29%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL221-228%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cornelinux%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cornelinux'><img src='https://avatars1.githubusercontent.com/u/1908620?v=4' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull e19a411996fb29d42d7143fe4cf9ba24f0b62176 privacyidea/lib/token.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1276#discussion_r225130897'>File: privacyidea/lib/token.py:L221-228</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Could there be any scenario, where we could run into an encoding error, when we use ``str`` - with cool uid's like "kölbel" or u"kölbel"?
Maybe we should only cast, if the ``type(uid)`` is ``int`` or is not ``str`` or ``unicode``.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Well, there *could* be a scenario... but according to the documentation of [getUserId()](https://github.com/privacyidea/privacyidea/blob/7a18294290e25aca98acf59c6e5064fa61c9d85f/privacyidea/lib/resolvers/UserIdResolver.py#L119) it should only return `int` or `str`.
I'll add a check and cast for `int` and pass all other values as is.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think there might indeed be a problem with ``uidtype=dn`` and a unicode username, because the result of ``getUserId`` will be unicode then :-/ The ``getUserId`` documentation is not really correct.
... one more reason for Python 3 :-)
- [x] <a href='#crh-comment-Pull c3bc4cc29bf27289106d72db00eacb29bcdeca88 privacyidea/lib/token.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1276#discussion_r225155206'>File: privacyidea/lib/token.py:L221-229</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I find this harder to read than
~~~~python
if type(uid) == int:
uid = str(uid)
~~~~
Especially since we do not need the else branch.
Is there any performance consideration or is it just style?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm yeah, now that you mention it, I also find the two-liner easier to read :-) I don't think this makes any noticeable performance difference.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Ok, i have to admit, i just wanted it to look fancy ;-)
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1276#issuecomment-429814715'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1276?src=pr&el=h1) Report
> Merging [#1276](https://codecov.io/gh/privacyidea/privacyidea/pull/1276?src=pr&el=desc) into [branch-2.23](https://codecov.io/gh/privacyidea/privacyidea/commit/1f1e61b6e5394b53aa5d573152d8e8466f299f0b?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `50%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1276/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1276?src=pr&el=tree)
```diff
@@              Coverage Diff               @@
##           branch-2.23   #1276      +/-   ##
==============================================
- Coverage        95.81%   95.8%   -0.01%
==============================================
Files              141     142       +1
Lines            17167   17203      +36
==============================================
+ Hits             16449   16482      +33
- Misses             718     721       +3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1276?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1276/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `95.18% <50%> (-0.11%)` | :arrow_down: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1276/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `94.16% <0%> (-1.67%)` | :arrow_down: |
| [privacyidea/lib/sqlutils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1276/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NxbHV0aWxzLnB5) | `100% <0%> (ø)` | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1276?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1276?src=pr&el=footer). Last update [1f1e61b...0971a4e](https://codecov.io/gh/privacyidea/privacyidea/pull/1276?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I can't test this with a real PostgreSQL database, but it looks good to me!
But might there be other places where we need a cast to string to make internal resolvers work with PostgreSQL?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1276?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1276?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1276?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1276'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>