### PR TITLE
First attempt of python 3 compatibility

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -150,7 +150,7 @@ class MyTestCase(unittest.TestCase):
                                            method='POST'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             self.at = result.get("value").get("token")
 
@@ -162,7 +162,7 @@ class MyTestCase(unittest.TestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_user = result.get("value").get("token")

--- a/tests/ldap3mock.py
+++ b/tests/ldap3mock.py
@@ -49,6 +49,7 @@ import hashlib
 import ldap3
 import re
 import pyparsing
+import codecs
 
 try:
     from six import cStringIO as BufferIO
@@ -738,7 +739,7 @@ class Ldap3Mock(object):
         label_removed = reference_pw[6:]
 
         # Decode base64 and strip salt
-        digest_salt = label_removed.decode('base64')
+        digest_salt = codecs.decode(label_removed, 'base64')
         reference_pw_sha = digest_salt[:20]
         # Strip off the salt for use encoding the user supplied password
         salt = digest_salt[20:]

--- a/tests/ldap3mock.py
+++ b/tests/ldap3mock.py
@@ -37,7 +37,7 @@ limitations under the License.
 """
 
 from __future__ import (
-    absolute_import, print_function, division, unicode_literals
+    absolute_import, division, unicode_literals
 )
 
 DIRECTORY = "tests/testdata/tmp_directory"
@@ -263,7 +263,7 @@ class Connection(object):
         entry = self.directory[index].get("attributes")
 
         # Loop over the changes hash and apply them
-        for k, v in changes.iteritems():
+        for k, v in six.iteritems(changes):
             if v[0] == "MODIFY_DELETE":
                 entry.pop(k)
             elif v[0] == "MODIFY_REPLACE" or v[0] == "MODIFY_ADD":
@@ -478,7 +478,7 @@ class Connection(object):
         deDuped = list()
         for entry in results:
             dn = entry.get("dn")
-            if not dn in found.keys():
+            if not dn in found:
                 found[dn] = 1
                 deDuped.append(entry)
 

--- a/tests/ldap3mock.py
+++ b/tests/ldap3mock.py
@@ -263,7 +263,7 @@ class Connection(object):
         entry = self.directory[index].get("attributes")
 
         # Loop over the changes hash and apply them
-        for k, v in six.iteritems(changes):
+        for k, v in changes.items():
             if v[0] == "MODIFY_DELETE":
                 entry.pop(k)
             elif v[0] == "MODIFY_REPLACE" or v[0] == "MODIFY_ADD":

--- a/tests/smppmock.py
+++ b/tests/smppmock.py
@@ -35,7 +35,10 @@ except ImportError:
 import inspect
 from collections import namedtuple, Sequence, Sized
 from functools import update_wrapper
-from smpplib.client import ConnectionError
+if six.PY2:
+    from smpplib.client import ConnectionError
+else:
+    from smpplib.exceptions import ConnectionError
 
 
 Call = namedtuple('Call', ['request', 'response'])

--- a/tests/test_api_2stepinit.py
+++ b/tests/test_api_2stepinit.py
@@ -458,7 +458,7 @@ class TwoStepInitTestCase(MyTestCase):
                           result.get("error").get("message"))
 
         # Authentication does not work yet!
-        wrong_otp_value = HmacOtp().generate(key=server_component, counter=int(time.time()/30))
+        wrong_otp_value = HmacOtp().generate(key=server_component, counter=int(time.time() // 30))
         with self.app.test_request_context('/validate/check',
                                            method='POST',
                                            data={"serial": serial,
@@ -491,7 +491,7 @@ class TwoStepInitTestCase(MyTestCase):
 
         # Now try to authenticate
         otpkey_bin = binascii.unhexlify(otpkey)
-        otp_value = HmacOtp().generate(key=otpkey_bin, counter=int(time.time()/30))
+        otp_value = HmacOtp().generate(key=otpkey_bin, counter=int(time.time() // 30))
         with self.app.test_request_context('/validate/check',
                                            method='POST',
                                            data={"serial": serial,
@@ -553,7 +553,9 @@ class TwoStepInitTestCase(MyTestCase):
             self.assertIn('2step_salt=11', google_url)
             self.assertIn('2step_output=64', google_url)
         # Authentication does not work yet!
-        wrong_otp_value = HmacOtp(digits=8, hashfunc=hashlib.sha512).generate(key=server_component, counter=int(time.time() / 60))
+        wrong_otp_value = HmacOtp(digits=8,
+                                  hashfunc=hashlib.sha512).generate(key=server_component,
+                                                                    counter=int(time.time() // 60))
         with self.app.test_request_context('/validate/check',
                                            method='POST',
                                            data={"serial": serial,
@@ -607,7 +609,9 @@ class TwoStepInitTestCase(MyTestCase):
 
         # Now try to authenticate
         otpkey_bin = binascii.unhexlify(otpkey)
-        otp_value = HmacOtp(digits=8, hashfunc=hashlib.sha512).generate(key=otpkey_bin, counter=int(time.time()/60))
+        otp_value = HmacOtp(digits=8,
+                            hashfunc=hashlib.sha512).generate(key=otpkey_bin,
+                                                              counter=int(time.time() // 60))
         with self.app.test_request_context('/validate/check',
                                            method='POST',
                                            data={"serial": serial,

--- a/tests/test_api_2stepinit.py
+++ b/tests/test_api_2stepinit.py
@@ -36,10 +36,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -51,9 +51,9 @@ class TwoStepInitTestCase(MyTestCase):
             self.assertEqual(detail['2step_salt'], 8)
             self.assertEqual(detail['2step_output'], 20)
 
-        client_component = "VRYSECRT"
+        client_component = b"VRYSECRT"
         checksum = hashlib.sha1(client_component).digest()[:4]
-        base32check_client_component = base64.b32encode(checksum + client_component).strip("=")
+        base32check_client_component = base64.b32encode(checksum + client_component).strip(b"=")
 
         # Try to do a 2stepinit on a second step will raise an error
         with self.app.test_request_context('/token/init',
@@ -66,7 +66,7 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertIn('2stepinit is only to be used in the first initialization step',
                           result.get("error").get("message"))
 
@@ -76,12 +76,12 @@ class TwoStepInitTestCase(MyTestCase):
                                            data={"type": "hotp",
                                                  "2stepinit": "1",
                                                  "serial": serial,
-                                                 "otpkey": "A" + base32check_client_component[1:],
+                                                 "otpkey": b"A" + base32check_client_component[1:],
                                                  "otpkeyformat": "base32check"},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertIn('Malformed base32check data: Incorrect checksum',
                           result.get("error").get("message"))
 
@@ -93,7 +93,7 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": wrong_otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
@@ -109,10 +109,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
             self.assertNotIn('2step', detail)
@@ -126,7 +126,7 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -166,10 +166,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -185,13 +185,13 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": wrong_otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
                          u'matching 1 tokens, Token is disabled')
 
-        client_component = "wrongsize" # 9 bytes
+        client_component = b"wrongsize" # 9 bytes
         hex_client_component = binascii.hexlify(client_component)
 
         # Supply a client secret of incorrect size
@@ -204,10 +204,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("status"))
 
-        client_component = "correctsize" # 11 bytes
+        client_component = b"correctsize" # 11 bytes
         hex_client_component = binascii.hexlify(client_component)
 
         # Now doing the correct 2nd step
@@ -223,10 +223,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
 
@@ -239,7 +239,7 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -278,15 +278,15 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
 
-        client_component = "wrongsize0" # 10 bytes
+        client_component = b"wrongsize0" # 10 bytes
         hex_client_component = binascii.hexlify(client_component)
 
         # Supply a client secret of incorrect size
@@ -299,10 +299,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("status"))
 
-        client_component = "correctsizeABCDE" # 16 bytes
+        client_component = b"correctsizeABCDE" # 16 bytes
         hex_client_component = binascii.hexlify(client_component)
 
         # Now doing the correct 2nd step
@@ -318,10 +318,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
 
@@ -334,7 +334,7 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -371,10 +371,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey_bin = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -388,7 +388,7 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -408,10 +408,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -423,9 +423,9 @@ class TwoStepInitTestCase(MyTestCase):
             self.assertEqual(detail['2step_salt'], 8)
             self.assertEqual(detail['2step_output'], 20)
 
-        client_component = "VRYSECRT"
+        client_component = b"VRYSECRT"
         checksum = hashlib.sha1(client_component).digest()[:4]
-        base32check_client_component = base64.b32encode(checksum + client_component).strip("=")
+        base32check_client_component = base64.b32encode(checksum + client_component).strip(b"=")
 
         # Try to do a 2stepinit on a second step will raise an error
         with self.app.test_request_context('/token/init',
@@ -438,7 +438,7 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertIn('2stepinit is only to be used in the first initialization step',
                           result.get("error").get("message"))
 
@@ -448,12 +448,12 @@ class TwoStepInitTestCase(MyTestCase):
                                            data={"type": "totp",
                                                  "2stepinit": "1",
                                                  "serial": serial,
-                                                 "otpkey": "A" + base32check_client_component[1:],
+                                                 "otpkey": b"A" + base32check_client_component[1:],
                                                  "otpkeyformat": "base32check"},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertIn('Malformed base32check data: Incorrect checksum',
                           result.get("error").get("message"))
 
@@ -465,7 +465,7 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": wrong_otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
@@ -481,10 +481,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
             self.assertNotIn('2step', detail)
@@ -498,7 +498,7 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -541,10 +541,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -560,13 +560,13 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": wrong_otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
                          u'matching 1 tokens, Token is disabled')
 
-        client_component = "wrongsize" # 9 bytes
+        client_component = b"wrongsize" # 9 bytes
         hex_client_component = binascii.hexlify(client_component)
 
         # Supply a client secret of incorrect size
@@ -579,10 +579,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("status"))
 
-        client_component = "correctsize" # 11 bytes
+        client_component = b"correctsize" # 11 bytes
         hex_client_component = binascii.hexlify(client_component)
 
         # Now doing the correct 2nd step
@@ -598,10 +598,10 @@ class TwoStepInitTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
 
@@ -614,7 +614,7 @@ class TwoStepInitTestCase(MyTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 

--- a/tests/test_api_applications.py
+++ b/tests/test_api_applications.py
@@ -6,6 +6,7 @@ api/applications.py
 import json
 from .base import MyTestCase
 
+
 class APIApplicationsResolverTestCase(MyTestCase):
 
     def test_get_applications(self):
@@ -14,9 +15,9 @@ class APIApplicationsResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             detail = json.loads(res.data).get("detail")
             value = result.get("value")
-            self.assertTrue("ssh" in value.keys())
-            self.assertTrue("luks" in value.keys())
+            self.assertTrue("ssh" in value)
+            self.assertTrue("luks" in value)
             self.assertTrue(value["ssh"]["options"]["optional"] == ["user"])

--- a/tests/test_api_audit.py
+++ b/tests/test_api_audit.py
@@ -20,7 +20,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue(json_response.get("result").get("value").get(
                 "current") == 1, res)
@@ -31,7 +31,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue("serial_plot" in json_response.get(
                 "result").get("value"), json_response.get("result"))
@@ -46,7 +46,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue("serial_plot" in json_response.get(
                 "result").get("value"), json_response.get("result"))
@@ -63,7 +63,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue("serial_plot" in json_response.get(
                 "result").get("value"), json_response.get("result"))
@@ -87,7 +87,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 2)
@@ -99,7 +99,7 @@ class APIAuditTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 3)
@@ -114,7 +114,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             # We now have 3 entries, as we added one by the search in line #43
             self.assertEqual(json_response.get("result").get("value").get(
@@ -139,7 +139,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 5)
@@ -151,7 +151,7 @@ class APIAuditTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 7)
@@ -180,7 +180,7 @@ class APIAuditTestCase(MyTestCase):
                                                                 'password': 'test'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             value = json_response.get("result").get("value")
             # Helpdesk user is allowed to view the audit log.
             self.assertTrue("auditlog" in value.get("rights"))
@@ -192,7 +192,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': helpdesk_authorization}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             # We now have 3 entries, as we added one by the search in line #43
             count = json_response.get("result").get("value").get("count")
@@ -208,7 +208,7 @@ class APIAuditTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             # We now have 3 entries, as we added one by the search in line #43
             count = json_response.get("result").get("value").get("count")

--- a/tests/test_api_caconnector.py
+++ b/tests/test_api_caconnector.py
@@ -25,7 +25,7 @@ class CAConnectorTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -42,7 +42,7 @@ class CAConnectorTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -58,7 +58,7 @@ class CAConnectorTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(len(value), 1)
@@ -73,7 +73,7 @@ class CAConnectorTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(len(value), 2)
@@ -85,7 +85,7 @@ class CAConnectorTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(len(value), 1)
@@ -100,7 +100,7 @@ class CAConnectorTestCase(MyTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             at_user = result.get("value").get("token")
@@ -115,7 +115,7 @@ class CAConnectorTestCase(MyTestCase):
                                            headers={'Authorization': at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(len(value), 2)
@@ -128,7 +128,7 @@ class CAConnectorTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(value, 1)

--- a/tests/test_api_clienttype.py
+++ b/tests/test_api_clienttype.py
@@ -13,7 +13,7 @@ class APIClienttypeTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue("PAM" in json_response.get("result").get("value"))
             self.assertTrue("RADIUS" in json_response.get("result").get(
@@ -34,7 +34,7 @@ class APIClienttypeTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue("PAM" in json_response.get("result").get("value"))
             self.assertTrue("RADIUS" in json_response.get("result").get(

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -1,6 +1,6 @@
 import json
 from .base import MyTestCase
-import smtpmock
+from . import smtpmock
 from privacyidea.lib.config import set_privacyidea_config
 
 
@@ -15,8 +15,8 @@ class APIEventsTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), [])
 
         # create an event configuration
@@ -33,8 +33,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the event
@@ -45,8 +45,8 @@ class APIEventsTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value")[0].get("action"), "sendmail")
             self.assertEqual(result.get("value")[0].get("conditions"),
                              {"blabla": "yes"})
@@ -67,8 +67,8 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the event
@@ -78,8 +78,8 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value")[0].get("action"),
                              "sendmail")
             self.assertEqual(result.get("value")[0].get("conditions"),
@@ -92,8 +92,8 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data).get("result")
-                detail = json.loads(res.data).get("detail")
+                result = json.loads(res.data.decode('utf8')).get("result")
+                detail = json.loads(res.data.decode('utf8')).get("detail")
                 self.assertEqual(result.get("value")[0].get("action"),
                                  "sendmail")
                 self.assertEqual(result.get("value")[0].get("conditions"),
@@ -107,8 +107,8 @@ class APIEventsTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty events
@@ -117,8 +117,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), [])
 
     def test_02_test_options(self):
@@ -139,8 +139,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list event with options
@@ -150,7 +150,7 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             event_list = result.get("value")
             self.assertEqual(len(event_list), 1)
             self.assertEqual(event_list[0].get("action"), "sendmail")
@@ -166,8 +166,8 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty events
@@ -176,8 +176,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), [])
 
     def test_03_available_events(self):
@@ -187,8 +187,8 @@ class APIEventsTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue("token_init" in result.get("value"))
             self.assertTrue("token_assign" in result.get("value"))
             self.assertTrue("token_unassign" in result.get("value"))
@@ -199,8 +199,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue("UserNotification" in result.get("value"))
 
     def test_05_get_handler_actions(self):
@@ -210,10 +210,10 @@ class APIEventsTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue("sendmail" in result.get("value"))
             self.assertTrue("sendsms" in result.get("value"))
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
 
     def test_05_get_handler_conditions(self):
         with self.app.test_request_context('/event/conditions/UserNotification',
@@ -221,10 +221,10 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue("logged_in_user" in result.get("value"))
             self.assertTrue("result_value" in result.get("value"))
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
 
     def test_06_test_enable_disable(self):
         # create an event configuration
@@ -243,8 +243,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list event with options
@@ -254,7 +254,7 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             event_list = result.get("value")
             self.assertEqual(len(event_list), 1)
             self.assertEqual(event_list[0].get("active"), True)
@@ -273,7 +273,7 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             event_list = result.get("value")
             self.assertEqual(len(event_list), 1)
             self.assertEqual(event_list[0].get("active"), False)
@@ -292,7 +292,7 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             event_list = result.get("value")
             self.assertEqual(len(event_list), 1)
             self.assertEqual(event_list[0].get("active"), True)
@@ -304,8 +304,8 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty events
@@ -314,8 +314,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), [])
 
     def test_07_positions(self):
@@ -326,7 +326,7 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue("post" in result.get("value"), result.get("value"))
             self.assertTrue("pre" in result.get("value"), result.get("value"))
 
@@ -345,8 +345,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the event
@@ -355,8 +355,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value")[0].get("position"), "post")
 
         # Update event with the position=pre
@@ -368,8 +368,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the event
@@ -378,8 +378,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value")[0].get("position"), "pre")
 
         # delete event
@@ -389,8 +389,8 @@ class APIEventsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty events
@@ -399,8 +399,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), [])
 
     @smtpmock.activate
@@ -432,8 +432,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         self.setUp_user_realm2()
@@ -446,8 +446,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value").get("tokens"), [])
 
         # user tries to authenticate. with the pin 1234.
@@ -460,8 +460,8 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"))
             self.assertTrue(detail.get("serial").startswith("PIEM"))
             # This is a challenge response!
@@ -477,7 +477,7 @@ class APIEventsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value").get("count"), 1)
             self.assertEqual(result.get("value").get("tokens")[0].get("tokentype"), u"email")

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -3,6 +3,7 @@ This test file tests the api.lib.policy.py
 
 The api.lib.policy.py depends on lib.policy and on flask!
 """
+from __future__ import print_function
 import json
 
 from .base import (MyTestCase, PWFILE)
@@ -39,7 +40,7 @@ from privacyidea.lib.user import User
 from privacyidea.lib.tokens.papertoken import PAPERACTION
 from privacyidea.lib.tokens.tantoken import TANACTION
 
-from flask import Response, Request, g, current_app
+from flask import Response, Request, g, current_app, jsonify
 from werkzeug.test import EnvironBuilder
 from privacyidea.lib.error import PolicyError, RegistrationError
 from privacyidea.lib.machineresolver import save_resolver
@@ -1280,7 +1281,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "PISP0000AB00",
                           "type": "spass"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # Set a policy, that does not allow the tokentype
         set_policy(name="pol1",
@@ -1327,7 +1328,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "id": 1,
                "detail": {"message": "matching 2 tokens",
                           "type": "undetermined"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # Set a policy, that does not allow the tokentype
         set_policy(name="pol1",
@@ -1363,7 +1364,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "PISP0001",
                           "type": "spass"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # Set a policy, that does match
         set_policy(name="pol1",
@@ -1421,7 +1422,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "HOTP123456",
                           "type": "hotp"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # Set a policy, that does not allow the tokentype
         set_policy(name="pol1",
@@ -1466,7 +1467,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "HOTP123456",
                           "type": "hotp"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # Set a policy, that does not allow the detail on success
         set_policy(name="pol2",
@@ -1497,7 +1498,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "HOTP123456",
                           "type": "hotp"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # Set a policy, that does not allow the detail on success
         set_policy(name="pol2",
@@ -1518,7 +1519,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "HOTP123456",
                           "type": "hotp"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         new_response = no_detail_on_fail(req, resp)
         jresult = json.loads(new_response.data)
@@ -1547,7 +1548,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "HOTP123456",
                           "type": "hotp"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         g.policy_object = PolicyClass()
 
@@ -1617,7 +1618,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                           "value": False},
                "version": "privacyIDEA test",
                "id": 1}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # Set the autoassign policy
         # to "any_pin"
@@ -1677,7 +1678,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                           "value": False},
                "version": "privacyIDEA test",
                "id": 1}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # Set the autoassign policy
         # to "userstore"
@@ -1743,7 +1744,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "version": "privacyIDEA test",
                "detail": {"serial": serial},
                "id": 1}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         new_response = offline_info(req, resp)
         jresult = json.loads(new_response.data)
@@ -1792,7 +1793,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                           "value": True},
                "version": "privacyIDEA test",
                "id": 1}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
         from privacyidea.lib.crypto import Sign
         g.sign_object = Sign("tests/testdata/private.pem",
                              "tests/testdata/public.pem")
@@ -1800,7 +1801,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
         new_response = sign_response(req, resp)
         jresult = json.loads(new_response.data)
         self.assertEqual(jresult.get("nonce"), "12345678")
-        self.assertEqual(jresult.get("signature"), "7220461805369685253863294214862525311437731987121534735993146952136348520396812489782945679627890785973634896605293523175424850299832912878523161817380029213546063467888018205435416020286712762804412024065559270543774578319469096483246637875013247101135063221604113204491121777932147776087110152414627230087278622508771143940031542890514380486863296102037208395371717795767683973979032142677315402422403254992482761563612174177151960004042109847122772813717599078313600692433727690239340230353616318691769042290314664126975201679642739717702497638318611217001361093950139025744740660953017413716736691777322916588328")
+        self.assertEqual(jresult.get("signature"), "12286563956186851222763777429695584644324740652565581988587414544297432783523785532070055857619627542347973153465187816396752261730111152465977744264826200787508894389937562519240189748382275312824518790194963440380306202638365223197802490803597478514617706281242938294159192617108210623265084867605251009544178231020920999223970535034040822922068576537239452191722786808074622369000594984335557065543495017539992338002123756259365978375186660886179484370560915820484600337343618193501989005733515794341174572697366915377218917268995598532737466873248560512717129014931617597408250418461112752400750722207570913588830")
 
     def test_08_get_webui_settings(self):
         # Test that a machine definition will return offline hashes
@@ -1840,7 +1841,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "version": "privacyIDEA test",
                "detail": {"serial": serial},
                "id": 1}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         new_response = get_webui_settings(req, resp)
         jresult = json.loads(new_response.data)
@@ -1936,7 +1937,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "changePIN1",
                           "type": "spass"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         # the token itself
         token = init_token({"serial": "changePIN1",
@@ -1963,7 +1964,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
                "detail": {"message": "matching 1 tokens",
                           "serial": "changePIN2",
                           "type": "spass"}}
-        resp = Response(json.dumps(res))
+        resp = jsonify(res)
 
         token = init_token({"type": "spass",
                             "serial": "changePIN2"}, tokenrealms=[self.realm1])

--- a/tests/test_api_machineresolver.py
+++ b/tests/test_api_machineresolver.py
@@ -15,8 +15,8 @@ class APIMachineResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"), result)
             self.assertEqual("Not Implemented", detail.get("description"))
 
@@ -30,7 +30,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -39,7 +39,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("machineresolver1" in result["value"], result)
             self.assertTrue("filename" in result["value"]["machineresolver1"][
@@ -51,7 +51,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             # The value is empty
             self.assertTrue(result["value"] == {}, result)
@@ -62,7 +62,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue("machineresolver1" in value, value)
 
@@ -71,7 +71,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("machineresolver1" in result["value"], result)
@@ -85,7 +85,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("machineresolver1" in result["value"], result)
             self.assertTrue("filename" in result["value"]["machineresolver1"][
@@ -96,8 +96,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            print(res.data)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
@@ -107,8 +106,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            print(res.data)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             # Trying to delete a non existing resolver returns -1
@@ -126,7 +124,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -135,7 +133,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("machineresolver2" in result["value"], result)
             self.assertTrue("LDAPURI" in result["value"]["machineresolver2"][
@@ -146,8 +144,7 @@ class APIMachineResolverTestCase(MyTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            print(res.data)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -45,7 +45,7 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -55,13 +55,13 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 5)
-            self.assertTrue("hostname" in result["value"][0].keys())
-            self.assertTrue("id" in result["value"][0].keys())
-            self.assertTrue("ip" in result["value"][0].keys())
-            self.assertTrue("resolver_name" in result["value"][0].keys())
+            self.assertTrue("hostname" in result["value"][0])
+            self.assertTrue("id" in result["value"][0])
+            self.assertTrue("ip" in result["value"][0])
+            self.assertTrue("resolver_name" in result["value"][0])
 
     def test_01_get_machine_list_any(self):
         with self.app.test_request_context('/machine/?any=192',
@@ -69,13 +69,13 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 4)
-            self.assertTrue("hostname" in result["value"][0].keys())
-            self.assertTrue("id" in result["value"][0].keys())
-            self.assertTrue("ip" in result["value"][0].keys())
-            self.assertTrue("resolver_name" in result["value"][0].keys())
+            self.assertTrue("hostname" in result["value"][0])
+            self.assertTrue("id" in result["value"][0])
+            self.assertTrue("ip" in result["value"][0])
+            self.assertTrue("resolver_name" in result["value"][0])
 
     def test_02_attach_token(self):
         serial = "S1"
@@ -91,7 +91,7 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
 
@@ -112,7 +112,7 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
 
@@ -132,7 +132,7 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
 
@@ -154,7 +154,7 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
 
@@ -173,7 +173,7 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 1)
             self.assertTrue(result["value"][0]["application"] == "luks")
@@ -183,7 +183,7 @@ class APIMachinesTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 1)
             self.assertTrue(result["value"][0]["application"] == "luks")
@@ -202,7 +202,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
 
@@ -229,7 +229,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             sshkey = result["value"].get("ssh")[0].get("sshkey")
             self.assertTrue(sshkey.startswith("ssh-rsa"), sshkey)
@@ -241,7 +241,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             sshkey = result["value"].get("ssh")[0].get("sshkey")
             self.assertTrue(sshkey.startswith("ssh-rsa"), sshkey)
@@ -257,7 +257,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             sshkey = result["value"].get("ssh")[0].get("sshkey")
             self.assertTrue(sshkey.startswith("ssh-rsa"), sshkey)
@@ -271,7 +271,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result["status"], True)
             sshkeys = result["value"].get("ssh")
             # No user DOMAIN\\testuser and no SSH keys
@@ -284,7 +284,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             sshkey = result["value"].get("ssh")[0].get("sshkey")
             self.assertTrue(sshkey.startswith("ssh-rsa"), sshkey)
 
@@ -308,7 +308,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             slot = result["value"].get("luks")[0].get("slot")
             self.assertEqual(slot, "1")
 
@@ -319,7 +319,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             slot = result["value"].get("luks")[0].get("slot")
             self.assertEqual(slot, "1")
             response = result["value"].get("luks")[0].get("response")
@@ -349,7 +349,7 @@ class APIMachinesTestCase(MyTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             offline_auth_item = result["value"].get("offline")[0]
             username = offline_auth_item.get("user")
             self.assertEqual(username, "cornelius")
@@ -368,7 +368,7 @@ class APIMachinesTestCase(MyTestCase):
                 method='GET'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             self.assertTrue(result['result']['status'])
             self.assertTrue(result['result']['value'])
             offline_auth_item = result["auth_items"]["offline"][0]
@@ -378,10 +378,10 @@ class APIMachinesTestCase(MyTestCase):
             response = offline_auth_item.get("response")
             self.assertEqual(len(response), 17)
             self.assertEqual(token_obj.token.count, 35) # 17 + 17 + 1, because we consumed 447589
-            self.assertTrue(passlib.hash. \
+            self.assertTrue(passlib.hash.
                             pbkdf2_sha512.verify("test903435", # count = 18
                                                  response.get('18')))
-            self.assertTrue(passlib.hash. \
+            self.assertTrue(passlib.hash.
                             pbkdf2_sha512.verify("test749439", # count = 34
                                                  response.get('34')))
         self.assertEqual(token_obj.check_otp('747439'), -1) # count = 34

--- a/tests/test_api_monitoring.py
+++ b/tests/test_api_monitoring.py
@@ -28,7 +28,7 @@ class APIMonitoringTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue("key1" in result.get("value"))
             self.assertTrue("key2" in result.get("value"))
 
@@ -39,7 +39,7 @@ class APIMonitoringTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(len(result.get("value")), 4)
             self.assertEqual(result.get("value")[0][1], 1)
             self.assertEqual(result.get("value")[1][1], 2)
@@ -54,7 +54,7 @@ class APIMonitoringTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(len(result.get("value")), 4)
 
         # End value in the past will return no data.
@@ -65,7 +65,7 @@ class APIMonitoringTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(len(result.get("value")), 0)
 
         # check with start timestamp after the 2nd value.
@@ -77,7 +77,7 @@ class APIMonitoringTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(len(result.get("value")), 2)
             self.assertEqual(result.get("value")[0][1], 3)
             self.assertEqual(result.get("value")[1][1], 4)
@@ -89,7 +89,7 @@ class APIMonitoringTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), 4)
 
     def test_02_delete_stats(self):
@@ -105,7 +105,7 @@ class APIMonitoringTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Number of deleted values
             self.assertEqual(result.get("value"), 3)
 
@@ -115,6 +115,6 @@ class APIMonitoringTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Number of remaining values
             self.assertEqual(len(result.get("value")), 1)

--- a/tests/test_api_periodictask.py
+++ b/tests/test_api_periodictask.py
@@ -34,7 +34,7 @@ class APIPeriodicTasksTestCase(MyTestCase):
         kwargs['headers'] = headers
         with self.app.test_request_context(*args, **kwargs):
             res = self.app.full_dispatch_request()
-            return res.status_code, json.loads(res.data)
+            return res.status_code, json.loads(res.data.decode('utf8'))
 
     def test_01_crud(self):
         # no tasks yet

--- a/tests/test_api_policy.py
+++ b/tests/test_api_policy.py
@@ -14,7 +14,7 @@ class APIPolicyTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue('"status": true' in res.data, res.data)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), [])
 
     def test_01_set_policy(self):
@@ -28,7 +28,7 @@ class APIPolicyTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             result = data.get("result")
             self.assertTrue("setPolicy pol1" in result.get("value"),
                             result.get("value"))
@@ -40,7 +40,7 @@ class APIPolicyTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue('"status": true' in res.data, res.data)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             result = data.get("result")
             value = result.get("value")
             self.assertEqual(len(value), 1)
@@ -61,7 +61,7 @@ class APIPolicyTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             result = data.get("result")
             self.assertTrue("setPolicy pol1" in result.get("value"),
                             result.get("value"))
@@ -74,7 +74,7 @@ class APIPolicyTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue('"status": true' in res.data, res.data)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             result = data.get("result")
             value = result.get("value")
             self.assertEqual(len(value), 1)

--- a/tests/test_api_privacyideaserver.py
+++ b/tests/test_api_privacyideaserver.py
@@ -29,7 +29,7 @@ class PrivacyIDEAServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
         # list servers
@@ -38,7 +38,7 @@ class PrivacyIDEAServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 1)
             server1 = server_list.get("server1")
@@ -58,7 +58,7 @@ class PrivacyIDEAServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 0)
 
@@ -89,5 +89,5 @@ class PrivacyIDEAServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)

--- a/tests/test_api_radiusserver.py
+++ b/tests/test_api_radiusserver.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from .base import MyTestCase
 import json
-import radiusmock
+from . import radiusmock
 from privacyidea.lib.config import set_privacyidea_config
 from privacyidea.lib.radiusserver import delete_radius
 DICT_FILE = "tests/testdata/dictionary"
@@ -34,7 +34,7 @@ class RADIUSServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
         # list servers
@@ -43,7 +43,7 @@ class RADIUSServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 1)
             server1 = server_list.get("server1")
@@ -64,7 +64,7 @@ class RADIUSServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 0)
 
@@ -85,7 +85,7 @@ class RADIUSServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
     def test_03_radiusserver_user(self):
@@ -122,7 +122,7 @@ class RADIUSServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
         # User is allowed to list the radius servers
@@ -131,7 +131,7 @@ class RADIUSServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 1)
             # The user does not get any information about the server!

--- a/tests/test_api_register.py
+++ b/tests/test_api_register.py
@@ -6,7 +6,7 @@ from privacyidea.lib.policy import SCOPE, ACTION, set_policy
 from privacyidea.lib.resolvers.SQLIdResolver import IdResolver as SQLResolver
 import json
 from privacyidea.lib.smtpserver import add_smtpserver
-import smtpmock
+from . import smtpmock
 from privacyidea.lib.config import set_privacyidea_config
 from privacyidea.lib.passwordreset import create_recoverycode
 from privacyidea.lib.user import User
@@ -82,7 +82,7 @@ class RegisterTestCase(MyTestCase):
                                                      "cornelius@privacyidea.org"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("error").get("code"), ERROR.REGISTRATION)
             self.assertEqual(data.get("result").get("error").get("message"),
                          u'ERR402: No SMTP server configuration specified!')
@@ -119,7 +119,7 @@ class RegisterTestCase(MyTestCase):
                                            method='GET'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
     @smtpmock.activate
@@ -134,7 +134,7 @@ class RegisterTestCase(MyTestCase):
                                                      "cornelius@privacyidea.org"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res.data)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
     @smtpmock.activate
@@ -155,7 +155,7 @@ class RegisterTestCase(MyTestCase):
                                                  "password": new_password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res.data)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
         # send an invalid recoverycode
@@ -167,7 +167,7 @@ class RegisterTestCase(MyTestCase):
                                                  "password": new_password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res.data)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), False)
 
         # test the new password

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -45,7 +45,7 @@ class APIAuthTestCase(MyTestCase):
                                                  "password": "testpw"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_admin = result.get("value").get("token")
@@ -61,7 +61,7 @@ class APIAuthTestCase(MyTestCase):
                                                         self.at_admin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue("4eyes" in result.get("value"))
             self.assertTrue("hotp" in result.get("value"))
             self.assertTrue(result.get("status"), res.data)
@@ -78,7 +78,7 @@ class APIAuthTestCase(MyTestCase):
                                                              "testadmin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue("token" in result.get("value"))
             self.assertTrue("username" in result.get("value"))
             self.assertEqual(result.get("value").get("role"), "admin")
@@ -92,7 +92,7 @@ class APIAuthTestCase(MyTestCase):
                                                              "cornelius"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue("token" in result.get("value"))
             self.assertTrue("username" in result.get("value"))
             self.assertEqual(result.get("value").get("role"), "user")
@@ -112,7 +112,7 @@ class APIAuthTestCase(MyTestCase):
                                                      "cornelius@adminrealm"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue("token" in result.get("value"))
             self.assertTrue("username" in result.get("value"))
             # ...and will have the role admin
@@ -137,7 +137,7 @@ class APIAuthTestCase(MyTestCase):
                                                         self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # In the result list should only be users from reso3.
             for user in result.get("value"):
                 self.assertEqual(user.get("resolver"), self.resolvername3)
@@ -165,7 +165,7 @@ class APIAuthChallengeResponse(MyTestCase):
                                                  "password": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 401, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertFalse(data.get("result").get("status"))
             detail = data.get("detail")
             self.assertTrue("enter otp" in detail.get("message"), detail.get("message"))
@@ -179,7 +179,7 @@ class APIAuthChallengeResponse(MyTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value").get("username"), "selfservice")
 
 
@@ -219,7 +219,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                  "password": "testpw"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_admin = result.get("value").get("token")
@@ -243,7 +243,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_admin = result.get("value").get("token")
@@ -329,7 +329,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             value = response.get("result").get("value")
             self.assertEqual(len(value), 1)
             self.assertEqual(value[0].get("username"), "selfservice")
@@ -341,7 +341,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             value = response.get("result").get("value")
             self.assertEqual(len(value), 1)
             self.assertEqual(value[0].get("username"), "selfservice")
@@ -361,7 +361,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
             serial = response.get("detail").get("serial")
@@ -381,7 +381,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
         # check if there is no token left
@@ -397,7 +397,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertFalse(response.get("result").get("value"),
                             response.get("result"))
         # check if the token still exists!
@@ -414,7 +414,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertFalse(response.get("result").get("value"),
                              response.get("result"))
         # check if the token still is enabled!
@@ -444,7 +444,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertFalse(response.get("result").get("value"),
                             response.get("result"))
         tokenobject = get_tokens(serial=self.foreign_serial)[0]
@@ -457,7 +457,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -471,7 +471,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -490,7 +490,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value") == 0,
                             response.get("result"))
 
@@ -508,7 +508,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -524,7 +524,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -561,7 +561,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value") == 0,
                             response.get("result"))
         # failcounter still on
@@ -575,7 +575,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
         # failcounter still on
@@ -593,7 +593,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value") == 0,
                             response.get("result"))
 
@@ -606,7 +606,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -681,7 +681,7 @@ class APISelfserviceTestCase(MyTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # Test logout time
             self.assertEqual(result.get("value").get("logout_time"), 200)

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -13,8 +13,8 @@ class APISmsGatewayTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), [])
 
         # create an sms gateway definition
@@ -30,8 +30,8 @@ class APISmsGatewayTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the gateway
@@ -42,8 +42,8 @@ class APISmsGatewayTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             sms_gw = result.get("value")[0]
             self.assertEqual(sms_gw.get("description"), "myGateway")
             self.assertEqual(sms_gw.get("name"), "myGW")
@@ -68,8 +68,8 @@ class APISmsGatewayTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the gateway
@@ -79,8 +79,8 @@ class APISmsGatewayTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             sms_gw = result.get("value")[0]
             self.assertEqual(sms_gw.get("description"), "new description")
 
@@ -93,8 +93,8 @@ class APISmsGatewayTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty gateways
@@ -103,8 +103,8 @@ class APISmsGatewayTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), [])
 
     def test_02_test_options(self):
@@ -122,8 +122,8 @@ class APISmsGatewayTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # add option
@@ -136,7 +136,7 @@ class APISmsGatewayTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
 
         # check options
         with self.app.test_request_context('/smsgateway',
@@ -145,7 +145,7 @@ class APISmsGatewayTestCase(MyTestCase):
                                                    'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             sms_gw = result.get("value")[0]
             self.assertEqual(sms_gw.get("options").get("URL"),
                              "http://example.com")
@@ -158,8 +158,8 @@ class APISmsGatewayTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
 
         # check options
         with self.app.test_request_context('/smsgateway',
@@ -168,7 +168,7 @@ class APISmsGatewayTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             sms_gw = result.get("value")[0]
             self.assertEqual(sms_gw.get("options").get("URL"), None)
             self.assertEqual(sms_gw.get("options").get("HTTP_METHOD"),
@@ -180,7 +180,7 @@ class APISmsGatewayTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            value = json.loads(res.data).get("result").get("value")
+            value = json.loads(res.data.decode('utf8')).get("result").get("value")
             self.assertEqual(len(value), 4)
             self.assertTrue('privacyidea.lib.smsprovider.HttpSMSProvider'
                             '.HttpSMSProvider' in value)

--- a/tests/test_api_smtpserver.py
+++ b/tests/test_api_smtpserver.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from .base import MyTestCase
 import json
-import smtpmock
+from . import smtpmock
 
 
 class SMTPServerTestCase(MyTestCase):
@@ -34,7 +34,7 @@ class SMTPServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
         # list servers
@@ -43,7 +43,7 @@ class SMTPServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 1)
             server1 = server_list.get("server1")
@@ -65,7 +65,7 @@ class SMTPServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 0)
 
@@ -87,6 +87,6 @@ class SMTPServerTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 

--- a/tests/test_api_subscriptions.py
+++ b/tests/test_api_subscriptions.py
@@ -16,7 +16,7 @@ class APISubscriptionsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value >= 1, result)
 
@@ -27,7 +27,7 @@ class APISubscriptionsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(len(value), 1)
             self.assertEqual(value[0].get("application"), "demo_application")
@@ -39,7 +39,7 @@ class APISubscriptionsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(len(value), 1)
             self.assertEqual(value[0].get("application"),
@@ -52,7 +52,7 @@ class APISubscriptionsTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value, 1)
 
@@ -62,7 +62,7 @@ class APISubscriptionsTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(len(value), 0)
 

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 from .base import MyTestCase
 from privacyidea.lib.error import (ParameterError, ConfigAdminError,
@@ -5,7 +6,7 @@ from privacyidea.lib.error import (ParameterError, ConfigAdminError,
 from privacyidea.lib.policy import PolicyClass
 from privacyidea.lib.config import (set_privacyidea_config,
                                     delete_privacyidea_config, SYSCONF)
-from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 
 PWFILE = "tests/testdata/passwords"
 POLICYFILE = "tests/testdata/policy.cfg"
@@ -37,7 +38,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value.get("key1"),
                              "insert",
@@ -65,7 +66,7 @@ class APIConfigTestCase(MyTestCase):
                                            method='POST',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"]["DefaultOtpLen"] == "insert",
@@ -76,7 +77,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1,result)
         
@@ -85,7 +86,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] is None, result)
 
@@ -113,7 +114,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue('"setPolicy pol1": 1' in res.data, res.data)
 
@@ -134,7 +135,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue('"setPolicy pol1": 1' in res.data, res.data)
         delete_privacyidea_config(SYSCONF.OVERRIDECLIENT)
@@ -168,7 +169,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("pol1" == result["value"][0].get("name"), res.data)
 
@@ -196,7 +197,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"]["setPolicy pol_update_del"] > 0,
                             res.data)
@@ -211,7 +212,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["value"]["setPolicy pol_update_del"] > 0,
                             res.data)
             
@@ -221,7 +222,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             policy = {}
             for pol in result["value"]:
@@ -237,7 +238,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
 
         # delete policy
@@ -246,7 +247,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
 
         # check policy
@@ -255,7 +256,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == [], result)
 
@@ -285,8 +286,8 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"), result)
             self.assertTrue("no active server available in server pool" in
                             detail.get("description"),
@@ -301,7 +302,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -310,7 +311,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("resolver1" in result["value"], result)
             self.assertTrue("filename" in result["value"]["resolver1"]["data"])
@@ -321,7 +322,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             # The value is empty
             self.assertTrue(result["value"] == {}, result)
@@ -334,7 +335,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             # The value is empty
             self.assertTrue(result["value"] == {}, result)
@@ -345,7 +346,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue("resolver1" in value, value)
 
@@ -357,7 +358,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue("resolver1" in value, value)
 
@@ -366,7 +367,7 @@ class APIConfigTestCase(MyTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("resolver1" in result["value"], result)
@@ -379,7 +380,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("resolver1" in result["value"], result)
             self.assertTrue("filename" in result["value"]["resolver1"]["data"])
@@ -389,8 +390,7 @@ class APIConfigTestCase(MyTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            print(res.data)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
@@ -400,8 +400,7 @@ class APIConfigTestCase(MyTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            print(res.data)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             # Trying to delete a non existing resolver returns -1
@@ -418,7 +417,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             # The resolver was created. The ID of the resolver is returend.
             self.assertTrue(result["value"] > 0, result)
@@ -430,7 +429,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             # The resolver was created
             self.assertTrue(len(result["value"].get("added")) == 1, result)
@@ -442,7 +441,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             # The resolver was created = 1
             self.assertTrue(realmname in result["value"], result)
@@ -456,7 +455,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("adminrealm" in result["value"], result)
 
@@ -475,7 +474,7 @@ class APIConfigTestCase(MyTestCase):
             # The realm gets deleted
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             # The realm is successfully deleted: value == 1
             self.assertTrue(result["value"] == 1, result)
@@ -487,7 +486,7 @@ class APIConfigTestCase(MyTestCase):
             # The resolver must not be deleted, since it is contained in a realm
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             # The resolver was deleted = 1
             self.assertTrue(result["value"] == 1, result)
@@ -504,7 +503,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
 
         # create a realm
@@ -515,7 +514,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
 
         # get the default realm
@@ -524,7 +523,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("defrealm" in result["value"], result)
 
@@ -534,7 +533,7 @@ class APIConfigTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
 
         # get the default realm
@@ -543,7 +542,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == {}, result)
 
@@ -553,7 +552,7 @@ class APIConfigTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
 
 
@@ -563,7 +562,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             self.assertTrue(res.status_code == 200, res)
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("defrealm" in result["value"], result)
 
@@ -575,7 +574,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 2, result)
             # check if policies are there
@@ -621,7 +620,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
 
 
         with self.app.test_request_context('/policy/pol2',
@@ -634,7 +633,7 @@ class APIConfigTestCase(MyTestCase):
                                                  "client": "172.16.1.1"},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
 
         # CHECK: user=superuser, action=action1, client=172.16.1.1
@@ -652,7 +651,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("value").get("allowed"), result)
 
         # CHECK: user=superuser, action=action1, client=172.16.1.2
@@ -667,7 +666,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value").get("allowed"), result)
 
 
@@ -683,7 +682,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("value").get("allowed"), result)
 
 
@@ -699,7 +698,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value").get("allowed"), result)
 
 
@@ -710,7 +709,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             policies = result.get("value")
             admin_pol = policies.get("admin")
             self.assertTrue("enable" in admin_pol, admin_pol)
@@ -722,7 +721,7 @@ class APIConfigTestCase(MyTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             admin_pol = result.get("value")
             self.assertTrue("enable" in admin_pol, admin_pol)
@@ -735,7 +734,7 @@ class APIConfigTestCase(MyTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             pol = result.get("value")
             self.assertTrue(pol[0].get("active"), pol[0])
@@ -745,14 +744,14 @@ class APIConfigTestCase(MyTestCase):
                                            method='POST',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
 
         with self.app.test_request_context('/policy/pol2',
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             pol = result.get("value")
             self.assertFalse(pol[0].get("active"), pol[0])
@@ -762,14 +761,14 @@ class APIConfigTestCase(MyTestCase):
                                            method='POST',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
 
         with self.app.test_request_context('/policy/pol2',
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             pol = result.get("value")
             self.assertTrue(pol[0].get("active"), pol[0])
@@ -789,7 +788,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value.get("is_ready"), value)
 
@@ -807,8 +806,8 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            details = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            details = json.loads(res.data.decode('utf8')).get("detail")
             value = result.get("value")
             self.assertEqual(value, False)
             self.assertEqual(details.get("message"), "Not implemented")
@@ -819,7 +818,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             # hex encoded value
             self.assertEqual(len(value), 64)
@@ -832,7 +831,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             # hex encoded value
             self.assertEqual(len(value), 44)
@@ -846,7 +845,7 @@ class APIConfigTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             # We probably have no keys in here
             # But value returns a dictionary with the KeyID and "armor" and

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -2,6 +2,7 @@ from .base import MyTestCase
 import json
 import os
 import datetime
+import codecs
 from privacyidea.lib.policy import (set_policy, delete_policy, SCOPE, ACTION,
                                     PolicyClass)
 from privacyidea.lib.token import get_tokens, init_token, remove_token
@@ -1464,7 +1465,7 @@ class APITokenTestCase(MyTestCase):
             seed_url = detail.get("otpkey").get("value")
             self.assertEqual(seed_url[:len('seed://')], 'seed://')
             seed = seed_url[len('seed://'):]
-            self.assertEqual(len(seed.decode('hex')), 42)
+            self.assertEqual(len(codecs.decode(seed, 'hex')), 42)
         remove_token(serial)
 
     def test_27_fail_to_assign_empty_serial(self):

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -7,7 +7,7 @@ from privacyidea.lib.policy import (set_policy, delete_policy, SCOPE, ACTION,
 from privacyidea.lib.token import get_tokens, init_token, remove_token
 from privacyidea.lib.user import User
 from privacyidea.lib.caconnector import save_caconnector
-from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 from privacyidea.lib.token import check_serial_pass
 from privacyidea.lib.tokenclass import DATE_FORMAT
 from privacyidea.lib.config import set_privacyidea_config, delete_privacyidea_config
@@ -121,8 +121,8 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue(result.get("status"), result)
             self.assertTrue(result.get("value"), result)
             self.assertTrue("value" in detail.get("googleurl"), detail)
@@ -135,7 +135,7 @@ class APITokenTestCase(MyTestCase):
                                                  "genkey": 0},
                                            headers={'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
-                data = json.loads(res.data)
+                data = json.loads(res.data.decode('utf8'))
                 self.assertTrue(res.status_code == 200, res)
                 result = data.get("result")
                 detail = data.get("detail")
@@ -155,7 +155,7 @@ class APITokenTestCase(MyTestCase):
                                                  "realm": self.realm1},
                                            headers={'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
-                data = json.loads(res.data)
+                data = json.loads(res.data.decode('utf8'))
                 self.assertTrue(res.status_code == 200, res)
                 result = data.get("result")
                 detail = data.get("detail")
@@ -172,8 +172,8 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             tokenlist = result.get("value").get("tokens")
             count = result.get("value").get("count")
             next = result.get("value").get("next")
@@ -200,8 +200,8 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             tokenlist = result.get("value").get("tokens")
             # NO token assigned, yet
             self.assertTrue(len(tokenlist) == 0, "{0!s}".format(tokenlist))
@@ -214,8 +214,8 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             tokenlist = result.get("value").get("tokens")
             self.assertTrue(len(tokenlist) == 1, len(tokenlist))
 
@@ -263,8 +263,8 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             tokenlist = result.get("value").get("tokens")
             count = result.get("value").get("count")
             next = result.get("value").get("next")
@@ -282,7 +282,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") is True, result)
 
         # Assign the same token to another user will fail
@@ -294,7 +294,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             error = result.get("error")
             self.assertEqual(error.get("message"), "ERR1103: Token already assigned to user User(login=u'cornelius', "
                                                    "realm=u'realm1', resolver=u'resolver1')")
@@ -307,7 +307,7 @@ class APITokenTestCase(MyTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_user = result.get("value").get("token")
@@ -318,7 +318,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             error = result.get("error")
             self.assertEqual(error.get("message"), "ERR1103: Token already assigned to another user.")
 
@@ -330,7 +330,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") is True, result)
 
         # Assign the same token to another user will success
@@ -342,7 +342,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") is True, result)
 
         # Unassign without any arguments will raise a ParameterError
@@ -361,7 +361,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # Try to remove token, that does not exist returns a value=0
@@ -370,7 +370,7 @@ class APITokenTestCase(MyTestCase):
                                            data={},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result.get("value") == 0, result)
 
@@ -392,7 +392,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # disable a disabled token will not count, so the value will be 0
@@ -402,7 +402,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 0, result)
 
         # enable the token again
@@ -412,7 +412,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # try to enable an already enabled token returns value=0
@@ -422,7 +422,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 0, result)
 
     def test_07_reset_failcounter(self):
@@ -441,7 +441,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # test the failcount
@@ -452,7 +452,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, value)
@@ -465,7 +465,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
     def test_07_resync(self):
@@ -476,7 +476,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
             """
@@ -502,7 +502,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") is False, result)
 
         # Successful resync with consecutive values
@@ -514,7 +514,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") is True, result)
 
         # Get the OTP token and inspect the counter
@@ -524,7 +524,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(token.get("count") == 4, result)
@@ -537,7 +537,7 @@ class APITokenTestCase(MyTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_user = result.get("value").get("token")
@@ -552,7 +552,7 @@ class APITokenTestCase(MyTestCase):
                                                          self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") is False, result)
 
         # assign the token to the user selfservice@realm1.
@@ -563,7 +563,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         # let the user resync the token
@@ -576,7 +576,7 @@ class APITokenTestCase(MyTestCase):
                                                          self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") is True, result)
 
 
@@ -590,7 +590,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # Set both PINs of the token
@@ -601,7 +601,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 2, result)
 
         # set a pin
@@ -611,7 +611,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # set an empty pin
@@ -621,7 +621,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
     def test_09_set_token_attributes(self):
@@ -634,7 +634,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
 
@@ -655,7 +655,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 9, result)
 
         # check the values
@@ -666,7 +666,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, result)
@@ -695,7 +695,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -705,7 +705,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(token.get("realms") == ["realm1"], token)
@@ -720,7 +720,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value == 3, result)
 
@@ -734,7 +734,7 @@ class APITokenTestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value == 3, result)
 
@@ -748,7 +748,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value == 3, result)
 
@@ -788,7 +788,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value == 1, result)
 
@@ -802,7 +802,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value == 1, result)
 
@@ -817,7 +817,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -828,7 +828,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value == 1, result)
 
@@ -840,7 +840,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -852,7 +852,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -885,7 +885,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -894,7 +894,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue("end_date" in value, value)
             self.assertTrue(value.get("serial") == "lostLOST001", value)
@@ -918,7 +918,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 28)
             self.assertEqual(value.get("serial"), None)
@@ -938,7 +938,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value.get("serial"), "GETSERIAL2")
 
@@ -948,7 +948,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value.get("serial"), None)
 
@@ -960,7 +960,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertNotEqual(value.get("serial"), "GETSERIAL2")
 
@@ -971,7 +971,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value.get("serial"), "GETSERIAL2")
 
@@ -986,9 +986,9 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             registrationcode = detail.get("registrationcode")
 
         # check password
@@ -998,7 +998,7 @@ class APITokenTestCase(MyTestCase):
                                            method="POST"):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
         # check password again. THe second time it will fail, since the token
@@ -1009,7 +1009,7 @@ class APITokenTestCase(MyTestCase):
                                            method="POST"):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("value"))
 
     def test_16_totp_timestep(self):
@@ -1025,9 +1025,9 @@ class APITokenTestCase(MyTestCase):
                                                headers={'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data).get("result")
+                result = json.loads(res.data.decode('utf8')).get("result")
                 self.assertTrue(result.get("value"))
-                detail = json.loads(res.data).get("detail")
+                detail = json.loads(res.data.decode('utf8')).get("detail")
 
             token = get_tokens(serial="totp{0!s}".format(timestep))[0]
             self.assertEqual(token.timestep, int(timestep))
@@ -1052,9 +1052,9 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             certificate = detail.get("certificate")
             self.assertTrue("-----BEGIN CERTIFICATE-----" in certificate)
 
@@ -1068,7 +1068,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # Try to enable the revoked token
@@ -1095,7 +1095,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 1)
             challenges = value.get("challenges")
@@ -1108,7 +1108,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 1)
             challenges = value.get("challenges")
@@ -1121,7 +1121,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 0)
 
@@ -1139,7 +1139,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), result)
             self.assertTrue(result.get("value"), result)
 
@@ -1216,8 +1216,8 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
 
             serial = detail.get("serial")
             token = get_tokens(serial=serial)[0]
@@ -1240,8 +1240,8 @@ class APITokenTestCase(MyTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
 
             serial = "SP001"
             token = get_tokens(serial=serial)[0]
@@ -1260,7 +1260,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"), result)
         with self.app.test_request_context('/token/info/INF001/key2',
                                             method="POST",
@@ -1268,7 +1268,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"), result)
 
         with self.app.test_request_context('/token/',
@@ -1278,7 +1278,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, result)
@@ -1293,7 +1293,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"), result)
 
         with self.app.test_request_context('/token/',
@@ -1303,7 +1303,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, result)
@@ -1317,7 +1317,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
            res = self.app.full_dispatch_request()
            self.assertTrue(res.status_code == 200, res)
-           result = json.loads(res.data).get("result")
+           result = json.loads(res.data.decode('utf8')).get("result")
            self.assertTrue(result.get("value"), result)
 
         # Delete a non-existing tokeninfo value
@@ -1326,7 +1326,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"), result)
 
         # Try to delete with an unknown serial
@@ -1335,7 +1335,7 @@ class APITokenTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") == False, result)
 
         # Check that the tokeninfo is correct
@@ -1346,7 +1346,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, result)
@@ -1379,9 +1379,9 @@ class APITokenTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             googleurl = detail.get("googleurl")
             self.assertTrue("sha256" in googleurl.get("value"))
             serial = detail.get("serial")
@@ -1407,9 +1407,9 @@ class APITokenTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             token = get_tokens(serial=serial)[0]
             self.assertEqual(token.token.otplen, 8)
@@ -1431,9 +1431,9 @@ class APITokenTestCase(MyTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             token = get_tokens(serial=serial)[0]
             self.assertEqual(token.token.otplen, 6)
@@ -1452,7 +1452,7 @@ class APITokenTestCase(MyTestCase):
                                                  "realm": self.realm1},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(res.status_code == 200, res)
             result = data.get("result")
             detail = data.get("detail")
@@ -1477,7 +1477,7 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("code"), 905)
 
@@ -1494,8 +1494,8 @@ class APITokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             self.assertTrue(u'image=https%3A//example.com/img.png' in detail.get("googleurl").get("value"),
@@ -1529,7 +1529,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value").get("count"), self.token_count)
 
     def test_02_several_requests(self):
@@ -1540,7 +1540,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value").get("count"), 0)
 
         # Run POST assign with a wildcard. This shall not assign.
@@ -1553,7 +1553,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*"
             self.assertEqual(result.get("error").get("message"), "ERR1102: no token found!")
 
@@ -1567,7 +1567,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("message"), "ERR1102: no token found!")
 
@@ -1582,7 +1582,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             # The number of revoked tokens is 0
             self.assertEqual(result.get("value"), 0)
@@ -1594,7 +1594,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("value"), 0)
 
@@ -1604,7 +1604,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("value"), 0)
 
@@ -1614,7 +1614,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("value"), 0)
 
@@ -1624,7 +1624,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("value"), 0)
 
@@ -1635,7 +1635,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("value"), 0)
 
@@ -1645,7 +1645,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("value"), 0)
 
@@ -1655,7 +1655,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("value"), 0)
 
@@ -1665,7 +1665,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("value"), 0)
 
@@ -1677,7 +1677,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 1016)
             self.assertEqual(result.get("error").get("message"), "ERR1016: No unique token to copy from found")
@@ -1689,7 +1689,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 1017)
             self.assertEqual(result.get("error").get("message"), "ERR1017: No unique token to copy to found")
@@ -1702,7 +1702,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 1016)
             self.assertEqual(result.get("error").get("message"), "ERR1016: No unique token to copy from found")
@@ -1715,7 +1715,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 1017)
             self.assertEqual(result.get("error").get("message"), "ERR1017: No unique token to copy to found")
@@ -1733,7 +1733,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 2012)
             self.assertEqual(result.get("error").get("message"), "ERR2012: You can only define a lost token for an assigned token.")
@@ -1749,7 +1749,7 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result.get("value"))
 
@@ -1763,6 +1763,6 @@ class API00TokenPerformance(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result.get("value"))

--- a/tests/test_api_ttype.py
+++ b/tests/test_api_ttype.py
@@ -1,4 +1,3 @@
-from urllib import urlencode
 import json
 from .base import MyTestCase
 from privacyidea.lib.user import (User)
@@ -34,7 +33,7 @@ class TtypeAPITestCase(MyTestCase):
                                                  "serial": "TIQR1",
                                                  "session": "12345"}):
             res = self.app.full_dispatch_request()
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             identity = data.get("identity")
             service = data.get("service")
             self.assertEqual(identity.get("displayName"), "Cornelius ")
@@ -47,7 +46,7 @@ class TtypeAPITestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             self.assertEqual(res.mimetype, u'application/fido.trusted-apps+json')
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue("trustedFacets" in data)
 
         # Check the audit log.
@@ -56,7 +55,7 @@ class TtypeAPITestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = json.loads(res.data.decode('utf8'))
             result = json_response.get("result")
             auditdata = result.get("value").get("auditdata")
             self.assertTrue(len(auditdata) > 0)

--- a/tests/test_api_u2f.py
+++ b/tests/test_api_u2f.py
@@ -56,7 +56,7 @@ class APIU2fTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             result = response.get("result")
             details = response.get("detail")
             self.assertEqual(result.get("value"), True)
@@ -82,7 +82,7 @@ class APIU2fTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data)
+            response = json.loads(res.data.decode('utf8'))
             result = response.get("result")
             details = response.get("detail")
             self.assertEqual(result.get("value"), True)
@@ -101,8 +101,8 @@ class APIU2fTestCase(MyTestCase):
                                                  "pass": "u2f"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), False)
             transaction_id = detail.get("transaction_id")
             self.assertEqual(len(transaction_id), len('01350277175811850842'))
@@ -145,8 +145,8 @@ class APIU2fTestCase(MyTestCase):
                                                      signature_data_url}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), False)
 
@@ -155,7 +155,7 @@ class APIU2fTestCase(MyTestCase):
                                            method='GET'):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue("trustedFacets" in data)
 
         set_policy(name="facet1", scope=SCOPE.AUTH,
@@ -165,7 +165,7 @@ class APIU2fTestCase(MyTestCase):
                                            method='GET'):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue("trustedFacets" in data)
             facets = data["trustedFacets"][0]
             ids = facets["ids"]
@@ -201,8 +201,8 @@ class APIU2fTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -216,8 +216,8 @@ class APIU2fTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -244,8 +244,8 @@ class APIU2fTestCase(MyTestCase):
                                                      signature_data}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -280,8 +280,8 @@ class APIU2fTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -295,8 +295,8 @@ class APIU2fTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -323,7 +323,7 @@ class APIU2fTestCase(MyTestCase):
                                                      signature_data}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 403)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("code"), ERROR.POLICY)
             self.assertEqual(result.get("error").get("message"),
@@ -360,8 +360,8 @@ class APIU2fTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -378,8 +378,8 @@ class APIU2fTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 403)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("message"),
                              u'The U2F device is not allowed to be registered '

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -3,7 +3,7 @@ from .base import MyTestCase
 import json
 from privacyidea.lib.resolver import (save_resolver)
 from privacyidea.lib.realm import (set_realm)
-from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 
 PWFILE = "tests/testdata/passwd"
 
@@ -31,8 +31,8 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue('"status": true' in res.data, res.data)
-            self.assertTrue('"value": []' in res.data, res.data)
+            self.assertTrue(b'"status": true' in res.data, res.data)
+            self.assertTrue(b'"value": []' in res.data, res.data)
 
     def test_01_get_passwd_user(self):
         # create resolver
@@ -56,7 +56,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             value = result.get("result").get("value")
             self.assertTrue('r1' in value["added"], res.data)
             self.assertTrue('r2' in value["failed"], res.data)
@@ -69,7 +69,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             value = result.get("result").get("value")
             self.assertTrue('"username": "cornelius"' in res.data, res.data)
             self.assertTrue('"username": "corny"' in res.data, res.data)
@@ -82,7 +82,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             value = result.get("result").get("value")
             self.assertTrue('"username": "cornelius"' in res.data, res.data)
             self.assertTrue('"username": "corny"' not in res.data, res.data)
@@ -95,7 +95,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             value = result.get("result").get("value")
             self.assertTrue('"username": "cornelius"' not in res.data, res.data)
             self.assertTrue('"username": "corny"' not in res.data, res.data)
@@ -128,7 +128,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") > 6, result.get("value"))
 
         # Get users
@@ -139,7 +139,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"))
             self.assertEqual(result.get("value")[0].get("username"), "wordy")
 
@@ -153,7 +153,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
         # Get user authentication and update by user.
@@ -163,7 +163,7 @@ class APIUsersTestCase(MyTestCase):
                                                  "password": "passwort"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             wordy_auth_token = result.get("value").get("token")
@@ -183,7 +183,7 @@ class APIUsersTestCase(MyTestCase):
                                                         wordy_auth_token}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
         # Although the user "wordy" tried to update the password of user
@@ -194,7 +194,7 @@ class APIUsersTestCase(MyTestCase):
                                                  "password": "newPassword"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             wordy_auth_token = result.get("value").get("token")
@@ -208,7 +208,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
     def test_03_create_update_delete_unicode_user(self):
@@ -239,7 +239,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") > 6, result.get("value"))
 
         # Get users
@@ -250,7 +250,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"))
             self.assertEqual(result.get("value")[0].get("username"), u"wördy")
 
@@ -264,7 +264,7 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
         # Get user authentication and update by user.
@@ -274,7 +274,7 @@ class APIUsersTestCase(MyTestCase):
                                                  "password": "passwort"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             wordy_auth_token = result.get("value").get("token")
@@ -294,7 +294,7 @@ class APIUsersTestCase(MyTestCase):
                                                         wordy_auth_token}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
         # Although the user "wördy" tried to update the password of user
@@ -305,7 +305,7 @@ class APIUsersTestCase(MyTestCase):
                                                  "password": "newPassword"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             wordy_auth_token = result.get("value").get("token")
@@ -319,5 +319,5 @@ class APIUsersTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 import json
+import responses
 
 from .base import MyTestCase
 from privacyidea.lib.user import (User)
@@ -20,7 +21,7 @@ from privacyidea.lib.resolver import save_resolver, get_resolver_list
 from privacyidea.lib.realm import set_realm, set_default_realm
 from privacyidea.lib import _
 
-import smtpmock, ldap3mock, responses
+from . import smtpmock, ldap3mock
 
 
 PWFILE = "tests/testdata/passwords"
@@ -179,7 +180,7 @@ class AuthorizationPolicyTestCase(MyTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -198,7 +199,7 @@ class AuthorizationPolicyTestCase(MyTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -223,7 +224,7 @@ class AuthorizationPolicyTestCase(MyTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -243,7 +244,7 @@ class DisplayTANTestCase(MyTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertTrue(value == 1, result)
 
@@ -260,10 +261,10 @@ class DisplayTANTestCase(MyTestCase):
                                                  "challenge": challenge}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             transaction_id = detail.get("transaction_id")
             hex_challenge = detail.get("attributes").get("challenge")
             self.assertEqual(hex_challenge, "7196501689c356046867728f4feb74458dcfd079")
@@ -278,7 +279,7 @@ class DisplayTANTestCase(MyTestCase):
                                                      transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
 
@@ -292,7 +293,7 @@ class DisplayTANTestCase(MyTestCase):
                                                      transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
 
@@ -307,10 +308,10 @@ class DisplayTANTestCase(MyTestCase):
                                                  "challenge": challenge}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             transaction_id = detail.get("transaction_id")
             hex_challenge = detail.get("attributes").get("challenge")
             self.assertEqual(len(hex_challenge), 40)
@@ -364,13 +365,13 @@ class AValidateOfflineTestCase(MyTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             result = data.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("otplen"), 6)
-            auth_items = json.loads(res.data).get("auth_items")
+            auth_items = json.loads(res.data.decode('utf8')).get("auth_items")
             offline = auth_items.get("offline")[0]
             # Check the number of OTP values
             self.assertEqual(len(offline.get("response")), 100)
@@ -390,11 +391,11 @@ class AValidateOfflineTestCase(MyTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
-            result = json.loads(res.data).get("result")
+            data = json.loads(res.data.decode('utf8'))
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            auth_items = json.loads(res.data).get("auth_items")
+            auth_items = json.loads(res.data.decode('utf8')).get("auth_items")
             offline = auth_items.get("offline")[0]
             # Check the number of OTP values
             self.assertEqual(len(offline.get("response")), 3)
@@ -418,7 +419,7 @@ class AValidateOfflineTestCase(MyTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR905: Token is not an offline token or refill token is incorrect")
 
@@ -431,11 +432,11 @@ class AValidateOfflineTestCase(MyTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
-            result = json.loads(res.data).get("result")
+            data = json.loads(res.data.decode('utf8'))
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            auth_items = json.loads(res.data).get("auth_items")
+            auth_items = json.loads(res.data.decode('utf8')).get("auth_items")
             offline = auth_items.get("offline")[0]
             # Check the number of OTP values
             self.assertEqual(len(offline.get("response")), 5)
@@ -463,7 +464,7 @@ class AValidateOfflineTestCase(MyTestCase):
                                                  "refilltoken": refilltoken_3},
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(res.status_code == 400, res)
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR401: You provided a wrong OTP value.")
@@ -478,7 +479,7 @@ class AValidateOfflineTestCase(MyTestCase):
                                                  "refilltoken": refilltoken_3},
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(res.status_code == 400, res)
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR905: The token does not exist")
@@ -493,7 +494,7 @@ class AValidateOfflineTestCase(MyTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(res.status_code == 400, res)
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR905: Token is not an offline token or refill token is incorrect")
@@ -572,10 +573,10 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("otplen"), 6)
 
         # Check that the counter is increased!
@@ -594,7 +595,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
 
@@ -614,10 +615,10 @@ class ValidateAPITestCase(MyTestCase):
                                                      "pass": "pin287082"})):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("otplen"), 6)
 
         # Check that the counter is increased!
@@ -637,7 +638,7 @@ class ValidateAPITestCase(MyTestCase):
                                                      "pass": "pin287082"})):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
 
@@ -649,7 +650,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin969429"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
 
@@ -660,8 +661,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin969429"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            details = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            details = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
             self.assertEqual(details.get("message"), "wrong otp value. "
@@ -678,8 +679,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            details = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            details = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -694,8 +695,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            details = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            details = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -711,7 +712,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -739,8 +740,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "XXXX123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"))
 
         tok = get_tokens(serial="SE1")[0]
@@ -758,8 +759,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("serial"), "SE1")
             self.assertEqual(detail.get("message"), "wrong otp value")
 
@@ -784,8 +785,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "XXXX123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"))
 
         tok = get_tokens(serial="SE1")[0]
@@ -803,8 +804,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("serial"), "SE1")
             self.assertEqual(detail.get("message"), "wrong otp value")
 
@@ -828,7 +829,7 @@ class ValidateAPITestCase(MyTestCase):
                                                      "pass": "123456"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data).get("result")
+                result = json.loads(res.data.decode('utf8')).get("result")
                 self.assertEqual(result.get("value"), True)
 
         # The 6th authentication will fail
@@ -838,8 +839,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), False)
             self.assertTrue("Authentication counter exceeded"
                             in detail.get("message"))
@@ -856,8 +857,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(result.get("value"), False)
             self.assertEqual(detail.get("message"), "matching 1 tokens, "
                                                     "Failcounter exceeded")
@@ -871,8 +872,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin338314"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             value = result.get("value")
             attributes = value.get("attributes")
             self.assertEqual(value.get("auth"), True)
@@ -887,8 +888,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin254676"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             value = result.get("value")
             attributes = value.get("attributes")
             self.assertEqual(value.get("auth"), True)
@@ -907,8 +908,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin254676"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             value = result.get("value")
             attributes = value.get("attributes")
             self.assertEqual(value.get("auth"), False)
@@ -926,8 +927,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pin254676"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             value = result.get("value")
             attributes = value.get("attributes")
             self.assertEqual(value.get("auth"), False)
@@ -951,7 +952,7 @@ class ValidateAPITestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue('"setPolicy pol_chal_resp": 1' in res.data,
                             res.data)
@@ -974,8 +975,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"))
             self.assertEqual(detail.get("message"), _("please enter otp: "))
             transaction_id = detail.get("transaction_id")
@@ -990,8 +991,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue(result.get("value"))
 
         self.assertEqual(token.get_failcount(), 0)
@@ -1010,7 +1011,7 @@ class ValidateAPITestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue('"setPolicy pol_chal_resp": 1' in res.data,
                             res.data)
@@ -1030,8 +1031,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"))
             self.assertTrue("The PIN was correct, "
                             "but the SMS could not be sent" in
@@ -1047,8 +1048,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"))
             self.assertEqual(detail.get("message"),
                              "No active challenge response token found")
@@ -1070,7 +1071,7 @@ class ValidateAPITestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue('"setPolicy pol_chal_resp": 1' in res.data,
                             res.data)
@@ -1090,8 +1091,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertFalse(result.get("value"))
             self.assertEqual(detail.get("message"), _("Enter the OTP from the Email:"))
             transaction_id = detail.get("transaction_id")
@@ -1106,8 +1107,8 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue(result.get("value"))
 
         # delete the token
@@ -1126,7 +1127,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
         # Set validity period
@@ -1138,9 +1139,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("value"))
-            details = json.loads(res.data).get("detail")
+            details = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue("Outside validity period" in details.get("message"))
 
         token_obj.set_validity_period_end("1999-01-01T10:00+0200")
@@ -1152,9 +1153,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("value"))
-            details = json.loads(res.data).get("detail")
+            details = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue("Outside validity period" in details.get("message"))
 
         # delete the token
@@ -1177,7 +1178,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": serial1}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
         set_privacyidea_config("splitAtSign", "0")
@@ -1197,7 +1198,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": serial2}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
         # The default behaviour - if the config entry does not exist,
@@ -1210,7 +1211,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": serial2}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value"))
 
     def test_16_autoresync_hotp(self):
@@ -1229,7 +1230,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "async399871"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), False)
 
         # counter = 9, will be autosynced.
@@ -1241,7 +1242,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "async520489"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         delete_privacyidea_config("AutoResync")
@@ -1266,7 +1267,7 @@ class ValidateAPITestCase(MyTestCase):
                                                      "pass": pin}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data).get("result")
+                result = json.loads(res.data.decode('utf8')).get("result")
                 self.assertEqual(result.get("value"), True)
 
         with self.app.test_request_context('/validate/check',
@@ -1276,7 +1277,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), False)
 
         delete_policy("pol_time1")
@@ -1301,7 +1302,7 @@ class ValidateAPITestCase(MyTestCase):
                                                      "pass": "wrongpin"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data).get("result")
+                result = json.loads(res.data.decode('utf8')).get("result")
                 self.assertEqual(result.get("value"), False)
 
         # Now we do the correct authentication, but
@@ -1313,9 +1314,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), False)
-            details = json.loads(res.data).get("detail")
+            details = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(details.get("message"),
                              "Only 2 failed authentications per 0:00:20")
 
@@ -1335,7 +1336,7 @@ class ValidateAPITestCase(MyTestCase):
                                         "pass": "pthru"})):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         # Passthru with POST Request
@@ -1346,7 +1347,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pthru"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         # Test if the policies "reset_all_tokens" and "passthru" work out fine at the same time
@@ -1359,7 +1360,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pthru"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         delete_policy("reset_all_tokens")
@@ -1393,7 +1394,7 @@ class ValidateAPITestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             value = result.get("value")
             self.assertEqual(value, True)
 
@@ -1404,9 +1405,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("value"))
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             transaction_id = detail.get("transaction_id")
             question = detail.get("message")
             self.assertTrue(question in questions)
@@ -1421,7 +1422,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": answer}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
     def test_21_validate_disabled(self):
@@ -1448,7 +1449,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "superSecret"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         # disable 2nd token
@@ -1463,7 +1464,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "superSecret"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         delete_policy("disabled")
@@ -1495,7 +1496,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "locked"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         remove_token("spass1l")
@@ -1527,9 +1528,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("serial"), serial)
 
         # User that does not exist, can authenticate
@@ -1540,9 +1541,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("message"),
                              u"user does not exist, accepted "
                              u"due to 'pass_no'")
@@ -1559,9 +1560,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("message"),
                              u"user does not exist, accepted "
                              u"due to 'pass_no'")
@@ -1578,9 +1579,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("message"),
                              u"user has no token, "
                              u"accepted due to 'pass_no'")
@@ -1596,9 +1597,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "wrongPiN"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), False)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("message"),
                              "wrong otp pin")
 
@@ -1614,7 +1615,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail, None)
 
     def test_23a_pass_no_user_resolver(self):
@@ -1636,7 +1637,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "secret"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("message"),
                              u'user does not exist, accepted due to \'pol1\'')
         delete_policy("pol1")
@@ -1684,9 +1685,9 @@ class ValidateAPITestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), 1)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("messages")[0],
                              _("Enter the OTP from the SMS:"))
             transaction_id = detail.get("transaction_ids")[0]
@@ -1701,7 +1702,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         # Trigger challenge for user
@@ -1713,9 +1714,9 @@ class ValidateAPITestCase(MyTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), 1)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("messages")[0],
                              _("Enter the OTP from the SMS:"))
             transaction_id = detail.get("transaction_ids")[0]
@@ -1730,7 +1731,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "969429"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         remove_token(serial)
@@ -1763,9 +1764,9 @@ class ValidateAPITestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), 1)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("messages")[0],
                              _("Enter the OTP from the Email:"))
             transaction_id = detail.get("transaction_ids")[0]
@@ -1803,9 +1804,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), False)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             transaction_id = detail.get("transaction_id")
             multi_challenge = detail.get("multi_challenge")
             self.assertEqual(multi_challenge[0].get("serial"), "CR2A")
@@ -1832,9 +1833,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             self.assertEqual(serial, "CR2B")
 
@@ -1875,9 +1876,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pinB}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), False)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             transaction_id = detail.get("transaction_id")
             multi_challenge = detail.get("multi_challenge")
             self.assertEqual(multi_challenge[0].get("serial"), "CR2B")
@@ -1902,9 +1903,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             self.assertEqual(serial, "CR2B")
 
@@ -1949,7 +1950,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "123456"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertFalse(result.get("status"))
 
     def test_29_several_CR_one_locked(self):
@@ -1979,10 +1980,10 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             # This is a challene, the value is False
             self.assertEqual(result.get("value"), False)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             serial = detail.get("serial")
             self.assertEqual(serial, "CR2A")
             # Only one challenge, the 2nd token was revoked.
@@ -2019,9 +2020,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("type"), "undetermined")
 
         # two same token types.
@@ -2036,9 +2037,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("type"), "spass")
 
         # A user has one HOTP token and two spass tokens.
@@ -2053,9 +2054,9 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail.get("type"), "spass")
 
         # policy only allows HOTP.
@@ -2069,10 +2070,10 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 403)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("code"), ERROR.POLICY)
-            detail = json.loads(res.data).get("detail")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertEqual(detail, None)
 
         # Define a passthru policy
@@ -2086,7 +2087,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "pthru"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertEqual(result.get("value"), True)
 
         delete_policy("onlyHOTP")
@@ -2153,7 +2154,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "email"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            resp = json.loads(res.data)
+            resp = json.loads(res.data.decode('utf8'))
             self.assertEqual(resp.get("detail").get("message"), "check your email")
 
         # Challenge Response with SMS
@@ -2163,7 +2164,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "sms"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            resp = json.loads(res.data)
+            resp = json.loads(res.data.decode('utf8'))
             self.assertEqual(resp.get("detail").get("message"), "check your sms")
 
         # Two different token types that are triggered by the same PIN:
@@ -2183,7 +2184,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": "PIN"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            resp = json.loads(res.data)
+            resp = json.loads(res.data.decode('utf8'))
             self.assertEqual(resp.get("detail").get("message"), "check your sms, check your email")
 
         delete_policy("chalsms")
@@ -2201,7 +2202,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": ""}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             error_msg = result.get("error").get("message")
             self.assertEqual("ERR905: You need to specify a serial or a user.", error_msg)
 
@@ -2212,7 +2213,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": ""}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             error_msg = result.get("error").get("message")
             self.assertEqual("ERR905: Invalid user.", error_msg)
 
@@ -2223,7 +2224,7 @@ class ValidateAPITestCase(MyTestCase):
                                                  "pass": ""}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             error_msg = result.get("error").get("message")
             self.assertEqual("ERR905: Invalid serial number.", error_msg)
 
@@ -2283,7 +2284,7 @@ class AChallengeResponse(MyTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2298,7 +2299,7 @@ class AChallengeResponse(MyTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(data.get("result").get("value"))
 
         # Now we send the challenge and then we disable the token
@@ -2308,7 +2309,7 @@ class AChallengeResponse(MyTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2326,7 +2327,7 @@ class AChallengeResponse(MyTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
             self.assertEqual(detail.get("message"), "Challenge matches, but token is inactive.")
@@ -2339,7 +2340,7 @@ class AChallengeResponse(MyTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2369,7 +2370,7 @@ class AChallengeResponse(MyTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2383,7 +2384,7 @@ class AChallengeResponse(MyTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = json.loads(res.data.decode('utf8'))
             self.assertTrue(data.get("result").get("status"))
             # Triggerchallenge returns the numbers of tokens in the "value
             self.assertEqual(data.get("result").get("value"), 1)

--- a/tests/test_lib_applications.py
+++ b/tests/test_lib_applications.py
@@ -180,8 +180,8 @@ class BaseApplicationTestCase(MyTestCase):
 
     def test_04_get_application_types(self):
         apps = get_application_types()
-        self.assertTrue("luks" in apps.keys())
-        self.assertTrue("ssh" in apps.keys())
+        self.assertTrue("luks" in apps)
+        self.assertTrue("ssh" in apps)
         self.assertEqual(apps["ssh"]["options"]["optional"], ["user"])
         self.assertEqual(apps["luks"]["options"]["optional"], ["slot",
                                                                "partition"])

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -61,9 +61,6 @@ class AuditTestCase(MyTestCase):
         self.assertTrue(tot == 3, tot)
         audit_log = self.Audit.search({}, sortorder="desc")
 
-        print("The Log:")
-        print(audit_log)
-
         # with search filter
         tot = self.Audit.get_total({"action": "action2",
                                     "bullshit": "value"})

--- a/tests/test_lib_authcache.py
+++ b/tests/test_lib_authcache.py
@@ -17,11 +17,11 @@ class AuthCacheTestCase(MyTestCase):
     """
     Test the policies on a database level
     """
-    password = "secret123456"
+    password = u"secret123456"
     username = "hans"
     realm = "realm"
     resolver = "resolver"
-    pw_hash = binascii.hexlify(hashlib.sha256(password).digest())
+    pw_hash = binascii.hexlify(hashlib.sha256(password.encode('utf8')).digest())
 
     def test_01_write_update_delete_cache(self):
         teststart = datetime.datetime.utcnow()

--- a/tests/test_lib_config.py
+++ b/tests/test_lib_config.py
@@ -178,7 +178,7 @@ class ConfigTestCase(MyTestCase):
         (classes, types) = get_machine_resolver_class_dict()
         self.assertTrue("hosts" in types.values(), types.values())
         self.assertTrue("privacyidea.lib.machines.hosts.HostsMachineResolver"
-                        in classes.keys(), classes)
+                        in classes, classes)
 
     def test_06_public_and_admin(self):
         # This tests the new public available config

--- a/tests/test_lib_config.py
+++ b/tests/test_lib_config.py
@@ -176,7 +176,7 @@ class ConfigTestCase(MyTestCase):
 
     def test_05_machine_resolvers(self):
         (classes, types) = get_machine_resolver_class_dict()
-        self.assertTrue("hosts" in types.values(), types.values())
+        self.assertTrue("hosts" in types.values(), list(types.values()))
         self.assertTrue("privacyidea.lib.machines.hosts.HostsMachineResolver"
                         in classes, classes)
 

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -5,7 +5,7 @@ lib/eventhandler/usernotification.py (one event handler module)
 lib/event.py (the decorator)
 """
 
-import smtpmock
+from . import smtpmock
 import responses
 from .base import MyTestCase, FakeFlaskG, FakeAudit
 from privacyidea.lib.eventhandler.usernotification import (
@@ -2341,7 +2341,7 @@ class UserNotificationTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("value") is True, result)
 
         # Cleanup

--- a/tests/test_lib_lifecycle.py
+++ b/tests/test_lib_lifecycle.py
@@ -36,7 +36,7 @@ class LifecycleTestCase(MyTestCase):
             register_finalizer(finalizer1)
             register_finalizer(finalizer2)
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"))
         finalizer1.assert_called_once()
         finalizer2.assert_called_once()
@@ -45,7 +45,7 @@ class LifecycleTestCase(MyTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"))
         finalizer1.assert_called_once()
         finalizer2.assert_called_once()
@@ -61,7 +61,7 @@ class LifecycleTestCase(MyTestCase):
             register_finalizer(finalizer1)
             register_finalizer(finalizer2)
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"))
         finalizer1.assert_called_once()
         finalizer2.assert_called_once()

--- a/tests/test_lib_machine_resolver_ldap.py
+++ b/tests/test_lib_machine_resolver_ldap.py
@@ -7,7 +7,7 @@ HOSTSFILE = "tests/testdata/hosts"
 from .base import MyTestCase
 from privacyidea.lib.machines.ldap import LdapMachineResolver
 from privacyidea.lib.machines.base import MachineResolverError
-import ldap3mock
+from . import ldap3mock
 import netaddr
 
 LDAPDirectory = [{"dn": "cn=admin,ou=example,o=test",

--- a/tests/test_lib_machines.py
+++ b/tests/test_lib_machines.py
@@ -93,13 +93,13 @@ class MachineResolverTestCase(MyTestCase):
     def test_02_list_resolvers(self):
         # check if the resolver, we created is in the database
         l = get_resolver_list()
-        self.assertTrue("testresolver" in l.keys(), l.keys())
+        self.assertTrue("testresolver" in l, l)
 
         l = get_resolver_list(filter_resolver_name="testresolver")
-        self.assertTrue("testresolver" in l.keys(), l.keys())
+        self.assertTrue("testresolver" in l, l)
 
         l = get_resolver_list(filter_resolver_type="hosts")
-        self.assertTrue("testresolver" in l.keys(), l.keys())
+        self.assertTrue("testresolver" in l, l)
 
     def test_03_get_resolver_config(self):
         c = get_resolver_config("testresolver")
@@ -130,7 +130,7 @@ class MachineResolverTestCase(MyTestCase):
     def test_99_delete_resolver(self):
         delete_resolver("testresolver")
         l = get_resolver_list(filter_resolver_name="testresolver")
-        self.assertTrue("testresolver" not in l.keys(), l.keys())
+        self.assertTrue("testresolver" not in l, l)
 
 
 class BaseMachineTestCase(MyTestCase):

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -28,7 +28,7 @@ from privacyidea.lib.token import (init_token, remove_token, check_user_pass,
 from privacyidea.lib.error import UserError, PolicyError
 from privacyidea.lib.radiusserver import add_radius
 import datetime
-import radiusmock
+from . import radiusmock
 import binascii
 import hashlib
 from privacyidea.models import AuthCache

--- a/tests/test_lib_radiusserver.py
+++ b/tests/test_lib_radiusserver.py
@@ -7,7 +7,7 @@ from privacyidea.lib.radiusserver import (add_radius, delete_radius,
                                           get_radiusservers, get_radius,
                                           RADIUSServer, test_radius)
 from privacyidea.lib.config import set_privacyidea_config
-import radiusmock
+from . import radiusmock
 DICT_FILE = "tests/testdata/dictionary"
 
 

--- a/tests/test_lib_realm.py
+++ b/tests/test_lib_realm.py
@@ -53,7 +53,7 @@ class ResolverTestCase(MyTestCase):
         realms = get_realms()
         self.assertTrue(self.realm1 in realms, realms)
         self.assertTrue(realms.get("realm1").get("default"), realms)
-        self.assertTrue(self.realm_dot in realms.keys())
+        self.assertTrue(self.realm_dot in realms, realms)
 
         # delete dot realm
         delete_realm(self.realm_dot)
@@ -74,7 +74,7 @@ class ResolverTestCase(MyTestCase):
     def test_03_get_specific_realm(self):
         realm = get_realms(self.realm1)
         self.assertTrue(self.realm1 in realm, realm)
-        self.assertTrue(len(realm.keys()) == 1, realm)
+        self.assertTrue(len(realm) == 1, realm)
         
     def test_02_set_default_realm(self):
         (added, failed) = set_realm("realm2",

--- a/tests/test_lib_recovery.py
+++ b/tests/test_lib_recovery.py
@@ -4,7 +4,7 @@ This test file tests the lib/passwordreset.py
 """
 from .base import MyTestCase
 from privacyidea.lib.smtpserver import add_smtpserver
-import smtpmock
+from . import smtpmock
 from privacyidea.lib.error import privacyIDEAError
 from privacyidea.lib.passwordreset import (create_recoverycode,
                                            check_recoverycode,

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -8,9 +8,8 @@ lib.resolvers.ldapresolver
 
 The lib.resolver.py only depends on the database model.
 """
-PWFILE = "tests/testdata/passwords"
 from .base import MyTestCase
-import ldap3mock
+from . import ldap3mock
 from ldap3.core.exceptions import LDAPOperationResult
 from ldap3.core.results import RESULT_SIZE_LIMIT_EXCEEDED
 import mock
@@ -30,6 +29,8 @@ from privacyidea.lib.resolver import (save_resolver,
                                       get_resolver_list,
                                       get_resolver_object, pretestresolver)
 from privacyidea.models import ResolverConfig
+
+PWFILE = "tests/testdata/passwords"
 
 objectGUIDs = [
     '039b36ef-e7c0-42f3-9bf9-ca6a6c0d4d31',
@@ -196,26 +197,30 @@ class SQLResolverTestCase(MyTestCase):
 
     def test_01_where_tests(self):
         y = SQLResolver()
-        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
-                                                              "hans"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "givenname == hans"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertTrue(len(userlist) == 1, userlist)
 
         y = SQLResolver()
-        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname like "
-                                                              "hans"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "givenname like hans"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertEqual(len(userlist), 1)
 
         y = SQLResolver()
-        y.loadConfig(
-            dict(self.parameters.items() + {"Where": "id > 2"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "id > 2"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertEqual(len(userlist), self.num_users - 2)
 
         y = SQLResolver()
-        y.loadConfig(dict(self.parameters.items() + {"Where": "id < "
-                                                              "5"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "id < 5"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertEqual(len(userlist), 4)
 
@@ -227,7 +232,6 @@ class SQLResolverTestCase(MyTestCase):
         # 772cb52221f19104310cd2f549f5131fbfd34e0f4de7590c87b1d73175812607
 
         result = y.checkPass(3, "dunno")
-        print(result)
         assert result is True
         '''
         SHA1 base64 encoded of "dunno"
@@ -308,38 +312,39 @@ class SQLResolverTestCase(MyTestCase):
         
     def test_06_append_where_filter(self):
         y = SQLResolver()
-        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
-                                                              "hans and name "
-                                                              "== dampf"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "givenname == hans and name == dampf"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertTrue(len(userlist) == 1, userlist)
         
         y = SQLResolver()
-        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
-                                                              "hans AND name "
-                                                              "== dampf"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "givenname == hans AND name == dampf"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertTrue(len(userlist) == 1, userlist)
 
         # Also allow more than one blank surrounding the "and"
         # SQLAlchemy strips the blanks in the condition
         y = SQLResolver()
-        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
-                                                              "hans   AND name "
-                                                              "== dampf"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "givenname == hans   AND name == dampf"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertTrue(len(userlist) == 1, userlist)
         
         y = SQLResolver()
-        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
-                                                              "hans and name "
-                                                              "== test"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "givenname == hans and name == test"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertTrue(len(userlist) == 0, userlist)
         
         y = SQLResolver()
-        y.loadConfig(dict(self.parameters.items() + {"Where": "givenname == "
-                                                              "chandler"}.items()))
+        d = self.parameters.copy()
+        d.update({"Where": "givenname == chandler"})
+        y.loadConfig(d)
         userlist = y.getUserList()
         self.assertTrue(len(userlist) == 0, userlist)
 

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -8,6 +8,7 @@ lib.resolvers.ldapresolver
 
 The lib.resolver.py only depends on the database model.
 """
+PWFILE = "tests/testdata/passwords"
 from .base import MyTestCase
 from . import ldap3mock
 from ldap3.core.exceptions import LDAPOperationResult
@@ -30,7 +31,6 @@ from privacyidea.lib.resolver import (save_resolver,
                                       get_resolver_object, pretestresolver)
 from privacyidea.models import ResolverConfig
 
-PWFILE = "tests/testdata/passwords"
 
 objectGUIDs = [
     '039b36ef-e7c0-42f3-9bf9-ca6a6c0d4d31',

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -22,8 +22,8 @@ from privacyidea.lib.smsprovider.SMSProvider import (SMSError,
                                                      create_sms_instance)
 from privacyidea.lib.smtpserver import add_smtpserver
 import responses
-import smtpmock
-import smppmock
+from . import smtpmock
+from . import smppmock
 
 
 class SMSTestCase(MyTestCase):

--- a/tests/test_lib_smtpserver.py
+++ b/tests/test_lib_smtpserver.py
@@ -7,7 +7,7 @@ from privacyidea.lib.smtpserver import (get_smtpservers, add_smtpserver,
                                         delete_smtpserver, get_smtpserver,
                                         SMTPServer)
 from privacyidea.models import SMTPServer as SMTPServerDB
-import smtpmock
+from . import smtpmock
 from smtplib import SMTPException
 
 

--- a/tests/test_lib_tasks.py
+++ b/tests/test_lib_tasks.py
@@ -7,6 +7,7 @@ lib/task/base.py
 
 from privacyidea.lib.task.base import BaseTask
 from .base import MyTestCase
+import six
 
 
 class BaseTaskTestCase(MyTestCase):
@@ -14,7 +15,7 @@ class BaseTaskTestCase(MyTestCase):
         task = BaseTask()
 
         self.assertEqual(task.identifier, "BaseTask")
-        self.assertIsInstance(task.description, basestring)
+        self.assertIsInstance(task.description, six.string_types)
         self.assertEqual(task.options, {})
 
         result1 = task.do()

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -13,9 +13,6 @@ getTokens4UserOrSerial
 gettokensoftype
 getToken....
 """
-PWFILE = "tests/testdata/passwords"
-OTPKEY = "3132333435363738393031323334353637383930"
-OTPKE2 = "31323334353637383930313233343536373839AA"
 
 from .base import MyTestCase
 from privacyidea.lib.user import (User)
@@ -62,6 +59,10 @@ from privacyidea.lib.error import (TokenAdminError, ParameterError,
                                    privacyIDEAError)
 from privacyidea.lib.tokenclass import DATE_FORMAT
 from dateutil.tz import tzlocal
+
+PWFILE = "tests/testdata/passwords"
+OTPKEY = "3132333435363738393031323334353637383930"
+OTPKE2 = "31323334353637383930313233343536373839AA"
 
 
 class TokenTestCase(MyTestCase):
@@ -946,8 +947,6 @@ class TokenTestCase(MyTestCase):
                         len(tokendata.get("tokens")))
 
         tokens = tokendata.get("tokens")
-        for token in tokens:
-            print(token.get("serial"))
 
         self.assertTrue(tokens[0].get("serial") == "A8",
                         tokens[0])
@@ -958,8 +957,6 @@ class TokenTestCase(MyTestCase):
         tokendata = get_tokens_paginate(sortby=Token.serial, page=1, psize=100,
                                         sortdir="desc")
         tokens = tokendata.get("tokens")
-        for token in tokens:
-            print(token.get("serial"))
 
         self.assertTrue(tokens[0].get("serial") == "hotptoken")
         self.assertTrue(tokens[-1].get("serial") == "A8")
@@ -968,8 +965,6 @@ class TokenTestCase(MyTestCase):
         tokendata = get_tokens_paginate(sortby="serial", page=1, psize=100,
                                         sortdir="asc")
         tokens = tokendata.get("tokens")
-        for token in tokens:
-            print(token.get("serial"))
 
         self.assertTrue(tokens[-1].get("serial") == "hotptoken")
         self.assertTrue(tokens[0].get("serial") == "A8")
@@ -977,8 +972,6 @@ class TokenTestCase(MyTestCase):
         tokendata = get_tokens_paginate(sortby="serial", page=1, psize=100,
                                         sortdir="desc")
         tokens = tokendata.get("tokens")
-        for token in tokens:
-            print(token.get("serial"))
 
         self.assertTrue(tokens[0].get("serial") == "hotptoken")
         self.assertTrue(tokens[-1].get("serial") == "A8")

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -3,7 +3,6 @@ This test file tests the lib.tokenclass
 
 The lib.tokenclass depends on the DB model and lib.user
 """
-PWFILE = "tests/testdata/passwords"
 
 from .base import MyTestCase
 from privacyidea.lib.resolver import (save_resolver, delete_resolver)
@@ -20,6 +19,8 @@ from privacyidea.models import (Token,
 import datetime
 from dateutil.tz import tzlocal
 import binascii
+
+PWFILE = "tests/testdata/passwords"
 
 class TokenBaseTestCase(MyTestCase):
     '''
@@ -620,7 +621,6 @@ class TokenBaseTestCase(MyTestCase):
         token = TokenClass(db_token)
         token_data = token.get_as_dict()
 
-        print(token_data)
         self.assertTrue("info" in token_data)
         self.assertTrue(token_data.get("user_id") == "2000")
         self.assertTrue(token_data.get("tokentype") == "newtype")

--- a/tests/test_lib_tokens_email.py
+++ b/tests/test_lib_tokens_email.py
@@ -1,8 +1,6 @@
 """
 This test file tests the lib.tokens.smstoken
 """
-PWFILE = "tests/testdata/passwords"
-TEMPLATE_FILE = "tests/testdata/emailtemplate.html"
 
 from .base import MyTestCase, FakeFlaskG
 from privacyidea.lib.resolver import (save_resolver)
@@ -19,8 +17,11 @@ from privacyidea.lib.smtpserver import add_smtpserver, delete_smtpserver
 from privacyidea.lib import _
 import datetime
 from dateutil.tz import tzlocal
-import smtpmock
+from . import smtpmock
 import mock
+
+PWFILE = "tests/testdata/passwords"
+TEMPLATE_FILE = "tests/testdata/emailtemplate.html"
 
 
 class EmailTokenTestCase(MyTestCase):

--- a/tests/test_lib_tokens_questionnaire.py
+++ b/tests/test_lib_tokens_questionnaire.py
@@ -60,7 +60,7 @@ class QuestionnaireTokenTestCase(MyTestCase):
         self.assertEqual(r[0], True)
         question = r[1]
         transactionid = r[2]
-        self.assertTrue(question in self.questions.keys())
+        self.assertTrue(question in self.questions)
 
         # Now that we have the question, we can give the answer
         r = token.check_challenge_response(passw=self.questions[question],

--- a/tests/test_lib_tokens_radius.py
+++ b/tests/test_lib_tokens_radius.py
@@ -8,7 +8,7 @@ from privacyidea.lib.tokens.radiustoken import RadiusTokenClass
 from privacyidea.models import Token
 from privacyidea.lib.error import ParameterError
 from privacyidea.lib.config import set_privacyidea_config
-import radiusmock
+from . import radiusmock
 from privacyidea.lib.token import init_token
 from privacyidea.lib.radiusserver import add_radius
 

--- a/tests/test_lib_tokens_ssh.py
+++ b/tests/test_lib_tokens_ssh.py
@@ -7,6 +7,7 @@ This depends on lib.tokenclass
 from .base import MyTestCase
 from privacyidea.lib.tokens.sshkeytoken import SSHkeyTokenClass
 from privacyidea.models import Token
+import six
 
 
 class SSHTokenTestCase(MyTestCase):
@@ -69,4 +70,4 @@ RyMSQe4mn8oHJma2VzepBRBpLt7Q==
         token = SSHkeyTokenClass(db_token)
         sshkey = token.get_sshkey()
         self.assertTrue(sshkey == self.sshkey, sshkey)
-        self.assertIsInstance(sshkey, unicode)
+        self.assertIsInstance(sshkey, six.text_type)

--- a/tests/test_lib_tokens_tiqr.py
+++ b/tests/test_lib_tokens_tiqr.py
@@ -14,8 +14,8 @@ from privacyidea.lib import _
 import re
 import binascii
 import hashlib
-from urlparse import urlparse
-from urllib import urlencode
+from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlencode
 import json
 from flask import Request, g
 from werkzeug.test import EnvironBuilder
@@ -501,8 +501,8 @@ class TiQRTokenTestCase(MyTestCase):
                                                "pass": pin})):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = json.loads(res.data.decode('utf8')).get("result")
+            detail = json.loads(res.data.decode('utf8')).get("detail")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
             transaction_id = detail.get("transaction_id")

--- a/tests/test_lib_tokens_vasco.py
+++ b/tests/test_lib_tokens_vasco.py
@@ -247,7 +247,7 @@ class VascoTokenTest(MyTestCase):
 
         self.assertTrue(token.check_failcount())
         # fail 10 times
-        for _ in xrange(10 + 1):
+        for _ in range(10 + 1):
             r = _step1()
             self.assertEqual(r[0], False)
             self.assertEqual(r[1].get('message'), 'wrong otp value')

--- a/tests/test_lib_user.py
+++ b/tests/test_lib_user.py
@@ -4,6 +4,7 @@ This test file tests the lib.user
 
 The lib.user.py only depends on the database model
 """
+import six
 PWFILE = "tests/testdata/passwd"
 PWFILE2 = "tests/testdata/passwords"
 
@@ -60,9 +61,8 @@ class UserTestCase(MyTestCase):
         
         user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
-        # check proper unicode() and str() handling
-        self.assertIsInstance(str(user), bytes)
-        self.assertIsInstance(unicode(user), unicode)
+        # check proper unicode() / str() handling
+        self.assertIsInstance(six.text_type(user), six.text_type)
         
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
@@ -365,6 +365,7 @@ class UserTestCase(MyTestCase):
 
         # check proper unicode() and str() handling
         user_object = User(login=u"nönäscii", realm=realm)
-        self.assertEqual(unicode(user_object), u'<nönäscii.SQL1@sqlrealm>')
-        self.assertEqual(str(user_object), '<n\xc3\xb6n\xc3\xa4scii.SQL1@sqlrealm>')
+        self.assertEqual(six.text_type(user_object), u'<nönäscii.SQL1@sqlrealm>')
+        self.assertEqual(six.text_type(user_object).encode('utf8'),
+                         b'<n\xc3\xb6n\xc3\xa4scii.SQL1@sqlrealm>')
 

--- a/tests/test_lib_user.py
+++ b/tests/test_lib_user.py
@@ -62,7 +62,11 @@ class UserTestCase(MyTestCase):
         user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
         # check proper unicode() / str() handling
-        self.assertIsInstance(six.text_type(user), six.text_type)
+        if six.PY2:
+            self.assertIsInstance(str(user), bytes)
+            self.assertIsInstance(unicode(user), unicode)
+        else:
+            self.assertIsInstance(six.text_type(user), six.text_type)
         
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
@@ -365,7 +369,11 @@ class UserTestCase(MyTestCase):
 
         # check proper unicode() and str() handling
         user_object = User(login=u"nönäscii", realm=realm)
-        self.assertEqual(six.text_type(user_object), u'<nönäscii.SQL1@sqlrealm>')
-        self.assertEqual(six.text_type(user_object).encode('utf8'),
-                         b'<n\xc3\xb6n\xc3\xa4scii.SQL1@sqlrealm>')
+        if six.PY2:
+            self.assertEqual(unicode(user_object), u'<nönäscii.SQL1@sqlrealm>')
+            self.assertEqual(str(user_object), '<n\xc3\xb6n\xc3\xa4scii.SQL1@sqlrealm>')
+        else:
+            self.assertEqual(six.text_type(user_object), u'<nönäscii.SQL1@sqlrealm>')
+            self.assertEqual(six.text_type(user_object).encode('utf8'),
+                             b'<n\xc3\xb6n\xc3\xa4scii.SQL1@sqlrealm>')
 

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -229,7 +229,7 @@ class UtilsTestCase(MyTestCase):
         self.assertEqual(d, datetime(2016, 12, 23, 0, 0))
 
         d = parse_date("2017-04-27T12:00+0200")
-        self.assertEqual(d, datetime(2017, 04, 27, 12, 0,
+        self.assertEqual(d, datetime(2017, 4, 27, 12, 0,
                                      tzinfo=tzoffset(None, 7200)))
 
         d = parse_date("2016/04/03")

--- a/tests/test_mock_ldap3.py
+++ b/tests/test_mock_ldap3.py
@@ -5,7 +5,7 @@ This test file tests the test.ldap3mock
 
 import unittest
 import ldap3
-import ldap3mock
+from . import ldap3mock
 from privacyidea.lib.resolvers.LDAPIdResolver import trim_objectGUID
 
 objectGUIDs = [

--- a/tests/test_mod_apache.py
+++ b/tests/test_mod_apache.py
@@ -7,7 +7,7 @@ from authmodules.apache2.privacyidea_apache import (OK, UNAUTHORIZED,
                                                     ROUNDS, SALT_SIZE)
 import responses
 import json
-import redismock
+from . import redismock
 import passlib.hash
 
 

--- a/tests/test_resolver_realm.py
+++ b/tests/test_resolver_realm.py
@@ -64,7 +64,7 @@ class APIResolverTestCase(MyTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data)
+            result = json.loads(res.data.decode('utf8'))
             value = result.get("result").get("value")
             self.assertTrue('r1' in value["added"], res.data)
             self.assertTrue('r2' in value["failed"], res.data)

--- a/tests/test_ui_certificate.py
+++ b/tests/test_ui_certificate.py
@@ -35,7 +35,7 @@ class WebUICertificateTestCase(MyTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             authtoken = result.get("value")
@@ -81,7 +81,7 @@ class WebUICertificateTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -93,7 +93,7 @@ class WebUICertificateTestCase(MyTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             authtoken = result.get("value")


### PR DESCRIPTION
The Tests contain now the necessary code to run with python 3 and python 2.
With python 2 the tests should work as expected, with python 3 there are
still issues since the privacyIDEA codebase is not changed yet.
This removes some `print` statements since they are unnecessary for the tests to work.

Working on #676
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23issuecomment-434740782%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r232956847%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r233013241%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r233013489%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r233799939%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r233800273%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r233800310%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23issuecomment-434740782%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1296%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231296%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1296%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/6fc1596ec8d5c220984cea85166ff9726759048b%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1296/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1296%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231296%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.81%25%20%20%2095.81%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20142%20%20%20%20%20%20142%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017227%20%20%20%2017227%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2016506%20%20%20%2016506%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20721%20%20%20%20%20%20721%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1296%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1296%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B6fc1596...2818393%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1296%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-10-31T15%3A51%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2028183933cb021474aeb1a09e8b81baedc9efeb6b%20tests/test_lib_user.py%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r233800310%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-11-15T11%3A06%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_user.py%3AL365-372%22%7D%2C%20%22Pull%2028183933cb021474aeb1a09e8b81baedc9efeb6b%20tests/smppmock.py%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r233013241%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Correct%2C%20it%20does%20not%20work%20with%20Python%203%20%28no%20changes%20since%202010%29.%5Cr%5CnThere%20are%20some%20other%20smpp%20packages%20but%20none%20of%20them%20can%20be%20used%20directly.%5Cr%5CnThe%20most%20promising%20seems%20to%20be%20%3Chttps%3A//github.com/podshumok/python-smpplib%3E.%22%2C%20%22created_at%22%3A%20%222018-11-13T12%3A15%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-11-15T11%3A05%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/smppmock.py%3AL35-45%22%7D%2C%20%22Pull%2028183933cb021474aeb1a09e8b81baedc9efeb6b%20tests/test_lib_user.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1296%23discussion_r232956847%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20think%20if%20we%20change%20this%20like%20that%2C%20the%20test%20isn%27t%20very%20interesting%20anymore%20if%20run%20in%20a%20Python%202%20environment%2C%20because%20there%2C%20we%20want%20str%28%29%20to%20return%20bytes%20and%20unicode%28%29%20to%20return%20unicode%20%3A-/%20I%20think%20it%20would%20be%20more%20sensible%20to%20have%20something%20like%5Cr%5Cn%60%60%60python%5Cr%5Cnif%20six.PY2%3A%5Cr%5Cn%20%20%20%23%20the%20two%20tests%20with%20str%28%29%20/%20unicode%28%29%20we%20had%20before%5Cr%5Cnelse%3A%5Cr%5Cn%20%20%20%20self.assertIsInstance%28str%28user%29%2C%20str%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222018-11-13T09%3A30%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22makes%20sense.%20Will%20change%20that.%22%2C%20%22created_at%22%3A%20%222018-11-13T12%3A16%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-11-15T11%3A06%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_user.py%3AL61-69%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1296#issuecomment-434740782'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1296?src=pr&el=h1) Report
> Merging [#1296](https://codecov.io/gh/privacyidea/privacyidea/pull/1296?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/6fc1596ec8d5c220984cea85166ff9726759048b?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1296/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1296?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master    #1296   +/-   ##
=======================================
Coverage   95.81%   95.81%
=======================================
Files         142      142
Lines       17227    17227
=======================================
Hits        16506    16506
Misses        721      721
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1296?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1296?src=pr&el=footer). Last update [6fc1596...2818393](https://codecov.io/gh/privacyidea/privacyidea/pull/1296?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull 28183933cb021474aeb1a09e8b81baedc9efeb6b tests/test_lib_user.py 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1296#discussion_r232956847'>File: tests/test_lib_user.py:L61-69</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, I think if we change this like that, the test isn't very interesting anymore if run in a Python 2 environment, because there, we want str() to return bytes and unicode() to return unicode :-/ I think it would be more sensible to have something like
```python
if six.PY2:
# the two tests with str() / unicode() we had before
else:
self.assertIsInstance(str(user), str)
```
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> makes sense. Will change that.
- [x] <a href='#crh-comment-Pull 28183933cb021474aeb1a09e8b81baedc9efeb6b tests/smppmock.py 8'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1296#discussion_r233013241'>File: tests/smppmock.py:L35-45</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Correct, it does not work with Python 3 (no changes since 2010).
There are some other smpp packages but none of them can be used directly.
The most promising seems to be <https://github.com/podshumok/python-smpplib>.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1296?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1296?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1296'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>