### PR TITLE
Add migration script to fix column sizes

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -70,7 +70,8 @@ def run_migrations_online():
     connection = engine.connect()
     context.configure(
                 connection=connection,
-                target_metadata=target_metadata
+                target_metadata=target_metadata,
+                compare_type=True
                 )
 
     try:

--- a/migrations/versions/d2ae8e54b628_.py
+++ b/migrations/versions/d2ae8e54b628_.py
@@ -1,0 +1,69 @@
+"""shorten columns used in UNIQUE constraints in periodictasklastrun, periodictaskoption
+
+Revision ID: d2ae8e54b628
+Revises: 1a0710df148b
+Create Date: 2018-10-24 11:17:40.279312
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd2ae8e54b628'
+down_revision = '1a0710df148b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # First, try to create the table with the shorter field sizes.
+    # This will fail if the tables already exist (which will be
+    # the case in most installations)
+    try:
+        op.create_table('periodictasklastrun',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('periodictask_id', sa.Integer(), nullable=True),
+        sa.Column('node', sa.Unicode(length=255), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['periodictask_id'], ['periodictask.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('periodictask_id', 'node', name='ptlrix_1'),
+        mysql_row_format='DYNAMIC'
+        )
+        op.create_table('periodictaskoption',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('periodictask_id', sa.Integer(), nullable=True),
+        sa.Column('key', sa.Unicode(length=255), nullable=False),
+        sa.Column('value', sa.Unicode(length=2000), nullable=True),
+        sa.ForeignKeyConstraint(['periodictask_id'], ['periodictask.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('periodictask_id', 'key', name='ptoix_1'),
+        mysql_row_format='DYNAMIC'
+        )
+        print('Successfully created shortened periodictasklastrun and periodictaskoption.')
+    except Exception as exx:
+        print('Creation of periodictasklastrun and periodictaskoption with shortened columns failed: {!r}'.format(exx))
+        print('This is expected behavior if they were already present.')
+    try:
+        op.alter_column('periodictasklastrun', 'node',
+                   existing_type=sa.VARCHAR(length=256),
+                   type_=sa.Unicode(length=255),
+                   existing_nullable=False)
+        op.alter_column('periodictaskoption', 'key',
+                   existing_type=sa.VARCHAR(length=256),
+                   type_=sa.Unicode(length=255),
+                   existing_nullable=False)
+        print('Successfully shortened columns of periodictasklastrun and periodictaskoption.')
+    except Exception as exx:
+        print('Shortening of periodictasklastrun and periodictaskoption columns failed: {!r}'.format(exx))
+        print('This is expected behavior if the columns have already been shorted.')
+
+
+def downgrade():
+    op.alter_column('periodictaskoption', 'key',
+               existing_type=sa.Unicode(length=255),
+               type_=sa.VARCHAR(length=256),
+               existing_nullable=False)
+    op.alter_column('periodictasklastrun', 'node',
+               existing_type=sa.Unicode(length=255),
+               type_=sa.VARCHAR(length=256),
+               existing_nullable=False)

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2656,7 +2656,7 @@ class PeriodicTaskOption(db.Model):
     id = db.Column(db.Integer, Sequence("periodictaskopt_seq"),
                    primary_key=True)
     periodictask_id = db.Column(db.Integer, db.ForeignKey('periodictask.id'))
-    key = db.Column(db.Unicode(256), nullable=False)
+    key = db.Column(db.Unicode(255), nullable=False)
     value = db.Column(db.Unicode(2000), default=u'')
 
     __table_args__ = (db.UniqueConstraint('periodictask_id',
@@ -2700,7 +2700,7 @@ class PeriodicTaskLastRun(db.Model):
     id = db.Column(db.Integer, Sequence("periodictasklastrun_seq"),
                    primary_key=True)
     periodictask_id = db.Column(db.Integer, db.ForeignKey('periodictask.id'))
-    node = db.Column(db.Unicode(256), nullable=False)
+    node = db.Column(db.Unicode(255), nullable=False)
     timestamp = db.Column(db.DateTime(False), nullable=False)
 
     __table_args__ = (db.UniqueConstraint('periodictask_id',


### PR DESCRIPTION
Closes #1273
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23issuecomment-432611228%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23issuecomment-432652545%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23discussion_r227780188%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23discussion_r227782667%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23discussion_r227782975%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23discussion_r227783335%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23discussion_r227783894%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23discussion_r227783906%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23issuecomment-432611228%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231284%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/7a18294290e25aca98acf59c6e5064fa61c9d85f%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231284%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.8%25%20%20%2095.82%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20141%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017150%20%20%20%2017150%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016431%20%20%20%2016434%20%20%20%20%20%20%20%2B3%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20719%20%20%20%20%20%20716%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.89%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B2.5%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B7a18294...942cf13%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1284%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-10-24T11%3A00%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-10-24T13%3A19%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20942cf13c98937725b6bc516aa292ee3911c13e04%20migrations/env.py%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23discussion_r227780188%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20does%20this%20do%3F%22%2C%20%22created_at%22%3A%20%222018-10-24T13%3A09%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20was%20required%20for%20the%20alembic%20autogenerator%20for%20migration%20scripts%20pick%20up%20the%20changed%20column%20lengths.%20Without%20that%20line%2C%20the%20generated%20migration%20script%20would%20do%20nothing.%22%2C%20%22created_at%22%3A%20%222018-10-24T13%3A17%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-10-24T13%3A19%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20migrations/env.py%3AL70-78%22%7D%2C%20%22Pull%20942cf13c98937725b6bc516aa292ee3911c13e04%20migrations/versions/d2ae8e54b628_.py%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1284%23discussion_r227782667%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Usually%20we%20do%20not%20do%20this%20print.%20-%20till%20now.%5Cr%5CnBut%20it%20looks%20nice.%22%2C%20%22created_at%22%3A%20%222018-10-24T13%3A16%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20I%20thought%20this%20would%20be%20nice%20because%20every%20installation%20would%20run%20into%20one%20of%20the%20%60%60except%60%60%20blocks%20--%20so%20it%20would%20be%20nice%20to%20have%20a%20message%20that%20all%20is%20fine%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-10-24T13%3A18%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-10-24T13%3A19%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20migrations/versions/d2ae8e54b628_.py%3AL1-70%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cornelinux%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cornelinux'><img src='https://avatars1.githubusercontent.com/u/1908620?v=4' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1284#issuecomment-432611228'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1284?src=pr&el=h1) Report
> Merging [#1284](https://codecov.io/gh/privacyidea/privacyidea/pull/1284?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/7a18294290e25aca98acf59c6e5064fa61c9d85f?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1284/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1284?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1284      +/-   ##
==========================================
+ Coverage    95.8%   95.82%   +0.01%
==========================================
Files         141      141
Lines       17150    17150
==========================================
+ Hits        16431    16434       +3
+ Misses        719      716       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1284?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1284/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.89% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1284/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+2.5%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1284?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1284?src=pr&el=footer). Last update [7a18294...942cf13](https://codecov.io/gh/privacyidea/privacyidea/pull/1284?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull 942cf13c98937725b6bc516aa292ee3911c13e04 migrations/env.py 6'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1284#discussion_r227780188'>File: migrations/env.py:L70-78</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What does this do?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> This was required for the alembic autogenerator for migration scripts pick up the changed column lengths. Without that line, the generated migration script would do nothing.
- [x] <a href='#crh-comment-Pull 942cf13c98937725b6bc516aa292ee3911c13e04 migrations/versions/d2ae8e54b628_.py 42'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1284#discussion_r227782667'>File: migrations/versions/d2ae8e54b628_.py:L1-70</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Usually we do not do this print. - till now.
But it looks nice.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, I thought this would be nice because every installation would run into one of the ``except`` blocks -- so it would be nice to have a message that all is fine :-)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1284?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1284?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1284?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1284'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>