### PR TITLE
1271/hide ldap password

### DIFF
--- a/privacyidea/api/resolver.py
+++ b/privacyidea/api/resolver.py
@@ -61,6 +61,10 @@ resolver_blueprint = Blueprint('resolver_blueprint', __name__)
 def get_resolvers(resolver=None):
     """
     returns a json list of the specified resolvers.
+    The passwords of resolvers (e.g. Bind PW of the LDAP resolver or password of the
+    SQL resolver) will be returned as "__CENSORED__".
+    You can run a POST request to update the data and privacyIDEA will ignore the "__CENSORED__"
+    password or you can even run a testresolver.
 
     :param resolver: the name of the resolver
     :type resolver: basestring
@@ -167,6 +171,12 @@ def delete_resolver_api(resolver=None):
 @log_with(log)
 def test_resolver():
     """
+    Send the complete parameters of a resolver to the privacyIDEA server
+    to test, if these settings will result in a successful connection.
+    If you are testing existing resolvers, you can send the "__CENSORED__"
+    password. privacyIDEA will use the already stored password from the
+    database.
+
     :return: a json result with True, if the given values can create a
         working resolver and a description.
     """

--- a/privacyidea/api/resolver.py
+++ b/privacyidea/api/resolver.py
@@ -169,6 +169,7 @@ def delete_resolver_api(resolver=None):
 
 @resolver_blueprint.route('/test', methods=["POST"])
 @log_with(log)
+@prepolicy(check_base_action, request, ACTION.RESOLVERWRITE)
 def test_resolver():
     """
     Send the complete parameters of a resolver to the privacyIDEA server

--- a/privacyidea/api/resolver.py
+++ b/privacyidea/api/resolver.py
@@ -67,11 +67,11 @@ def get_resolvers(resolver=None):
     password or you can even run a testresolver.
 
     :param resolver: the name of the resolver
-    :type resolver: basestring
+    :type resolver: str
     :param type: Only return resolvers of type (like passwdresolver..)
-    :type type: basestring
+    :type type: str
     :param editable: Set to "1" if only editable resolvers should be returned.
-    :type editable: basestring
+    :type editable: str
     :return: a json result with the configuration of resolvers
     """
     typ = getParam(request.all_data, "type", optional)
@@ -105,10 +105,10 @@ def set_resolver(resolver=None):
     it will produce an error.
 
     :param resolver: the name of the resolver.
-    :type resolver: basestring
+    :type resolver: str
     :param type: the type of the resolver. Valid types are passwdresolver,
     ldapresolver, sqlresolver, scimresolver
-    :type type: string
+    :type type: str
     :return: a json result with the value being the database id (>0)
 
     Additional parameters depend on the resolver type.

--- a/privacyidea/api/resolver.py
+++ b/privacyidea/api/resolver.py
@@ -168,12 +168,13 @@ def get_resolver(resolver=None):
     :param resolver: the name of the resolver
     :return: a json result with the configuration of a specified resolver
     """
-    res = get_resolver_list(filter_resolver_name=resolver)
+    res = get_resolver_list(filter_resolver_name=resolver, censor=True)
 
     g.audit_object.log({"success": True,
                         "info": resolver})
 
     return send_result(res)
+
 
 @resolver_blueprint.route('/test', methods=["POST"])
 @log_with(log)

--- a/privacyidea/api/resolver.py
+++ b/privacyidea/api/resolver.py
@@ -77,7 +77,7 @@ def get_resolvers():
         editable = True
     elif editable == "0":
         editable = False
-    res = get_resolver_list(filter_resolver_type=typ, editable=editable)
+    res = get_resolver_list(filter_resolver_type=typ, editable=editable, censor=True)
     g.audit_object.log({"success": True})
     return send_result(res)
 

--- a/privacyidea/api/resolver.py
+++ b/privacyidea/api/resolver.py
@@ -55,21 +55,20 @@ log = logging.getLogger(__name__)
 resolver_blueprint = Blueprint('resolver_blueprint', __name__)
 
 
-# ----------------------------------------------------------------------
-#
-#   Resolver methods
-#
-
 @resolver_blueprint.route('/', methods=['GET'])
+@resolver_blueprint.route('/<resolver>', methods=['GET'])
 @log_with(log)
-def get_resolvers():
+def get_resolvers(resolver=None):
     """
-    returns a json list of all resolver.
+    returns a json list of the specified resolvers.
 
+    :param resolver: the name of the resolver
+    :type resolver: basestring
     :param type: Only return resolvers of type (like passwdresolver..)
     :type type: basestring
     :param editable: Set to "1" if only editable resolvers should be returned.
     :type editable: basestring
+    :return: a json result with the configuration of resolvers
     """
     typ = getParam(request.all_data, "type", optional)
     editable = getParam(request.all_data, "editable", optional)
@@ -77,8 +76,13 @@ def get_resolvers():
         editable = True
     elif editable == "0":
         editable = False
-    res = get_resolver_list(filter_resolver_type=typ, editable=editable, censor=True)
-    g.audit_object.log({"success": True})
+
+    res = get_resolver_list(filter_resolver_name=resolver,
+                            filter_resolver_type=typ,
+                            editable=editable,
+                            censor=True)
+    g.audit_object.log({"success": True,
+                        "info": resolver})
     return send_result(res)
 
 
@@ -154,23 +158,6 @@ def delete_resolver_api(resolver=None):
     """
     res = delete_resolver(resolver)
     g.audit_object.log({"success": res,
-                        "info": resolver})
-
-    return send_result(res)
-
-
-@resolver_blueprint.route('/<resolver>', methods=['GET'])
-@log_with(log)
-def get_resolver(resolver=None):
-    """
-    This function retrieves the definition of a single resolver.
-
-    :param resolver: the name of the resolver
-    :return: a json result with the configuration of a specified resolver
-    """
-    res = get_resolver_list(filter_resolver_name=resolver, censor=True)
-
-    g.audit_object.log({"success": True,
                         "info": resolver})
 
     return send_result(res)

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -125,12 +125,12 @@ class ConfigClass(with_metaclass(Singleton, object)):
                 for resolver in Resolver.query.all():
                     resolverdef = {"type": resolver.rtype,
                                    "resolvername": resolver.name,
-                                   "__CENSOR_KEYS__": []}
+                                   "censor_keys": []}
                     data = {}
                     for rconf in resolver.config_list:
                         if rconf.Type == "password":
                             value = decryptPassword(rconf.Value, convert_unicode=True)
-                            resolverdef["__CENSOR_KEYS__"].append(rconf.Key)
+                            resolverdef["censor_keys"].append(rconf.Key)
                         else:
                             value = rconf.Value
                         data[rconf.Key] = value

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -124,11 +124,13 @@ class ConfigClass(with_metaclass(Singleton, object)):
                         "Description": sysconf.Description}
                 for resolver in Resolver.query.all():
                     resolverdef = {"type": resolver.rtype,
-                                   "resolvername": resolver.name}
+                                   "resolvername": resolver.name,
+                                   "__CENSOR_KEYS__": []}
                     data = {}
                     for rconf in resolver.config_list:
                         if rconf.Type == "password":
                             value = decryptPassword(rconf.Value, convert_unicode=True)
+                            resolverdef["__CENSOR_KEYS__"].append(rconf.Key)
                         else:
                             value = rconf.Value
                         data[rconf.Key] = value

--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -229,7 +229,7 @@ def get_resolver_list(filter_resolver_type=None,
         resolvers = reduced_resolvers
     if censor:
         for reso_name, reso in resolvers.items():
-            for censor_key in reso.get("__CENSOR_KEYS__", []):
+            for censor_key in reso.get("censor_keys", []):
                 reso["data"][censor_key] = CENSORED
 
     return resolvers
@@ -387,7 +387,7 @@ def pretestresolver(resolvertype, params):
     if params.get("resolver"):
         old_config_list = get_resolver_list(filter_resolver_name=params.get("resolver")) or {}
         old_config = old_config_list.get(params.get("resolver")) or {}
-        for key in old_config.get("__CENSOR_KEYS__"):
+        for key in old_config.get("censor_keys"):
             if params.get(key) == CENSORED:
                 # Overwrite with the value from the database
                 params[key] = old_config.get("data").get(key)

--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -59,6 +59,7 @@ from sqlalchemy import func
 from .crypto import encryptPassword, decryptPassword
 from privacyidea.lib.utils import sanity_name_check
 from privacyidea.lib.utils import is_true
+import copy
 
 CENSORED = "__CENSORED__"
 log = logging.getLogger(__name__)
@@ -195,7 +196,10 @@ def get_resolver_list(filter_resolver_type=None,
     """
     # We need to check if we need to update the config object
     config_object = update_config_object()
-    resolvers = config_object.resolver
+    if censor:
+        resolvers = copy.deepcopy(config_object.resolver)
+    else:
+        resolvers = config_object.resolver
     if filter_resolver_type:
         reduced_resolvers = {}
         for reso_name, reso in resolvers.items():

--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -387,7 +387,7 @@ def pretestresolver(resolvertype, params):
     if params.get("resolver"):
         old_config_list = get_resolver_list(filter_resolver_name=params.get("resolver")) or {}
         old_config = old_config_list.get(params.get("resolver")) or {}
-        for key in old_config.get("censor_keys"):
+        for key in old_config.get("censor_keys", []):
             if params.get(key) == CENSORED:
                 # Overwrite with the value from the database
                 params[key] = old_config.get("data").get(key)

--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -171,7 +171,8 @@ def save_resolver(params):
 #@cache.memoize(10)
 def get_resolver_list(filter_resolver_type=None,
                       filter_resolver_name=None,
-                      editable=None):
+                      editable=None,
+                      censor=False):
     """
     Gets the list of configured resolvers from the database
 
@@ -181,6 +182,9 @@ def get_resolver_list(filter_resolver_type=None,
     :type filter_resolver_name: basestring
     :param editable: Whether only return editable resolvers
     :type editable: bool
+    :param censor: censor sensitive data. Each resolver class decides on its own,
+        which data should be censored.
+    :type censor: bool
     :rtype: Dictionary of the resolvers and their configuration
     """
     # We need to check if we need to update the config object
@@ -213,6 +217,10 @@ def get_resolver_list(filter_resolver_type=None,
                 if not check_editable:
                     reduced_resolvers[reso_name] = resolvers[reso_name]
         resolvers = reduced_resolvers
+    if censor:
+        for reso_name, reso in resolvers.items():
+            for censor_key in reso.get("__CENSOR_KEYS__", []):
+                reso["data"][censor_key] = "__CENSORED__"
 
     return resolvers
 

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -85,6 +85,7 @@ from ldap3.utils.conv import escape_bytes
 from operator import itemgetter
 from six import string_types
 
+CENSORED = "__CENSORED__"
 CACHE = {}
 
 log = logging.getLogger(__name__)

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -2,6 +2,8 @@
 #  Copyright (C) 2014 Cornelius Kölbel
 #  contact:  corny@cornelinux.de
 #
+#  2018-12-14 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Add censored password functionality
 #  2017-12-22 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add configurable multi-value-attributes
 #             with the help of Nomen Nescio
@@ -85,7 +87,6 @@ from ldap3.utils.conv import escape_bytes
 from operator import itemgetter
 from six import string_types
 
-CENSORED = "__CENSORED__"
 CACHE = {}
 
 log = logging.getLogger(__name__)
@@ -872,12 +873,9 @@ class IdResolver (UserIdResolver):
         """
         This function lets you test the to be saved LDAP connection.
 
-        
-
         :param param: A dictionary with all necessary parameter to test
                         the connection.
         :type param: dict
-
         :return: Tuple of success and a description
         :rtype: (bool, string)
 

--- a/privacyidea/lib/resolvers/SCIMIdResolver.py
+++ b/privacyidea/lib/resolvers/SCIMIdResolver.py
@@ -223,7 +223,6 @@ class IdResolver (UserIdResolver):
         :param param: A dictionary with all necessary parameter to test the
                         connection.
         :type param: dict
-        
         :return: Tuple of success and a description
         :rtype: (bool, string)
         

--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -492,7 +492,6 @@ class IdResolver (UserIdResolver):
         :param param: A dictionary with all necessary parameter
                         to test the connection.
         :type param: dict
-
         :return: Tuple of success and a description
         :rtype: (bool, string)
 

--- a/privacyidea/lib/resolvers/UserIdResolver.py
+++ b/privacyidea/lib/resolvers/UserIdResolver.py
@@ -250,8 +250,8 @@ class UserIdResolver(object):
         attributes = attributes or {}
         return None
 
-    @staticmethod
-    def testconnection(param):
+    @classmethod
+    def testconnection(cls, param):
         """
         This function lets you test if the parameters can be used to create a
         working resolver.
@@ -260,10 +260,10 @@ class UserIdResolver(object):
         In case of success it should return a text like
         "Resolver config seems OK. 123 Users found."
 
-        param param: The parameters that should be saved as the resolver
-        type param: dict
-        return: returns True in case of success and a descriptive text
-        rtype: tuple
+        :param param: The parameters that should be saved as the resolver
+        :type param: dict
+        :return: returns True in case of success and a descriptive text
+        :rtype: tuple
         """
         success = False
         desc = "Not implemented"

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -1055,9 +1055,9 @@ myApp.controller("SqlResolverController", function ($scope, ConfigFactory,
 
     $scope.testSQL = function () {
 
-        ConfigFactory.testResolver($scope.params, function (data) {
-            var params = $.extend({}, $scope.params);
-            params["resolver"] = $scope.resolvername;
+        var params = $.extend({}, $scope.params);
+        params["resolver"] = $scope.resolvername;
+        ConfigFactory.testResolver(params, function (data) {
             if (data.result.value >= 0) {
                 inform.add(data.detail.description,
                     {type: "success", ttl: 10000});

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -932,6 +932,7 @@ myApp.controller("LdapResolverController", function ($scope, ConfigFactory, $sta
     $scope.testResolver = function (size_limit) {
         var params = $.extend({}, $scope.params);
         params["SIZELIMIT"] = size_limit;
+        params["resolver"] = $scope.resolvername;
         ConfigFactory.testResolver(params, function (data) {
             if (data.result.value === true) {
                 inform.add(data.detail.description,
@@ -1053,8 +1054,10 @@ myApp.controller("SqlResolverController", function ($scope, ConfigFactory,
     };
 
     $scope.testSQL = function () {
+
         ConfigFactory.testResolver($scope.params, function (data) {
-            //debug: console.log(data.result);
+            var params = $.extend({}, $scope.params);
+            params["resolver"] = $scope.resolvername;
             if (data.result.value >= 0) {
                 inform.add(data.detail.description,
                     {type: "success", ttl: 10000});

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -2233,6 +2233,13 @@ class ResolverTestCase(MyTestCase):
         # Check that the email is NOT contained in the UI
         self.assertTrue("email" not in ui, ui)
 
+    def test_14_censor_resolver(self):
+        reso_list = get_resolver_list()
+        self.assertEqual(reso_list.get("myLDAPres").get("data").get(u"BINDPW"), "ldaptest")
+        reso_list = get_resolver_list(censor=True)
+        self.assertEqual(reso_list.get("myLDAPres").get("data").get(u"BINDPW"), "__CENSORED__")
+
+
 class PasswordHashTestCase(MyTestCase):
     """
     Test the password hashing in the SQL database


### PR DESCRIPTION
This pull request returns resolver attributes of the ``type`` *password* as "`__CENSORED__`".
This works for LDAP resolver and for SQL resolvers.

If a resolver is tested in the UI, the backend will again replace the `__CENSORED__` password with the original one.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447310864%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242116871%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447835827%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447839254%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447841691%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242141942%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242143690%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242144591%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242147490%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242151334%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242152486%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242167585%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242173794%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242174985%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242175730%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242176824%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242177214%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242178868%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242178909%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242180304%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242182169%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242183282%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242184652%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447880400%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447881676%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447882348%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447888734%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447890352%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242199688%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242207657%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23issuecomment-447310864%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231341%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.26%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6095%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231341%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2096.38%25%20%20%2096.65%25%20%20%20%2B0.26%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017300%20%20%20%2018365%20%20%20%20%2B1065%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016674%20%20%20%2017750%20%20%20%20%2B1076%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20626%20%20%20%20%20%20615%20%20%20%20%20%20-11%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6093.41%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/SQLIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TUUxJZFJlc29sdmVyLnB5%29%20%7C%20%6097.9%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/SCIMIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TQ0lNSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/UserIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9Vc2VySWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/resolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3Jlc29sdmVyLnB5%29%20%7C%20%6091.48%25%20%3C100%25%3E%20%28-0.67%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/config.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ%3D%3D%29%20%7C%20%6094.68%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVyLnB5%29%20%7C%20%6099.38%25%20%3C92.85%25%3E%20%28-0.62%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/audit.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2F1ZGl0LnB5%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/monitoring.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL21vbml0b3JpbmcucHk%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/monitoringstats.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL21vbml0b3JpbmdzdGF0cy5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20...%20and%20%5B8%20more%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341/diff%3Fsrc%3Dpr%26el%3Dtree-more%29%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bc71da1d...c7cba8b%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1341%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-14T12%3A28%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20I%20just%20noticed%20another%20thing%3A%20If%20go%20to%20the%20resolver%20config%20page%20of%20a%20resolver%20A%20and%20test%20it%2C%20it%20will%20work%20because%20the%20server%20replaces%20the%20censored%20password%20with%20the%20real%20one%20when%20testing.%20But%20if%20I%20then%20rename%20the%20resolver%20to%20B%2C%20won%27t%20the%20BINDPW%20be%20%60%60__CENSORED__%60%60%3F%5Cr%5Cn%28I%20cannot%20test%20it%20currently%20because%20of%20the%20bug%20I%20mentioned%20in%20the%20review%20above%29%5Cr%5Cn%5Cr%5CnAlso%3A%20If%20it%20were%20possible%20that%20an%20admin%20can%20view%20the%20config%20of%20resolver%20A%2C%20but%20not%20resolver%20B%2C%20the%20admin%20could%20use%20the%20%60%60resolver%60%60%20parameter%20to%20check%20if%20resolver%20A%20and%20B%20have%20the%20same%20password%2C%20without%20knowing%20the%20password%20of%20A%20nor%20B%20%28by%20viewing%20the%20config%20of%20A%2C%20manually%20editing%20the%20%60%60resolver%60%60%20parameter%20to%20B%20and%20testing%20the%20configuration%29.%20But%20our%20permission%20model%20doesn%27t%20allow%20that%2C%20right%3F%22%2C%20%22created_at%22%3A%20%222018-12-17T12%3A53%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Oh%2C%20I%20just%20noticed%20another%20thing%3A%20If%20go%20to%20the%20resolver%20config%20page%20of%20a%20resolver%20A%20and%20test%20it%2C%20it%20will%20work%20because%20the%20server%20replaces%20the%20censored%20password%20with%20the%20real%20one%20when%20testing.%20But%20if%20I%20then%20rename%20the%20resolver%20to%20B%2C%20won%27t%20the%20BINDPW%20be%20__CENSORED__%3F%5Cr%5Cn%5Cr%5CnYes%20it%20will.%20The%20UI%20does%20not%20know%20the%20password%2C%20so%20it%20can%20not%20send%20the%20real%20one.%5Cr%5CnThe%20backend%20does%20not%20know%2C%20that%20the%20resolver%2C%20that%20is%20currently%20saved%2C%20is%20supposed%20to%20be%20a%20copy%20of%20the%20other%20one.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A07%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Also%3A%20If%20it%20were%20possible%20that%20an%20admin%20can%20view%20the%20config%20of%20resolver%20A%2C%20but%20not%20resolver%20B%2C%20the%20admin%20could%20use%20the%20resolver%20parameter%20to%20check%20if%20resolver%20A%20and%20B%20have%20the%20same%20password%2C%20without%20knowing%20the%20password%20of%20A%20nor%20B%20%28by%20viewing%20the%20config%20of%20A%2C%20manually%20editing%20the%20resolver%20parameter%20to%20B%20and%20testing%20the%20configuration%29.%20But%20our%20permission%20model%20doesn%27t%20allow%20that%2C%20right%3F%5Cr%5Cn%5Cr%5CnYes%2C%20you%20are%20right.%20This%20could%20happen.%5Cr%5CnI%20think%20it%20is%20not%20theoretically%20possible%20to%20separate%20resolver%20creation%20rights.%20Based%20on%20what%3F%20The%20resolver%20does%20not%20yet%20exist.%20Thus%20an%20admin%20can%20only%20have%20the%20right%20to%20create%20resolvers%20or%20not.%5Cr%5CnAn%20admin%2C%20that%20has%20resolver%20creation%20rights%20could%20also%20change%20any%20existing%20resolver.%20This%20might%20be%20a%20access%20role%20flaw%2C%20but%20in%20reality%20_creating_%20resolvers%20is%20not%20that%20fine%20grained.%5Cr%5CnSo%20bottom%20line%2C%20an%20admin%2C%20that%20is%20allowed%20to%20create%20resolvers%2C%20can%20create%20all%20resolvers%20and%20as%20such%20would%20be%20able%20to%20alter%20resolvers%2C%20and%20also%20usually%20knows%20passwords%20of%20resolvers.%5Cr%5Cn%28The%20initial%20issue%20was%2C%20that%20admins%2C%20who%20only%20have%20read%20access%20%28i.e.%20all%20admins%29%20would%20be%20able%20to%20see%20the%20pw%29.%5Cr%5Cn%5Cr%5CnHowever%2C%20the%20test_resolver%20endpoint%20is%20not%20limited%20to%20those%20admins%2C%20who%20are%20allowed%20to%20create%20resolvers.%20The%20test%20endpoint%20can%20be%20used%20by%20any%20admin.%20The%20admin%20could%20use%20the%20test%20endpoint%20to%20brute%20force%20the%20resolver%20password.%20well%2C%20he%20could%20brute%20force%20the%20password%20by%20any%20other%20means.%5Cr%5CnNevertheless%3A%20Do%20you%20think%20we%20should%20restrict%20the%20test%20endpoint%20to%20only%20admins%2C%20that%20have%20resolver-create-right%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A15%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20%3E%20Oh%2C%20I%20just%20noticed%20another%20thing%3A%20If%20go%20to%20the%20resolver%20config%20page%20of%20a%20resolver%20A%20and%20test%20it%2C%20it%20will%20work%20because%20the%20server%20replaces%20the%20censored%20password%20with%20the%20real%20one%20when%20testing.%20But%20if%20I%20then%20rename%20the%20resolver%20to%20B%2C%20won%27t%20the%20BINDPW%20be%20%2A%2ACENSORED%2A%2A%3F%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20Yes%20it%20will.%20The%20UI%20does%20not%20know%20the%20password%2C%20so%20it%20can%20not%20send%20the%20real%20one.%5Cr%5Cn%3E%20The%20backend%20does%20not%20know%2C%20that%20the%20resolver%2C%20that%20is%20currently%20saved%2C%20is%20supposed%20to%20be%20a%20copy%20of%20the%20other%20one.%5Cr%5Cn%5Cr%5CnAh%2C%20I%20just%20tested%20it%3A%5Cr%5Cn%2A%20I%20open%20an%20existing%20resolver%2C%20testing%20works%20as%20long%20as%20I%20don%27t%20change%20the%20password%20and%20the%20name%5Cr%5Cn%2A%20After%20changing%20the%20resolver%20name%2C%20testing%20fails%20with%20%5C%22wrong%20credentials%5C%22.%5Cr%5Cn%5Cr%5CnActually%2C%20I%20think%20this%20is%20reasonable%20behavior.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A15%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20%3E%20%3E%20Oh%2C%20I%20just%20noticed%20another%20thing%3A%20If%20go%20to%20the%20resolver%20config%20page%20of%20a%20resolver%20A%20and%20test%20it%2C%20it%20will%20work%20because%20the%20server%20replaces%20the%20censored%20password%20with%20the%20real%20one%20when%20testing.%20But%20if%20I%20then%20rename%20the%20resolver%20to%20B%2C%20won%27t%20the%20BINDPW%20be%20%2A%2ACENSORED%2A%2A%3F%5Cr%5Cn%3E%20%3E%20%5Cr%5Cn%3E%20%3E%20%5Cr%5Cn%3E%20%3E%20Yes%20it%20will.%20The%20UI%20does%20not%20know%20the%20password%2C%20so%20it%20can%20not%20send%20the%20real%20one.%5Cr%5Cn%3E%20%3E%20The%20backend%20does%20not%20know%2C%20that%20the%20resolver%2C%20that%20is%20currently%20saved%2C%20is%20supposed%20to%20be%20a%20copy%20of%20the%20other%20one.%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20Ah%2C%20I%20just%20tested%20it%3A%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20%20%20%20%20%2A%20I%20open%20an%20existing%20resolver%2C%20testing%20works%20as%20long%20as%20I%20don%27t%20change%20the%20password%20and%20the%20name%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20%20%20%20%20%2A%20After%20changing%20the%20resolver%20name%2C%20testing%20fails%20with%20%5C%22wrong%20credentials%5C%22.%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20Actually%2C%20I%20think%20this%20is%20reasonable%20behavior.%20What%20do%20you%20think%3F%5Cr%5Cn%5Cr%5CnThis%20totally%20works%20for%20me.%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A19%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20So%20bottom%20line%2C%20an%20admin%2C%20that%20is%20allowed%20to%20create%20resolvers%2C%20can%20create%20all%20resolvers%20and%20as%20such%20would%20be%20able%20to%20alter%20resolvers%2C%20and%20also%20usually%20knows%20passwords%20of%20resolvers.%5Cr%5Cn%3E%20%28The%20initial%20issue%20was%2C%20that%20admins%2C%20who%20only%20have%20read%20access%20%28i.e.%20all%20admins%29%20would%20be%20able%20to%20see%20the%20pw%29.%5Cr%5Cn%5Cr%5CnThanks%2C%20makes%20sense%21%20I%20just%20wanted%20to%20make%20sure%20that%20I%20don%27t%20misremember%20our%20access%20role%20model%20%3A-%29%5Cr%5Cn%5Cr%5Cn%3E%20However%2C%20the%20test_resolver%20endpoint%20is%20not%20limited%20to%20those%20admins%2C%20who%20are%20allowed%20to%20create%20resolvers.%20The%20test%20endpoint%20can%20be%20used%20by%20any%20admin.%20The%20admin%20could%20use%20the%20test%20endpoint%20to%20brute%20force%20the%20resolver%20password.%20well%2C%20he%20could%20brute%20force%20the%20password%20by%20any%20other%20means.%5Cr%5Cn%3E%20Nevertheless%3A%20Do%20you%20think%20we%20should%20restrict%20the%20test%20endpoint%20to%20only%20admins%2C%20that%20have%20resolver-create-right%3F%5Cr%5Cn%5Cr%5CnHm%21%20Up%20until%20now%2C%20the%20%5C%22test%20resolver%5C%22%20endpoint%20didn%27t%20really%20deal%20with%20sensitive%20information%2C%20it%20just%20carried%20out%20e.g.%20a%20LDAP%20BIND%20request.%20But%20with%20this%20PR%2C%20it%20%2Adoes%2A%20access%20the%20password%20of%20the%20resolver%20given%20in%20%60%60resolver%60%60.%20Maybe%20it%20would%20be%20better%20to%20restrict%20the%20endpoint%20to%20admins%20then.%20If%20I%20understand%20correctly%2C%20this%20wouldn%27t%20really%20affect%20the%20Web%20UI%20because%20only%20admins%20can%20see%20the%20%5C%22test%20resolver%5C%22%20button%20anyway%2C%20right%3F%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A21%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20Hm%21%20Up%20until%20now%2C%20the%20%5C%22test%20resolver%5C%22%20endpoint%20didn%27t%20really%20deal%20with%20sensitive%20information%2C%20it%20just%20carried%20out%20e.g.%20a%20LDAP%20BIND%20request.%20But%20with%20this%20PR%2C%20it%20_does_%20access%20the%20password%20of%20the%20resolver%20given%20in%20%60resolver%60.%20Maybe%20it%20would%20be%20better%20to%20restrict%20the%20endpoint%20to%20admins%20then.%20If%20I%20understand%20correctly%2C%20this%20wouldn%27t%20really%20affect%20the%20Web%20UI%20because%20only%20admins%20can%20see%20the%20%5C%22test%20resolver%5C%22%20button%20anyway%2C%20right%3F%20What%20do%20you%20think%3F%5Cr%5Cn%5Cr%5CnIt%20does%20access%20the%20password%20on%20the%20server%20side.%20%5Cr%5CnOnly%20admins%20can%20use%20the%20test%20resolver%20endpoint.%20The%20complete%20/resolver%20endpoints%20are%20only%20accessable%20for%20admins.%20So%20an%20admin%20who%20is%20not%20allowed%20to%20create%20resolvers%2C%20could%20change%20check%20other%20data%20of%20a%20resolver%20%28he%20can%20not%20change%20the%20data%20of%20the%20resolver%2C%20that%20is%20actually%20used%29.%20But%20he%20can%20issue%20e.g.%20search%20requests%20with%20a%20service%20account%20against%20other%20OUs%20and%20this%20way%20only%20find%20out%2C%20how%20many%20users%20are%20located%20in%20a%20certain%20OU.%20This%20is%20no%20big%20security%20issue%2C%20but...%5Cr%5CnHowever%2C%20since%20%2A%2Athere%20is%20no%20sense%20for%20this%20admin%20to%20do%2A%2A%20so%2C%20I%20would%20like%20to%20restrict%20the%20test%20resolver%20to%20admins%20with%20the%20create%20right.%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A38%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20%3E%20Hm%21%20Up%20until%20now%2C%20the%20%5C%22test%20resolver%5C%22%20endpoint%20didn%27t%20really%20deal%20with%20sensitive%20information%2C%20it%20just%20carried%20out%20e.g.%20a%20LDAP%20BIND%20request.%20But%20with%20this%20PR%2C%20it%20_does_%20access%20the%20password%20of%20the%20resolver%20given%20in%20%60resolver%60.%20Maybe%20it%20would%20be%20better%20to%20restrict%20the%20endpoint%20to%20admins%20then.%20If%20I%20understand%20correctly%2C%20this%20wouldn%27t%20really%20affect%20the%20Web%20UI%20because%20only%20admins%20can%20see%20the%20%5C%22test%20resolver%5C%22%20button%20anyway%2C%20right%3F%20What%20do%20you%20think%3F%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20It%20does%20access%20the%20password%20on%20the%20server%20side.%5Cr%5Cn%3E%20Only%20admins%20can%20use%20the%20test%20resolver%20endpoint.%20The%20complete%20/resolver%20endpoints%20are%20only%20accessable%20for%20admins.%20So%20an%20admin%20who%20is%20not%20allowed%20to%20create%20resolvers%2C%20could%20change%20check%20other%20data%20of%20a%20resolver%20%28he%20can%20not%20change%20the%20data%20of%20the%20resolver%2C%20that%20is%20actually%20used%29.%20But%20he%20can%20issue%20e.g.%20search%20requests%20with%20a%20service%20account%20against%20other%20OUs%20and%20this%20way%20only%20find%20out%2C%20how%20many%20users%20are%20located%20in%20a%20certain%20OU.%20This%20is%20no%20big%20security%20issue%2C%20but...%5Cr%5Cn%3E%20However%2C%20since%20%2A%2Athere%20is%20no%20sense%20for%20this%20admin%20to%20do%2A%2A%20so%2C%20I%20would%20like%20to%20restrict%20the%20test%20resolver%20to%20admins%20with%20the%20create%20right.%5Cr%5Cn%5Cr%5Cndone%20in%209c102a22%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A43%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ee144bc1406ca19f34f95161f6b03e161bfc2cb9%20privacyidea/lib/config.py%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242141942%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20chose%20this%20on%20purpose.%20Imho%20it%20is%20internal%20and%20I%20wanted%20to%20avoid%20any%20conflict%20with%20potential%20new%20resolvers.%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A16%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20but%20how%20could%20a%20conflict%20arise%3F%20Doesn%27t%20the%20%60%60resolverdef%60%60%20dictionary%20only%20contain%20the%20keys%20%60%60type%60%60%2C%20%60%60resolvername%60%60%20and%20%60%60data%60%60%20%28and%20%60%60__CENSOR_KEYS__%60%60%29%20in%20any%20case%3F%5Cr%5Cn%5Cr%5CnI%20think%20this%20is%20not%20entirely%20internal%2C%20because%20the%20standard%20%60%60GET%20/resolver%60%60%20endpoint%20now%20doesn%27t%20return%20passwords%20anymore%2C%20and%20the%20%60%60__CENSOR_KEYS__%60%60%20information%20will%20be%20useful%20for%20users%20of%20our%20REST%20API%20in%20order%20to%20know%20which%20keys%20are%20censored.%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A49%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22interesting%20aspect.%20Will%20change%20the%20key%20accordingly.%22%2C%20%22created_at%22%3A%20%222018-12-17T14%3A45%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%2076ae8895%22%2C%20%22created_at%22%3A%20%222018-12-17T14%3A52%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A05%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/config.py%3AL124-137%22%7D%2C%20%22Pull%20ee144bc1406ca19f34f95161f6b03e161bfc2cb9%20privacyidea/lib/resolver.py%2074%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242143690%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20config%20should%20always%20contain%20the%20CENSOR_KEYS.%20These%20are%20loaded%20right%20at%20the%20beginning%20in%20the%20config%20object%20here%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/1271/hide-ldap-password/privacyidea/lib/config.py%23L128%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A22%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20okay%2C%20but%20I%20just%20realized%20we%20should%20still%20have%20%60%60for%20key%20in%20old_config.get%28%5C%22__CENSOR_KEYS__%5C%22%2C%20%5B%5D%29%60%60%20here%20in%20case%20the%20resolver%20given%20in%20the%20%60%60resolver%60%60%20parameter%20does%20not%20exist.%22%2C%20%22created_at%22%3A%20%222018-12-17T14%3A30%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20is%20the%20corner%20case%20you%20are%20thinking%20of%20here%3F%22%2C%20%22created_at%22%3A%20%222018-12-17T14%3A53%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%20f853a40d%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A00%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A07%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolver.py%3AL378-394%22%7D%2C%20%22Pull%20ee144bc1406ca19f34f95161f6b03e161bfc2cb9%20privacyidea/static/components/config/controllers/configControllers.js%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242144591%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yes%20it%20has.%20otherwise%20it%20would%20have%20no%20effect...%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A25%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A11%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/static/components/config/controllers/configControllers.js%3AL1054-1064%22%7D%2C%20%22Pull%20ee144bc1406ca19f34f95161f6b03e161bfc2cb9%20privacyidea/lib/resolver.py%2061%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242116871%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20think%20this%20actually%20censors%20the%20password%20in%20%60%60config_object.resolver%60%60%2C%20which%20could%20lead%20to%20bugs%20if%20the%20resolver%20config%20is%20used%20later%20in%20the%20same%20request%2C%20or%20concurrently%20by%20other%20threads.%20It%20would%20be%20better%20to%20do%20something%20like%5Cr%5Cn%60%60%60python%5Cr%5Cnreso%5B%5C%22data%5C%22%5D%20%3D%20reso%5B%5C%22data%5C%22%5D.copy%28%29%5Cr%5Cnreso%5B%5C%22data%5C%22%5D%5Bcensor_key%5D%20%3D%20CENSORED%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cn...%20I%20just%20noticed%20we%20can%20actually%20reproduce%20this%3A%20I%20have%20a%20LDAP%20resolver%20with%20a%20correct%20password%2C%20I%20click%20%60%60Test%20Connection%60%60%2C%20it%20works.%20I%20navigate%20to%20another%20page%20and%20back%20to%20the%20LDAP%20resolver%20page%2C%20I%20click%20%60%60Test%20Connection%60%60%20again%20and%20it%20says%20%5C%22Wrong%20Credentials%5C%22%20because%20it%20tries%20to%20authenticate%20with%20%60%60__CENSORED__%60%60%20as%20the%20bind%20password%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-12-17T11%3A45%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20obviously%20the%20dictionary-reference%20problem.%20I%20think%20we%20would%20simply%20need%20a%20deep%20copy%20in%20the%20first%20place%20here%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/1271/hide-ldap-password/privacyidea/lib/resolver.py%23L198%5Cr%5Cn%5Cr%5CnOr%20we%20might%20itereate%20of%20the%20resolvers%20and%20write%20the%20results%20to%20%60reduced_resolvers%60%20as%20we%20did%20before%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/1271/hide-ldap-password/privacyidea/lib/resolver.py%23L212%5Cr%5Cn%5Cr%5CnWhat%20do%20you%20think.%5Cr%5CnIn%20the%20meantime%20I%20will%20try%20to%20create%20a%20testcase%20for%20this...%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A34%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20difference%20to%20the%20%60%60reduced_resolvers%60%60%20code%20above%20is%20that%20we%20did%20not%20modify%20the%20actual%20contents%20of%20the%20resolver%20config%20there%2C%20so%20in%20this%20case%20we%20would%20need%20to%20iterate%20over%20the%20actual%20resolver%20config.%5Cr%5CnMaybe%20a%20deep%20copy%20would%20be%20clearer%20and%20less%20error-prone.%5Cr%5CnAs%20a%20middle%20route%2C%20we%20could%20also%20just%20do%20the%20deep%20copy%20only%20if%20%60%60censor%60%60%20is%20True%2C%20just%20before%20line%20227.%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A46%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20added%20a%20test%20case%20in%20e95e6536.%5Cr%5CnIt%20turns%20out%2C%20that%20it%20%20only%20works%20out%20if%20I%20use%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Epython%20%5Cr%5Cnimport%20copy%5Cr%5Cncopy.deepcopy%28resolvers%29%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cn%5Cr%5CnI%20could%20add%20a%20conditional%20deepcopy%20at%20the%20top%3A%5Cr%5Cn%7E%7E%7E%7Epython%5Cr%5Cn%20%20%20%20if%20censor%3A%5Cr%5Cn%20%20%20%20%20%20%20%20resolvers%20%3D%20copy.deepcopy%28config_object.resolver%29%5Cr%5Cn%20%20%20%20else%3A%5Cr%5Cn%20%20%20%20%20%20%20%20resolvers%20%3D%20config_object.resolver%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cn%5Cr%5CnThe%20deep%20copy%20would%20only%20be%20performed%20on%20API%20resolver%20GETs.%20%28this%20is%20the%20only%20case%20were%20%60censor%3DTrue%60.%29%20I%20think%20this%20is%20an%20acceptable%20performance%20impact.%22%2C%20%22created_at%22%3A%20%222018-12-17T14%3A48%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%20bc17b555%22%2C%20%22created_at%22%3A%20%222018-12-17T14%3A49%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20the%20deep%20copy%20is%20totally%20okay.%20Thanks%21%22%2C%20%22created_at%22%3A%20%222018-12-17T14%3A57%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-17T14%3A57%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/resolver.py%3AL223-233%22%7D%2C%20%22Pull%209c102a224591176d5059eca74aaa6ff74e172f8a%20privacyidea/api/resolver.py%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1341%23discussion_r242199688%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20is%20no%20builtin%20type%20%60basestring%60%20in%20Python%203.%20I%20would%20prefer%20just%20%60str%60%20because%20this%20covers%20most%20cases.%5Cr%5CnWhat%20do%20You%20think%3F%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A45%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-17T16%3A04%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/resolver.py%3AL55-93%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1341#issuecomment-447310864'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1341?src=pr&el=h1) Report
> Merging [#1341](https://codecov.io/gh/privacyidea/privacyidea/pull/1341?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda?src=pr&el=desc) will **increase** coverage by `0.26%`.
> The diff coverage is `95%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1341?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1341      +/-   ##
==========================================
+ Coverage   96.38%   96.65%   +0.26%
==========================================
Files         144      144
Lines       17300    18365    +1065
==========================================
+ Hits        16674    17750    +1076
+ Misses        626      615      -11
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1341?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `93.41% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/resolvers/SQLIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TUUxJZFJlc29sdmVyLnB5) | `97.9% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/resolvers/SCIMIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9TQ0lNSWRSZXNvbHZlci5weQ==) | `100% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/resolvers/UserIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9Vc2VySWRSZXNvbHZlci5weQ==) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/api/resolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3Jlc29sdmVyLnB5) | `91.48% <100%> (-0.67%)` | :arrow_down: |
| [privacyidea/lib/config.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NvbmZpZy5weQ==) | `94.68% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/lib/resolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVyLnB5) | `99.38% <92.85%> (-0.62%)` | :arrow_down: |
| [privacyidea/lib/audit.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2F1ZGl0LnB5) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/api/monitoring.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL21vbml0b3JpbmcucHk=) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/monitoringstats.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL21vbml0b3JpbmdzdGF0cy5weQ==) | `100% <0%> (ø)` | :arrow_up: |
| ... and [8 more](https://codecov.io/gh/privacyidea/privacyidea/pull/1341/diff?src=pr&el=tree-more) | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1341?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1341?src=pr&el=footer). Last update [c71da1d...c7cba8b](https://codecov.io/gh/privacyidea/privacyidea/pull/1341?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Oh, I just noticed another thing: If go to the resolver config page of a resolver A and test it, it will work because the server replaces the censored password with the real one when testing. But if I then rename the resolver to B, won't the BINDPW be ``__CENSORED__``?
(I cannot test it currently because of the bug I mentioned in the review above)
Also: If it were possible that an admin can view the config of resolver A, but not resolver B, the admin could use the ``resolver`` parameter to check if resolver A and B have the same password, without knowing the password of A nor B (by viewing the config of A, manually editing the ``resolver`` parameter to B and testing the configuration). But our permission model doesn't allow that, right?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> > Oh, I just noticed another thing: If go to the resolver config page of a resolver A and test it, it will work because the server replaces the censored password with the real one when testing. But if I then rename the resolver to B, won't the BINDPW be __CENSORED__?
Yes it will. The UI does not know the password, so it can not send the real one.
The backend does not know, that the resolver, that is currently saved, is supposed to be a copy of the other one.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> > Also: If it were possible that an admin can view the config of resolver A, but not resolver B, the admin could use the resolver parameter to check if resolver A and B have the same password, without knowing the password of A nor B (by viewing the config of A, manually editing the resolver parameter to B and testing the configuration). But our permission model doesn't allow that, right?
Yes, you are right. This could happen.
I think it is not theoretically possible to separate resolver creation rights. Based on what? The resolver does not yet exist. Thus an admin can only have the right to create resolvers or not.
An admin, that has resolver creation rights could also change any existing resolver. This might be a access role flaw, but in reality _creating_ resolvers is not that fine grained.
So bottom line, an admin, that is allowed to create resolvers, can create all resolvers and as such would be able to alter resolvers, and also usually knows passwords of resolvers.
(The initial issue was, that admins, who only have read access (i.e. all admins) would be able to see the pw).
However, the test_resolver endpoint is not limited to those admins, who are allowed to create resolvers. The test endpoint can be used by any admin. The admin could use the test endpoint to brute force the resolver password. well, he could brute force the password by any other means.
Nevertheless: Do you think we should restrict the test endpoint to only admins, that have resolver-create-right?
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> > > Oh, I just noticed another thing: If go to the resolver config page of a resolver A and test it, it will work because the server replaces the censored password with the real one when testing. But if I then rename the resolver to B, won't the BINDPW be **CENSORED**?
>
> Yes it will. The UI does not know the password, so it can not send the real one.
> The backend does not know, that the resolver, that is currently saved, is supposed to be a copy of the other one.
Ah, I just tested it:
* I open an existing resolver, testing works as long as I don't change the password and the name
* After changing the resolver name, testing fails with "wrong credentials".
Actually, I think this is reasonable behavior. What do you think?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> > > > Oh, I just noticed another thing: If go to the resolver config page of a resolver A and test it, it will work because the server replaces the censored password with the real one when testing. But if I then rename the resolver to B, won't the BINDPW be **CENSORED**?
> >
> >
> > Yes it will. The UI does not know the password, so it can not send the real one.
> > The backend does not know, that the resolver, that is currently saved, is supposed to be a copy of the other one.
>
> Ah, I just tested it:
>
>     * I open an existing resolver, testing works as long as I don't change the password and the name
>
>     * After changing the resolver name, testing fails with "wrong credentials".
>
>
> Actually, I think this is reasonable behavior. What do you think?
This totally works for me.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> > So bottom line, an admin, that is allowed to create resolvers, can create all resolvers and as such would be able to alter resolvers, and also usually knows passwords of resolvers.
> (The initial issue was, that admins, who only have read access (i.e. all admins) would be able to see the pw).
Thanks, makes sense! I just wanted to make sure that I don't misremember our access role model :-)
> However, the test_resolver endpoint is not limited to those admins, who are allowed to create resolvers. The test endpoint can be used by any admin. The admin could use the test endpoint to brute force the resolver password. well, he could brute force the password by any other means.
> Nevertheless: Do you think we should restrict the test endpoint to only admins, that have resolver-create-right?
Hm! Up until now, the "test resolver" endpoint didn't really deal with sensitive information, it just carried out e.g. a LDAP BIND request. But with this PR, it *does* access the password of the resolver given in ``resolver``. Maybe it would be better to restrict the endpoint to admins then. If I understand correctly, this wouldn't really affect the Web UI because only admins can see the "test resolver" button anyway, right? What do you think?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> >
> Hm! Up until now, the "test resolver" endpoint didn't really deal with sensitive information, it just carried out e.g. a LDAP BIND request. But with this PR, it _does_ access the password of the resolver given in `resolver`. Maybe it would be better to restrict the endpoint to admins then. If I understand correctly, this wouldn't really affect the Web UI because only admins can see the "test resolver" button anyway, right? What do you think?
It does access the password on the server side.
Only admins can use the test resolver endpoint. The complete /resolver endpoints are only accessable for admins. So an admin who is not allowed to create resolvers, could change check other data of a resolver (he can not change the data of the resolver, that is actually used). But he can issue e.g. search requests with a service account against other OUs and this way only find out, how many users are located in a certain OU. This is no big security issue, but...
However, since **there is no sense for this admin to do** so, I would like to restrict the test resolver to admins with the create right.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> > > Hm! Up until now, the "test resolver" endpoint didn't really deal with sensitive information, it just carried out e.g. a LDAP BIND request. But with this PR, it _does_ access the password of the resolver given in `resolver`. Maybe it would be better to restrict the endpoint to admins then. If I understand correctly, this wouldn't really affect the Web UI because only admins can see the "test resolver" button anyway, right? What do you think?
>
> It does access the password on the server side.
> Only admins can use the test resolver endpoint. The complete /resolver endpoints are only accessable for admins. So an admin who is not allowed to create resolvers, could change check other data of a resolver (he can not change the data of the resolver, that is actually used). But he can issue e.g. search requests with a service account against other OUs and this way only find out, how many users are located in a certain OU. This is no big security issue, but...
> However, since **there is no sense for this admin to do** so, I would like to restrict the test resolver to admins with the create right.
done in 9c102a22
- [x] <a href='#crh-comment-Pull ee144bc1406ca19f34f95161f6b03e161bfc2cb9 privacyidea/lib/resolver.py 61'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1341#discussion_r242116871'>File: privacyidea/lib/resolver.py:L223-233</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hmm, I think this actually censors the password in ``config_object.resolver``, which could lead to bugs if the resolver config is used later in the same request, or concurrently by other threads. It would be better to do something like
```python
reso["data"] = reso["data"].copy()
reso["data"][censor_key] = CENSORED
```
... I just noticed we can actually reproduce this: I have a LDAP resolver with a correct password, I click ``Test Connection``, it works. I navigate to another page and back to the LDAP resolver page, I click ``Test Connection`` again and it says "Wrong Credentials" because it tries to authenticate with ``__CENSORED__`` as the bind password :-)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This is obviously the dictionary-reference problem. I think we would simply need a deep copy in the first place here:
https://github.com/privacyidea/privacyidea/blob/1271/hide-ldap-password/privacyidea/lib/resolver.py#L198
Or we might itereate of the resolvers and write the results to `reduced_resolvers` as we did before:
https://github.com/privacyidea/privacyidea/blob/1271/hide-ldap-password/privacyidea/lib/resolver.py#L212
What do you think.
In the meantime I will try to create a testcase for this...
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> The difference to the ``reduced_resolvers`` code above is that we did not modify the actual contents of the resolver config there, so in this case we would need to iterate over the actual resolver config.
Maybe a deep copy would be clearer and less error-prone.
As a middle route, we could also just do the deep copy only if ``censor`` is True, just before line 227.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I added a test case in e95e6536.
It turns out, that it  only works out if I use
~~~~python
import copy
copy.deepcopy(resolvers)
~~~~
I could add a conditional deepcopy at the top:
~~~~python
if censor:
resolvers = copy.deepcopy(config_object.resolver)
else:
resolvers = config_object.resolver
~~~~
The deep copy would only be performed on API resolver GETs. (this is the only case were `censor=True`.) I think this is an acceptable performance impact.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in bc17b555
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I think the deep copy is totally okay. Thanks!
- [x] <a href='#crh-comment-Pull ee144bc1406ca19f34f95161f6b03e161bfc2cb9 privacyidea/lib/config.py 6'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1341#discussion_r242141942'>File: privacyidea/lib/config.py:L124-137</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I chose this on purpose. Imho it is internal and I wanted to avoid any conflict with potential new resolvers.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, but how could a conflict arise? Doesn't the ``resolverdef`` dictionary only contain the keys ``type``, ``resolvername`` and ``data`` (and ``__CENSOR_KEYS__``) in any case?
I think this is not entirely internal, because the standard ``GET /resolver`` endpoint now doesn't return passwords anymore, and the ``__CENSOR_KEYS__`` information will be useful for users of our REST API in order to know which keys are censored.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> interesting aspect. Will change the key accordingly.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in 76ae8895
- [x] <a href='#crh-comment-Pull ee144bc1406ca19f34f95161f6b03e161bfc2cb9 privacyidea/lib/resolver.py 74'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1341#discussion_r242143690'>File: privacyidea/lib/resolver.py:L378-394</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The config should always contain the CENSOR_KEYS. These are loaded right at the beginning in the config object here:
https://github.com/privacyidea/privacyidea/blob/1271/hide-ldap-password/privacyidea/lib/config.py#L128
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Ah okay, but I just realized we should still have ``for key in old_config.get("__CENSOR_KEYS__", [])`` here in case the resolver given in the ``resolver`` parameter does not exist.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> What is the corner case you are thinking of here?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in f853a40d
- [x] <a href='#crh-comment-Pull ee144bc1406ca19f34f95161f6b03e161bfc2cb9 privacyidea/static/components/config/controllers/configControllers.js 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1341#discussion_r242144591'>File: privacyidea/static/components/config/controllers/configControllers.js:L1054-1064</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Yes it has. otherwise it would have no effect...
- [x] <a href='#crh-comment-Pull 9c102a224591176d5059eca74aaa6ff74e172f8a privacyidea/api/resolver.py 23'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1341#discussion_r242199688'>File: privacyidea/api/resolver.py:L55-93</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> There is no builtin type `basestring` in Python 3. I would prefer just `str` because this covers most cases.
What do You think?


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1341?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1341?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1341'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>