### PR TITLE
Allow the script handler to wait for the script

### DIFF
--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -880,3 +880,7 @@ def get_privacyidea_nodes():
     if own_node_name not in nodes:
         nodes.append(own_node_name)
     return nodes
+
+
+def get_app_config(key, default=None):
+    return current_app.config.get(key, default)

--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -62,7 +62,7 @@ class ScriptEventHandler(BaseEventHandler):
             try:
                 self.script_directory = get_from_config("PI_SCRIPT_HANDLER_DIRECTORY",
                                                         "/etc/privacyidea/scripts")
-            except RuntimeError:
+            except RuntimeError as e:
                 # In case of the tests we are outside of the application context
                 self.script_directory = "tests/testdata/scripts"
 

--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -198,10 +198,11 @@ class ScriptEventHandler(BaseEventHandler):
                 script_name, e))
             log.warning(traceback.format_exc())
 
-        if rcode and handler_options.get("raise_error"):
+        if rcode:
             log.warning("Script {script!r} failed to execute with error code {error!r}".format(script=script_name,
                                                                                                error=rcode))
-            raise ServerError("Error during execution of the script.")
+            if handler_options.get("raise_error"):
+                raise ServerError("Error during execution of the script.")
 
         return ret
 

--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -197,6 +197,8 @@ class ScriptEventHandler(BaseEventHandler):
             log.warning("Failed to execute script {0!r}: {1!r}".format(
                 script_name, e))
             log.warning(traceback.format_exc())
+            if handler_options.get("background") == SCRIPT_WAIT and is_true(handler_options.get("raise_error")):
+                raise ServerError("Failed to start script.")
 
         if rcode:
             log.warning("Script {script!r} failed to execute with error code {error!r}".format(script=script_name,

--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -64,7 +64,7 @@ class ScriptEventHandler(BaseEventHandler):
                                                         "/etc/privacyidea/scripts")
             except RuntimeError:
                 # In case of the tests we are outside of the application context
-                script_directory = "tests/testdata/scripts"
+                self.script_directory = "tests/testdata/scripts"
 
         else:
             self.script_directory = script_directory

--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -32,10 +32,10 @@ The scripts can take parameters like
 * logged_in_user
 """
 from privacyidea.lib.eventhandler.base import BaseEventHandler
+from privacyidea.lib.utils import is_true
 from privacyidea.lib.config import get_app_config
 from privacyidea.lib.error import ServerError
 from privacyidea.lib import _
-import json
 import logging
 import subprocess
 import os
@@ -201,7 +201,7 @@ class ScriptEventHandler(BaseEventHandler):
         if rcode:
             log.warning("Script {script!r} failed to execute with error code {error!r}".format(script=script_name,
                                                                                                error=rcode))
-            if handler_options.get("raise_error"):
+            if is_true(handler_options.get("raise_error")):
                 raise ServerError("Error during execution of the script.")
 
         return ret

--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -32,7 +32,7 @@ The scripts can take parameters like
 * logged_in_user
 """
 from privacyidea.lib.eventhandler.base import BaseEventHandler
-from privacyidea.lib.config import get_from_config
+from privacyidea.lib.config import get_app_config
 from privacyidea.lib.error import ServerError
 from privacyidea.lib import _
 import json
@@ -43,8 +43,8 @@ import traceback
 
 log = logging.getLogger(__name__)
 
-SCRIPT_BACKGROUND = "Run in background"
-SCRIPT_WAIT = "Wait for script to finish"
+SCRIPT_BACKGROUND = "background"
+SCRIPT_WAIT = "wait"
 
 
 class ScriptEventHandler(BaseEventHandler):
@@ -60,8 +60,8 @@ class ScriptEventHandler(BaseEventHandler):
     def __init__(self, script_directory=None):
         if not script_directory:
             try:
-                self.script_directory = get_from_config("PI_SCRIPT_HANDLER_DIRECTORY",
-                                                        "/etc/privacyidea/scripts")
+                self.script_directory = get_app_config("PI_SCRIPT_HANDLER_DIRECTORY",
+                                                       "/etc/privacyidea/scripts")
             except RuntimeError as e:
                 # In case of the tests we are outside of the application context
                 self.script_directory = "tests/testdata/scripts"

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -7,6 +7,7 @@ lib/event.py (the decorator)
 
 import smtpmock
 import responses
+import os
 from .base import MyTestCase, FakeFlaskG, FakeAudit
 from privacyidea.lib.eventhandler.usernotification import (
     UserNotificationEventHandler, NOTIFY_TYPE)
@@ -521,7 +522,9 @@ class ScriptEventTestCase(MyTestCase):
                    }
 
         script_name = "ls.sh"
-        t_handler = ScriptEventHandler()
+        d = os.getcwd()
+        d = "{0!s}/tests/testdata/scripts/".format(d)
+        t_handler = ScriptEventHandler(script_directory=d)
         res = t_handler.do(script_name, options=options)
         self.assertTrue(res)
         remove_token("SPASS01")
@@ -565,7 +568,9 @@ class ScriptEventTestCase(MyTestCase):
                    }
 
         script_name = "fail.sh"
-        t_handler = ScriptEventHandler()
+        d = os.getcwd()
+        d = "{0!s}/tests/testdata/scripts/".format(d)
+        t_handler = ScriptEventHandler(script_directory=d)
         self.assertRaises(Exception, t_handler.do, script_name, options=options)
         remove_token("SPASS01")
 

--- a/tests/testdata/scripts/fail.sh
+++ b/tests/testdata/scripts/fail.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 1


### PR DESCRIPTION
Script handles can now be configured to wait for the
script to execute.
The default behaviour is to put the script in the background.

Closes #1222
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23issuecomment-437938017%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r232978609%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r232978947%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r232980206%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r232980583%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233032680%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233125476%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233619722%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233841913%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233842969%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233848647%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233849154%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233851603%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233851697%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233851768%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233851863%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233853642%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233857837%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233857880%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233858350%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233858581%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233859954%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233860988%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233861180%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233861221%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233861983%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233863232%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233863472%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233863778%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233868651%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233880070%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233881813%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233881822%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233881829%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233881839%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233881842%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233881850%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23issuecomment-437938017%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231307%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/f1d0351c3347ddfdbbb463978f84744648bbe6ef%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.1%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6081.81%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231307%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.81%25%20%20%2095.91%25%20%20%20%2B0.1%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20142%20%20%20%20%20%20142%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017233%20%20%20%2017839%20%20%20%20%2B606%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016512%20%20%20%2017111%20%20%20%20%2B599%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20721%20%20%20%20%20%20728%20%20%20%20%20%20%2B7%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/config.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ%3D%3D%29%20%7C%20%6094.83%25%20%3C%5Cu00f8%3E%20%28%2B0.02%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/eventhandler/scripthandler.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9zY3JpcHRoYW5kbGVyLnB5%29%20%7C%20%6081.57%25%20%3C81.81%25%3E%20%28-5.31%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/log.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2xvZy5weQ%3D%3D%29%20%7C%20%6034.24%25%20%3C0%25%3E%20%28-9.59%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6094.16%25%20%3C0%25%3E%20%28-1.67%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.84%25%20%3C0%25%3E%20%28%2B0.43%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/subscriptions.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk%3D%29%20%7C%20%6087.7%25%20%3C0%25%3E%20%28%2B0.81%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5%29%20%7C%20%6097.33%25%20%3C0%25%3E%20%28%2B0.88%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6097.64%25%20%3C0%25%3E%20%28%2B0.99%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/error.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5%29%20%7C%20%6091.91%25%20%3C0%25%3E%20%28%2B1.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20...%20and%20%5B1%20more%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307/diff%3Fsrc%3Dpr%26el%3Dtree-more%29%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bf1d0351...7bd3d27%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1307%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-12T16%3A11%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208f306ebd579df56e3c8e7d12e2ec46c60f3636db%20privacyidea/lib/eventhandler/scripthandler.py%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233125476%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20this%20should%20be%20%60%60self.script_directory%60%60%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-11-13T16%3A40%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22True%21%22%2C%20%22created_at%22%3A%20%222018-11-14T21%3A06%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-11-15T13%3A32%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A18%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-15T15%3A13%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/scripthandler.py%3AL51-74%22%7D%2C%20%22Pull%20bea23091f26552a9f3a9e53212dcadaa8835e4d1%20privacyidea/lib/eventhandler/scripthandler.py%2056%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233851697%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20do%20you%20think%20about%20changing%20the%20values%20of%20%60%60SCRIPT_BACKGROUND%60%60%20and%20%60%60SCRIPT_WAIT%60%60%20to%20%5C%22background%5C%22%20and%20%5C%22wait%5C%22%2C%20respectively%3F%20We%20cannot%20localize%20the%20phrases%20%5C%22Run%20in%20background%5C%22%20and%20%5C%22Wait%20for%20script%20to%20finish%5C%22%20anyway%2C%20which%20would%20look%20weird%20in%20German.%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A02%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A19%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20in%205fc5322%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A27%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-15T15%3A13%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/scripthandler.py%3AL89-108%22%7D%2C%20%22Pull%2013c2c35becb91e8fbc8f0b8e5ea7e8a246c29beb%20privacyidea/lib/eventhandler/scripthandler.py%2061%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r232978609%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20this%20is%20mergable%2C%20but%20just%20wanted%20to%20point%20out%20potential%20for%20code%20deduplication%20here%3A%20We%20could%20get%20rid%20of%20the%20outer%20if-branch%20and%20instead%20use%5Cr%5Cn%60%60%60python%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20try%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20p%20%3D%20subprocess.Popen%28proc_args%2C%20cwd%3Dself.script_directory%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20log.info%28%5C%22Started%20script%20%7Bscript%21r%7D%3A%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22%20%7Bprocess%21r%7D%5C%22.format%28script%3Dscript_name%2C%20process%3Dp%29%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20handler_options.get%28%5C%22background%5C%22%29%20%3D%3D%20SCRIPT_WAIT%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20log.info%28%5C%22waiting%20for%20script%20to%20finish%20...%5C%22%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ret%20%3D%20p.wait%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20handle%20error%20case%20if%20ret%20%21%3D%200%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20...%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20except%20Exception%20as%20e%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20log.warning%28%5C%22Failed%20to%20execute%20script%20%7B0%21r%7D%3A%20%7B1%21r%7D%5C%22.format%28%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20script_name%2C%20e%29%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20log.warning%28traceback.format_exc%28%29%29%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnWhat%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-11-13T10%3A28%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20was%20not%20aware%20of%20p.wait%28%29.%20The%20question%20is%2C%20if%20it%20also%20raises%20an%20error%20accordingly%3F%5Cr%5CnThen%20we%20would%20-%20if%20%60%60raise_error%60%60%20was%20configured%20-%20have%20to%20reraise%20the%20error.%22%2C%20%22created_at%22%3A%20%222018-11-13T10%3A32%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%27re%20right%2C%20we%20would%20need%20to%20re-raise%20an%20error.%20We%20could%2C%20however%2C%20just%20raise%20a%20privacyIDEA%20%60%60ServerError%60%60%20then.%22%2C%20%22created_at%22%3A%20%222018-11-13T10%3A33%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20problem%20is%2C%20that%20different%20situations%20would%20be%20handled%20differently.%20%60%60p.wait%28%29%60%60%20does%20not%20raise%20an%20exception%20in%20case%20of%20an%20exit%20code%20%3C%3E%200.%5Cr%5Cn%5Cr%5CnThe%20next%20problem%20is%2C%20that%20for%20some%20reason%20the%20tests%20do%20not%20work%20anymore%20-%20since%20the%20%60%60fail.sh%60%60%20script%20somehow%20does%20not%20work%20%3A-/%5Cr%5Cn%20%20%20%22%2C%20%22created_at%22%3A%20%222018-11-13T13%3A18%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-15T15%3A13%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/scripthandler.py%3AL180-206%22%7D%2C%20%22Pull%2013c2c35becb91e8fbc8f0b8e5ea7e8a246c29beb%20privacyidea/lib/eventhandler/scripthandler.py%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r232978947%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20we%20add%20an%20%60%60else%60%60%20branch%20like%5Cr%5Cn%60%60%60python%5Cr%5Cnelse%3A%5Cr%5Cn%20%20%20%20log.warning%28%5C%22Invalid%20value%3A%20%7B%21r%7D%5C%22.format%28handler_options.get%28%5C%22background%5C%22%29%29%29%5Cr%5Cn%60%60%60%5Cr%5Cn%3F%22%2C%20%22created_at%22%3A%20%222018-11-13T10%3A29%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%2C%20but%20I%20will%20add%20an%20else%20branch%2C%20if%20raise_error%20is%20not%20set.%5Cr%5CnThen%20it%20would%20be%20great%20to%20have%20this%20merged%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-11-15T13%3A36%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A18%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-15T15%3A13%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/scripthandler.py%3AL180-206%22%7D%2C%20%22Pull%20bea23091f26552a9f3a9e53212dcadaa8835e4d1%20privacyidea/lib/eventhandler/scripthandler.py%2083%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233851863%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20we%20raise%20an%20error%20here%20if%20%60%60raise_error%60%60%20is%20True%3F%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A02%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20did%20not%20raise%20an%20error%20before.%20I%20would%20like%20to%20keep%20it%20that%20way.%5Cr%5CnRaising%20an%20error%20could%20result%20in%20the%20request%20to%20fail.%20But%20imho%20the%20script%20is%20often%20just%20an%20addon%2C%20which%20should%20not%20interfer%20with%20the%20functinoality%20of%20e.g.%20the%20authentication.%5Cr%5Cn%5Cr%5CnImagine%20an%20event%20handler%2C%20that%20is%20supposed%20to%20write%20a%20backup%20to%20a%20SMB%20mount%20on%20every%20100th%20auth%20request.%20Now%20the%20SMB%20is%20down%20or%20someone%20change%20a%20password%20or%20deleted%20the%20script.%5Cr%5CnFull%20denial%20of%20service%20of%20your%20authentication%20%3B-%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A23%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20if%20I%20want%20to%20avoid%20that%20situation%2C%20I%20would%20probably%20set%20%60%60raise_error%60%60%20to%20False%20%3A-%29%20If%20the%20script%20is%20important%20enough%20for%20me%20that%20I%20set%20%60%60raise_error%3DTrue%60%60%2C%20I%20would%20probably%20also%20want%20the%20request%20to%20fail%20if%20the%20script%20is%20deleted%20and%20cannot%20be%20executed%20because%20of%20that.%5Cr%5Cn%5Cr%5CnAnyway%2C%20I%27m%20also%20OK%20with%20keeping%20this%20as%20it%20is.%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A29%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20adding%20Feature%20requests%20in%20the%20reviews%21%20%3B-%29%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A33%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Currently%20%5C%22raise_error%5C%22%20can%20only%20be%20set%20for%20%5C%22background%5C%22%20mode.%5Cr%5CnShould%20we%20change%20this%3F%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A33%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20in%20e2b1d60%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A42%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-11-15T15%3A09%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/scripthandler.py%3AL186-209%22%7D%2C%20%22Pull%20bea23091f26552a9f3a9e53212dcadaa8835e4d1%20privacyidea/lib/eventhandler/scripthandler.py%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233848647%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20this%20really%20be%20%60%60get_from_config%60%60%2C%20i.e.%20to%20read%20from%20the%20%60%60config%60%60%20database%20table%3F%20From%20the%20look%20of%20the%20option%2C%20I%20would%20think%20it%20should%20rather%20be%20set%20in%20%60%60pi.cfg%60%60%3F%22%2C%20%22created_at%22%3A%20%222018-11-15T13%3A53%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20in%205fc5322%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A27%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-15T15%3A13%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/scripthandler.py%3AL43-74%22%7D%2C%20%22Pull%20bea23091f26552a9f3a9e53212dcadaa8835e4d1%20privacyidea/lib/eventhandler/scripthandler.py%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233851768%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20missing%20a%20%60%60is_true%60%60%2C%20I%20think%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A02%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22No.%20If%20raise%20error%20is%20set%2C%20then%20we%20will%20raise%20an%20error.%5Cr%5CnIf%20it%20is%20not%20set%2C%20we%20will%20not%20raise%20an%20error%20-%20right%3F%20Or%20am%20I%20missing%20something%3F%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A20%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20the%20option%20is%20disabled%2C%20%60%60handler_options.get%28%5C%22raise_error%5C%22%29%60%60%20is%20actually%20the%20string%20%60%60%5C%22False%5C%22%60%60%2C%20so%20we%20need%20to%20use%20%60%60is_true%60%60.%20I%20forgot%20about%20that%20too%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A26%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%20Done%20in%2083f6eaa%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A32%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-15T15%3A13%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/scripthandler.py%3AL186-209%22%7D%2C%20%22Pull%20bea23091f26552a9f3a9e53212dcadaa8835e4d1%20privacyidea/lib/eventhandler/scripthandler.py%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1307%23discussion_r233849154%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20use%20%60except%20RuntimeError%20as%20e%3A%60%20since%20Python%203%20doesn%27t%20allow%20the%20old%20syntax.%22%2C%20%22created_at%22%3A%20%222018-11-15T13%3A54%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20in%20bea2309%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A01%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-11-15T14%3A07%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/eventhandler/scripthandler.py%3AL43-74%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#issuecomment-437938017'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1307?src=pr&el=h1) Report
> Merging [#1307](https://codecov.io/gh/privacyidea/privacyidea/pull/1307?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/f1d0351c3347ddfdbbb463978f84744648bbe6ef?src=pr&el=desc) will **increase** coverage by `0.1%`.
> The diff coverage is `81.81%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1307?src=pr&el=tree)
```diff
@@            Coverage Diff            @@
##           master    #1307     +/-   ##
=========================================
+ Coverage   95.81%   95.91%   +0.1%
=========================================
Files         142      142
Lines       17233    17839    +606
=========================================
+ Hits        16512    17111    +599
- Misses        721      728      +7
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1307?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/config.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ==) | `94.83% <ø> (+0.02%)` | :arrow_up: |
| [privacyidea/lib/eventhandler/scripthandler.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50aGFuZGxlci9zY3JpcHRoYW5kbGVyLnB5) | `81.57% <81.81%> (-5.31%)` | :arrow_down: |
| [privacyidea/lib/log.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2xvZy5weQ==) | `34.24% <0%> (-9.59%)` | :arrow_down: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `94.16% <0%> (-1.67%)` | :arrow_down: |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.84% <0%> (+0.43%)` | :arrow_up: |
| [privacyidea/lib/subscriptions.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk=) | `87.7% <0%> (+0.81%)` | :arrow_up: |
| [privacyidea/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5) | `97.33% <0%> (+0.88%)` | :arrow_up: |
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `97.64% <0%> (+0.99%)` | :arrow_up: |
| [privacyidea/lib/error.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5) | `91.91% <0%> (+1.01%)` | :arrow_up: |
| ... and [1 more](https://codecov.io/gh/privacyidea/privacyidea/pull/1307/diff?src=pr&el=tree-more) | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1307?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1307?src=pr&el=footer). Last update [f1d0351...7bd3d27](https://codecov.io/gh/privacyidea/privacyidea/pull/1307?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull 13c2c35becb91e8fbc8f0b8e5ea7e8a246c29beb privacyidea/lib/eventhandler/scripthandler.py 61'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#discussion_r232978609'>File: privacyidea/lib/eventhandler/scripthandler.py:L180-206</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think this is mergable, but just wanted to point out potential for code deduplication here: We could get rid of the outer if-branch and instead use
```python
try:
p = subprocess.Popen(proc_args, cwd=self.script_directory)
log.info("Started script {script!r}:"
" {process!r}".format(script=script_name, process=p))
if handler_options.get("background") == SCRIPT_WAIT:
log.info("waiting for script to finish ...")
ret = p.wait()
# handle error case if ret != 0
...
except Exception as e:
log.warning("Failed to execute script {0!r}: {1!r}".format(
script_name, e))
log.warning(traceback.format_exc())
```
What do you think?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I was not aware of p.wait(). The question is, if it also raises an error accordingly?
Then we would - if ``raise_error`` was configured - have to reraise the error.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> You're right, we would need to re-raise an error. We could, however, just raise a privacyIDEA ``ServerError`` then.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The problem is, that different situations would be handled differently. ``p.wait()`` does not raise an exception in case of an exit code <> 0.
The next problem is, that for some reason the tests do not work anymore - since the ``fail.sh`` script somehow does not work :-/
- [x] <a href='#crh-comment-Pull 13c2c35becb91e8fbc8f0b8e5ea7e8a246c29beb privacyidea/lib/eventhandler/scripthandler.py 62'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#discussion_r232978947'>File: privacyidea/lib/eventhandler/scripthandler.py:L180-206</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Should we add an ``else`` branch like
```python
else:
log.warning("Invalid value: {!r}".format(handler_options.get("background")))
```
?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> No, but I will add an else branch, if raise_error is not set.
Then it would be great to have this merged ;-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done
- [x] <a href='#crh-comment-Pull 8f306ebd579df56e3c8e7d12e2ec46c60f3636db privacyidea/lib/eventhandler/scripthandler.py 32'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#discussion_r233125476'>File: privacyidea/lib/eventhandler/scripthandler.py:L51-74</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think this should be ``self.script_directory`` :-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> True!
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> :+1:
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done
- [x] <a href='#crh-comment-Pull bea23091f26552a9f3a9e53212dcadaa8835e4d1 privacyidea/lib/eventhandler/scripthandler.py 36'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#discussion_r233848647'>File: privacyidea/lib/eventhandler/scripthandler.py:L43-74</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Should this really be ``get_from_config``, i.e. to read from the ``config`` database table? From the look of the option, I would think it should rather be set in ``pi.cfg``?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done in 5fc5322
- [x] <a href='#crh-comment-Pull bea23091f26552a9f3a9e53212dcadaa8835e4d1 privacyidea/lib/eventhandler/scripthandler.py 38'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#discussion_r233849154'>File: privacyidea/lib/eventhandler/scripthandler.py:L43-74</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Please use `except RuntimeError as e:` since Python 3 doesn't allow the old syntax.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done in bea2309
- [x] <a href='#crh-comment-Pull bea23091f26552a9f3a9e53212dcadaa8835e4d1 privacyidea/lib/eventhandler/scripthandler.py 56'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#discussion_r233851697'>File: privacyidea/lib/eventhandler/scripthandler.py:L89-108</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> What do you think about changing the values of ``SCRIPT_BACKGROUND`` and ``SCRIPT_WAIT`` to "background" and "wait", respectively? We cannot localize the phrases "Run in background" and "Wait for script to finish" anyway, which would look weird in German.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> ok
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done in 5fc5322
- [x] <a href='#crh-comment-Pull bea23091f26552a9f3a9e53212dcadaa8835e4d1 privacyidea/lib/eventhandler/scripthandler.py 88'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#discussion_r233851768'>File: privacyidea/lib/eventhandler/scripthandler.py:L186-209</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> This is missing a ``is_true``, I think
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> No. If raise error is set, then we will raise an error.
If it is not set, we will not raise an error - right? Or am I missing something?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> If the option is disabled, ``handler_options.get("raise_error")`` is actually the string ``"False"``, so we need to use ``is_true``. I forgot about that too :-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Thanks. Done in 83f6eaa
- [x] <a href='#crh-comment-Pull bea23091f26552a9f3a9e53212dcadaa8835e4d1 privacyidea/lib/eventhandler/scripthandler.py 83'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1307#discussion_r233851863'>File: privacyidea/lib/eventhandler/scripthandler.py:L186-209</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Should we raise an error here if ``raise_error`` is True?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We did not raise an error before. I would like to keep it that way.
Raising an error could result in the request to fail. But imho the script is often just an addon, which should not interfer with the functinoality of e.g. the authentication.
Imagine an event handler, that is supposed to write a backup to a SMB mount on every 100th auth request. Now the SMB is down or someone change a password or deleted the script.
Full denial of service of your authentication ;-)
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> But if I want to avoid that situation, I would probably set ``raise_error`` to False :-) If the script is important enough for me that I set ``raise_error=True``, I would probably also want the request to fail if the script is deleted and cannot be executed because of that.
Anyway, I'm also OK with keeping this as it is.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are adding Feature requests in the reviews! ;-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Currently "raise_error" can only be set for "background" mode.
Should we change this?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Done in e2b1d60 :-)


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1307?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1307?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1307'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>