### PR TITLE
Handle non-existent resources more strictly

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -64,7 +64,7 @@ from .monitoring import monitoring_blueprint
 from privacyidea.api.lib.postpolicy import postrequest, sign_response
 from ..lib.error import (privacyIDEAError,
                          AuthError, UserError,
-                         PolicyError)
+                         PolicyError, ResourceNotFoundError)
 from privacyidea.lib.utils import get_client_ip
 from privacyidea.lib.user import User
 
@@ -293,6 +293,31 @@ def policy_error(error):
         g.audit_object.log({"info": error.message})
         g.audit_object.finalize_log()
     return send_error(error.message, error_code=error.id), 403
+
+
+@system_blueprint.app_errorhandler(ResourceNotFoundError)
+@realm_blueprint.app_errorhandler(ResourceNotFoundError)
+@defaultrealm_blueprint.app_errorhandler(ResourceNotFoundError)
+@resolver_blueprint.app_errorhandler(ResourceNotFoundError)
+@policy_blueprint.app_errorhandler(ResourceNotFoundError)
+@user_blueprint.app_errorhandler(ResourceNotFoundError)
+@token_blueprint.app_errorhandler(ResourceNotFoundError)
+@audit_blueprint.app_errorhandler(ResourceNotFoundError)
+@application_blueprint.app_errorhandler(ResourceNotFoundError)
+@smtpserver_blueprint.app_errorhandler(ResourceNotFoundError)
+@register_blueprint.app_errorhandler(ResourceNotFoundError)
+@recover_blueprint.app_errorhandler(ResourceNotFoundError)
+@subscriptions_blueprint.app_errorhandler(ResourceNotFoundError)
+@postrequest(sign_response, request=request)
+def resource_not_found_error(error):
+    """
+    This function is called when an ResourceNotFoundError occurs.
+    It sends a 404.
+    """
+    if "audit_object" in g:
+        g.audit_object.log({"info": error.message})
+        g.audit_object.finalize_log()
+    return send_error(error.message, error_code=error.id), 404
 
 
 @system_blueprint.app_errorhandler(privacyIDEAError)

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -46,7 +46,7 @@ from privacyidea.lib.error import PolicyError
 from flask import g, current_app, make_response
 from privacyidea.lib.policy import SCOPE, ACTION, AUTOASSIGNVALUE
 from privacyidea.lib.user import get_user_from_param
-from privacyidea.lib.token import get_tokens, assign_token, get_realms_of_token
+from privacyidea.lib.token import get_tokens, assign_token, get_realms_of_token, get_one_token
 from privacyidea.lib.machine import get_hostname, get_auth_items
 from .prepolicy import check_max_token_user, check_max_token_realm
 import functools
@@ -430,7 +430,7 @@ def save_pin_change(request, response, serial=None):
                                                 scope=SCOPE.ENROLL, realm=realm,
                                                 client=g.client_ip, active=True)
             if pinpol:
-                token = get_tokens(serial=serial)[0]
+                token = get_one_token(serial=serial)
                 token.set_next_pin_change(diff="0d")
 
         elif g.logged_in_user.get("role") == ROLE.USER:
@@ -439,7 +439,7 @@ def save_pin_change(request, response, serial=None):
             pin = request.all_data.get("pin")
             # The user sets a pin or enrolls a token. -> delete the pin_change
             if otppin or pin:
-                token = get_tokens(serial=serial)[0]
+                token = get_one_token(serial=serial)
                 token.del_tokeninfo("next_pin_change")
 
                 # If there is a change_pin_every policy, we need to set the PIN
@@ -448,7 +448,7 @@ def save_pin_change(request, response, serial=None):
                     ACTION.CHANGE_PIN_EVERY, scope=SCOPE.ENROLL,
                     realm=realm, client=g.client_ip, unique=True)
                 if pinpol:
-                    token = get_tokens(serial=serial)[0]
+                    token = get_one_token(serial=serial)
                     token.set_next_pin_change(diff=pinpol[0])
 
     # we do not modify the response!

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -426,9 +426,8 @@ def assign_api():
         err_message = "Token already assigned to another user."
     else:
         err_message = None
-    res = assign_token(serial, user, pin=pin, encrypt_pin=encrypt_pin,
-                       err_message=err_message)
-    g.audit_object.log({"success": True})
+    res = assign_token(serial, user, pin=pin, encrypt_pin=encrypt_pin, err_message=err_message)
+    g.audit_object.log({"success": res})
     return send_result(res)
 
 
@@ -442,13 +441,15 @@ def unassign_api():
     You can either provide "serial" as an argument to unassign this very
     token or you can provide user and realm, to unassign all tokens of a user.
 
-    :return: In case of success it returns "value": True.
-    :rtype: json object
+    :return: In case of success it returns the number of unassigned tokens in "value".
+    :rtype: JSON object
     """
     user = get_user_from_param(request.all_data, optional)
     serial = getParam(request.all_data, "serial", optional)
+    g.audit_object.log({"serial": serial})
+
     res = unassign_token(serial, user=user)
-    g.audit_object.log({"success": True})
+    g.audit_object.log({"success": res > 0})
     return send_result(res)
 
 
@@ -546,13 +547,11 @@ def disable_api(serial=None):
 @prepolicy(check_base_action, request, action=ACTION.DELETE)
 @event("token_delete", request, g)
 @log_with(log)
-def delete_api(serial=None):
+def delete_api(serial):
     """
-    Delete a token by its serial number or delete all tokens of a user.
+    Delete a token by its serial number.
 
     :jsonparam serial: The serial number of a single token.
-    :jsonparam user: The username of the user, whose tokens should be deleted.
-    :jsonparam realm: The realm of the user.
 
     :return: In case of success it return the number of deleted tokens in
         "value"
@@ -800,9 +799,9 @@ def tokenrealm_api(serial=None):
         realm_list = [r.strip() for r in realms.split(",")]
     g.audit_object.log({"serial": serial})
 
-    res = set_realms(serial, realms=realm_list)
+    set_realms(serial, realms=realm_list)
     g.audit_object.log({"success": True})
-    return send_result(res == 1)
+    return send_result(True)
 
 
 @token_blueprint.route('/load/<filename>', methods=['POST'])

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -427,7 +427,7 @@ def assign_api():
     else:
         err_message = None
     res = assign_token(serial, user, pin=pin, encrypt_pin=encrypt_pin, err_message=err_message)
-    g.audit_object.log({"success": res})
+    g.audit_object.log({"success": True})
     return send_result(res)
 
 
@@ -449,7 +449,7 @@ def unassign_api():
     g.audit_object.log({"serial": serial})
 
     res = unassign_token(serial, user=user)
-    g.audit_object.log({"success": res > 0})
+    g.audit_object.log({"success": True})
     return send_result(res)
 
 
@@ -480,7 +480,7 @@ def revoke_api(serial=None):
     g.audit_object.log({"serial": serial})
 
     res = revoke_token(serial, user=user)
-    g.audit_object.log({"success": res > 0})
+    g.audit_object.log({"success": True})
     return send_result(res)
 
 
@@ -508,7 +508,7 @@ def enable_api(serial=None):
     g.audit_object.log({"serial": serial})
 
     res = enable_token(serial, enable=True, user=user)
-    g.audit_object.log({"success": res > 0})
+    g.audit_object.log({"success": True})
     return send_result(res)
 
 
@@ -538,7 +538,7 @@ def disable_api(serial=None):
     g.audit_object.log({"serial": serial})
 
     res = enable_token(serial, enable=False, user=user)
-    g.audit_object.log({"success": res > 0})
+    g.audit_object.log({"success": True})
     return send_result(res)
 
 

--- a/privacyidea/lib/auth.py
+++ b/privacyidea/lib/auth.py
@@ -25,6 +25,7 @@ from privacyidea.models import Admin
 from privacyidea.lib.token import check_user_pass
 from privacyidea.lib.policydecorators import libpolicy, login_mode
 from privacyidea.lib.crypto import hash_with_pepper, verify_with_pepper
+from privacyidea.lib.utils import fetch_one_resource
 
 
 class ROLE(object):
@@ -87,7 +88,7 @@ def get_db_admin(username):
 
 def delete_db_admin(username):
     print("Deleting admin {0!s}".format(username))
-    Admin.query.filter(Admin.username == username).first().delete()
+    fetch_one_resource(Admin, username=username).delete()
 
 
 @libpolicy(login_mode)

--- a/privacyidea/lib/caconnector.py
+++ b/privacyidea/lib/caconnector.py
@@ -40,7 +40,7 @@ from ..api.lib.utils import getParam
 from .error import ConfigAdminError
 from sqlalchemy import func
 from .crypto import encryptPassword, decryptPassword
-from privacyidea.lib.utils import (sanity_name_check, get_data_from_params)
+from privacyidea.lib.utils import (sanity_name_check, get_data_from_params, fetch_one_resource)
 #from privacyidea.lib.cache import cache
 
 log = logging.getLogger(__name__)
@@ -177,20 +177,14 @@ def get_caconnector_list(filter_caconnector_type=None,
 def delete_caconnector(connector_name):
     """
     delete a CA connector and all related config entries.
-    If there was no CA connector, that could be deleted, it returns -1
+    If there was no CA connector, that could be deleted, a ResourceNotFoundError is raised.
 
     :param connector_name: The name of the CA connector that is to be deleted
     :type connector_name: basestring
     :return: The Id of the resolver
     :rtype: int
     """
-    ret = -1
-
-    conn = CAConnector.query.filter_by(name=connector_name).first()
-    if conn:
-        conn.delete()
-        ret = conn.id
-    return ret
+    return fetch_one_resource(CAConnector, name=connector_name).delete()
 
 
 @log_with(log)

--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -48,6 +48,7 @@ class ERROR:
     AUTHENTICATE_TOKEN_EXPIRED = 4305
     AUTHENTICATE_MISSING_RIGHT = 4306
     CA = 503
+    RESOURCE_NOT_FOUND = 601
     HSM = 707
     SELFSERVICE = 807
     SERVER = 903
@@ -112,7 +113,12 @@ class AuthError(privacyIDEAError):
     def __init__(self, description, id=ERROR.AUTHENTICATE, details=None):
         self.details = details
         privacyIDEAError.__init__(self, description=description, id=id)
-        
+
+
+class ResourceNotFoundError(privacyIDEAError):
+    def __init__(self, description, id=ERROR.RESOURCE_NOT_FOUND):
+        privacyIDEAError.__init__(self, description=description, id=id)
+
 
 class PolicyError(privacyIDEAError):
     def __init__(self, description, id=ERROR.POLICY):

--- a/privacyidea/lib/event.py
+++ b/privacyidea/lib/event.py
@@ -22,6 +22,7 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
+from privacyidea.lib.utils import fetch_one_resource
 from privacyidea.models import EventHandler, EventHandlerOption, db
 from privacyidea.lib.error import ParameterError
 from privacyidea.lib.audit import getAudit
@@ -178,11 +179,7 @@ def enable_event(event_id, enable=True):
     :param event_id: ID of the event
     :return:
     """
-    ev = EventHandler.query.filter_by(id=event_id).first()
-    if not ev:
-        raise ParameterError("The event with id '{0!s}' does not "
-                             "exist".format(event_id))
-
+    ev = fetch_one_resource(EventHandler, id=event_id)
     # Update the event
     ev.active = enable
     r = ev.save()
@@ -241,7 +238,7 @@ def delete_event(event_id):
     :return:
     """
     event_id = int(event_id)
-    ev = EventHandler.query.filter_by(id=event_id).first()
+    ev = fetch_one_resource(EventHandler, id=event_id)
     r = ev.delete()
     return r
 

--- a/privacyidea/lib/event.py
+++ b/privacyidea/lib/event.py
@@ -238,9 +238,7 @@ def delete_event(event_id):
     :return:
     """
     event_id = int(event_id)
-    ev = fetch_one_resource(EventHandler, id=event_id)
-    r = ev.delete()
-    return r
+    return fetch_one_resource(EventHandler, id=event_id).delete()
 
 
 class EventConfiguration(object):

--- a/privacyidea/lib/machine.py
+++ b/privacyidea/lib/machine.py
@@ -34,6 +34,7 @@ from privacyidea.models import (MachineToken, db, MachineTokenOptions,
                                 MachineResolver, get_token_id,
                                 get_machineresolver_id,
                                 get_machinetoken_id)
+from privacyidea.lib.utils import fetch_one_resource
 from netaddr import IPAddress
 from sqlalchemy import and_
 import logging
@@ -327,11 +328,10 @@ def list_token_machines(serial):
     :return: returns a list of machines and apps
     """
     res = []
-    db_token = Token.query.filter(Token.serial == serial).first()
+    db_token = fetch_one_resource(Token, serial=serial)
 
     for machine in db_token.machine_list:
-        MR = MachineResolver.query.filter(MachineResolver.id ==
-                                          machine.machineresolver_id).first()
+        MR = fetch_one_resource(MachineResolver, id=machine.machineresolver_id)
         resolver_name = MR.name
 
         option_list = machine.option_list

--- a/privacyidea/lib/machineresolver.py
+++ b/privacyidea/lib/machineresolver.py
@@ -40,7 +40,7 @@ from ..api.lib.utils import getParam
 from sqlalchemy import func
 from .crypto import encryptPassword, decryptPassword
 from privacyidea.lib.config import get_machine_resolver_class_dict
-from privacyidea.lib.utils import (sanity_name_check, get_data_from_params)
+from privacyidea.lib.utils import (sanity_name_check, get_data_from_params, fetch_one_resource)
 
 
 log = logging.getLogger(__name__)
@@ -162,20 +162,14 @@ def get_resolver_list(filter_resolver_type=None,
 def delete_resolver(resolvername):
     """
     delete a machine resolver and all related MachineResolverConfig entries
-    If there was no resolver, that could be deleted, it returns -1
+    If there was no resolver, this raises a ResourceNotFoundError.
 
     :param resolvername: the name of the to be deleted resolver
     :type resolvername: string
     :return: The Id of the resolver
     :rtype: int
     """
-    ret = -1
-
-    reso = MachineResolver.query.filter_by(name=resolvername).first()
-    if reso:
-        reso.delete()
-        ret = reso.id
-    return ret
+    return fetch_one_resource(MachineResolver, name=resolvername).delete()
 
 
 @log_with(log)

--- a/privacyidea/lib/periodictask.py
+++ b/privacyidea/lib/periodictask.py
@@ -26,7 +26,8 @@ from datetime import datetime
 from croniter import croniter
 from dateutil.tz import tzutc, tzlocal
 
-from privacyidea.lib.error import ServerError, ParameterError
+from privacyidea.lib.error import ServerError, ParameterError, ResourceNotFoundError
+from privacyidea.lib.utils import fetch_one_resource
 from privacyidea.lib.task.eventcounter import EventCounterTask
 from privacyidea.lib.task.simplestats import SimpleStatsTask
 from privacyidea.models import PeriodicTask
@@ -183,7 +184,7 @@ def get_periodic_task_by_name(name):
     """
     periodic_tasks = get_periodic_tasks(name)
     if len(periodic_tasks) != 1:
-        raise ParameterError("The periodic task with unique name {!r} does not exist".format(name))
+        raise ResourceNotFoundError(u"The periodic task with unique name {!r} does not exist".format(name))
     return periodic_tasks[0]
 
 
@@ -199,15 +200,12 @@ def get_periodic_task_by_id(ptask_id):
 
 def _get_periodic_task_entry(ptask_id):
     """
-    Get a periodic task entry by ID. Raise ParameterError if the task could not be found.
+    Get a periodic task entry by ID. Raise ResourceNotFoundError if the task could not be found.
     This is only for internal use.
     :param id: task ID as integer
     :return: PeriodicTask object
     """
-    periodic_task = PeriodicTask.query.filter_by(id=ptask_id).first()
-    if periodic_task is None:
-        raise ParameterError("The periodic task with id {!r} does not exist".format(ptask_id))
-    return periodic_task
+    return fetch_one_resource(PeriodicTask, id=ptask_id)
 
 
 def set_periodic_task_last_run(ptask_id, node, last_run_timestamp):

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -164,12 +164,12 @@ from ..models import (Policy, Config, PRIVACYIDEA_TIMESTAMP, db,
 from flask import current_app
 from privacyidea.lib.config import (get_token_classes, get_token_types,
                                     Singleton)
-from privacyidea.lib.error import ParameterError, PolicyError
+from privacyidea.lib.error import ParameterError, PolicyError, ResourceNotFoundError
 from privacyidea.lib.realm import get_realms
 from privacyidea.lib.resolver import get_resolver_list
 from privacyidea.lib.smtpserver import get_smtpservers
 from privacyidea.lib.radiusserver import get_radiusservers
-from privacyidea.lib.utils import check_time_in_range, reload_db
+from privacyidea.lib.utils import check_time_in_range, reload_db, fetch_one_resource
 from privacyidea.lib.user import User
 from privacyidea.lib import _
 import datetime
@@ -941,7 +941,7 @@ def enable_policy(name, enable=True):
     :return: ID of the policy
     """
     if not Policy.query.filter(Policy.name == name).first():
-        raise ParameterError("The policy with name '{0!s}' does not exist".format(name))
+        raise ResourceNotFoundError(u"The policy with name '{0!s}' does not exist".format(name))
 
     # Update the policy
     p = set_policy(name=name, active=enable)
@@ -951,17 +951,14 @@ def enable_policy(name, enable=True):
 @log_with(log)
 def delete_policy(name):
     """
-    Function to delete one named policy
+    Function to delete one named policy.
+    Raise ResourceNotFoundError if there is no such policy.
 
     :param name: the name of the policy to be deleted
-    :return: the count of the deleted policies.
+    :return: the ID of the deletec policy
     :rtype: int
     """
-    res = False
-    p = Policy.query.filter_by(name=name).first()
-    if p:
-        res = p.delete()
-    return res
+    return fetch_one_resource(Policy, name=name).delete()
 
 
 @log_with(log)

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -955,7 +955,7 @@ def delete_policy(name):
     Raise ResourceNotFoundError if there is no such policy.
 
     :param name: the name of the policy to be deleted
-    :return: the ID of the deletec policy
+    :return: the ID of the deleted policy
     :rtype: int
     """
     return fetch_one_resource(Policy, name=name).delete()

--- a/privacyidea/lib/privacyideaserver.py
+++ b/privacyidea/lib/privacyideaserver.py
@@ -20,6 +20,7 @@
 from privacyidea.models import PrivacyIDEAServer as PrivacyIDEAServerDB
 import logging
 from privacyidea.lib.log import log_with
+from privacyidea.lib.utils import fetch_one_resource
 from privacyidea.lib.error import ConfigAdminError, privacyIDEAError
 import json
 from privacyidea.lib import _
@@ -158,15 +159,9 @@ def add_privacyideaserver(identifier, url, tls=True, description=""):
 @log_with(log)
 def delete_privacyideaserver(identifier):
     """
-    Delete the given server from the database
+    Delete the given server from the database.
+    Raise ResourceNotFoundError if it couldn't be found.
     :param identifier: The identifier/name of the server
     :return: The ID of the database entry, that was deleted
     """
-    ret = -1
-    pi = PrivacyIDEAServerDB.query.filter(PrivacyIDEAServerDB.identifier ==
-                                              identifier).first()
-    if pi:
-        pi.delete()
-        ret = pi.id
-    return ret
-
+    return fetch_one_resource(PrivacyIDEAServerDB, identifier=identifier).delete()

--- a/privacyidea/lib/radiusserver.py
+++ b/privacyidea/lib/radiusserver.py
@@ -30,6 +30,7 @@ from pyrad.client import Client
 from pyrad.client import Timeout
 from pyrad.dictionary import Dictionary
 from privacyidea.lib import _
+from privacyidea.lib.utils import fetch_one_resource
 
 __doc__ = """
 This is the library for creating, listing and deleting RADIUS server objects in
@@ -239,15 +240,10 @@ def test_radius(identifier, server, secret, user, password, port=1812, descripti
 @log_with(log)
 def delete_radius(identifier):
     """
-    Delete the given server from the database
+    Delete the given server from the database.
+    If no such entry could be found, a ResourceNotFoundError is raised.
     :param identifier: The identifier/name of the server
     :return: The ID of the database entry, that was deleted
     """
-    ret = -1
-    radius = RADIUSServerDB.query.filter(RADIUSServerDB.identifier ==
-                                         identifier).first()
-    if radius:
-        radius.delete()
-        ret = radius.id
-    return ret
+    return fetch_one_resource(RADIUSServerDB, identifier=identifier).delete()
 

--- a/privacyidea/lib/realm.py
+++ b/privacyidea/lib/realm.py
@@ -43,7 +43,7 @@ from log import log_with
 from flask import g
 from privacyidea.lib.config import ConfigClass
 import logging
-from privacyidea.lib.utils import sanity_name_check
+from privacyidea.lib.utils import sanity_name_check, fetch_one_resource
 log = logging.getLogger(__name__)
 
 
@@ -154,7 +154,7 @@ def delete_realm(realmname):
     defRealm = get_default_realm()
     hadDefRealmBefore = (defRealm != "")
 
-    realm = Realm.query.filter_by(name=realmname).first()
+    realm = fetch_one_resource(Realm, name=realmname)
     ret = realm.delete()
 
     # If there was a default realm before

--- a/privacyidea/lib/realm.py
+++ b/privacyidea/lib/realm.py
@@ -154,8 +154,7 @@ def delete_realm(realmname):
     defRealm = get_default_realm()
     hadDefRealmBefore = (defRealm != "")
 
-    realm = fetch_one_resource(Realm, name=realmname)
-    ret = realm.delete()
+    ret = fetch_one_resource(Realm, name=realmname).delete()
 
     # If there was a default realm before
     # and if there is only one realm left, we set the

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -25,6 +25,7 @@
 #               GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+
 __doc__="""This is the base class for SMS Modules, that can send SMS via
 different means.
 The function get_sms_provider_class loads an SMS Provider Module dynamically
@@ -34,6 +35,7 @@ The code is tested in tests/test_lib_smsprovider
 """
 
 from privacyidea.models import SMSGateway, SMSGatewayOption
+from privacyidea.lib.utils import fetch_one_resource
 import logging
 log = logging.getLogger(__name__)
 
@@ -184,11 +186,7 @@ def delete_smsgateway(identifier):
     :type identifier: basestring
     :return:
     """
-    r = -1
-    gw = SMSGateway.query.filter_by(identifier=identifier).first()
-    if gw:
-        r = gw.delete()
-    return r
+    return fetch_one_resource(SMSGateway, identifier=identifier).delete()
 
 
 def delete_smsgateway_option(id, option_key):
@@ -199,9 +197,7 @@ def delete_smsgateway_option(id, option_key):
     :param option_key: The identifier/key of the option
     :return: True
     """
-    r = SMSGatewayOption.query.filter_by(gateway_id=id,
-                                         Key=option_key).first().delete()
-    return r
+    return fetch_one_resource(SMSGatewayOption, gateway_id=id, Key=option_key).delete()
 
 
 def get_smsgateway(identifier=None, id=None):

--- a/privacyidea/lib/smtpserver.py
+++ b/privacyidea/lib/smtpserver.py
@@ -20,6 +20,7 @@
 from privacyidea.models import SMTPServer as SMTPServerDB
 from privacyidea.lib.crypto import (decryptPassword, encryptPassword,
                                     FAILED_TO_DECRYPT_PASSWORD)
+from privacyidea.lib.utils import fetch_one_resource
 import logging
 from privacyidea.lib.log import log_with
 from time import gmtime, strftime
@@ -244,15 +245,9 @@ def add_smtpserver(identifier, server, port=25, username="", password="",
 @log_with(log)
 def delete_smtpserver(identifier):
     """
-    Delete the given server from the database
+    Delete the given server from the database.
+    Raise a ResourceNotFoundError if it couldn't be found.
     :param identifier: The identifier/name of the server
     :return: The ID of the database entry, that was deleted
     """
-    ret = -1
-    smtp = SMTPServerDB.query.filter(SMTPServerDB.identifier ==
-                                     identifier).first()
-    if smtp:
-        smtp.delete()
-        ret = smtp.id
-    return ret
-
+    return fetch_one_resource(SMTPServerDB, identifier=identifier).delete()

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -68,7 +68,7 @@ import logging
 from sqlalchemy import (and_, func)
 from privacyidea.lib.error import (TokenAdminError,
                                    ParameterError,
-                                   privacyIDEAError)
+                                   privacyIDEAError, ResourceNotFoundError)
 from privacyidea.lib.decorators import (check_user_or_serial,
                                         check_copy_serials)
 from privacyidea.lib.tokenclass import TokenClass
@@ -479,6 +479,38 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
     return ret
 
 
+def get_one_token(*args, **kwargs):
+    """
+    Fetch exactly one token according to the given filter arguments, which are passed to
+    ``get_tokens``. Raise ``ResourceNotFoundError`` if no token was found. Raise
+    ``ParameterError`` if more than one token was found.
+    """
+    result = get_tokens(*args, **kwargs)
+    if not result:
+        raise ResourceNotFoundError(u"The requested token could not be found.")
+    elif len(result) > 1:
+        raise ParameterError(u"More than one matching token were found.")
+    else:
+        return result[0]
+
+
+def get_tokens_from_serial_or_user(serial, user, **kwargs):
+    """
+    Fetch tokens, either by (exact) serial, or all tokens of a single user.
+    In case a serial number is given, check that exactly one token is returned
+    and raise a ResourceNotFoundError if that is not the case.
+    In case a user is given, the result can also be empty.
+    :param serial: exact serial number or None
+    :param user: a user object or None
+    :param kwargs: additional argumens to ``get_tokens``
+    :return: a (possibly empty) list of tokens
+    """
+    if serial:
+        return [get_one_token(serial=serial, user=user, **kwargs)]
+    else:
+        return get_tokens(serial=serial, user=user, **kwargs)
+
+
 @log_with(log)
 def get_token_type(serial):
     """
@@ -490,16 +522,10 @@ def get_token_type(serial):
     :return: tokentype
     :rtype: string
     """
-    if serial and "*" in serial:
+    try:
+        return get_one_token(serial=serial).type
+    except ResourceNotFoundError:
         return ""
-
-    tokenobject_list = get_tokens(serial=serial)
-
-    tokentype = ""
-    for tokenobject in tokenobject_list:
-        tokentype = tokenobject.type
-
-    return tokentype
 
 
 @log_with(log)
@@ -559,16 +585,13 @@ def get_realms_of_token(serial, only_first_realm=False):
     :return: list of the realm names
     :rtype: list
     """
-    if "*" in serial:
-        return []
-
-    tokenobject_list = get_tokens(serial=serial)
-
-    realms = []
-    for tokenobject in tokenobject_list:
+    try:
+        tokenobject = get_one_token(serial=serial)
         realms = tokenobject.get_realms()
+    except ResourceNotFoundError:
+        realms = []
 
-    if realms > 1:
+    if len(realms) > 1:
         log.debug(
             "Token {0!s} in more than one realm: {1!s}".format(serial, realms))
 
@@ -603,8 +626,8 @@ def get_token_owner(serial):
 
     If the token has no owner, None is returned
     
-    In case the serial number matches several tokens (like when containing a 
-    wildcard), also None is returned.
+    Wildcards in the serial number are ignored. This raises
+    ``ResourceNotFoundError`` if the token could not be found.
 
     :param serial: serial number of the token
     :type serial: basestring
@@ -612,15 +635,8 @@ def get_token_owner(serial):
     :return: The owner of the token
     :rtype: User object or None
     """
-    user = None
-
-    tokenobject_list = get_tokens(serial=serial)
-
-    if len(tokenobject_list) == 1:
-        tokenobject = tokenobject_list[0]
-        user = tokenobject.user
-
-    return user
+    tokenobject = get_one_token(serial=serial)
+    return tokenobject.user
 
 
 @log_with(log)
@@ -712,6 +728,7 @@ def get_otp(serial, current_time=None):
     This function returns the current OTP value for a given Token.
     The tokentype needs to support this function.
     if the token does not support getting the OTP value, a -2 is returned.
+    If the token could not be found, ResourceNotFoundError is raised.
 
     :param serial: serial number of the token
     :param current_time: a fake servertime for testing of TOTP token
@@ -719,14 +736,7 @@ def get_otp(serial, current_time=None):
     :return: tuple with (result, pin, otpval, passw)
     :rtype: tuple
     """
-    tokenobject_list = get_tokens(serial=serial)
-
-    if not tokenobject_list:
-        log.warning("there is no token with serial {0!r}".format(serial))
-        return -1, "", "", ""
-
-    tokenobject = tokenobject_list[0]
-
+    tokenobject = get_one_token(serial=serial)
     return tokenobject.get_otp(current_time=current_time)
 
 
@@ -754,29 +764,23 @@ def get_multi_otp(serial, count=0, epoch_start=0, epoch_end=0,
     :rtype: dictionary
     """
     ret = {"result": False}
-    tokenobject_list = get_tokens(serial=serial)
-    if not tokenobject_list:
-        log.warning("there is no token with serial {0!r}".format(serial))
-        ret["error"] = "No token with serial {0!s} found.".format(serial)
+    tokenobject = get_one_token(serial=serial)
+    log.debug("getting multiple otp values for token {0!r}. curTime={1!r}".format(tokenobject, curTime))
 
+    res, error, otp_dict = tokenobject.\
+        get_multi_otp(count=count,
+                      epoch_start=epoch_start,
+                      epoch_end=epoch_end,
+                      curTime=curTime,
+                      timestamp=timestamp)
+    log.debug("received {0!r}, {1!r}, and {2!r} otp values".format(res, error,
+                                                      len(otp_dict)))
+
+    if res is True:
+        ret = otp_dict
+        ret["result"] = True
     else:
-        tokenobject = tokenobject_list[0]
-        log.debug("getting multiple otp values for token {0!r}. curTime={1!r}".format(tokenobject, curTime))
-
-        res, error, otp_dict = tokenobject.\
-            get_multi_otp(count=count,
-                          epoch_start=epoch_start,
-                          epoch_end=epoch_end,
-                          curTime=curTime,
-                          timestamp=timestamp)
-        log.debug("received {0!r}, {1!r}, and {2!r} otp values".format(res, error,
-                                                          len(otp_dict)))
-
-        if res is True:
-            ret = otp_dict
-            ret["result"] = True
-        else:
-            ret["error"] = error
+        ret["error"] = error
 
     return ret
 
@@ -1059,7 +1063,7 @@ def remove_token(serial=None, user=None):
     :return: The number of deleted token
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
     token_count = len(tokenobject_list)
 
     # Delete challenges of such a token
@@ -1091,6 +1095,8 @@ def set_realms(serial, realms=None, add=False):
     realms. So realms that are not contained in the list will not be assigned
     to the token anymore.
 
+    If the token could not be found, a ResourceNotFoundError is raised.
+
     Thus, setting realms=[] clears all realms assignments.
 
     :param serial: the serial number of the token (exact)
@@ -1099,9 +1105,6 @@ def set_realms(serial, realms=None, add=False):
     :type realms: list
     :param add: if the realms should be added and not replaced
     :type add: bool
-    :return: the number of tokens, to which realms where added. As a serial
-    number should be unique, this is either 1 or 0.
-    :rtype: int
     """
     realms = realms or []
     corrected_realms = []
@@ -1111,13 +1114,9 @@ def set_realms(serial, realms=None, add=False):
         if realm_is_defined(realm):
             corrected_realms.append(realm)
 
-    tokenobject_list = get_tokens(serial=serial)
-
-    for tokenobject in tokenobject_list:
-        tokenobject.set_realms(corrected_realms, add=add)
-        tokenobject.save()
-
-    return len(tokenobject_list)
+    tokenobject = get_one_token(serial=serial)
+    tokenobject.set_realms(corrected_realms, add=add)
+    tokenobject.save()
 
 
 @log_with(log)
@@ -1128,16 +1127,13 @@ def set_defaults(serial):
     :type serial: basestring
     :return: None
     """
-    tokenobject_list = get_tokens(serial=serial)
-    if tokenobject_list:
-        db_token = tokenobject_list[0].token
-        db_token.otplen = int(get_from_config("DefaultOtpLen", 6))
-        db_token.count_window = int(get_from_config("DefaultCountWindow", 15))
-        db_token.maxfail = int(get_from_config("DefaultMaxFailCount", 15))
-        db_token.sync_window = int(get_from_config("DefaultSyncWindow", 1000))
-        db_token.tokentype = u"hotp"
-        db_token.save()
-
+    db_token = get_one_token(serial=serial).token
+    db_token.otplen = int(get_from_config("DefaultOtpLen", 6))
+    db_token.count_window = int(get_from_config("DefaultCountWindow", 15))
+    db_token.maxfail = int(get_from_config("DefaultMaxFailCount", 15))
+    db_token.sync_window = int(get_from_config("DefaultSyncWindow", 1000))
+    db_token.tokentype = u"hotp"
+    db_token.save()
 
 
 @log_with(log)
@@ -1156,18 +1152,8 @@ def assign_token(serial, user, pin=None, encrypt_pin=False, err_message=None):
     :type encrypt_pin: bool
     :param err_message: The error message, that is displayed in case the token is already assigned
     :type err_message: basestring
-
-    :return: True if the token was assigned, in case of an error an exception
-    is thrown
-    :rtype: bool
     """
-    tokenobject_list = get_tokens(serial=serial)
-
-    if not tokenobject_list:
-        log.warning("no tokens found with serial: {0!r}".format(serial))
-        raise TokenAdminError("no token found!", id=1102)
-
-    tokenobject = tokenobject_list[0]
+    tokenobject = get_one_token(serial=serial)
 
     # Check if the token already belongs to another user
     old_user = tokenobject.user
@@ -1198,41 +1184,38 @@ def assign_token(serial, user, pin=None, encrypt_pin=False, err_message=None):
 @check_user_or_serial
 def unassign_token(serial, user=None):
     """
-    unassign the user from the token
+    unassign the user from the token, or all tokens of a user
 
-    :param serial: The serial number of the token to unassign (exact)
-    :return: True
+    :param serial: The serial number of the token to unassign (exact). Can be None
+    :param user: A user whose tokens should be unassigned
+    :return: number of unassigned tokens
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
+    for tokenobject in tokenobject_list:
+        tokenobject.token.user_id = ""
+        tokenobject.token.resolver = ""
+        tokenobject.token.resolver_type = ""
+        tokenobject.set_pin("")
+        tokenobject.set_failcount(0)
 
-    if not tokenobject_list:
-        log.warning("no tokens found with serial: {0!r}".format(serial))
-        raise TokenAdminError("no token found!", id=1102)
+        try:
+            tokenobject.save()
+        except Exception as e:  # pragma: no cover
+            log.error('update token DB failed')
+            raise TokenAdminError("Token unassign failed for {0!r}/{1!r}: {2!r}".format(serial, user, e), id=1105)
 
-    tokenobject = tokenobject_list[0]
-    tokenobject.token.user_id = ""
-    tokenobject.token.resolver = ""
-    tokenobject.token.resolver_type = ""
-    tokenobject.set_pin("")
-    tokenobject.set_failcount(0)
-
-    try:
-        tokenobject.save()
-    except Exception as e:  # pragma: no cover
-        log.error('update token DB failed')
-        raise TokenAdminError("Token unassign failed for {0!r}: {1!r}".format(serial, e), id=1105)
-
-    log.debug("successfully unassigned token with serial {0!r}".format(serial))
-    return True
+        log.debug("successfully unassigned token with serial {0!r}".format(tokenobject))
+    # TODO: test with more than 1 token
+    return len(tokenobject_list)
 
 
 @log_with(log)
 def resync_token(serial, otp1, otp2, options=None, user=None):
     """
-    Resyncronize the token of the given serial number by searching the
+    Resyncronize the token of the given serial number and user by searching the
     otp1 and otp2 in the future otp values.
 
-    :param serial: token serial number
+    :param serial: token serial number (exact)
     :type serial: basestring
     :param otp1: first OTP value
     :type otp1: basestring
@@ -1244,7 +1227,7 @@ def resync_token(serial, otp1, otp2, options=None, user=None):
     """
     ret = False
 
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         ret = tokenobject.resync(otp1, otp2, options)
@@ -1256,13 +1239,13 @@ def resync_token(serial, otp1, otp2, options=None, user=None):
 @check_user_or_serial
 def reset_token(serial, user=None):
     """
-    Reset the failcounter
+    Reset the failcounter of a single token, or of all tokens of one user.
     :param serial: serial number (exact)
     :param user:
     :return: The number of tokens, that were resetted
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.reset()
@@ -1295,7 +1278,7 @@ def set_pin(serial, pin, user=None, encrypt_pin=False):
         raise ParameterError("Parameter user must not be a string: {0!r}".format(
                              user), id=1212)
 
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_pin(pin, encrypt=encrypt_pin)
@@ -1317,7 +1300,7 @@ def set_pin_user(serial, user_pin, user=None):
     :return: The number of PINs set (usually 1)
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_user_pin(user_pin)
@@ -1340,7 +1323,7 @@ def set_pin_so(serial, so_pin, user=None):
     :return: The number of SO PINs set. (usually 1)
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_so_pin(so_pin)
@@ -1353,7 +1336,7 @@ def set_pin_so(serial, so_pin, user=None):
 @check_user_or_serial
 def revoke_token(serial, user=None):
     """
-    Revoke a token.
+    Revoke a token, or all tokens of a single user.
 
     :param serial: The serial number of the token (exact)
     :type serial: basestring
@@ -1364,7 +1347,7 @@ def revoke_token(serial, user=None):
     :return: Number of tokens that were enabled/disabled
     :rtype:
     """
-    tokenobject_list = get_tokens(user=user, serial=serial)
+    tokenobject_list = get_tokens_from_serial_or_user(user=user, serial=serial)
 
     for tokenobject in tokenobject_list:
         tokenobject.revoke()
@@ -1377,7 +1360,8 @@ def revoke_token(serial, user=None):
 @check_user_or_serial
 def enable_token(serial, enable=True, user=None):
     """
-    Enable or disable a token. This can be checked with is_token_active
+    Enable or disable a token, or all tokens of a single user.
+    This can be checked with is_token_active.
 
     Enabling an already active token will return 0.
 
@@ -1390,34 +1374,32 @@ def enable_token(serial, enable=True, user=None):
     :return: Number of tokens that were enabled/disabled
     :rtype:
     """
-    # We only search for those tokens, that need action.
-    # Tokens that are already active, do not need to be enabled, tokens
-    # that are inactive do not need to be disabled.
-    tokenobject_list = get_tokens(user=user, serial=serial, active=not enable)
+    # We search for all matching tokens first, in case the user has
+    # provided a wrong serial number. Then we filter for the desired tokens.
+    tokenobject_list = get_tokens_from_serial_or_user(user=user, serial=serial)
+    count = 0
 
     for tokenobject in tokenobject_list:
-        tokenobject.enable(enable)
-        tokenobject.save()
+        if tokenobject.is_active() == (not enable):
+            tokenobject.enable(enable)
+            tokenobject.save()
+            count += 1
 
-    return len(tokenobject_list)
+    return count
 
 
 def is_token_active(serial):
     """
     Return True if the token is active, otherwise false
-    Returns None, if the token does not exist.
+    Raise ResourceError if the token could not be found.
 
     :param serial: The serial number of the token
     :type serial: basestring
     :return: True or False
     :rtype: bool
     """
-    ret = None
-    tokenobject_list = get_tokens(serial=serial)
-    for tokenobject in tokenobject_list:
-        ret = tokenobject.token.active
-
-    return ret
+    tokenobject = get_one_token(serial=serial)
+    return tokenobject.token.active
 
 
 @log_with(log)
@@ -1437,7 +1419,7 @@ def set_otplen(serial, otplen=6, user=None):
     :return: number of modified tokens
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_otplen(otplen)
@@ -1462,7 +1444,7 @@ def set_hashlib(serial, hashlib="sha1", user=None):
     :return: the number of token infos set
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_hashlib(hashlib)
@@ -1497,7 +1479,7 @@ def set_count_auth(serial, count, user=None, max=False, success=False):
     :return: number of modified tokens
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         if max:
@@ -1536,7 +1518,7 @@ def add_tokeninfo(serial, info, value=None,
     :return: the number of modified tokens
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.add_tokeninfo(info, value)
@@ -1561,7 +1543,7 @@ def delete_tokeninfo(serial, key, user=None):
     the token info *key* set in the first place!
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
     for tokenobject in tokenobject_list:
         tokenobject.del_tokeninfo(key)
         tokenobject.save()
@@ -1580,7 +1562,7 @@ def set_validity_period_start(serial, user, start):
     :param start: Timestamp in the format DD/MM/YY HH:MM
     :type start: basestring
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
     for tokenobject in tokenobject_list:
         tokenobject.set_validity_period_start(start)
         tokenobject.save()
@@ -1598,7 +1580,7 @@ def set_validity_period_end(serial, user, end):
     :param end: Timestamp in the format DD/MM/YY HH:MM
     :type end: basestring
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
     for tokenobject in tokenobject_list:
         tokenobject.set_validity_period_end(end)
         tokenobject.save()
@@ -1622,7 +1604,7 @@ def set_sync_window(serial, syncwindow=1000, user=None):
     :return: number of modified tokens
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_sync_window(syncwindow)
@@ -1647,7 +1629,7 @@ def set_count_window(serial, countwindow=10, user=None):
     :return: number of modified tokens
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_count_window(countwindow)
@@ -1671,7 +1653,7 @@ def set_description(serial, description, user=None):
     :return: number of modified tokens
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_description(description)
@@ -1691,7 +1673,7 @@ def set_failcounter(serial, counter, user=None):
     :param user: An optional user
     :return: Number of tokens, where the fail counter was set.
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_failcount(counter)
@@ -1716,7 +1698,7 @@ def set_max_failcount(serial, maxfail, user=None):
     :return: number of modified tokens
     :rtype: int
     """
-    tokenobject_list = get_tokens(serial=serial, user=user)
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
 
     for tokenobject in tokenobject_list:
         tokenobject.set_maxfail(maxfail)
@@ -1742,11 +1724,11 @@ def copy_token_pin(serial_from, serial_to):
     :return: True. In case of an error raise an exception
     :rtype: bool
     """
-    tokenobject_list_from = get_tokens(serial=serial_from)
-    tokenobject_list_to = get_tokens(serial=serial_to)
-    pinhash, seed = tokenobject_list_from[0].get_pin_hash_seed()
-    tokenobject_list_to[0].set_pin_hash_seed(pinhash, seed)
-    tokenobject_list_to[0].save()
+    tokenobject_from = get_one_token(serial=serial_from)
+    tokenobject_to = get_one_token(serial=serial_to)
+    pinhash, seed = tokenobject_from.get_pin_hash_seed()
+    tokenobject_to.set_pin_hash_seed(pinhash, seed)
+    tokenobject_to.save()
     return True
 
 
@@ -1764,15 +1746,15 @@ def copy_token_user(serial_from, serial_to):
     :return: True. In case of an error raise an exception
     :rtype: bool
     """
-    tokenobject_list_from = get_tokens(serial=serial_from)
-    tokenobject_list_to = get_tokens(serial=serial_to)
-    user_id = tokenobject_list_from[0].token.user_id
-    resolver = tokenobject_list_from[0].token.resolver
-    resolver_type = tokenobject_list_from[0].token.resolver_type
-    tokenobject_list_to[0].set_user_identifiers(user_id, resolver,
+    tokenobject_from = get_one_token(serial=serial_from)
+    tokenobject_to = get_one_token(serial=serial_to)
+    user_id = tokenobject_from.token.user_id
+    resolver = tokenobject_from.token.resolver
+    resolver_type = tokenobject_from.token.resolver_type
+    tokenobject_to.set_user_identifiers(user_id, resolver,
                                                 resolver_type)
     copy_token_realms(serial_from, serial_to)
-    tokenobject_list_to[0].save()
+    tokenobject_to.save()
     return True
 
 @check_copy_serials
@@ -1784,10 +1766,10 @@ def copy_token_realms(serial_from, serial_to):
     :param serial_to: The token to copy to
     :return: None
     """
-    tokenobject_list_from = get_tokens(serial=serial_from)
-    tokenobject_list_to = get_tokens(serial=serial_to)
-    realm_list = tokenobject_list_from[0].token.get_realms()
-    tokenobject_list_to[0].set_realms(realm_list)
+    tokenobject_from = get_one_token(serial=serial_from)
+    tokenobject_to = get_one_token(serial=serial_to)
+    realm_list = tokenobject_from.token.get_realms()
+    tokenobject_to.set_realms(realm_list)
 
 
 @log_with(log)
@@ -1927,16 +1909,10 @@ def check_serial_pass(serial, passw, options=None):
     :rtype: tuple
     """
     reply_dict = {}
-    tokenobject_list = get_tokens(serial=serial)
-    if not tokenobject_list:
-        # The serial does not exist
-        res = False
-        reply_dict["message"] = "The token with this serial does not exist"
-    else:
-        tokenobject = tokenobject_list[0]
-        res, reply_dict = check_token_list(tokenobject_list, passw,
-                                           user=tokenobject.user,
-                                           options=options)
+    tokenobject = get_one_token(serial=serial)
+    res, reply_dict = check_token_list([tokenobject], passw,
+                                       user=tokenobject.user,
+                                       options=options)
 
     return res, reply_dict
 
@@ -1950,15 +1926,10 @@ def check_otp(serial, otpval):
     :return:
     """
     reply_dict = {}
-    tokenobject_list = get_tokens(serial=serial)
-    if not tokenobject_list:
-        res = False
-        reply_dict["message"] = "The token with this serial does not exist"
-    else:
-        tokenobject = tokenobject_list[0]
-        res = tokenobject.check_otp(otpval) >= 0
-        if not res:
-            reply_dict["message"] = "OTP verification failed."
+    tokenobject = get_one_token(serial=serial)
+    res = tokenobject.check_otp(otpval) >= 0
+    if not res:
+        reply_dict["message"] = "OTP verification failed."
     return res, reply_dict
 
 

--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -32,10 +32,11 @@ import binascii
 import base64
 import qrcode
 import urlparse
+import sqlalchemy
 import StringIO
 import urllib
 from privacyidea.lib.crypto import urandom, geturandom
-from privacyidea.lib.error import ParameterError
+from privacyidea.lib.error import ParameterError, ResourceNotFoundError
 import string
 import re
 from datetime import timedelta, datetime
@@ -1127,3 +1128,14 @@ def censor_connect_string(connect_string):
     except Exception:
         return "<error when censoring connect string>"
 
+
+def fetch_one_resource(table, **query):
+    """
+    Given an SQLAlchemy table and query keywords, fetch exactly one result and return it.
+    If no results is found, this raises a ``ResourceNotFoundError``.
+    If more than one result is found, this raises SQLAlchemy's ``MultipleResultsFound``
+    """
+    try:
+        return table.query.filter_by(**query).one()
+    except sqlalchemy.orm.exc.NoResultFound:
+        raise ResourceNotFoundError(u"The requested {!s} could not be found.".format(table.__name__))

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1774,7 +1774,6 @@ class PostPolicyDecoratorTestCase(MyTestCase):
         # check that we can authenticate online with the correct value
         res = tokenobject.check_otp("295165")  # count = 100
         self.assertEqual(res, 100)
-        delete_policy("pol2")
 
     def test_07_sign_response(self):
         builder = EnvironBuilder(method='POST',

--- a/tests/test_api_machineresolver.py
+++ b/tests/test_api_machineresolver.py
@@ -107,13 +107,9 @@ class APIMachineResolverTestCase(MyTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            print(res.data)
             result = json.loads(res.data).get("result")
-            self.assertTrue(res.status_code == 200, res)
-            self.assertTrue(result["status"] is True, result)
-            # Trying to delete a non existing resolver returns -1
-            self.assertTrue(result["value"] == -1, result)
-
+            self.assertEqual(res.status_code, 404)
+            self.assertFalse(result["status"])
 
     def test_03_resolvers_ldap(self):
 

--- a/tests/test_api_periodictask.py
+++ b/tests/test_api_periodictask.py
@@ -176,7 +176,7 @@ class APIPeriodicTasksTestCase(MyTestCase):
 
         # unknown ID
         status_code, data = self.simulate_request('/periodictask/4242', method='GET')
-        self.assertEqual(status_code, 400)
+        self.assertEqual(status_code, 404)
         self.assertFalse(data['result']['status'])
 
         # update existing task
@@ -252,7 +252,7 @@ class APIPeriodicTasksTestCase(MyTestCase):
 
         # get updated task impossible now
         status_code, data = self.simulate_request('/periodictask/{}'.format(ptask_id1), method='GET')
-        self.assertEqual(status_code, 400)
+        self.assertEqual(status_code, 404)
         self.assertFalse(data['result']['status'], False)
 
         # only 1 task left

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -396,10 +396,9 @@ class APISelfserviceTestCase(MyTestCase):
                                            headers={'Authorization':
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 404)
             response = json.loads(res.data)
-            self.assertFalse(response.get("result").get("value"),
-                            response.get("result"))
+            self.assertFalse(response["result"]["status"])
         # check if the token still exists!
         tokenobject_list = get_tokens(serial=self.foreign_serial)
         self.assertTrue(len(tokenobject_list) == 1, len(tokenobject_list))
@@ -413,10 +412,9 @@ class APISelfserviceTestCase(MyTestCase):
                                            headers={'Authorization':
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 404)
             response = json.loads(res.data)
-            self.assertFalse(response.get("result").get("value"),
-                             response.get("result"))
+            self.assertFalse(response["result"]["status"])
         # check if the token still is enabled!
         tokenobject_list = get_tokens(serial=self.foreign_serial)
         self.assertTrue(len(tokenobject_list) == 1, len(tokenobject_list))
@@ -443,10 +441,10 @@ class APISelfserviceTestCase(MyTestCase):
                                            headers={'Authorization':
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 404)
             response = json.loads(res.data)
-            self.assertFalse(response.get("result").get("value"),
-                            response.get("result"))
+            self.assertFalse(response["result"]["status"])
+
         tokenobject = get_tokens(serial=self.foreign_serial)[0]
         self.assertTrue(tokenobject.token.active, tokenobject.token.active)
 
@@ -489,10 +487,9 @@ class APISelfserviceTestCase(MyTestCase):
                                            headers={'Authorization':
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 404)
             response = json.loads(res.data)
-            self.assertTrue(response.get("result").get("value") == 0,
-                            response.get("result"))
+            self.assertFalse(response["result"]["status"])
 
         # token still inactive
         tokenobject = get_tokens(serial=self.foreign_serial)[0]
@@ -540,7 +537,7 @@ class APISelfserviceTestCase(MyTestCase):
                                            headers={'Authorization':
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 400, res)
+            self.assertEqual(res.status_code, 404)
 
     def test_07_user_can_reset_failcount(self):
         self.authenticate_selfservice_user()
@@ -560,10 +557,10 @@ class APISelfserviceTestCase(MyTestCase):
                                            headers={'Authorization':
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 404)
             response = json.loads(res.data)
-            self.assertTrue(response.get("result").get("value") == 0,
-                            response.get("result"))
+            self.assertFalse(response["result"]["status"])
+
         # failcounter still on
         self.assertTrue(fT.token.failcount == 12, fT.token.failcount)
 
@@ -592,10 +589,9 @@ class APISelfserviceTestCase(MyTestCase):
                                            headers={'Authorization':
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 404)
             response = json.loads(res.data)
-            self.assertTrue(response.get("result").get("value") == 0,
-                            response.get("result"))
+            self.assertFalse(response["result"]["status"])
 
         # can set pin for own token
         with self.app.test_request_context('/token/setpin',

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -245,9 +245,9 @@ class APIConfigTestCase(MyTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 404)
             result = json.loads(res.data).get("result")
-            self.assertTrue(result["status"] is True, result)
+            self.assertFalse(result["status"])
 
         # check policy
         with self.app.test_request_context('/policy/pol_update_del',

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1915,7 +1915,7 @@ class ValidateAPITestCase(MyTestCase):
 
         remove_token("CR2A")
         remove_token("CR2B")
-        delete_policy("test49")
+        delete_policy("test48")
 
     def test_28_validate_radiuscheck(self):
         # setup a spass token
@@ -2089,7 +2089,6 @@ class ValidateAPITestCase(MyTestCase):
             result = json.loads(res.data).get("result")
             self.assertEqual(result.get("value"), True)
 
-        delete_policy("onlyHOTP")
         delete_policy("onlyHOTP")
         delete_policy("passthru")
         remove_token("SPASS1")

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -32,7 +32,7 @@ from privacyidea.lib.token import (init_token, remove_token, unassign_token,
 from privacyidea.lib.tokenclass import DATE_FORMAT
 from privacyidea.lib.user import create_user, User
 from privacyidea.lib.policy import ACTION
-from privacyidea.lib.error import ParameterError
+from privacyidea.lib.error import ParameterError, ResourceNotFoundError
 from privacyidea.lib.utils import is_true
 from datetime import datetime, timedelta
 from dateutil.parser import parse as parse_date_string
@@ -100,7 +100,7 @@ class EventHandlerLibTestCase(MyTestCase):
         self.assertEqual(r[0].get("position"), "post")
 
         # We can not enable an event, that does not exist.
-        self.assertRaises(ParameterError, enable_event, 1234567, True)
+        self.assertRaises(ResourceNotFoundError, enable_event, 1234567, True)
 
         # Cleanup
         r = delete_event(n_eid)
@@ -524,7 +524,6 @@ class ScriptEventTestCase(MyTestCase):
         t_handler = ScriptEventHandler()
         res = t_handler.do(script_name, options=options)
         self.assertTrue(res)
-        remove_token("SPASS01")
 
 
 class FederationEventTestCase(MyTestCase):
@@ -2342,7 +2341,7 @@ class UserNotificationTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data).get("result")
-            self.assertTrue(result.get("value") is True, result)
+            self.assertEqual(result.get("value"), 1)
 
         # Cleanup
         delete_event(eid)

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -571,7 +571,6 @@ class ScriptEventTestCase(MyTestCase):
         d = "{0!s}/tests/testdata/scripts/".format(d)
         t_handler = ScriptEventHandler(script_directory=d)
         self.assertRaises(Exception, t_handler.do, script_name, options=options)
-        remove_token("SPASS01")
 
 
 class FederationEventTestCase(MyTestCase):

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -614,7 +614,6 @@ class ImportOTPTestCase(MyTestCase):
         remove_token("t2")
         remove_token("t3")
         remove_token("t4")
-        remove_token("t5")
         # import the tokens again
         tokens = parsePSKCdata(export, preshared_key_hex=psk)
         self.assertEqual(len(tokens), 3)

--- a/tests/test_lib_periodictask.py
+++ b/tests/test_lib_periodictask.py
@@ -10,7 +10,7 @@ from dateutil.parser import parse as parse_timestamp
 from dateutil.tz import gettz, tzutc
 from mock import mock
 
-from privacyidea.lib.error import ServerError, ParameterError
+from privacyidea.lib.error import ServerError, ParameterError, ResourceNotFoundError
 from privacyidea.lib.periodictask import calculate_next_timestamp, set_periodic_task, get_periodic_tasks, \
     enable_periodic_task, delete_periodic_task, set_periodic_task_last_run, get_scheduled_periodic_tasks, \
     get_periodic_task_by_name, TASK_MODULES, execute_task, get_periodic_task_by_id
@@ -233,17 +233,17 @@ class BasePeriodicTaskTestCase(MyTestCase):
         task1_last_update = get_periodic_task_by_id(task1)["last_update"]
 
         self.assertEqual(get_periodic_task_by_name("task three")["id"], task3)
-        with self.assertRaises(ParameterError):
+        with self.assertRaises(ResourceNotFoundError):
             get_periodic_task_by_name("task does not exist")
 
         self.assertEqual(get_periodic_task_by_id(task3)["name"], "task three")
-        with self.assertRaises(ParameterError):
+        with self.assertRaises(ResourceNotFoundError):
             get_periodic_task_by_id(1337)
 
         self.assertEqual(len(PeriodicTask.query.all()), 3)
 
         # Updating an nonexistent task fails
-        with self.assertRaises(ParameterError):
+        with self.assertRaises(ResourceNotFoundError):
             set_periodic_task("some task", "0 0 1 * *", ["pinode1"], "some.task.module", 5, {}, id=123456)
 
         task1_modified = set_periodic_task("every month", "0 0 1 * *", ["pinode1"], "some.task.module", 3, {
@@ -288,7 +288,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
 
         enable_periodic_task(task1, False)
         delete_periodic_task(task3)
-        with self.assertRaises(ParameterError):
+        with self.assertRaises(ResourceNotFoundError):
             enable_periodic_task(task3)
 
         active_tasks_on_pinode1 = get_periodic_tasks(active=True, node="pinode1")
@@ -300,7 +300,7 @@ class BasePeriodicTaskTestCase(MyTestCase):
 
         delete_periodic_task(task1)
         delete_periodic_task(task2)
-        with self.assertRaises(ParameterError):
+        with self.assertRaises(ResourceNotFoundError):
             delete_periodic_task(task2)
 
         self.assertEqual(get_periodic_tasks(), [])

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -56,10 +56,10 @@ from privacyidea.lib.token import (create_tokenclass_object,
                                    get_tokens_paginate,
                                    set_validity_period_end,
                                    set_validity_period_start, remove_token, delete_tokeninfo,
-                                   import_token)
+                                   import_token, get_one_token, get_tokens_from_serial_or_user)
 
 from privacyidea.lib.error import (TokenAdminError, ParameterError,
-                                   privacyIDEAError)
+                                   privacyIDEAError, ResourceNotFoundError)
 from privacyidea.lib.tokenclass import DATE_FORMAT
 from dateutil.tz import tzlocal
 
@@ -148,6 +148,7 @@ class TokenTestCase(MyTestCase):
         # get tokens for a given serial number
         tokenobject_list = get_tokens(serial="hotptoken")
         self.assertTrue(len(tokenobject_list) == 1, tokenobject_list)
+
         # ...but not in an unassigned state!
         tokenobject_list = get_tokens(serial="hotptoken", assigned=False)
         self.assertTrue(len(tokenobject_list) == 0, tokenobject_list)
@@ -241,8 +242,8 @@ class TokenTestCase(MyTestCase):
         user = get_token_owner(self.serials[0])
         self.assertTrue(user is None, user)
         # for non existing token
-        user = get_token_owner("does not exist")
-        self.assertTrue(user is None, user)
+        with self.assertRaises(ResourceNotFoundError):
+            user = get_token_owner("does not exist")
 
         # check if the token owner is cornelius
         user = User("cornelius", realm=self.realm1, resolver=self.resolvername1)
@@ -286,8 +287,8 @@ class TokenTestCase(MyTestCase):
                       current_time=datetime.datetime(2014, 12, 4, 12, 0))
         self.assertTrue(otp[2] == "938938", otp)
         # the serial does not exist
-        otp = get_otp("does not exist")
-        self.assertTrue(otp[2] == "", otp)
+        with self.assertRaises(ResourceNotFoundError):
+            get_otp("does not exist")
 
     def test_12_get_token_by_otp(self):
         tokenobject = get_token_by_otp(get_tokens(), otp="755224")
@@ -409,8 +410,7 @@ class TokenTestCase(MyTestCase):
                                   "otpkey": "1234567890123456"})
         realms = get_realms_of_token(serial)
         self.assertTrue(realms == [], "{0!s}".format(realms))
-        rnum = set_realms(serial, [self.realm1])
-        self.assertTrue(rnum == 1, rnum)
+        set_realms(serial, [self.realm1])
         realms = get_realms_of_token(serial)
         self.assertTrue(realms == [self.realm1], "{0!s}".format(realms))
         remove_token(serial=serial)
@@ -452,8 +452,8 @@ class TokenTestCase(MyTestCase):
 
         remove_token(serial)
         # assign or unassign a token, that does not exist
-        self.assertRaises(TokenAdminError, assign_token, serial, user)
-        self.assertRaises(TokenAdminError, unassign_token, serial)
+        self.assertRaises(ResourceNotFoundError, assign_token, serial, user)
+        self.assertRaises(ResourceNotFoundError, unassign_token, serial)
 
     def test_19_reset_resync(self):
         serial = "reset"
@@ -513,7 +513,8 @@ class TokenTestCase(MyTestCase):
         self.assertTrue(is_token_active(serial))
 
         remove_token(serial)
-        self.assertTrue(is_token_active(serial) is None)
+        with self.assertRaises(ResourceNotFoundError):
+            is_token_active(serial)
 
         self.assertRaises(ParameterError, enable_token)
 
@@ -575,8 +576,8 @@ class TokenTestCase(MyTestCase):
         # tokeninfo has not changed
         self.assertEqual(tokenobject.token.get_info(), tinfo2)
         # try to delete non-existing tokeninfo
-        r = delete_tokeninfo('UNKNOWN-SERIAL', 'something')
-        self.assertEqual(r, 0)
+        with self.assertRaises(ResourceNotFoundError):
+            delete_tokeninfo('UNKNOWN-SERIAL', 'something')
         remove_token(serial)
 
     def test_26_set_sync_window(self):
@@ -615,10 +616,8 @@ class TokenTestCase(MyTestCase):
         self.assertTrue(len(r.get("otp")) == 12, r.get("otp"))
 
         # unknown serial number
-        r = get_multi_otp("unknown", count=12)
-        self.assertTrue(r.get("result") is False, r)
-        self.assertTrue(r.get("error") == "No token with serial unknown "
-                                          "found.", r)
+        with self.assertRaises(ResourceNotFoundError):
+            get_multi_otp("unknown", count=12)
 
     def test_30_set_max_failcount(self):
         serial = "t1"
@@ -681,7 +680,8 @@ class TokenTestCase(MyTestCase):
         self.assertTrue(r, r)
 
         # call the losttoken
-        self.assertRaises(TokenAdminError, lost_token, "doesnotexist")
+        with self.assertRaises(ResourceNotFoundError):
+            lost_token("doesnotexist")
         validity = 10
         r = lost_token(serial1)
         end_date = (datetime.datetime.now(tzlocal())
@@ -792,8 +792,8 @@ class TokenTestCase(MyTestCase):
         hotp_tokenobject.set_pin("hotppin")
         hotp_tokenobject.save()
 
-        r, reply = check_serial_pass("XXXXXXXXX", "password")
-        self.assertFalse(r)
+        with self.assertRaises(ResourceNotFoundError):
+            check_serial_pass("XXXXXXXXX", "password")
 
         #r = get_multi_otp("hotptoken", count=20)
         #self.assertTrue(r == 0, r)
@@ -1368,6 +1368,43 @@ class TokenTestCase(MyTestCase):
         self.assertEqual(tok.get_user_displayname(), (u'cornelius_realm1', u'Cornelius '))
         remove_token("IMP002")
 
+    def test_54_helper_functions(self):
+        user = User("cornelius", self.realm1)
+        # unassign all tokens of cornelius, assign S1 and S2
+        unassign_token(serial=None, user=user)
+        assign_token(serial="S1", user=user)
+        assign_token(serial="S2", user=user)
+        self.assertEqual(get_one_token(serial="S1", user=None).token.serial, "S1")
+        self.assertEqual(get_one_token(serial="hotptoken", user=None).token.serial, "hotptoken")
+        self.assertEqual(get_one_token(serial="S1", user=user).token.serial, "S1")
+        with self.assertRaises(ResourceNotFoundError):
+            get_one_token(serial="doesnotexist", user=None)
+        with self.assertRaises(ResourceNotFoundError):
+            get_one_token(serial="hotptoken", user=user)
+        with self.assertRaises(ResourceNotFoundError):
+            get_one_token(serial="doesnotexist", user=user)
+        with self.assertRaises(ResourceNotFoundError):
+            get_one_token(serial="doesnotexist", user=user)
+        # exact match
+        with self.assertRaises(ResourceNotFoundError):
+            get_one_token(serial="*", user=None)
+        # more than 1 token
+        with self.assertRaises(ParameterError):
+            get_one_token(user=user)
+        # get_tokens_from_serial_or_user tests
+        shadow = User("shadow", self.realm1)
+        self.assertEqual(len(get_tokens_from_serial_or_user(serial=None, user=user)), 2)
+        self.assertEqual(len(get_tokens_from_serial_or_user(serial=None, user=shadow)), 0)
+        self.assertEqual(len(get_tokens_from_serial_or_user(serial="S1", user=user)), 1)
+        self.assertEqual(len(get_tokens_from_serial_or_user(serial="S2", user=user)), 1)
+        self.assertEqual(len(get_tokens_from_serial_or_user(serial="hotptoken", user=None)), 1)
+        with self.assertRaises(ResourceNotFoundError):
+            get_tokens_from_serial_or_user(serial="S*", user=None)
+        with self.assertRaises(ResourceNotFoundError):
+            get_tokens_from_serial_or_user(serial="doesnotexist", user=None)
+        with self.assertRaises(ResourceNotFoundError):
+            get_tokens_from_serial_or_user(serial="S1", user=shadow)
+        unassign_token(serial=None, user=user)
 
 class TokenFailCounterTestCase(MyTestCase):
     """


### PR DESCRIPTION
On the library level, this introduces a new ResourceNotFoundError
that is thrown when a non-existent resource is referenced.

In particular, this improves the matching of tokens in lib/token.py.

The API level transforms these errors into HTTP 404 responses.
Thus, this commit changes API behavior.

Fixes #817
Fixes #1285
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23issuecomment-438298182%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23issuecomment-439014450%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23issuecomment-439862158%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r233115819%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r233811133%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234514735%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234515642%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234516600%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234517817%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234518441%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234518590%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234522030%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234547914%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234549616%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234549808%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234552687%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234560680%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234560689%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234572825%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234575501%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234575601%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234575791%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234576364%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234579262%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234579732%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234580506%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234580911%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234583023%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234583026%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234583641%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234583818%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234583820%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234606307%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234607155%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234607655%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234607892%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23issuecomment-438298182%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231310%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/cadd085705de3842a9b66b32fdc58172ddebce07%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6098.84%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231310%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2095.8%25%20%20%2095.81%25%20%20%20%2B0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20142%20%20%20%20%20%20142%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017238%20%20%20%2017208%20%20%20%20%20%20-30%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2016515%20%20%20%2016488%20%20%20%20%20%20-27%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20723%20%20%20%20%20%20720%20%20%20%20%20%20%20-3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/periodictask.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BlcmlvZGljdGFzay5weQ%3D%3D%29%20%7C%20%6096.77%25%20%3C100%25%3E%20%28-0.07%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/radiusserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3JhZGl1c3NlcnZlci5weQ%3D%3D%29%20%7C%20%6097.26%25%20%3C100%25%3E%20%28-0.15%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/realm.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3JlYWxtLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/machineresolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmVyZXNvbHZlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/smtpserver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NtdHBzZXJ2ZXIucHk%3D%29%20%7C%20%6098.83%25%20%3C100%25%3E%20%28-0.06%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6096.67%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5%29%20%7C%20%6098.6%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5%29%20%7C%20%6096.49%25%20%3C100%25%3E%20%28%2B0.04%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/event.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50LnB5%29%20%7C%20%6099.07%25%20%3C100%25%3E%20%28-0.03%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/error.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5%29%20%7C%20%6091.26%25%20%3C100%25%3E%20%28%2B0.35%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20...%20and%20%5B10%20more%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310/diff%3Fsrc%3Dpr%26el%3Dtree-more%29%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bcadd085...708fb4c%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1310%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-13T15%3A04%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Of%20course%20the%20tests%20have%20conflicts%20now%20because%20of%20%231296%20--%20I%27ll%20resolve%20these%20after%20we%20the%20review%20of%20this%20PR.%20If%20I%20now%20merge%20master%20into%20this%20PR%2C%20it%20will%20get%20messy%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-11-15T11%3A50%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A28%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204ea0cc874fc4cf1cafd9fb0765b643f94381c427%20privacyidea/lib/error.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234517817%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20did%20yo%20choose%20601%3F%20Why%20not%20a%20404%3F%5Cr%5CnOr%20did%20you%20want%20to%20leave%20our%204xx%20errors%20to%20the%20authentication%20process%3F%20%28I%20do%20not%20know%20the%20number-spaces%20myself%29%22%2C%20%22created_at%22%3A%20%222018-11-19T07%3A44%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Works%20for%20me.%22%2C%20%22created_at%22%3A%20%222018-11-19T09%3A42%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-11-19T09%3A43%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/error.py%3AL48-55%22%7D%2C%20%22Pull%204ea0cc874fc4cf1cafd9fb0765b643f94381c427%20privacyidea/api/token.py%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234516600%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20does%20also%20not%20seem%20quite%20consistent%20to%20me.%5Cr%5CnIn%20this%20case%20we%20always%20add%20%60%60%5C%22success%5C%22%3A%20True%60%60%20to%20the%20audit.%20Setting%20an%20empty%20list%20would%20remove%20the%20realms%3F%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-19T07%3A38%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20I%27m%20not%20sure%20here%3A%20%60%60set_realms%60%60%20only%20gets%20a%20serial%2C%20not%20a%20user%2C%20so%20it%20will%20raise%20a%20%60%60ResourceNotFound%60%60%20if%20the%20token%20with%20the%20serial%20does%20not%20exist.%20So%20if%20the%20line%20after%20%60%60set_realms%60%60%20is%20executed%2C%20I%20would%20say%20the%20request%20is%20successful%3F%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A16%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20you%20can%20forget%20my%20comment.%20It%20was%20in%20conjunction%20with%20the%20other%20success-audit-thingies.%5Cr%5CnI%20also%20think%20that%20we%20can%20return%20True%2C%20if%20realms%20were%20successfully%20set%2C%20no%20matter%20if%20they%20were%20overwritten%2C%20added%20or%20deleted%21%5Cr%5CnWorks%20for%20me.%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A27%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A28%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/token.py%3AL799-808%22%7D%2C%20%22Pull%204ea0cc874fc4cf1cafd9fb0765b643f94381c427%20privacyidea/lib/privacyideaserver.py%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234518441%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20am%20currently%20not%20sure%20-%20does%20%60%60.delete%28%29%60%60%20return%20the%20ID%20of%20the%20deleted%20object%3F%22%2C%20%22created_at%22%3A%20%222018-11-19T07%3A47%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20forgot%20about%20this%20too%2C%20but%20%60%60.delete%28%29%60%60%20is%20actually%20our%20own%20%60%60MethodsMixin%60%60%20method%20which%20returns%20the%20ID%20of%20the%20deleted%20object%20%3A-%29%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/e4e736a4442e1f88f391a8f639b6d7497b9ed6bf/privacyidea/models.py%23L87%22%2C%20%22created_at%22%3A%20%222018-11-19T10%3A50%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh.%20This%20is%20something%20I%20added%20right%20at%20the%20beginning%20-%20so%20I%20would%20have%20had%20to%20know%20about%20this%21%20%3A-/%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A00%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A00%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/privacyideaserver.py%3AL159-168%22%7D%2C%20%22Pull%202f0d61f7bda0d34ec250f2e61aa04ffbe91eafb9%20tests/test_lib_events.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234606307%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20changed%20here%3F%5Cr%5CnIf%20the%20token%20does%20not%20exist%2C%20we%20can%20catch%20an%20exception.%5Cr%5Cn%5Cr%5CnOK%2C%20due%20to%20the%20failing%20script%2C%20the%20token%20was%20not%20created%3F%20-%20right%20it%20is%20raise-error%3DTrue.%5Cr%5CnMaybe%20it%20is%20a%20good%20idea%20to%20realy%20check%20in%20this%20case%2C%20that%20the%20originial%20request%20also%20failed.%5Cr%5Cn%5Cr%5Cn%20%20%20self.assertRaises%28Exception%2C%20remove_token%2C%20%5C%22SPASS01%5C%22%29%22%2C%20%22created_at%22%3A%20%222018-11-19T12%3A51%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20this%20is%20a%20new%20test%20from%20%231307.%20My%20understanding%20is%20that%20the%20token%20%5C%22SPASS01%5C%22%20does%20not%20actually%20exist%20from%20the%20perspective%20of%20privacyIDEA%20%28because%20we%20only%20test%20the%20ScriptEventHandler%29%2C%20so%20no%20need%20to%20try%20to%20remove%20it%20%3A-%29%20%5Cr%5CnI%20think%20I%27ve%20already%20done%20the%20same%20for%20%60%60test_01_runscript%60%60.%22%2C%20%22created_at%22%3A%20%222018-11-19T12%3A54%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right.%20The%20token%20really%20does%20not%20exist%21%5Cr%5CnSo%20this%20is%20fine%21%22%2C%20%22created_at%22%3A%20%222018-11-19T12%3A56%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-11-19T12%3A57%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_events.py%3AL571-577%22%7D%2C%20%22Pull%204ea0cc874fc4cf1cafd9fb0765b643f94381c427%20privacyidea/lib/realm.py%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234518590%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20not%20do%20this%20as%20a%20one-liner%3F%22%2C%20%22created_at%22%3A%20%222018-11-19T07%3A48%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%20this%20in%20708fb4c25cb559eb1cecfe3be209642ea2c3ef3a%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A17%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A25%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/realm.py%3AL154-161%22%7D%2C%20%22Pull%204ea0cc874fc4cf1cafd9fb0765b643f94381c427%20privacyidea/lib/token.py%20255%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234522030%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20logic%20now%20is%20very%20API%20centric.%5Cr%5CnThe%20library%20call%20%5C%22set_defaults%5C%22%20will%20now%20raise%20an%20exception%20is%20the%20serial%20does%20not%20exist.%20This%20is%20fine%20for%20an%20API%20call%20but%20may%20result%20in%20unexpected%20behaviour%2C%20if%20%60%60set_detaults%60%60%20is%20called%20from%20without%20other%20code.%5Cr%5Cn%28justsaying%29%22%2C%20%22created_at%22%3A%20%222018-11-19T08%3A07%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Works%20for%20me.%22%2C%20%22created_at%22%3A%20%222018-11-19T09%3A51%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-19T10%3A15%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL1127-1140%22%7D%2C%20%22Pull%2098150567cca356c907de708b3fc771676c606bf8%20privacyidea/lib/policy.py%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r233115819%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22typo%20%3A-%29%20%5C%22deletec%5C%22%22%2C%20%22created_at%22%3A%20%222018-11-13T16%3A19%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thx%20%3A%29%20fixed%21%22%2C%20%22created_at%22%3A%20%222018-11-15T11%3A45%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-11-19T07%3A28%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/policy.py%3AL951-965%22%7D%2C%20%22Pull%204ea0cc874fc4cf1cafd9fb0765b643f94381c427%20privacyidea/api/token.py%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234515642%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22By%20changing%20%5C%22True%5C%22%20to%20%5C%22res%20%3E%200%5C%22%20this%20would%20mean%2C%20if%20I%20assign%20%5C%22all%20tokens%5C%22%20of%20a%20user%2C%20who%20has%20not%20token%2C%20I%20would%20get%20a%20success%3DFalse.%5Cr%5CnIs%20that%2C%20what%20we%20want%3F%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-19T07%3A33%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20changed%20this%20to%20%60%60True%60%60%20again%20in%20dc564c7f3faaaf2ebc6315523cd0cdd481131c74%20%3A%29%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A13%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A28%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/token.py%3AL441-456%22%7D%2C%20%22Pull%204ea0cc874fc4cf1cafd9fb0765b643f94381c427%20privacyidea/lib/token.py%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234560689%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-19T10%3A15%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL522-533%22%7D%2C%20%22Pull%204ea0cc874fc4cf1cafd9fb0765b643f94381c427%20privacyidea/api/token.py%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1310%23discussion_r234547914%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%7B%5C%22success%5C%22%3A%20True%7D%22%2C%20%22created_at%22%3A%20%222018-11-19T09%3A38%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%2C%20%60%60assign_token%60%60%20either%20raises%20an%20error%20or%20returns%20%60%60True%60%60%2C%20so%20if%20this%20line%20is%20executed%20at%20all%2C%20%60%60res%60%60%20will%20always%20be%20True.%5Cr%5Cn%5Cr%5CnBut%20maybe%20we%20should%20make%20this%20more%20explicit%3F%22%2C%20%22created_at%22%3A%20%222018-11-19T10%3A59%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20it%20is%20more%20clear%20to%20revert%20it%20to%20%5C%22True%5C%22%20again.Thanks%20a%20lot.%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A02%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20problem%2C%20did%20this%20in%20dc564c7f3faaaf2ebc6315523cd0cdd481131c74%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A11%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-19T11%3A25%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/token.py%3AL426-434%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cornelinux%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cornelinux'><img src='https://avatars1.githubusercontent.com/u/1908620?v=4' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#issuecomment-438298182'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1310?src=pr&el=h1) Report
> Merging [#1310](https://codecov.io/gh/privacyidea/privacyidea/pull/1310?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/cadd085705de3842a9b66b32fdc58172ddebce07?src=pr&el=desc) will **increase** coverage by `0.01%`.
> The diff coverage is `98.84%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1310?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1310      +/-   ##
==========================================
+ Coverage    95.8%   95.81%   +0.01%
==========================================
Files         142      142
Lines       17238    17208      -30
==========================================
- Hits        16515    16488      -27
+ Misses        723      720       -3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1310?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/periodictask.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BlcmlvZGljdGFzay5weQ==) | `96.77% <100%> (-0.07%)` | :arrow_down: |
| [privacyidea/lib/radiusserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3JhZGl1c3NlcnZlci5weQ==) | `97.26% <100%> (-0.15%)` | :arrow_down: |
| [privacyidea/lib/realm.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3JlYWxtLnB5) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/machineresolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21hY2hpbmVyZXNvbHZlci5weQ==) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/smtpserver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NtdHBzZXJ2ZXIucHk=) | `98.83% <100%> (-0.06%)` | :arrow_down: |
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `96.67% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5) | `98.6% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5) | `96.49% <100%> (+0.04%)` | :arrow_up: |
| [privacyidea/lib/event.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2V2ZW50LnB5) | `99.07% <100%> (-0.03%)` | :arrow_down: |
| [privacyidea/lib/error.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2Vycm9yLnB5) | `91.26% <100%> (+0.35%)` | :arrow_up: |
| ... and [10 more](https://codecov.io/gh/privacyidea/privacyidea/pull/1310/diff?src=pr&el=tree-more) | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1310?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1310?src=pr&el=footer). Last update [cadd085...708fb4c](https://codecov.io/gh/privacyidea/privacyidea/pull/1310?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Of course the tests have conflicts now because of #1296 -- I'll resolve these after we the review of this PR. If I now merge master into this PR, it will get messy :-)
- [x] <a href='#crh-comment-Pull 98150567cca356c907de708b3fc771676c606bf8 privacyidea/lib/policy.py 34'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r233115819'>File: privacyidea/lib/policy.py:L951-965</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> typo :-) "deletec"
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Thx :) fixed!
- [x] <a href='#crh-comment-Pull 4ea0cc874fc4cf1cafd9fb0765b643f94381c427 privacyidea/api/token.py 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r234515642'>File: privacyidea/api/token.py:L441-456</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> By changing "True" to "res > 0" this would mean, if I assign "all tokens" of a user, who has not token, I would get a success=False.
Is that, what we want?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I changed this to ``True`` again in dc564c7f3faaaf2ebc6315523cd0cdd481131c74 :)
- [x] <a href='#crh-comment-Pull 4ea0cc874fc4cf1cafd9fb0765b643f94381c427 privacyidea/api/token.py 55'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r234516600'>File: privacyidea/api/token.py:L799-808</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This does also not seem quite consistent to me.
In this case we always add ``"success": True`` to the audit. Setting an empty list would remove the realms?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, I'm not sure here: ``set_realms`` only gets a serial, not a user, so it will raise a ``ResourceNotFound`` if the token with the serial does not exist. So if the line after ``set_realms`` is executed, I would say the request is successful?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think you can forget my comment. It was in conjunction with the other success-audit-thingies.
I also think that we can return True, if realms were successfully set, no matter if they were overwritten, added or deleted!
Works for me.
- [x] <a href='#crh-comment-Pull 4ea0cc874fc4cf1cafd9fb0765b643f94381c427 privacyidea/lib/error.py 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r234517817'>File: privacyidea/lib/error.py:L48-55</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Why did yo choose 601? Why not a 404?
Or did you want to leave our 4xx errors to the authentication process? (I do not know the number-spaces myself)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Works for me.
- [x] <a href='#crh-comment-Pull 4ea0cc874fc4cf1cafd9fb0765b643f94381c427 privacyidea/lib/privacyideaserver.py 26'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r234518441'>File: privacyidea/lib/privacyideaserver.py:L159-168</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I am currently not sure - does ``.delete()`` return the ID of the deleted object?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I forgot about this too, but ``.delete()`` is actually our own ``MethodsMixin`` method which returns the ID of the deleted object :-)
https://github.com/privacyidea/privacyidea/blob/e4e736a4442e1f88f391a8f639b6d7497b9ed6bf/privacyidea/models.py#L87
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Oh. This is something I added right at the beginning - so I would have had to know about this! :-/
- [x] <a href='#crh-comment-Pull 4ea0cc874fc4cf1cafd9fb0765b643f94381c427 privacyidea/lib/realm.py 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r234518590'>File: privacyidea/lib/realm.py:L154-161</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Why not do this as a one-liner?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> fixed this in 708fb4c25cb559eb1cecfe3be209642ea2c3ef3a
- [x] <a href='#crh-comment-Pull 4ea0cc874fc4cf1cafd9fb0765b643f94381c427 privacyidea/lib/token.py 255'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r234522030'>File: privacyidea/lib/token.py:L1127-1140</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The logic now is very API centric.
The library call "set_defaults" will now raise an exception is the serial does not exist. This is fine for an API call but may result in unexpected behaviour, if ``set_detaults`` is called from without other code.
(justsaying)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Works for me.
- [x] <a href='#crh-comment-Pull 4ea0cc874fc4cf1cafd9fb0765b643f94381c427 privacyidea/api/token.py 8'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r234547914'>File: privacyidea/api/token.py:L426-434</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> {"success": True}
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Actually, ``assign_token`` either raises an error or returns ``True``, so if this line is executed at all, ``res`` will always be True.
But maybe we should make this more explicit?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think it is more clear to revert it to "True" again.Thanks a lot.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> No problem, did this in dc564c7f3faaaf2ebc6315523cd0cdd481131c74
- [x] <a href='#crh-comment-Pull 2f0d61f7bda0d34ec250f2e61aa04ffbe91eafb9 tests/test_lib_events.py 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1310#discussion_r234606307'>File: tests/test_lib_events.py:L571-577</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What changed here?
If the token does not exist, we can catch an exception.
OK, due to the failing script, the token was not created? - right it is raise-error=True.
Maybe it is a good idea to realy check in this case, that the originial request also failed.
self.assertRaises(Exception, remove_token, "SPASS01")
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think this is a new test from #1307. My understanding is that the token "SPASS01" does not actually exist from the perspective of privacyIDEA (because we only test the ScriptEventHandler), so no need to try to remove it :-)
I think I've already done the same for ``test_01_runscript``.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are right. The token really does not exist!
So this is fine!


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1310?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1310?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1310?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1310'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>