### PR TITLE
Reset Cryptoki Memory in case of an HSM failure

### DIFF
--- a/doc/installation/system/securitymodule.rst
+++ b/doc/installation/system/securitymodule.rst
@@ -97,6 +97,14 @@ located (default: ``1``).
 
 ``PI_HSM_MODULE_PASSWORD`` is the password to access the slot.
 
+``PI_HSM_MODULE_MAX_RETRIES`` is the number privacyIDEA tries to perform a cryptographic
+operation like *decrypt*, *encrypt* or *random* if the first attempt with the HSM fails.
+The default value is 5.
+
+.. note:: Some PKCS11 libraries for network attached HSMs also implement a retry.
+   You should take this into account, since retries would multiply and it could take
+   a while till a request would finally fail.
+
 ``PI_HSM_MODULE_KEY_LABEL`` is the label prefix for the keys on the
 HSM (default: ``privacyidea``). In order to locate the keys, the
 module will search for key with a label equal to the concatenation of
@@ -111,4 +119,3 @@ this prefix, ``_`` and the key identifier (respectively ``token``,
 
 ``PI_HSM_MODULE_KEY_LABEL_VALUE`` is the label for ``value`` key
 (defaults to value based on ``PI_HSM_MODULE_KEY_LABEL`` setting).
-

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -98,6 +98,8 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         log.debug("Setting a password: {0!s}".format(bool(self.password)))
         self.module = config.get("module")
         log.debug("Setting the modules: {0!s}".format(self.module))
+        self.max_retries = config.get("max_retries", MAX_RETRIES)
+        log.debug("Setting max retires: {0!s}".format(self.max_retries))
         self.session = None
         self.key_handles = {}
 
@@ -183,7 +185,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 self.pkcs11.lib.C_Finalize()
                 self.initialize_hsm()
                 retries += 1
-                if retries > MAX_RETRIES:
+                if retries > self.max_retries:
                     raise HSMException("Failed to generate random number after multiple retries.")
 
         # convert the array of the random integers to a string
@@ -206,7 +208,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 self.pkcs11.lib.C_Finalize()
                 self.initialize_hsm()
                 retries += 1
-                if retries > MAX_RETRIES:
+                if retries > self.max_retries:
                     raise HSMException("Failed to encrypt after multiple retries.")
 
         return int_list_to_bytestring(r)
@@ -228,7 +230,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 self.pkcs11.lib.C_Finalize()
                 self.initialize_hsm()
                 retries += 1
-                if retries > MAX_RETRIES:
+                if retries > self.max_retries:
                     raise HSMException("Failed to decrypt after multiple retries.")
 
         return int_list_to_bytestring(r)

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -179,6 +179,8 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 break
             except PyKCS11.PyKCS11Error as exx:
                 log.warning(u"Generate Random failed: {0!s}".format(exx))
+                # If something goes wrong in this process, we free memory, session and handles
+                self.pkcs11.lib.C_Finalize()
                 self.initialize_hsm()
                 retries += 1
                 if retries > MAX_RETRIES:
@@ -200,6 +202,8 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 break
             except PyKCS11.PyKCS11Error as exx:
                 log.warning(u"Encryption failed: {0!s}".format(exx))
+                # If something goes wrong in this process, we free memory,session and handles
+                self.pkcs11.lib.C_Finalize()
                 self.initialize_hsm()
                 retries += 1
                 if retries > MAX_RETRIES:
@@ -220,6 +224,8 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 break
             except PyKCS11.PyKCS11Error as exx:
                 log.warning(u"Decryption failed: {0!s}".format(exx))
+                # If something goes wrong in this process, we free memory, session and handlers
+                self.pkcs11.lib.C_Finalize()
                 self.initialize_hsm()
                 retries += 1
                 if retries > MAX_RETRIES:

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -99,7 +99,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         self.module = config.get("module")
         log.debug("Setting the modules: {0!s}".format(self.module))
         self.max_retries = config.get("max_retries", MAX_RETRIES)
-        log.debug("Setting max retires: {0!s}".format(self.max_retries))
+        log.debug("Setting max retries: {0!s}".format(self.max_retries))
         self.session = None
         self.key_handles = {}
 


### PR DESCRIPTION
...using C_Finalize.
Thus improve the self healing functionality of the HSM connection.

With this code and the securosys HSM it takes a few minutes to recover from the network failure after the cable is replugged. But it will start working again without any user interaction!
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1283%23issuecomment-432211639%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1283%23issuecomment-432562921%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1283%23issuecomment-432211639%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231283%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.23%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/d37798c7dfc21e597f8ddae9e6875e614ffe06b4%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.23%20%20%20%20%231283%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%20%20%20%20%20%2095.8%25%20%20%2095.82%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20142%20%20%20%20%20%20142%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2017203%20%20%20%2017203%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2016482%20%20%20%2016484%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20721%20%20%20%20%20%20719%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/security/aeshsm.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2Flc2hzbS5weQ%3D%3D%29%20%7C%20%6036.58%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bd37798c...5c45706%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1283%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-10-23T11%3A39%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20the%20%5BCryptoki%20docs%5D%28https%3A//www.cryptsoft.com/pkcs11doc/v220/pkcs11__all_8h.html%23aC_Finalize%29%20say%20that%20%5C%22C_Finalize%20%5B...%5D%20should%20be%20the%20last%20Cryptoki%20call%20made%20by%20an%20application.%5C%22%2C%20and%20here%20we%20would%20do%20the%20C_Initialize%28%29%20-%3E%20C_Finalize%28%29%20once%20for%20each%20retry%3F%5Cr%5CnBut%20I%20mean%2C%20if%20the%20%60%60C_Finalize%60%60%20call%20improves%20HSM%20failure%20recovery%2C%20we%20should%20do%20it%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-10-24T08%3A30%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1283#issuecomment-432211639'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1283?src=pr&el=h1) Report
> Merging [#1283](https://codecov.io/gh/privacyidea/privacyidea/pull/1283?src=pr&el=desc) into [branch-2.23](https://codecov.io/gh/privacyidea/privacyidea/commit/d37798c7dfc21e597f8ddae9e6875e614ffe06b4?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1283/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1283?src=pr&el=tree)
```diff
@@               Coverage Diff               @@
##           branch-2.23    #1283      +/-   ##
===============================================
+ Coverage         95.8%   95.82%   +0.01%
===============================================
Files              142      142
Lines            17203    17203
===============================================
+ Hits             16482    16484       +2
+ Misses             721      719       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1283?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/security/aeshsm.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1283/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2Flc2hzbS5weQ==) | `36.58% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1283/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1283?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1283?src=pr&el=footer). Last update [d37798c...5c45706](https://codecov.io/gh/privacyidea/privacyidea/pull/1283?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, the [Cryptoki docs](https://www.cryptsoft.com/pkcs11doc/v220/pkcs11__all_8h.html#aC_Finalize) say that "C_Finalize [...] should be the last Cryptoki call made by an application.", and here we would do the C_Initialize() -> C_Finalize() once for each retry?
But I mean, if the ``C_Finalize`` call improves HSM failure recovery, we should do it :)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1283?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1283?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1283'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>