### PR TITLE
If user has more than on mobile number,

### DIFF
--- a/privacyidea/lib/eventhandler/tokenhandler.py
+++ b/privacyidea/lib/eventhandler/tokenhandler.py
@@ -377,7 +377,7 @@ class TokenEventHandler(BaseEventHandler):
                         init_param["dynamic_phone"] = 1
                     else:
                         init_param['phone'] = user.get_user_phone(
-                            phone_type='mobile')
+                            phone_type='mobile', index=0)
                         if not init_param['phone']:
                             log.warning("Enrolling SMS token. But the user "
                                         "{0!r} has no mobile number!".format(user))

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -285,7 +285,9 @@ class User(object):
         :param phone_type: The type of the phone, i.e. either mobile or
                            phone (land line)
         :type phone_type: string
-        :param index: The index of the list of the phones of the user. If the
+        :param index: The index of the selected phone number of list of the phones of the user.
+            If the index is given, this phone number as string is returned.
+            If the index is omitted, all phone numbers are returned.
     
         :returns: list with phone numbers of this user object
         """
@@ -297,7 +299,8 @@ class User(object):
                 if len(phone) > index:
                     return phone[index]
                 else:
-                    log.warning("userobject ({0!r}) has not that much phone numbers (1!r).".format(self, index))
+                    log.warning("userobject ({0!r}) has not that much "
+                                "phone numbers ({1!r} of {2!r}).".format(self, index, phone))
                     return ""
             else:
                 return phone

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -278,20 +278,29 @@ class User(object):
         return userInfo
     
     @log_with(log)
-    def get_user_phone(self, phone_type='phone'):
+    def get_user_phone(self, phone_type='phone', index=None):
         """
-        Returns the phone number of a user
+        Returns the phone number or a list of phone numbers of a user.
     
         :param phone_type: The type of the phone, i.e. either mobile or
                            phone (land line)
         :type phone_type: string
+        :param index: The index of the list of the phones of the user. If the
     
         :returns: list with phone numbers of this user object
         """
         userinfo = self.info
         if phone_type in userinfo:
-            log.debug("got user phone {0!r} of type {1!r}".format(userinfo[phone_type], phone_type))
-            return userinfo[phone_type]
+            phone = userinfo[phone_type]
+            log.debug("got user phone {0!r} of type {1!r}".format(phone, phone_type))
+            if type(phone) == list and index is not None:
+                if len(phone) > index:
+                    return phone[index]
+                else:
+                    log.warning("userobject ({0!r}) has not that much phone numbers (1!r).".format(self, index))
+                    return ""
+            else:
+                return phone
         else:
             log.warning("userobject ({0!r}) has no phone of type {1!r}.".format(self, phone_type))
             return ""

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -29,7 +29,9 @@ from privacyidea.lib.resolver import (save_resolver,
                                       get_resolver_config,
                                       get_resolver_list,
                                       get_resolver_object, pretestresolver)
+from privacyidea.lib.realm import (set_realm, delete_realm)
 from privacyidea.models import ResolverConfig
+
 
 objectGUIDs = [
     '039b36ef-e7c0-42f3-9bf9-ca6a6c0d4d31',
@@ -103,7 +105,13 @@ LDAPDirectory_small = [{"dn": 'cn=bob,ou=example,o=test',
                                 'userPassword': 'ldaptest',
                                 "accountExpires": 9223372036854775807,
                                 "objectGUID": objectGUIDs[1],
-                                'oid': "1"}}
+                                'oid': "1"}},
+                       {"dn": 'cn=salesman,ou=example,o=test',
+                        "attributes": {'cn': 'salesman',
+                                       'givenName': 'hans',
+                                       'sn': 'Meyer',
+                                       'mobile': ['1234', '3456'],
+                                       'objectGUID': objectGUIDs[2]}}
                        ]
 # Same as above, but with curly-braced string representation of objectGUID
 # to imitate ldap3 > 2.4.1


### PR DESCRIPTION
only return the first one during enrollment in
event handler.

Closes #1300
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23issuecomment-436275548%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23issuecomment-436282140%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23discussion_r231176476%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23discussion_r231178303%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23discussion_r231178752%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23discussion_r231182104%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23issuecomment-436275548%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20may%20not%20like%20it%2C%20if%20the%20method%20sometimes%20returns%20a%20string%20and%20sometimes%20a%20list.%5Cr%5CnBut%20I%20would%20like%20to%20encapsulate%20the%20logic%2C%20if%20the%20resolver%20would%20return%20an%20empty%20list%2C%20so%20that%20we%20would%20be%20able%20to%20return%20an%20empty%20string%20to%20work%20with.%22%2C%20%22created_at%22%3A%20%222018-11-06T14%3A41%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231301%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/6fc1596ec8d5c220984cea85166ff9726759048b%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231301%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.81%25%20%20%2095.81%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20142%20%20%20%20%20%20142%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017227%20%20%20%2017233%20%20%20%20%20%20%20%2B6%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016506%20%20%20%2016512%20%20%20%20%20%20%20%2B6%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20721%20%20%20%20%20%20721%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/tokenhandler.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci90b2tlbmhhbmRsZXIucHk%3D%29%20%7C%20%6093.75%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/user.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3VzZXIucHk%3D%29%20%7C%20%6099.65%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B6fc1596...5c35175%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1301%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-06T14%3A59%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205c35175673ee50d2502d97862b4a082dc406d87f%20privacyidea/lib/user.py%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23discussion_r231178303%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20add%20the%20current%20amount%20of%20phone%20numbers%20to%20the%20warning%20to%20ease%20debugging.%22%2C%20%22created_at%22%3A%20%222018-11-06T15%3A52%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/user.py%3AL278-307%22%7D%2C%20%22Pull%205c35175673ee50d2502d97862b4a082dc406d87f%20privacyidea/lib/user.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23discussion_r231176476%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20You%20want%20to%20finish%20the%20sentence%3F%22%2C%20%22created_at%22%3A%20%222018-11-06T15%3A48%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22Isn%27t%20this%20obvious%3F%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-11-06T15%3A53%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/user.py%3AL278-307%22%7D%2C%20%22Pull%205c35175673ee50d2502d97862b4a082dc406d87f%20tests/test_lib_user.py%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1301%23discussion_r231182104%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20we%20should%20use%20a%20special%20file%20for%20these%20definitions%20so%20we%20don%27t%20have%20to%20import%20other%20test-scripts.%22%2C%20%22created_at%22%3A%20%222018-11-06T16%3A00%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_user.py%3AL8-24%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1301#issuecomment-436275548'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You may not like it, if the method sometimes returns a string and sometimes a list.
But I would like to encapsulate the logic, if the resolver would return an empty list, so that we would be able to return an empty string to work with.
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1301?src=pr&el=h1) Report
> Merging [#1301](https://codecov.io/gh/privacyidea/privacyidea/pull/1301?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/6fc1596ec8d5c220984cea85166ff9726759048b?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1301/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1301?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1301      +/-   ##
==========================================
+ Coverage   95.81%   95.81%   +<.01%
==========================================
Files         142      142
Lines       17227    17233       +6
==========================================
+ Hits        16506    16512       +6
Misses        721      721
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1301?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/eventhandler/tokenhandler.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1301/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci90b2tlbmhhbmRsZXIucHk=) | `93.75% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/user.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1301/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3VzZXIucHk=) | `99.65% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1301?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1301?src=pr&el=footer). Last update [6fc1596...5c35175](https://codecov.io/gh/privacyidea/privacyidea/pull/1301?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 5c35175673ee50d2502d97862b4a082dc406d87f privacyidea/lib/user.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1301#discussion_r231176476'>File: privacyidea/lib/user.py:L278-307</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Do You want to finish the sentence?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Isn't this obvious? ;-)
- [ ] <a href='#crh-comment-Pull 5c35175673ee50d2502d97862b4a082dc406d87f privacyidea/lib/user.py 27'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1301#discussion_r231178303'>File: privacyidea/lib/user.py:L278-307</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> maybe add the current amount of phone numbers to the warning to ease debugging.
- [ ] <a href='#crh-comment-Pull 5c35175673ee50d2502d97862b4a082dc406d87f tests/test_lib_user.py 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1301#discussion_r231182104'>File: tests/test_lib_user.py:L8-24</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Maybe we should use a special file for these definitions so we don't have to import other test-scripts.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1301?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1301?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1301'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>