### PR TITLE
Fix the counting of users with active tokens

### DIFF
--- a/privacyidea/lib/subscriptions.py
+++ b/privacyidea/lib/subscriptions.py
@@ -235,11 +235,11 @@ def check_subscription(application, max_free_subscriptions=None):
     if application.lower() in APPLICATIONS.keys():
         subscriptions = get_subscription(application) or get_subscription(
             application.lower())
-        # get the number of active assigned tokens
-        active_tokens = get_tokens(assigned=True, active=True, count=True)
+        # get the number of users with active tokens
+        token_users = get_users_with_active_tokens()
         free_subscriptions = max_free_subscriptions or APPLICATIONS.get(application.lower())
         if len(subscriptions) == 0:
-            if active_tokens > free_subscriptions:
+            if token_users > free_subscriptions:
                 raise SubscriptionError(description="No subscription for your client.",
                                         application=application)
         else:
@@ -254,7 +254,7 @@ def check_subscription(application, max_free_subscriptions=None):
             else:
                 # subscription is still valid, so check the signature.
                 check_signature(subscription)
-                if active_tokens > subscription.get("num_tokens"):
+                if token_users > subscription.get("num_tokens"):
                     # subscription is exceeded
                     raise SubscriptionError(description="Too many tokens "
                                                         "enrolled. "

--- a/privacyidea/lib/subscriptions.py
+++ b/privacyidea/lib/subscriptions.py
@@ -256,8 +256,8 @@ def check_subscription(application, max_free_subscriptions=None):
                 check_signature(subscription)
                 if token_users > subscription.get("num_tokens"):
                     # subscription is exceeded
-                    raise SubscriptionError(description="Too many tokens "
-                                                        "enrolled. "
+                    raise SubscriptionError(description="Too many users "
+                                                        "with assigned tokens. "
                                                         "Subscription exceeded.",
                                             application="privacyIDEA")
 


### PR DESCRIPTION
Acutally we a licensing based on the number of
users, who have an active token and not by the
number of active tokens at all.
E.g. 500 users with 2 tokens each requires a
500-subscription, not a 1000-subscrition.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23issuecomment-437337192%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23discussion_r232238552%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23discussion_r232252010%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23discussion_r232271443%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23issuecomment-437382793%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23issuecomment-437842446%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23discussion_r232618708%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23issuecomment-437337192%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20actually%20something%2C%20that%20we%20missed%20to%20fix%20for%20a%20while%21%22%2C%20%22created_at%22%3A%20%222018-11-09T11%3A49%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231302%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/57e0aaca11da462789e8c6f94682bbbb6cb3aebf%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Anot%20change%2A%2A%20coverage.%5Cn%3E%20The%20diff%20coverage%20is%20%6066.66%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231302%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%2095.81%25%20%20%2095.81%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20142%20%20%20%20%20%20142%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017233%20%20%20%2017233%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2016512%20%20%20%2016512%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20721%20%20%20%20%20%20721%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/subscriptions.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk%3D%29%20%7C%20%6086.88%25%20%3C66.66%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B57e0aac...6a63a99%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1302%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-09T14%3A53%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22looks%20good.%5Cr%5CnWe%20should%20add%20a%20test%20for%20users%20with%20active%20tokens%20to%20improve%20coverage.%22%2C%20%22created_at%22%3A%20%222018-11-12T11%3A11%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206a63a99c21a80419505d081c83c4ef415ce2b35b%20privacyidea/lib/subscriptions.py%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1302%23discussion_r232238552%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20error%20message%20might%20be%20misleading%20in%20this%20case.%22%2C%20%22created_at%22%3A%20%222018-11-09T12%3A37%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20totally%20right.%5Cr%5CnProbably%20need%20to%20change%20some%20tests%2C%20too.%22%2C%20%22created_at%22%3A%20%222018-11-09T13%3A27%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40plettich%20I%20gave%20it%20a%202nd%20thought.%20An%20I%20think%20the%20text%20is%20not%20so%20bad.%20The%20correct%20text%20would%20be%20%5Cr%5Cn%5Cr%5Cn%5C%22Tokens%20enrolled%20to%20too%20many%20users%5C%22.%5Cr%5Cn%5Cr%5CnBut%20would%20you%20understand%20this%3F%20A%20text%20like%5Cr%5Cn%5Cr%5Cn%5C%22There%20are%20too%20many%20users%20with%20an%20active%20token%20in%20your%20system.%5C%22%5Cr%5Cn%5Cr%5CnSounds%20a%20bit%20awkward.%20But%20I%20am%20open%20for%20suggestions%21%20%22%2C%20%22created_at%22%3A%20%222018-11-09T14%3A32%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40plettich%20Please%20take%20a%20look%20at%20my%20new%20text%21%22%2C%20%22created_at%22%3A%20%222018-11-12T11%3A12%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/subscriptions.py%3AL254-261%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1302#issuecomment-437337192'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This is actually something, that we missed to fix for a while!
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1302?src=pr&el=h1) Report
> Merging [#1302](https://codecov.io/gh/privacyidea/privacyidea/pull/1302?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/57e0aaca11da462789e8c6f94682bbbb6cb3aebf?src=pr&el=desc) will **not change** coverage.
> The diff coverage is `66.66%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1302/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1302?src=pr&el=tree)
```diff
@@           Coverage Diff           @@
##           master    #1302   +/-   ##
=======================================
Coverage   95.81%   95.81%
=======================================
Files         142      142
Lines       17233    17233
=======================================
Hits        16512    16512
Misses        721      721
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1302?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/subscriptions.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1302/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk=) | `86.88% <66.66%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1302?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1302?src=pr&el=footer). Last update [57e0aac...6a63a99](https://codecov.io/gh/privacyidea/privacyidea/pull/1302?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> looks good.
We should add a test for users with active tokens to improve coverage.
- [ ] <a href='#crh-comment-Pull 6a63a99c21a80419505d081c83c4ef415ce2b35b privacyidea/lib/subscriptions.py 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1302#discussion_r232238552'>File: privacyidea/lib/subscriptions.py:L254-261</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> The error message might be misleading in this case.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are totally right.
Probably need to change some tests, too.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @plettich I gave it a 2nd thought. An I think the text is not so bad. The correct text would be
"Tokens enrolled to too many users".
But would you understand this? A text like
"There are too many users with an active token in your system."
Sounds a bit awkward. But I am open for suggestions!
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @plettich Please take a look at my new text!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1302?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1302?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1302'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>