### PR TITLE
Improve tests and coverage for `localca.py`

### DIFF
--- a/privacyidea/lib/caconnectors/localca.py
+++ b/privacyidea/lib/caconnectors/localca.py
@@ -597,7 +597,7 @@ class LocalCAConnector(BaseCAConnector):
 
         :param name: The name of the CA connector.
         :type name: str
-        :return The LocalCAConnector configuration
+        :return: The LocalCAConnector configuration
         :rtype: dict
         """
         config = CONFIG(name)

--- a/privacyidea/lib/caconnectors/localca.py
+++ b/privacyidea/lib/caconnectors/localca.py
@@ -359,8 +359,8 @@ class LocalCAConnector(BaseCAConnector):
         :param options: Additional options like the validity time or the
             template or spkac=1
         :type options: dict
-        :return: Returns the certificate
-        :rtype: basestring
+        :return: Returns the certificate object
+        :rtype: X509
         """
         # Sign the certificate for one year
         options = options or {}
@@ -504,6 +504,7 @@ class LocalCAConnector(BaseCAConnector):
             cert_obj = certificate
         else:
             raise CAError("Certificate in unsupported format")
+
         serial = cert_obj.get_serial_number()
         serial_hex = int_to_hex(serial)
         filename = serial_hex + ".pem"
@@ -568,12 +569,14 @@ class LocalCAConnector(BaseCAConnector):
 
         return ret
 
-    @classmethod
-    def create_ca(cls, name):
+    @staticmethod
+    def create_ca(name):
         """
-        Create a new CA connector.
-        The configurations is requested at the command line in questions and
-        answers. The CA connector definition is also written to the database.
+        Create parameters for a new CA connector.
+        The configuration is requested at the command line in questions and
+        answers.
+        If the configuration is valid, the CA will be created on the file system
+        and the configuration for the new LocalCAConnector is returned.
 
         We are asking for the following:
 
@@ -593,7 +596,9 @@ class LocalCAConnector(BaseCAConnector):
         * We create two templates for users and for servers.
 
         :param name: The name of the CA connector.
-        :return:
+        :type name: str
+        :return The LocalCAConnector configuration
+        :rtype: dict
         """
         config = CONFIG(name)
 
@@ -728,4 +733,3 @@ def _init_ca(config):
     print("Please check the ownership of the private key")
     print("{0!s}/cakey.pem".format(config.directory))
     print("!" * 60)
-

--- a/tests/test_lib_caconnector.py
+++ b/tests/test_lib_caconnector.py
@@ -4,11 +4,10 @@ lib.caconnectors.localca.py
 """
 from .base import MyTestCase
 import os
-import sys
 import six
 import shutil
 from io import StringIO
-from contextlib import contextmanager
+from mock import patch
 from privacyidea.lib.caconnectors.localca import LocalCAConnector, ATTR
 from OpenSSL import crypto
 from privacyidea.lib.utils import int_to_hex
@@ -76,14 +75,6 @@ SPKAC = "SPKAC=MIICQDCCASgwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggE" \
         "rmtBFA3aIp5RExiEpvBD88hg==\n" \
         "CN=Steve Test\n" \
         "emailAddress=steve@openssl.org"
-
-
-@contextmanager
-def replace_stdin(target):
-    orig = sys.stdin
-    sys.stdin = target
-    yield
-    sys.stdin = orig
 
 
 class CAConnectorTestCase(MyTestCase):
@@ -300,7 +291,7 @@ class CreateLocalCATestCase(MyTestCase):
         if os.path.exists(workdir):
             shutil.rmtree(workdir)
         inputstr = six.text_type(workdir + '\n\n\n\n\n\ny\n')
-        with replace_stdin(StringIO(inputstr)):
+        with patch('sys.stdin', StringIO(inputstr)):
             caconfig = LocalCAConnector.create_ca('localCA2')
             self.assertEqual(caconfig.get("WorkingDir"), workdir)
             cacon = LocalCAConnector('localCA2', caconfig)

--- a/tests/test_lib_caconnector.py
+++ b/tests/test_lib_caconnector.py
@@ -4,6 +4,11 @@ lib.caconnectors.localca.py
 """
 from .base import MyTestCase
 import os
+import sys
+import six
+import shutil
+from io import StringIO
+from contextlib import contextmanager
 from privacyidea.lib.caconnectors.localca import LocalCAConnector, ATTR
 from OpenSSL import crypto
 from privacyidea.lib.utils import int_to_hex
@@ -71,6 +76,14 @@ SPKAC = "SPKAC=MIICQDCCASgwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggE" \
         "rmtBFA3aIp5RExiEpvBD88hg==\n" \
         "CN=Steve Test\n" \
         "emailAddress=steve@openssl.org"
+
+
+@contextmanager
+def replace_stdin(target):
+    orig = sys.stdin
+    sys.stdin = target
+    yield
+    sys.stdin = orig
 
 
 class CAConnectorTestCase(MyTestCase):
@@ -277,3 +290,21 @@ class LocalCATestCase(MyTestCase):
         self.assertTrue(ddiff.days < 760, ddiff.days)
 
 
+class CreateLocalCATestCase(MyTestCase):
+    """
+    test creating a new CA using the local caconnector
+    """
+    def test_01_create_ca(self):
+        cwd = os.getcwd()
+        workdir = os.path.join(cwd, WORKINGDIR + '2')
+        if os.path.exists(workdir):
+            shutil.rmtree(workdir)
+        inputstr = six.text_type(workdir + '\n\n\n\n\n\ny\n')
+        with replace_stdin(StringIO(inputstr)):
+            caconfig = LocalCAConnector.create_ca('localCA2')
+            self.assertEqual(caconfig.get("WorkingDir"), workdir)
+            cacon = LocalCAConnector('localCA2', caconfig)
+            self.assertEqual(cacon.name, 'localCA2')
+            self.assertEqual(cacon.workingdir, workdir)
+            # check if the generated files exist
+            self.assertTrue(os.path.exists(os.path.join(workdir, 'cacert.pem')))


### PR DESCRIPTION
Testing the `create_ca()` function with a predefined input string.
Also added more accurate descriptions.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23issuecomment-442087853%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r236990959%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r237022835%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r237518311%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r237519079%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r237859575%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r237867367%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r238012012%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r238012016%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r238012515%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23issuecomment-442087853%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231324%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/4da61fa77746f45d10f079c66db99deb9223510d%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.38%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231324%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2096.01%25%20%20%2096.39%25%20%20%20%2B0.38%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20141%20%20%20%20%20%20141%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017175%20%20%20%2017175%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016490%20%20%20%2016556%20%20%20%20%20%20%2B66%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20685%20%20%20%20%20%20619%20%20%20%20%20%20-66%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/caconnectors/localca.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NhY29ubmVjdG9ycy9sb2NhbGNhLnB5%29%20%7C%20%6096.55%25%20%3C100%25%3E%20%28%2B25.28%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B4da61fa...64c6c6a%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1324%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-11-27T14%3A56%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%202427347d975fcbf08d55c4df0130475a25526b04%20tests/test_lib_caconnector.py%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r236990959%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Nifty%20%3A%29%20Maybe%20one%20could%20also%20do%20this%20with%20%60%60mock.patch%60%60%2C%20but%20I%20think%20this%20is%20nice%20already%21%22%2C%20%22created_at%22%3A%20%222018-11-28T09%3A01%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22First%20i%20was%20looking%20into%20patching%20the%20%60input%60%20function%20but%20now%20i%20use%20mock%20to%20patch%20%60sys.stdin%60%22%2C%20%22created_at%22%3A%20%222018-11-28T10%3A25%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-30T21%3A46%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_caconnector.py%3AL78-92%22%7D%2C%20%22Pull%2064c6c6ad4f1b7be62753a9020fe8ecbcb4d61bb0%20privacyidea/lib/caconnectors/localca.py%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r237518311%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20the%20original%20idea%20was%2C%20that%20if%20we%20one%20day%20have%20other%20CA%20types%20like%20a%20MS%20CA%2C%20the%20create%20method%20could%20need%20some%20more%20information%2C%20this%20is%20why%20it%20was%20created%20as%20classmethod.%20%28Well%2C%20actually%20the%20method%20is%20missing%20in%20the%20baseclass.%5Cr%5Cn%5Cr%5CnBut%20the%20the%20%60%60pi-manage%20ca%20create%20-t%20msca%60%60%20could%20also%20work.%5Cr%5Cn%5Cr%5CnWe%20can%20however%20change%20this%20and%20if%20necessary%20change%20this%20back%2C%20when%20we%20create%20an%20MSCA%20connector%20one%20day.%5Cr%5CnWhat%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-11-29T14%3A54%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20been%20thinking%20about%20that%20as%20well.%5Cr%5CnOne%20idea%20would%20be%20to%20create%20some%20kind%20of%20factory%20function%20which%20returns%20a%20%60LocalCAConnector%60%20object.%5Cr%5CnCurrently%20the%20%60CAConnector%60%20objects%20are%20only%20instantiated%20inside%20the%20%60lib/caconnector.py%60%20module.%20Outside%20they%20are%20only%20described%20by%20their%20configuration.%5Cr%5CnThe%20%60create_ca%28%29%60%20function%20only%20generates%20a%20suitable%20configuration%20which%20is%20then%20passed%20to%20%60save_caconnector%28%29%60%20in%20%60lib/caconnector.py%60.%20This%20is%20also%20called%20by%20the%20caconnector%20api%20endpoint.%5Cr%5Cn%5Cr%5CnSo%20i%20think%2C%20%60create_ca%28%29%60%20should%20not%20be%20part%20of%20the%20%60caconnector%60%20class%2C%20since%2C%20in%20this%20case%2C%20it%20creates%20the%20CA%20on%20disk.%20Would%20this%20be%20the%20same%20for%20the%20MS%20CA%3F%20I%20think%20this%20fits%20better%20in%20%60pi-manage%60%20or%20a%20separate%20script.%22%2C%20%22created_at%22%3A%20%222018-11-30T13%3A28%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20%60%60localca.create_ca%60%60%20must%20not%20be%20part%20of%20pi-manage.%20It%20must%20be%20part%20of%20the%20localca%20module%2C%20since%20each%20connecter%20would%20have%20it%27s%20own%20logic%20of%20creating%20a%20CA%20setup.%20So%20this%20logic%20needs%20to%20be%20part%20of%20the%20module.%20Not%20sure%20if%20it%20needs%20to%20be%20part%20of%20the%20class%20-%20probably%20not.%5Cr%5Cn%5Cr%5CnCurrently%20I%20do%20not%20know%2C%20how%20the%20creation%20of%20a%20MS%20CA%20would%20look%20like.%20No%20idea%2C%20so%20we%20should%20stay%20flexible%20enough.%5Cr%5Cn%5Cr%5Cn%60%60staticmethod%60%60%20is%20totally%20fine%20for%20me%2C%20now.%22%2C%20%22created_at%22%3A%20%222018-11-30T13%3A54%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-11-30T21%3A46%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/caconnectors/localca.py%3AL569-583%22%7D%2C%20%22Pull%2064c6c6ad4f1b7be62753a9020fe8ecbcb4d61bb0%20privacyidea/lib/caconnectors/localca.py%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1324%23discussion_r237519079%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20is%20a%20colon%20missing%5Cr%5Cn%5Cr%5Cn%20%20%20%20%3Areturn%3A%20The%20LocalCAConnector%20configuration%22%2C%20%22created_at%22%3A%20%222018-11-29T14%3A56%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-11-30T21%3A48%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/caconnectors/localca.py%3AL596-605%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1324#issuecomment-442087853'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1324?src=pr&el=h1) Report
> Merging [#1324](https://codecov.io/gh/privacyidea/privacyidea/pull/1324?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/4da61fa77746f45d10f079c66db99deb9223510d?src=pr&el=desc) will **increase** coverage by `0.38%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1324/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1324?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1324      +/-   ##
==========================================
+ Coverage   96.01%   96.39%   +0.38%
==========================================
Files         141      141
Lines       17175    17175
==========================================
+ Hits        16490    16556      +66
+ Misses        685      619      -66
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1324?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/caconnectors/localca.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1324/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NhY29ubmVjdG9ycy9sb2NhbGNhLnB5) | `96.55% <100%> (+25.28%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1324?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1324?src=pr&el=footer). Last update [4da61fa...64c6c6a](https://codecov.io/gh/privacyidea/privacyidea/pull/1324?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull 2427347d975fcbf08d55c4df0130475a25526b04 tests/test_lib_caconnector.py 17'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1324#discussion_r236990959'>File: tests/test_lib_caconnector.py:L78-92</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Nifty :) Maybe one could also do this with ``mock.patch``, but I think this is nice already!
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> First i was looking into patching the `input` function but now i use mock to patch `sys.stdin`
- [x] <a href='#crh-comment-Pull 64c6c6ad4f1b7be62753a9020fe8ecbcb4d61bb0 privacyidea/lib/caconnectors/localca.py 26'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1324#discussion_r237518311'>File: privacyidea/lib/caconnectors/localca.py:L569-583</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think the original idea was, that if we one day have other CA types like a MS CA, the create method could need some more information, this is why it was created as classmethod. (Well, actually the method is missing in the baseclass.
But the the ``pi-manage ca create -t msca`` could also work.
We can however change this and if necessary change this back, when we create an MSCA connector one day.
What do you think?
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> I have been thinking about that as well.
One idea would be to create some kind of factory function which returns a `LocalCAConnector` object.
Currently the `CAConnector` objects are only instantiated inside the `lib/caconnector.py` module. Outside they are only described by their configuration.
The `create_ca()` function only generates a suitable configuration which is then passed to `save_caconnector()` in `lib/caconnector.py`. This is also called by the caconnector api endpoint.
So i think, `create_ca()` should not be part of the `caconnector` class, since, in this case, it creates the CA on disk. Would this be the same for the MS CA? I think this fits better in `pi-manage` or a separate script.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The ``localca.create_ca`` must not be part of pi-manage. It must be part of the localca module, since each connecter would have it's own logic of creating a CA setup. So this logic needs to be part of the module. Not sure if it needs to be part of the class - probably not.
Currently I do not know, how the creation of a MS CA would look like. No idea, so we should stay flexible enough.
``staticmethod`` is totally fine for me, now.
- [x] <a href='#crh-comment-Pull 64c6c6ad4f1b7be62753a9020fe8ecbcb4d61bb0 privacyidea/lib/caconnectors/localca.py 45'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1324#discussion_r237519079'>File: privacyidea/lib/caconnectors/localca.py:L596-605</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> There is a colon missing
:return: The LocalCAConnector configuration


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1324?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1324?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1324'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>