### PR TITLE
Token janitor now forbids --chunksize for modification actions

### DIFF
--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -242,9 +242,13 @@ def build_tokenvalue_filter(key,
 
 
 def _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
-                   tokeninfo_value_filter, orphaned, tokentype, serial, description, psize, page):
-    tlist = []
-    filter_tokentype = None
+                   tokeninfo_value_filter, orphaned, tokentype, serial, description,
+                   psize=None):
+    """
+    This is a generator that generates one or more lists of token objects.
+    If ``psize`` is None, this generates one big list containing all matching token objects.
+    If ``psize`` is not None, this generates several lists, each of length ``psize``.
+    """
     filter_active = None
     filter_assigned = None
 
@@ -253,48 +257,62 @@ def _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
     if active is not None:
         filter_active = active.lower() == "true"
 
-    count, prev, next, tokenobj_list = get_tokens(tokentype=tokentype,
-                                                  active=filter_active,
-                                                  assigned=filter_assigned,
-                                                  page=page,
-                                                  psize=psize)
+    page = 1
+    while page is not None:
+        tlist = []
+        if psize is not None:
+            sys.stderr.write("+ Reading tokens from database in chunks of {}...\n".format(psize))
+            _, _, next_page, tokenobj_list = get_tokens(tokentype=tokentype,
+                                                        active=filter_active,
+                                                        assigned=filter_assigned,
+                                                        page=page,
+                                                        psize=psize)
+            # Read the next page in the next iteration of the loop
+            page = next_page
+        else:
+            sys.stderr.write("+ Reading tokens from database...\n")
+            tokenobj_list = get_tokens(tokentype=tokentype,
+                                       active=filter_active,
+                                       assigned=filter_assigned)
+            # Exit the loop after one iteration
+            page = None
 
-    sys.stderr.write("++ Creating token object list.\n")
-    tok_count = 0
-    tok_found = 0
-    for token_obj in tokenobj_list:
-        sys.stderr.write('{0} Tokens processed / {1} Tokens found\r'.format(tok_count, tok_found))
+        sys.stderr.write("++ Creating token object list.\n")
+        tok_count = 0
+        tok_found = 0
+        for token_obj in tokenobj_list:
+            sys.stderr.write('{0} Tokens processed / {1} Tokens found\r'.format(tok_count, tok_found))
+            sys.stderr.flush()
+            tok_count += 1
+            if last_auth and token_obj.check_last_auth_newer(last_auth):
+                continue
+            if serial and not re.search(serial, token_obj.token.serial):
+                continue
+            if description and not re.search(description,
+                                             token_obj.token.description):
+                continue
+            if tokeninfo_value_filter and tokeninfo_key:
+                value = token_obj.get_tokeninfo(tokeninfo_key)
+                # if the tokeninfo key is not even set, it does not match the filter
+                if value is None:
+                    continue
+                # suppose not all comparator functions return True
+                # => at least one comparator function returns False
+                # => at least one user-supplied criterion does not match
+                # => the token object does not match the user-supplied criteria
+                if not all(comparator(value) for comparator in tokeninfo_value_filter):
+                    continue
+            if orphaned and not token_obj.is_orphaned():
+                continue
+
+            tok_found += 1
+            # if everything matched, we append the token object
+            tlist.append(token_obj)
+
+        sys.stderr.write('{0} Tokens processed / {1} Tokens found\r\n'.format(tok_count, tok_found))
+        sys.stderr.write("++ Token object list created.\n")
         sys.stderr.flush()
-        tok_count += 1
-        if last_auth and token_obj.check_last_auth_newer(last_auth):
-            continue
-        if serial and not re.search(serial, token_obj.token.serial):
-            continue
-        if description and not re.search(description,
-                                         token_obj.token.description):
-            continue
-        if tokeninfo_value_filter and tokeninfo_key:
-            value = token_obj.get_tokeninfo(tokeninfo_key)
-            # if the tokeninfo key is not even set, it does not match the filter
-            if value is None:
-                continue
-            # suppose not all comparator functions return True
-            # => at least one comparator function returns False
-            # => at least one user-supplied criterion does not match
-            # => the token object does not match the user-supplied criteria
-            if not all(comparator(value) for comparator in tokeninfo_value_filter):
-                continue
-        if orphaned and not token_obj.is_orphaned():
-            continue
-
-        tok_found += 1
-        # if everything matched, we append the token object
-        tlist.append(token_obj)
-
-    sys.stderr.write('{0} Tokens processed / {1} Tokens found\r\n'.format(tok_count, tok_found))
-    sys.stderr.write("++ Token object list created.\n")
-    sys.stderr.flush()
-    return count, prev, next, tlist
+        yield tlist
 
 
 def export_token_data(token_list):
@@ -379,7 +397,7 @@ def export_user_data(token_list):
 @manager.option('--csv', dest='csv', action='store_true',
                 help='In case of a simple find, the output is written as CSV instead of the '
                      'formatted output.')
-@manager.option('--chunksize', default=1000,
+@manager.option('--chunksize', default=None,
                 help='Read tokens from the database in smaller chunks to perform operations.')
 def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
          tokeninfo_value_greater_than, tokeninfo_value_less_than,
@@ -401,13 +419,12 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
                                      tokeninfo_value_after,
                                      tokeninfo_value_before)
 
-    next = 1
-    chunksize = int(chunksize)
-    while next:
-        sys.stderr.write("+ Reading tokens in chunk from database...\n")
-        _, _, next, tlist = _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
-                                                    filter, orphaned, tokentype, serial,
-                                                    description, chunksize, next)
+    if chunksize is not None:
+        chunksize = int(chunksize)
+    chunk_iterator = _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
+                                    filter, orphaned, tokentype, serial,
+                                    description, chunksize)
+    for tlist in chunk_iterator:
         sys.stderr.write("+ Tokens read. Starting action.\n")
         if not action:
             if not csv:
@@ -439,12 +456,20 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
                     print(u"{0!s},{1!s}".format(user, len(tokens)))
 
         elif action == "export":
+            if chunksize is not None:
+                sys.stderr.write("The argument --chunksize in conjunction with --action export"
+                                 "is currently unsupported. Exiting.\n")
+                sys.exit(1)
             key, token_num, soup = export_pskc(tlist)
             sys.stderr.write("\n{0!s} tokens exported.\n".format(token_num))
             sys.stderr.write("\nThis is the AES encryption key of the token seeds.\n"
                              "You need this key to import the tokens again:\n\n\t{0!s}\n\n".format(key))
             print("{0!s}".format(soup))
         else:
+            if chunksize is not None:
+                sys.stderr.write("The argument --chunksize in conjunction with actions that modify the "
+                                 "database is currently unsupported. Exiting.\n")
+                sys.exit(1)
             for token_obj in tlist:
                 try:
                     if action == "disable":


### PR DESCRIPTION
For several combinations of filter criteria and actions, the --chunksize parameter resulted in matching tokens for which no action was performed.

This PR does change behavior to fix this! In 2.23, ``privacyidea-token-janitor`` default behavior was to query the database in chunks of 1000, the new default behavior is to not use chunked search at all, but it can be enabled by passing ``--chunksize X``. The token janitor now forbids ``--chunksize`` in conjunction with actions that modify the database. This fixes the issues given in #1322, but also forbids some combinations of filter criteria and actions that would, in fact, work correctly. This may be cumbersome for users with a large number of tokens.

So ... I'm not sure if that's the best fix :-) Happy about any comments!
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1323%23issuecomment-442015016%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1323%23issuecomment-442862962%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1323%23issuecomment-446119213%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1323%23issuecomment-446223780%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1323%23issuecomment-451130650%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1323%23issuecomment-442015016%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231323%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bbranch-2.23%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/44c02e09931b7797a33af81aa2d1f0815e1ce0a7%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.25%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20branch-2.23%20%20%20%231323%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%20%20%20%20%20%2096.06%25%20%20%2095.8%25%20%20%20-0.26%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%20142%20%20%20%20%20142%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%2018165%20%20%2017203%20%20%20%20%20-962%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%2017450%20%20%2016482%20%20%20%20%20-968%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%20715%20%20%20%20%20721%20%20%20%20%20%20%20%2B6%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6094.16%25%20%3C0%25%3E%20%28-1.67%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6095.18%25%20%3C0%25%3E%20%28-1.15%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/postpolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5%29%20%7C%20%6096.61%25%20%3C0%25%3E%20%28-1.01%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5%29%20%7C%20%6098.59%25%20%3C0%25%3E%20%28-0.72%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/lib/prepolicy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wcmVwb2xpY3kucHk%3D%29%20%7C%20%6096.59%25%20%3C0%25%3E%20%28-0.59%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.39%25%20%3C0%25%3E%20%28-0.46%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/hotptoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/vascotoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjb3Rva2VuLnB5%29%20%7C%20%6096.55%25%20%3C0%25%3E%20%28%2B1.39%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B44c02e0...1382e49%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1323%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-27T10%3A52%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20pagination%20in%20this%20variant%20is%20not%20useful%20here%20since%20we%20don%27t%20want%20to%20display%20any%20results%20with%20%60prev%7Cnext%7Clast%60%20links.%5Cr%5Cn%5BHere%5D%28https%3A//stackoverflow.com/a/28737351/7036742%29%20is%20an%20interesting%20%5Bapproach%5D%28http%3A//mysql.rjweb.org/doc.php/pagination%29%20which%20deals%20with%20this%20kind%20of%20problems.%5Cr%5CnBut%20we%20have%20to%20build%20the%20requests%20by%20hand%20in%20this%20case%2C%20i%20guess.%22%2C%20%22created_at%22%3A%20%222018-11-29T14%3A56%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20clever%3A%20Our%20current%20%60%60Pagination%60%60-based%20approach%20issues%20exactly%20the%20inefficient%20%60%60LIMIT%20...%60%60%20queries%20mentioned%20in%20the%20post%20above%3A%5Cr%5Cn%60%60%60sql%5Cr%5CnSELECT%20...%20FROM%20token%20WHERE%20...%20LIMIT%200%2C%201000%5Cr%5CnSELECT%20...%20FROM%20token%20WHERE%20...%20LIMIT%201000%2C%201000%5Cr%5Cn...%5Cr%5Cn%60%60%60%5Cr%5Cnwhich%20may%20also%20cause%20problems%20if%20the%20set%20of%20tokens%20matching%20the%20WHERE%20clause%20changes%20between%20the%20first%20and%20the%20second%20query%20%28e.g.%20because%20some%20are%20deleted%29.%5Cr%5CnWe%20could%20instead%20do%20%5Cr%5Cn%60%60%60sql%5Cr%5CnSELECT%20...%20FROM%20token%20WHERE%20...%20ORDER%20BY%20id%20ASC%20LIMIT%200%2C%201001%5Cr%5CnSELECT%20...%20FROM%20token%20WHERE%20id%20%3E%3D%201219%20...%20ORDER%20BY%20id%20ASC%20LIMIT%201001%5Cr%5Cn...%5Cr%5Cn%60%60%60%5Cr%5Cnwhich%20should%20work%20even%20if%20we%20delete%20tokens%20between%20query%201%20and%202.%5Cr%5Cn%5Cr%5CnThis%20is%20a%20good%20idea%21%20However%2C%20as%20this%20would%20require%20quite%20some%20additional%20code%2C%20I%27m%20not%20sure%20if%20we%20should%20implement%20this%20in%20%60%60branch-2.23%60%60.%20Maybe%20we%20should%20instead%20plan%20that%20for%20the%203.0%20code%20cleanup.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-12-11T08%3A46%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Pagination%20is%20nice%20for%20displaying%20but%20not%20not%20for%20chunk-wise%20processing.%5Cr%5CnMaybe%20we%20could%20introduce%20a%20%60get_tokens_chunk%28%29%60%20function%20which%20also%20returns%20the%20%60id%60%20of%20the%20next%20starting%20point.%5Cr%5CnOr%20we%20cannibalize%20the%20%5B%60get_tokens%28%29%60%5D%28https%3A//github.com/privacyidea/privacyidea/blob/2890368d83ed9543a5c7ecf1758d709a2da55859/privacyidea/lib/token.py%23L277%29%20function%20which%20already%20has%20some%20kind%20of%20pagination%20feature%20%28is%20it%20used%20anywhere%20else%20besides%20the%20token%20janitor%3F%29.%5Cr%5CnIf%20this%20is%20no%20pressing%20issue%2C%20we%20should%20plan%20this%20for%203.0/3.1%22%2C%20%22created_at%22%3A%20%222018-12-11T14%3A35%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22On%20a%20second%20thought%2C%20I%20think%20we%20can%20implement%20the%20pagination%20approach%20from%20your%20link%20quite%20nicely%20with%20a%20generator%20%3A-%29%20This%20seems%20cleaner%20to%20me.%20I%27ll%20open%20another%20PR%20against%20master.%5Cr%5Cn%5Cr%5CnShould%20we%20even%20fix%20this%20issue%20in%20%60%60branch-2.23%60%60%3F%20If%20not%2C%20we%20can%20close%20this%20PR.%22%2C%20%22created_at%22%3A%20%222019-01-03T12%3A32%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1323#issuecomment-442015016'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1323?src=pr&el=h1) Report
> Merging [#1323](https://codecov.io/gh/privacyidea/privacyidea/pull/1323?src=pr&el=desc) into [branch-2.23](https://codecov.io/gh/privacyidea/privacyidea/commit/44c02e09931b7797a33af81aa2d1f0815e1ce0a7?src=pr&el=desc) will **decrease** coverage by `0.25%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1323?src=pr&el=tree)
```diff
@@              Coverage Diff               @@
##           branch-2.23   #1323      +/-   ##
==============================================
- Coverage        96.06%   95.8%   -0.26%
==============================================
Files              142     142
Lines            18165   17203     -962
==============================================
- Hits             17450   16482     -968
- Misses             715     721       +6
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1323?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `94.16% <0%> (-1.67%)` | :arrow_down: |
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `95.18% <0%> (-1.15%)` | :arrow_down: |
| [privacyidea/api/lib/postpolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wb3N0cG9saWN5LnB5) | `96.61% <0%> (-1.01%)` | :arrow_down: |
| [privacyidea/api/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Rva2VuLnB5) | `98.59% <0%> (-0.72%)` | :arrow_down: |
| [privacyidea/api/lib/prepolicy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2xpYi9wcmVwb2xpY3kucHk=) | `96.59% <0%> (-0.59%)` | :arrow_down: |
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.39% <0%> (-0.46%)` | :arrow_down: |
| [privacyidea/lib/tokens/hotptoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy9ob3RwdG9rZW4ucHk=) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/tokens/vascotoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1323/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy92YXNjb3Rva2VuLnB5) | `96.55% <0%> (+1.39%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1323?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1323?src=pr&el=footer). Last update [44c02e0...1382e49](https://codecov.io/gh/privacyidea/privacyidea/pull/1323?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Maybe pagination in this variant is not useful here since we don't want to display any results with `prev|next|last` links.
[Here](https://stackoverflow.com/a/28737351/7036742) is an interesting [approach](http://mysql.rjweb.org/doc.php/pagination) which deals with this kind of problems.
But we have to build the requests by hand in this case, i guess.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah, clever: Our current ``Pagination``-based approach issues exactly the inefficient ``LIMIT ...`` queries mentioned in the post above:
```sql
SELECT ... FROM token WHERE ... LIMIT 0, 1000
SELECT ... FROM token WHERE ... LIMIT 1000, 1000
...
```
which may also cause problems if the set of tokens matching the WHERE clause changes between the first and the second query (e.g. because some are deleted).
We could instead do
```sql
SELECT ... FROM token WHERE ... ORDER BY id ASC LIMIT 0, 1001
SELECT ... FROM token WHERE id >= 1219 ... ORDER BY id ASC LIMIT 1001
...
```
which should work even if we delete tokens between query 1 and 2.
This is a good idea! However, as this would require quite some additional code, I'm not sure if we should implement this in ``branch-2.23``. Maybe we should instead plan that for the 3.0 code cleanup. What do you think?
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Pagination is nice for displaying but not not for chunk-wise processing.
Maybe we could introduce a `get_tokens_chunk()` function which also returns the `id` of the next starting point.
Or we cannibalize the [`get_tokens()`](https://github.com/privacyidea/privacyidea/blob/2890368d83ed9543a5c7ecf1758d709a2da55859/privacyidea/lib/token.py#L277) function which already has some kind of pagination feature (is it used anywhere else besides the token janitor?).
If this is no pressing issue, we should plan this for 3.0/3.1
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> On a second thought, I think we can implement the pagination approach from your link quite nicely with a generator :-) This seems cleaner to me. I'll open another PR against master.
Should we even fix this issue in ``branch-2.23``? If not, we can close this PR.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1323?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1323?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1323'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>