### PR TITLE
Update U2F API JS to v1.1

### DIFF
--- a/privacyidea/static/components/login/factories/u2f.js
+++ b/privacyidea/static/components/login/factories/u2f.js
@@ -64,10 +64,13 @@ angular.module("privacyideaAuth")
                     // set variables for U2F API v1.1
                     var appId = signRequests[0].appId;
                     var challenge = signRequests[0].challenge;
-                    var registeredKeys= [{
-                        version: signRequests[0].version,
-                        keyHandle: signRequests[0].keyHandle
-                    }];
+                    var registeredKeys = [];
+                    for (let signRequest of signRequests) {
+                        registeredKeys.push({
+                            version: signRequest.version,
+                            keyHandle: signRequest.keyHandle
+                        });
+                    }
 
                     u2f.sign(appId, challenge, registeredKeys, function (result) {
                         inform.clear();

--- a/privacyidea/static/components/login/factories/u2f.js
+++ b/privacyidea/static/components/login/factories/u2f.js
@@ -32,7 +32,17 @@ angular.module("privacyideaAuth")
 
             return {
                 register_request: function (registerRequest, callback) {
-                    u2f.register([registerRequest], [], function (result) {
+
+                    // set variables for U2F API v1.1
+                    var appId = registerRequest.appId;
+                    var registerRequests = [{
+                      version : registerRequest.version,
+                      challenge : registerRequest.challenge,
+                      attestation : "direct"
+                    }];
+                    var registeredKeys = [];
+
+                    u2f.register(appId, registerRequests, registeredKeys, function (result) {
                         //debug: console.log(result);
                         if (result.errorCode > 0) {
                             inform.add(u2fErrors[result.errorCode] + " / " + result.errorMessage,
@@ -50,7 +60,16 @@ angular.module("privacyideaAuth")
                 },
                 sign_request: function (data, signRequests, username, transactionid,
                                         login_callback) {
-                    u2f.sign(signRequests, function (result) {
+
+                    // set variables for U2F API v1.1
+                    var appId = signRequests[0].appId;
+                    var challenge = signRequests[0].challenge;
+                    var registeredKeys= [{
+                        version: signRequests[0].version,
+                        keyHandle: signRequests[0].keyHandle
+                    }];
+
+                    u2f.sign(appId, challenge, registeredKeys, function (result) {
                         inform.clear();
                         if (result.errorCode > 0) {
                             //debug: console.log("U2F error.");

--- a/privacyidea/static/contrib/js/u2f-api.js
+++ b/privacyidea/static/contrib/js/u2f-api.js
@@ -1,26 +1,40 @@
-// Copyright 2014 Google Inc. All rights reserved
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file or at
-// https://developers.google.com/open-source/licenses/bsd
+//Copyright 2014-2015 Google Inc. All rights reserved.
+
+//Use of this source code is governed by a BSD-style
+//license that can be found in the LICENSE file or at
+//https://developers.google.com/open-source/licenses/bsd
 
 /**
  * @fileoverview The U2F api.
  */
-
 'use strict';
 
-/** Namespace for the U2F api.
+
+/**
+ * Namespace for the U2F api.
  * @type {Object}
  */
 var u2f = u2f || {};
 
 /**
- * The U2F extension id
- * @type {string}
- * @const
+ * FIDO U2F Javascript API Version
+ * @number
  */
-u2f.EXTENSION_ID = 'kmendfapggjehodndflmmgagdbamhnfd';
+var js_api_version;
+
+/**
+ * The U2F extension id
+ * @const {string}
+ */
+// The Chrome packaged app extension ID.
+// Uncomment this if you want to deploy a server instance that uses
+// the package Chrome app and does not require installing the U2F Chrome extension.
+ u2f.EXTENSION_ID = 'kmendfapggjehodndflmmgagdbamhnfd';
+// The U2F Chrome extension ID.
+// Uncomment this if you want to deploy a server instance that uses
+// the U2F Chrome extension to authenticate.
+// u2f.EXTENSION_ID = 'pfboblefjcgdjicmnffhdgionmgcdmne';
+
 
 /**
  * Message types for messsages to/from the extension
@@ -28,11 +42,14 @@ u2f.EXTENSION_ID = 'kmendfapggjehodndflmmgagdbamhnfd';
  * @enum {string}
  */
 u2f.MessageTypes = {
-  'U2F_REGISTER_REQUEST': 'u2f_register_request',
-  'U2F_SIGN_REQUEST': 'u2f_sign_request',
-  'U2F_REGISTER_RESPONSE': 'u2f_register_response',
-  'U2F_SIGN_RESPONSE': 'u2f_sign_response'
+    'U2F_REGISTER_REQUEST': 'u2f_register_request',
+    'U2F_REGISTER_RESPONSE': 'u2f_register_response',
+    'U2F_SIGN_REQUEST': 'u2f_sign_request',
+    'U2F_SIGN_RESPONSE': 'u2f_sign_response',
+    'U2F_GET_API_VERSION_REQUEST': 'u2f_get_api_version_request',
+    'U2F_GET_API_VERSION_RESPONSE': 'u2f_get_api_version_response'
 };
+
 
 /**
  * Response status codes
@@ -40,25 +57,26 @@ u2f.MessageTypes = {
  * @enum {number}
  */
 u2f.ErrorCodes = {
-  'OK': 0,
-  'OTHER_ERROR': 1,
-  'BAD_REQUEST': 2,
-  'CONFIGURATION_UNSUPPORTED': 3,
-  'DEVICE_INELIGIBLE': 4,
-  'TIMEOUT': 5
+    'OK': 0,
+    'OTHER_ERROR': 1,
+    'BAD_REQUEST': 2,
+    'CONFIGURATION_UNSUPPORTED': 3,
+    'DEVICE_INELIGIBLE': 4,
+    'TIMEOUT': 5
 };
 
+
 /**
- * A message type for registration requests
+ * A message for registration requests
  * @typedef {{
  *   type: u2f.MessageTypes,
- *   signRequests: Array.<u2f.SignRequest>,
- *   registerRequests: ?Array.<u2f.RegisterRequest>,
+ *   appId: ?string,
  *   timeoutSeconds: ?number,
  *   requestId: ?number
  * }}
  */
-u2f.Request;
+u2f.U2fRequest;
+
 
 /**
  * A message for registration responses
@@ -68,7 +86,8 @@ u2f.Request;
  *   requestId: ?number
  * }}
  */
-u2f.Response;
+u2f.U2fResponse;
+
 
 /**
  * An error object for responses
@@ -81,6 +100,19 @@ u2f.Error;
 
 /**
  * Data object for a single sign request.
+ * @typedef {enum {BLUETOOTH_RADIO, BLUETOOTH_LOW_ENERGY, USB, NFC}}
+ */
+u2f.Transport;
+
+
+/**
+ * Data object for a single sign request.
+ * @typedef {Array<u2f.Transport>}
+ */
+u2f.Transports;
+
+/**
+ * Data object for a single sign request.
  * @typedef {{
  *   version: string,
  *   challenge: string,
@@ -89,6 +121,7 @@ u2f.Error;
  * }}
  */
 u2f.SignRequest;
+
 
 /**
  * Data object for a sign response.
@@ -100,27 +133,51 @@ u2f.SignRequest;
  */
 u2f.SignResponse;
 
+
 /**
  * Data object for a registration request.
  * @typedef {{
  *   version: string,
- *   challenge: string,
- *   appId: string
+ *   challenge: string
  * }}
  */
 u2f.RegisterRequest;
 
+
 /**
  * Data object for a registration response.
  * @typedef {{
- *   registrationData: string,
- *   clientData: string
+ *   version: string,
+ *   keyHandle: string,
+ *   transports: Transports,
+ *   appId: string
  * }}
  */
 u2f.RegisterResponse;
 
 
-// Low level MessagePort API support
+/**
+ * Data object for a registered key.
+ * @typedef {{
+ *   version: string,
+ *   keyHandle: string,
+ *   transports: ?Transports,
+ *   appId: ?string
+ * }}
+ */
+u2f.RegisteredKey;
+
+
+/**
+ * Data object for a get API register response.
+ * @typedef {{
+ *   js_api_version: number
+ * }}
+ */
+u2f.GetJsApiVersionResponse;
+
+
+//Low level MessagePort API support
 
 /**
  * Sets up a MessagePort to the U2F extension using the
@@ -133,8 +190,8 @@ u2f.getMessagePort = function(callback) {
     // for the callback to run. Thus, send an empty signature request
     // in order to get a failure response.
     var msg = {
-      type: u2f.MessageTypes.U2F_SIGN_REQUEST,
-      signRequests: []
+        type: u2f.MessageTypes.U2F_SIGN_REQUEST,
+        signRequests: []
     };
     chrome.runtime.sendMessage(u2f.EXTENSION_ID, msg, function() {
       if (!chrome.runtime.lastError) {
@@ -147,6 +204,10 @@ u2f.getMessagePort = function(callback) {
         u2f.getIframePort_(callback);
       }
     });
+  } else if (u2f.isAndroidChrome_()) {
+    u2f.getAuthenticatorPort_(callback);
+  } else if (u2f.isIosChrome_()) {
+    u2f.getIosPort_(callback);
   } else {
     // chrome.runtime was not available at all, which is normal
     // when this origin doesn't have access to any extensions.
@@ -155,15 +216,55 @@ u2f.getMessagePort = function(callback) {
 };
 
 /**
- * Connects directly to the extension via chrome.runtime.connect
+ * Detect chrome running on android based on the browser's useragent.
+ * @private
+ */
+u2f.isAndroidChrome_ = function() {
+  var userAgent = navigator.userAgent;
+  return userAgent.indexOf('Chrome') != -1 &&
+  userAgent.indexOf('Android') != -1;
+};
+
+/**
+ * Detect chrome running on iOS based on the browser's platform.
+ * @private
+ */
+u2f.isIosChrome_ = function() {
+  return ["iPhone", "iPad", "iPod"].indexOf(navigator.platform) > -1;
+};
+
+/**
+ * Connects directly to the extension via chrome.runtime.connect.
  * @param {function(u2f.WrappedChromeRuntimePort_)} callback
  * @private
  */
 u2f.getChromeRuntimePort_ = function(callback) {
   var port = chrome.runtime.connect(u2f.EXTENSION_ID,
-    {'includeTlsChannelId': true});
+      {'includeTlsChannelId': true});
   setTimeout(function() {
     callback(new u2f.WrappedChromeRuntimePort_(port));
+  }, 0);
+};
+
+/**
+ * Return a 'port' abstraction to the Authenticator app.
+ * @param {function(u2f.WrappedAuthenticatorPort_)} callback
+ * @private
+ */
+u2f.getAuthenticatorPort_ = function(callback) {
+  setTimeout(function() {
+    callback(new u2f.WrappedAuthenticatorPort_());
+  }, 0);
+};
+
+/**
+ * Return a 'port' abstraction to the iOS client app.
+ * @param {function(u2f.WrappedIosPort_)} callback
+ * @private
+ */
+u2f.getIosPort_ = function(callback) {
+  setTimeout(function() {
+    callback(new u2f.WrappedIosPort_());
   }, 0);
 };
 
@@ -178,12 +279,95 @@ u2f.WrappedChromeRuntimePort_ = function(port) {
 };
 
 /**
+ * Format and return a sign request compliant with the JS API version supported by the extension.
+ * @param {Array<u2f.SignRequest>} signRequests
+ * @param {number} timeoutSeconds
+ * @param {number} reqId
+ * @return {Object}
+ */
+u2f.formatSignRequest_ =
+  function(appId, challenge, registeredKeys, timeoutSeconds, reqId) {
+  if (js_api_version === undefined || js_api_version < 1.1) {
+    // Adapt request to the 1.0 JS API
+    var signRequests = [];
+    for (var i = 0; i < registeredKeys.length; i++) {
+      signRequests[i] = {
+          version: registeredKeys[i].version,
+          challenge: challenge,
+          keyHandle: registeredKeys[i].keyHandle,
+          appId: appId
+      };
+    }
+    return {
+      type: u2f.MessageTypes.U2F_SIGN_REQUEST,
+      signRequests: signRequests,
+      timeoutSeconds: timeoutSeconds,
+      requestId: reqId
+    };
+  }
+  // JS 1.1 API
+  return {
+    type: u2f.MessageTypes.U2F_SIGN_REQUEST,
+    appId: appId,
+    challenge: challenge,
+    registeredKeys: registeredKeys,
+    timeoutSeconds: timeoutSeconds,
+    requestId: reqId
+  };
+};
+
+/**
+ * Format and return a register request compliant with the JS API version supported by the extension..
+ * @param {Array<u2f.SignRequest>} signRequests
+ * @param {Array<u2f.RegisterRequest>} signRequests
+ * @param {number} timeoutSeconds
+ * @param {number} reqId
+ * @return {Object}
+ */
+u2f.formatRegisterRequest_ =
+  function(appId, registeredKeys, registerRequests, timeoutSeconds, reqId) {
+  if (js_api_version === undefined || js_api_version < 1.1) {
+    // Adapt request to the 1.0 JS API
+    for (var i = 0; i < registerRequests.length; i++) {
+      registerRequests[i].appId = appId;
+    }
+    var signRequests = [];
+    for (var i = 0; i < registeredKeys.length; i++) {
+      signRequests[i] = {
+          version: registeredKeys[i].version,
+          challenge: registerRequests[0],
+          keyHandle: registeredKeys[i].keyHandle,
+          appId: appId
+      };
+    }
+    return {
+      type: u2f.MessageTypes.U2F_REGISTER_REQUEST,
+      signRequests: signRequests,
+      registerRequests: registerRequests,
+      timeoutSeconds: timeoutSeconds,
+      requestId: reqId
+    };
+  }
+  // JS 1.1 API
+  return {
+    type: u2f.MessageTypes.U2F_REGISTER_REQUEST,
+    appId: appId,
+    registerRequests: registerRequests,
+    registeredKeys: registeredKeys,
+    timeoutSeconds: timeoutSeconds,
+    requestId: reqId
+  };
+};
+
+
+/**
  * Posts a message on the underlying channel.
  * @param {Object} message
  */
 u2f.WrappedChromeRuntimePort_.prototype.postMessage = function(message) {
   this.port_.postMessage(message);
 };
+
 
 /**
  * Emulates the HTML 5 addEventListener interface. Works only for the
@@ -201,6 +385,120 @@ u2f.WrappedChromeRuntimePort_.prototype.addEventListener =
     });
   } else {
     console.error('WrappedChromeRuntimePort only supports onMessage');
+  }
+};
+
+/**
+ * Wrap the Authenticator app with a MessagePort interface.
+ * @constructor
+ * @private
+ */
+u2f.WrappedAuthenticatorPort_ = function() {
+  this.requestId_ = -1;
+  this.requestObject_ = null;
+}
+
+/**
+ * Launch the Authenticator intent.
+ * @param {Object} message
+ */
+u2f.WrappedAuthenticatorPort_.prototype.postMessage = function(message) {
+  var intentUrl =
+    u2f.WrappedAuthenticatorPort_.INTENT_URL_BASE_ +
+    ';S.request=' + encodeURIComponent(JSON.stringify(message)) +
+    ';end';
+  document.location = intentUrl;
+};
+
+/**
+ * Tells what type of port this is.
+ * @return {String} port type
+ */
+u2f.WrappedAuthenticatorPort_.prototype.getPortType = function() {
+  return "WrappedAuthenticatorPort_";
+};
+
+
+/**
+ * Emulates the HTML 5 addEventListener interface.
+ * @param {string} eventName
+ * @param {function({data: Object})} handler
+ */
+u2f.WrappedAuthenticatorPort_.prototype.addEventListener = function(eventName, handler) {
+  var name = eventName.toLowerCase();
+  if (name == 'message') {
+    var self = this;
+    /* Register a callback to that executes when
+     * chrome injects the response. */
+    window.addEventListener(
+        'message', self.onRequestUpdate_.bind(self, handler), false);
+  } else {
+    console.error('WrappedAuthenticatorPort only supports message');
+  }
+};
+
+/**
+ * Callback invoked  when a response is received from the Authenticator.
+ * @param function({data: Object}) callback
+ * @param {Object} message message Object
+ */
+u2f.WrappedAuthenticatorPort_.prototype.onRequestUpdate_ =
+    function(callback, message) {
+  var messageObject = JSON.parse(message.data);
+  var intentUrl = messageObject['intentURL'];
+
+  var errorCode = messageObject['errorCode'];
+  var responseObject = null;
+  if (messageObject.hasOwnProperty('data')) {
+    responseObject = /** @type {Object} */ (
+        JSON.parse(messageObject['data']));
+  }
+
+  callback({'data': responseObject});
+};
+
+/**
+ * Base URL for intents to Authenticator.
+ * @const
+ * @private
+ */
+u2f.WrappedAuthenticatorPort_.INTENT_URL_BASE_ =
+  'intent:#Intent;action=com.google.android.apps.authenticator.AUTHENTICATE';
+
+/**
+ * Wrap the iOS client app with a MessagePort interface.
+ * @constructor
+ * @private
+ */
+u2f.WrappedIosPort_ = function() {};
+
+/**
+ * Launch the iOS client app request
+ * @param {Object} message
+ */
+u2f.WrappedIosPort_.prototype.postMessage = function(message) {
+  var str = JSON.stringify(message);
+  var url = "u2f://auth?" + encodeURI(str);
+  location.replace(url);
+};
+
+/**
+ * Tells what type of port this is.
+ * @return {String} port type
+ */
+u2f.WrappedIosPort_.prototype.getPortType = function() {
+  return "WrappedIosPort_";
+};
+
+/**
+ * Emulates the HTML 5 addEventListener interface.
+ * @param {string} eventName
+ * @param {function({data: Object})} handler
+ */
+u2f.WrappedIosPort_.prototype.addEventListener = function(eventName, handler) {
+  var name = eventName.toLowerCase();
+  if (name !== 'message') {
+    console.error('WrappedIosPort only supports message');
   }
 };
 
@@ -236,7 +534,7 @@ u2f.getIframePort_ = function(callback) {
 };
 
 
-// High-level JS API
+//High-level JS API
 
 /**
  * Default extension response timeout in seconds.
@@ -253,7 +551,7 @@ u2f.port_ = null;
 
 /**
  * Callbacks waiting for a port
- * @type {Array.<function((MessagePort|u2f.WrappedChromeRuntimePort_))>}
+ * @type {Array<function((MessagePort|u2f.WrappedChromeRuntimePort_))>}
  * @private
  */
 u2f.waitingForPort_ = [];
@@ -286,7 +584,7 @@ u2f.getPortSingleton_ = function(callback) {
       u2f.getMessagePort(function(port) {
         u2f.port_ = port;
         u2f.port_.addEventListener('message',
-          /** @type {function(Event)} */ (u2f.responseHandler_));
+            /** @type {function(Event)} */ (u2f.responseHandler_));
 
         // Careful, here be async callbacks. Maybe.
         while (u2f.waitingForPort_.length)
@@ -316,21 +614,45 @@ u2f.responseHandler_ = function(message) {
 
 /**
  * Dispatches an array of sign requests to available U2F tokens.
- * @param {Array.<u2f.SignRequest>} signRequests
+ * If the JS API version supported by the extension is unknown, it first sends a
+ * message to the extension to find out the supported API version and then it sends
+ * the sign request.
+ * @param {string=} appId
+ * @param {string=} challenge
+ * @param {Array<u2f.RegisteredKey>} registeredKeys
  * @param {function((u2f.Error|u2f.SignResponse))} callback
  * @param {number=} opt_timeoutSeconds
  */
-u2f.sign = function(signRequests, callback, opt_timeoutSeconds) {
+u2f.sign = function(appId, challenge, registeredKeys, callback, opt_timeoutSeconds) {
+  if (js_api_version === undefined) {
+    // Send a message to get the extension to JS API version, then send the actual sign request.
+    u2f.getApiVersion(
+        function (response) {
+          js_api_version = response['js_api_version'] === undefined ? 0 : response['js_api_version'];
+          console.log("Extension JS API Version: ", js_api_version);
+          u2f.sendSignRequest(appId, challenge, registeredKeys, callback, opt_timeoutSeconds);
+        });
+  } else {
+    // We know the JS API version. Send the actual sign request in the supported API version.
+    u2f.sendSignRequest(appId, challenge, registeredKeys, callback, opt_timeoutSeconds);
+  }
+};
+
+/**
+ * Dispatches an array of sign requests to available U2F tokens.
+ * @param {string=} appId
+ * @param {string=} challenge
+ * @param {Array<u2f.RegisteredKey>} registeredKeys
+ * @param {function((u2f.Error|u2f.SignResponse))} callback
+ * @param {number=} opt_timeoutSeconds
+ */
+u2f.sendSignRequest = function(appId, challenge, registeredKeys, callback, opt_timeoutSeconds) {
   u2f.getPortSingleton_(function(port) {
     var reqId = ++u2f.reqCounter_;
     u2f.callbackMap_[reqId] = callback;
-    var req = {
-      type: u2f.MessageTypes.U2F_SIGN_REQUEST,
-      signRequests: signRequests,
-      timeoutSeconds: (typeof opt_timeoutSeconds !== 'undefined' ?
-        opt_timeoutSeconds : u2f.EXTENSION_TIMEOUT_SEC),
-      requestId: reqId
-    };
+    var timeoutSeconds = (typeof opt_timeoutSeconds !== 'undefined' ?
+        opt_timeoutSeconds : u2f.EXTENSION_TIMEOUT_SEC);
+    var req = u2f.formatSignRequest_(appId, challenge, registeredKeys, timeoutSeconds, reqId);
     port.postMessage(req);
   });
 };
@@ -338,22 +660,87 @@ u2f.sign = function(signRequests, callback, opt_timeoutSeconds) {
 /**
  * Dispatches register requests to available U2F tokens. An array of sign
  * requests identifies already registered tokens.
- * @param {Array.<u2f.RegisterRequest>} registerRequests
- * @param {Array.<u2f.SignRequest>} signRequests
+ * If the JS API version supported by the extension is unknown, it first sends a
+ * message to the extension to find out the supported API version and then it sends
+ * the register request.
+ * @param {string=} appId
+ * @param {Array<u2f.RegisterRequest>} registerRequests
+ * @param {Array<u2f.RegisteredKey>} registeredKeys
  * @param {function((u2f.Error|u2f.RegisterResponse))} callback
  * @param {number=} opt_timeoutSeconds
  */
-u2f.register = function(registerRequests, signRequests,
-    callback, opt_timeoutSeconds) {
+u2f.register = function(appId, registerRequests, registeredKeys, callback, opt_timeoutSeconds) {
+  if (js_api_version === undefined) {
+    // Send a message to get the extension to JS API version, then send the actual register request.
+    u2f.getApiVersion(
+        function (response) {
+          js_api_version = response['js_api_version'] === undefined ? 0: response['js_api_version'];
+          console.log("Extension JS API Version: ", js_api_version);
+          u2f.sendRegisterRequest(appId, registerRequests, registeredKeys,
+              callback, opt_timeoutSeconds);
+        });
+  } else {
+    // We know the JS API version. Send the actual register request in the supported API version.
+    u2f.sendRegisterRequest(appId, registerRequests, registeredKeys,
+        callback, opt_timeoutSeconds);
+  }
+};
+
+/**
+ * Dispatches register requests to available U2F tokens. An array of sign
+ * requests identifies already registered tokens.
+ * @param {string=} appId
+ * @param {Array<u2f.RegisterRequest>} registerRequests
+ * @param {Array<u2f.RegisteredKey>} registeredKeys
+ * @param {function((u2f.Error|u2f.RegisterResponse))} callback
+ * @param {number=} opt_timeoutSeconds
+ */
+u2f.sendRegisterRequest = function(appId, registerRequests, registeredKeys, callback, opt_timeoutSeconds) {
   u2f.getPortSingleton_(function(port) {
     var reqId = ++u2f.reqCounter_;
     u2f.callbackMap_[reqId] = callback;
+    var timeoutSeconds = (typeof opt_timeoutSeconds !== 'undefined' ?
+        opt_timeoutSeconds : u2f.EXTENSION_TIMEOUT_SEC);
+    var req = u2f.formatRegisterRequest_(
+        appId, registeredKeys, registerRequests, timeoutSeconds, reqId);
+    port.postMessage(req);
+  });
+};
+
+
+/**
+ * Dispatches a message to the extension to find out the supported
+ * JS API version.
+ * If the user is on a mobile phone and is thus using Google Authenticator instead
+ * of the Chrome extension, don't send the request and simply return 0.
+ * @param {function((u2f.Error|u2f.GetJsApiVersionResponse))} callback
+ * @param {number=} opt_timeoutSeconds
+ */
+u2f.getApiVersion = function(callback, opt_timeoutSeconds) {
+ u2f.getPortSingleton_(function(port) {
+   // If we are using Android Google Authenticator or iOS client app,
+   // do not fire an intent to ask which JS API version to use.
+   if (port.getPortType) {
+     var apiVersion;
+     switch (port.getPortType()) {
+       case 'WrappedIosPort_':
+       case 'WrappedAuthenticatorPort_':
+         apiVersion = 1.1;
+         break;
+
+       default:
+         apiVersion = 0;
+         break;
+     }
+     callback({ 'js_api_version': apiVersion });
+     return;
+   }
+    var reqId = ++u2f.reqCounter_;
+    u2f.callbackMap_[reqId] = callback;
     var req = {
-      type: u2f.MessageTypes.U2F_REGISTER_REQUEST,
-      signRequests: signRequests,
-      registerRequests: registerRequests,
+      type: u2f.MessageTypes.U2F_GET_API_VERSION_REQUEST,
       timeoutSeconds: (typeof opt_timeoutSeconds !== 'undefined' ?
-        opt_timeoutSeconds : u2f.EXTENSION_TIMEOUT_SEC),
+          opt_timeoutSeconds : u2f.EXTENSION_TIMEOUT_SEC),
       requestId: reqId
     };
     port.postMessage(req);


### PR DESCRIPTION
Updating U2F API to version 1.1 and mapping of existing API calls to it.
(Firefox supports only v1.1)

Closes #860
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23issuecomment-438196538%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23issuecomment-438198563%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23issuecomment-439460600%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23issuecomment-439460676%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23discussion_r233660410%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23discussion_r233691570%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23discussion_r234281196%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23issuecomment-438196538%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231308%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/0e6fb7bf3edca213ead323d82125b7f73b4b26cc%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231308%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2095.81%25%20%20%2095.82%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20142%20%20%20%20%20%20142%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017238%20%20%20%2017238%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016517%20%20%20%2016518%20%20%20%20%20%20%20%2B1%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20721%20%20%20%20%20%20720%20%20%20%20%20%20%20-1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/subscriptions.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk%3D%29%20%7C%20%6087.7%25%20%3C0%25%3E%20%28%2B0.81%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B0e6fb7b...dda3157%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1308%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-13T09%3A27%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Source%20of%20the%20U2F%20API%3A%20%60https%3A//github.com/google/u2f-ref-code/blob/master/u2f-gae-demo/war/js/u2f-api.js%60%22%2C%20%22created_at%22%3A%20%222018-11-13T09%3A33%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/38477631%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/blsho%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-16T17%3A07%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-11-16T17%3A08%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f485066db9d7092eb493a9f549eb65397bd4f6c0%20privacyidea/static/components/login/factories/u2f.js%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1308%23discussion_r233660410%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20can%20call%20multiple%20challenge%20response.%20So%20we%20should%20be%20able%20iterate%20over%20the%20elements%20of%20%60%60signRequests%60%60.%5Cr%5CnThis%20can%20actually%20contain%20a%20list%2C%20if%20the%20response%20in%20%60%60attributes%60%60%20contains%20several%20challenges.%5Cr%5Cn%5Cr%5CnHere%20we%20create%20the%20u2fSignRequest%20of%20a%20single%20U2F%20token.%20https%3A//github.com/privacyidea/privacyidea/blob/master/privacyidea/lib/tokens/u2ftoken.py%23L437%5Cr%5CnBut%20actually%20a%20challenge%20response%20authentication%20can%20contain%20several%20challenge-tokens%2C%20if%20they%20all%20have%20the%20same%20pin.%5Cr%5CnThis%20is%20also%20true%20for%20U2F%20tokens%20%28https%3A//github.com/privacyidea/privacyidea/blob/master/privacyidea/lib/token.py%23L2221%29.%5Cr%5CnThen%20these%20challenges%20will%20be%20added%20up%20in%20the%20%60%60multi-challenge%60%60%20key%20%28https%3A//github.com/privacyidea/privacyidea/blob/master/privacyidea/lib/token.py%23L2247%29%20which%20will%20finally%20result%20in%20a%20list%20of%20several%20challenges%20%28and%20keyhandles%29%20in%20the%20%60%60signRequests%60%60%20parameter%20of%20this%20%60%60u2f.sign%60%60%20function.%22%2C%20%22created_at%22%3A%20%222018-11-14T23%3A24%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right.%20I%20was%20too%20focused%20on%20my%20own%20PI%20installation%20with%20a%20single%20U2F%20Token.%20Latest%20commit%20deals%20with%20it.%22%2C%20%22created_at%22%3A%20%222018-11-15T02%3A13%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/38477631%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/blsho%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-16T17%3A07%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/login/factories/u2f.js%3AL60-76%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cornelinux%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cornelinux'><img src='https://avatars1.githubusercontent.com/u/1908620?v=4' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1308#issuecomment-438196538'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1308?src=pr&el=h1) Report
> Merging [#1308](https://codecov.io/gh/privacyidea/privacyidea/pull/1308?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/0e6fb7bf3edca213ead323d82125b7f73b4b26cc?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1308/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1308?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1308      +/-   ##
==========================================
+ Coverage   95.81%   95.82%   +<.01%
==========================================
Files         142      142
Lines       17238    17238
==========================================
+ Hits        16517    16518       +1
+ Misses        721      720       -1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1308?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/subscriptions.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1308/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3N1YnNjcmlwdGlvbnMucHk=) | `87.7% <0%> (+0.81%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1308?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1308?src=pr&el=footer). Last update [0e6fb7b...dda3157](https://codecov.io/gh/privacyidea/privacyidea/pull/1308?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/blsho'><img border=0 src='https://avatars3.githubusercontent.com/u/38477631?v=4' height=16 width=16></a> Source of the U2F API: `https://github.com/google/u2f-ref-code/blob/master/u2f-gae-demo/war/js/u2f-api.js`
- [x] <a href='#crh-comment-Pull f485066db9d7092eb493a9f549eb65397bd4f6c0 privacyidea/static/components/login/factories/u2f.js 28'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1308#discussion_r233660410'>File: privacyidea/static/components/login/factories/u2f.js:L60-76</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> We can call multiple challenge response. So we should be able iterate over the elements of ``signRequests``.
This can actually contain a list, if the response in ``attributes`` contains several challenges.
Here we create the u2fSignRequest of a single U2F token. https://github.com/privacyidea/privacyidea/blob/master/privacyidea/lib/tokens/u2ftoken.py#L437
But actually a challenge response authentication can contain several challenge-tokens, if they all have the same pin.
This is also true for U2F tokens (https://github.com/privacyidea/privacyidea/blob/master/privacyidea/lib/token.py#L2221).
Then these challenges will be added up in the ``multi-challenge`` key (https://github.com/privacyidea/privacyidea/blob/master/privacyidea/lib/token.py#L2247) which will finally result in a list of several challenges (and keyhandles) in the ``signRequests`` parameter of this ``u2f.sign`` function.
- <a href='https://github.com/blsho'><img border=0 src='https://avatars3.githubusercontent.com/u/38477631?v=4' height=16 width=16></a> You are right. I was too focused on my own PI installation with a single U2F Token. Latest commit deals with it.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1308?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1308?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1308?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1308'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>