### PR TITLE
Always use the first loginname-attribute as Username

### DIFF
--- a/migrations/versions/cb6d7b7bae63_.py
+++ b/migrations/versions/cb6d7b7bae63_.py
@@ -1,0 +1,29 @@
+"""Add column used_login to usercache
+
+Revision ID: cb6d7b7bae63
+Revises: a63df077051a
+Create Date: 2018-12-18 11:59:27.486883
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'cb6d7b7bae63'
+down_revision = 'a63df077051a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    try:
+        op.add_column('usercache', sa.Column('used_login', sa.Unicode(length=64), nullable=True))
+        op.create_index(op.f('ix_usercache_used_login'), 'usercache', ['used_login'], unique=False)
+    except Exception as exx:
+        print('Adding of column "used_login" in table usercache failed: {!r}'.format(exx))
+        print('This is expected behavior if this column already exists.')
+
+
+def downgrade():
+    op.drop_index(op.f('ix_usercache_used_login'), table_name='usercache')
+    op.drop_column('usercache', 'used_login')
+

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -59,7 +59,7 @@ from datetime import (datetime,
 from privacyidea.lib.audit import getAudit
 from privacyidea.lib.auth import check_webui_user, ROLE
 from privacyidea.lib.user import User
-from privacyidea.lib.user import split_user
+from privacyidea.lib.user import split_user, log_used_user
 from privacyidea.lib.policy import PolicyClass
 from privacyidea.lib.realm import get_default_realm
 from privacyidea.api.lib.postpolicy import postpolicy, get_webui_settings
@@ -179,10 +179,18 @@ def get_auth_token():
     password = getParam(request.all_data, "password")
     realm = getParam(request.all_data, "realm")
     details = {}
+
+    if username is None:
+        raise AuthError(_("Authentication failure. Missing Username"),
+                        id=ERROR.AUTHENTICATE_MISSING_USERNAME)
+
     if realm:
         username = username + "@" + realm
 
-    g.audit_object.log({"user": username})
+    # Failsafe to have the user attempt in the log, whatever happens
+    # This can be overwritten later
+    g.audit_object.log({"user": username,
+                        "realm": realm})
 
     secret = current_app.secret_key
     superuser_realms = current_app.config.get("SUPERUSER_REALM", [])
@@ -194,9 +202,6 @@ def get_auth_token():
     # "pi" = The admin or the user is authenticated against privacyIDEA
     # "remote_user" = authenticated by webserver
     authtype = "password"
-    if username is None:
-        raise AuthError(_("Authentication failure. Missing Username"),
-                        id=ERROR.AUTHENTICATE_MISSING_USERNAME)
     # Verify the password
     admin_auth = False
     user_auth = False
@@ -222,6 +227,9 @@ def get_auth_token():
         else:
             # check, if the user exists
             user_obj = User(loginname, realm)
+            g.audit_object.log({"user": user_obj.login,
+                                "realm": user_obj.realm,
+                                "info": log_used_user(user_obj)})
             if user_obj.exist():
                 user_auth = True
                 if user_obj.realm in superuser_realms:
@@ -254,7 +262,13 @@ def get_auth_token():
                                                     superuser_realms)
         if role == ROLE.ADMIN:
             g.audit_object.log({"user": "",
-                                "administrator": username})
+                                "administrator": user_obj.login,
+                                "realm": user_obj.realm,
+                                "info": log_used_user(user_obj)})
+        else:
+            g.audit_object.log({"user": user_obj.login,
+                                "realm": user_obj.realm,
+                                "info": log_used_user(user_obj)})
 
     if not admin_auth and not user_auth:
         raise AuthError(_("Authentication failure. Wrong credentials"),

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -138,6 +138,9 @@ def before_request():
 
     try:
         request.User = get_user_from_param(request.all_data)
+        # overwrite or set the resolver parameter in case of a logged in user
+        if g.logged_in_user.get("role") == "user":
+            request.all_data["resolver"] = request.User.resolver
     except AttributeError:
         # Some endpoints do not need users OR e.g. the setPolicy endpoint
         # takes a list as the userobject

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -162,14 +162,20 @@ def before_request():
     else:
         tokentype = None
 
-    realm = getParam(request.all_data, "realm")
-    resolver = getParam(request.all_data, "resolver")
+    if request.User:
+        audit_username = request.User.login
+        audit_realm = request.User.realm
+        audit_resolver = request.User.resolver
+    else:
+        audit_realm = getParam(request.all_data, "realm")
+        audit_resolver = getParam(request.all_data, "resolver")
+        audit_username = getParam(request.all_data, "user")
 
     g.audit_object.log({"success": False,
                         "serial": serial,
-                        "user": request.User.login,
-                        "realm": request.User.realm or realm,
-                        "resolver": request.User.resolver or resolver,
+                        "user": audit_username,
+                        "realm": audit_realm,
+                        "resolver": audit_resolver,
                         "token_type": tokentype,
                         "client": g.client_ip,
                         "client_user_agent": request.user_agent.browser,

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -249,7 +249,7 @@ def init():
     #    log.debug("setting tokenrealm %s" % res['realms'])
     #    tokenrealm = res['realms']
 
-    user = get_user_from_param(param)
+    user = request.User
     tokenobject = init_token(param,
                              user,
                              tokenrealms=tokenrealms)
@@ -353,7 +353,7 @@ def list_api():
     :rtype: json
     """
     param = request.all_data
-    user = get_user_from_param(param, optional)
+    user = request.User
     serial = getParam(param, "serial", optional)
     page = int(getParam(param, "page", optional, default=1))
     tokentype = getParam(param, "type", optional)
@@ -444,7 +444,7 @@ def unassign_api():
     :return: In case of success it returns the number of unassigned tokens in "value".
     :rtype: JSON object
     """
-    user = get_user_from_param(request.all_data, optional)
+    user = request.User
     serial = getParam(request.all_data, "serial", optional)
     g.audit_object.log({"serial": serial})
 
@@ -474,7 +474,7 @@ def revoke_api(serial=None):
         tokens in "value".
     :rtype: JSON object
     """
-    user = get_user_from_param(request.all_data, optional)
+    user = request.User
     if not serial:
         serial = getParam(request.all_data, "serial", optional)
     g.audit_object.log({"serial": serial})
@@ -502,7 +502,7 @@ def enable_api(serial=None):
         tokens in "value".
     :rtype: json object
     """
-    user = get_user_from_param(request.all_data, optional)
+    user = request.User
     if not serial:
         serial = getParam(request.all_data, "serial", optional)
     g.audit_object.log({"serial": serial})
@@ -532,7 +532,7 @@ def disable_api(serial=None):
         tokens in "value".
     :rtype: json object
     """
-    user = get_user_from_param(request.all_data, optional)
+    user = request.User
     if not serial:
         serial = getParam(request.all_data, "serial", optional)
     g.audit_object.log({"serial": serial})
@@ -559,7 +559,7 @@ def delete_api(serial):
     """
     # If the API is called by a user, we pass the User Object to the function
     g.audit_object.log({"serial": serial})
-    user = get_user_from_param(request.all_data)
+    user = request.User
     res = remove_token(serial, user=user)
     g.audit_object.log({"success": True})
     return send_result(res)
@@ -580,7 +580,7 @@ def reset_api(serial=None):
     :return: In case of success it returns "value"=True
     :rtype: json object
     """
-    user = get_user_from_param(request.all_data, optional)
+    user = request.User
     if not serial:
         serial = getParam(request.all_data, "serial", optional)
     g.audit_object.log({"serial": serial})
@@ -605,7 +605,7 @@ def resync_api(serial=None):
     :return: In case of success it returns "value"=True
     :rtype: json object
     """
-    user = get_user_from_param(request.all_data, optional)
+    user = request.User
     if not serial:
         serial = getParam(request.all_data, "serial", required)
     g.audit_object.log({"serial": serial})
@@ -647,7 +647,7 @@ def setpin_api(serial=None):
     userpin = getParam(request.all_data, "userpin")
     sopin = getParam(request.all_data, "sopin")
     otppin = getParam(request.all_data, "otppin")
-    user = get_user_from_param(request.all_data)
+    user = request.User
     encrypt_pin = getParam(request.all_data, "encryptpin")
 
     res = 0
@@ -703,7 +703,7 @@ def set_api(serial=None):
     if not serial:
         serial = getParam(request.all_data, "serial", required)
     g.audit_object.log({"serial": serial})
-    user = get_user_from_param(request.all_data)
+    user = request.User
 
     description = getParam(request.all_data, "description")
     count_window = getParam(request.all_data, "count_window")
@@ -974,7 +974,7 @@ def lost_api(serial=None):
     """
     # check if a user is given, that the user matches the token owner.
     g.audit_object.log({"serial": serial})
-    userobj = get_user_from_param(request.all_data)
+    userobj = request.User
     if userobj:
         toks = get_tokens(serial=serial, user=userobj)
         if not toks:

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -326,7 +326,6 @@ def check():
     .. note:: All challenge response tokens have the same transaction_id in
        this case.
     """
-    #user = get_user_from_param(request.all_data)
     user = request.User
     serial = getParam(request.all_data, "serial")
     password = getParam(request.all_data, "pass", required)
@@ -420,7 +419,7 @@ def samlcheck():
     (like "myOwn") which you can define in the LDAP resolver in the attribute
     mapping.
     """
-    user = get_user_from_param(request.all_data)
+    user = request.User
     password = getParam(request.all_data, "pass", required)
     options = {"g": g,
                "clientip": g.client_ip}

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -110,6 +110,10 @@ log = logging.getLogger(__name__)
 validate_blueprint = Blueprint('validate_blueprint', __name__)
 
 
+def _log_used_user(used_login, loginname, other_text):
+    return u"logged in as {0}. {1}".format(used_login, other_text) if used_login != loginname else other_text
+
+
 @validate_blueprint.before_request
 @register_blueprint.before_request
 @recover_blueprint.before_request
@@ -351,7 +355,7 @@ def check():
     else:
         result, details = check_user_pass(user, password, options=options)
 
-    g.audit_object.log({"info": details.get("message"),
+    g.audit_object.log({"info": _log_used_user(user.used_login, user.login, details.get("message")),
                         "success": result,
                         "serial": serial or details.get("serial"),
                         "tokentype": details.get("type")})
@@ -449,7 +453,7 @@ def samlcheck():
             for k, v in ui.items():
                 result_obj["attributes"][k] = v
 
-    g.audit_object.log({"info": details.get("message"),
+    g.audit_object.log({"info": _log_used_user(user.used_login, user.login, details.get("message")),
                         "success": auth,
                         "serial": details.get("serial"),
                         "tokentype": details.get("type"),
@@ -562,7 +566,7 @@ def trigger_challenge():
         "resolver": user.resolver,
         "realm": user.realm,
         "success": result_obj > 0,
-        "info": "triggered {0!s} challenges".format(result_obj),
+        "info": _log_used_user(user.used_login, user.login, "triggered {0!s} challenges".format(result_obj))
     })
 
     return send_result(result_obj, details=details)

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -65,7 +65,7 @@ In case if authenitcating a serial number:
 
 """
 from flask import (Blueprint, request, g, current_app)
-from privacyidea.lib.user import get_user_from_param
+from privacyidea.lib.user import get_user_from_param, log_used_user
 from .lib.utils import send_result, getParam
 from ..lib.decorators import (check_user_or_serial_in_request)
 from .lib.utils import required
@@ -108,10 +108,6 @@ import json
 log = logging.getLogger(__name__)
 
 validate_blueprint = Blueprint('validate_blueprint', __name__)
-
-
-def _log_used_user(used_login, loginname, other_text):
-    return u"logged in as {0}. {1}".format(used_login, other_text) if used_login != loginname else other_text
 
 
 @validate_blueprint.before_request
@@ -355,7 +351,7 @@ def check():
     else:
         result, details = check_user_pass(user, password, options=options)
 
-    g.audit_object.log({"info": _log_used_user(user.used_login, user.login, details.get("message")),
+    g.audit_object.log({"info": log_used_user(user, details.get("message")),
                         "success": result,
                         "serial": serial or details.get("serial"),
                         "tokentype": details.get("type")})
@@ -453,7 +449,7 @@ def samlcheck():
             for k, v in ui.items():
                 result_obj["attributes"][k] = v
 
-    g.audit_object.log({"info": _log_used_user(user.used_login, user.login, details.get("message")),
+    g.audit_object.log({"info": log_used_user(user, details.get("message")),
                         "success": auth,
                         "serial": details.get("serial"),
                         "tokentype": details.get("type"),
@@ -566,7 +562,7 @@ def trigger_challenge():
         "resolver": user.resolver,
         "realm": user.realm,
         "success": result_obj > 0,
-        "info": _log_used_user(user.used_login, user.login, "triggered {0!s} challenges".format(result_obj))
+        "info": log_used_user(user, "triggered {0!s} challenges".format(result_obj))
     })
 
     return send_result(result_obj, details=details)

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -248,7 +248,6 @@ class IdResolver (UserIdResolver):
 
     # If the resolver could be configured editable
     updateable = True
-    support_multiple_loginnames = True
 
     def __init__(self):
         self.i_am_bound = False
@@ -750,6 +749,14 @@ class IdResolver (UserIdResolver):
         self.serverpool_skip = int(config.get("SERVERPOOL_SKIP") or SERVERPOOL_SKIP)
 
         return self
+
+    @property
+    def has_multiple_loginnames(self):
+        """
+        Return if this resolver has multiple loginname attributes
+        :return: bool
+        """
+        return len(self.loginname_attribute) > 1
 
     @staticmethod
     def split_uri(uri):

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -248,6 +248,7 @@ class IdResolver (UserIdResolver):
 
     # If the resolver could be configured editable
     updateable = True
+    support_multiple_loginnames = True
 
     def __init__(self):
         self.i_am_bound = False

--- a/privacyidea/lib/resolvers/UserIdResolver.py
+++ b/privacyidea/lib/resolvers/UserIdResolver.py
@@ -63,7 +63,6 @@ class UserIdResolver(object):
 
     # If the resolver could be configured editable
     updateable = False
-    support_multiple_loginnames = False
 
     def close(self):
         """
@@ -274,5 +273,13 @@ class UserIdResolver(object):
         """
         Return true, if the Instance! of this resolver is configured editable.
         :return:
+        """
+        return False
+
+    @property
+    def has_multiple_loginnames(self):
+        """
+        Return if this resolver has multiple loginname attributes
+        :return: bool
         """
         return False

--- a/privacyidea/lib/resolvers/UserIdResolver.py
+++ b/privacyidea/lib/resolvers/UserIdResolver.py
@@ -63,6 +63,7 @@ class UserIdResolver(object):
 
     # If the resolver could be configured editable
     updateable = False
+    support_multiple_loginnames = False
 
     def close(self):
         """
@@ -114,7 +115,6 @@ class UserIdResolver(object):
         :rtype:  dict
         """
         return UserIdResolver.getResolverClassDescriptor()
-
 
     def getUserId(self, loginName):
         """

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -87,6 +87,7 @@ class User(object):
 
     def __init__(self, login="", realm="", resolver=""):
         self.login = login or ""
+        self.used_login = ""
         self.realm = (realm or "").lower()
         if resolver == "**":
             resolver = ""
@@ -112,6 +113,10 @@ class User(object):
                 raise UserError("The resolver '{0!s}' does not exist!".format(
                     self.resolver))
             self.uid = y.getUserId(self.login)
+            if y.support_multiple_loginnames:
+                # In case the used loginname was not the primary loginname!
+                self.used_login = self.login
+                self.login = y.getUsername(self.uid)
 
     def is_empty(self):
         # ignore if only resolver is set! as it makes no sense

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -113,9 +113,8 @@ class User(object):
                 raise UserError("The resolver '{0!s}' does not exist!".format(
                     self.resolver))
             self.uid = y.getUserId(self.login)
-            if y.support_multiple_loginnames:
-                # In case the used loginname was not the primary loginname!
-                self.used_login = self.login
+            if y.has_multiple_loginnames:
+                # In this case the primary login might be another value!
                 self.login = y.getUsername(self.uid)
 
     def is_empty(self):
@@ -135,7 +134,6 @@ class User(object):
         :return: True or False
         :rtype: bool
         """
-        # TODO: Should we add a check for `uid` here?
         return isinstance(other, type(self)) and (self.login == other.login) and (
                 self.resolver == other.resolver) and (self.realm == other.realm)
 

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -87,7 +87,7 @@ class User(object):
 
     def __init__(self, login="", realm="", resolver=""):
         self.login = login or ""
-        self.used_login = ""
+        self.used_login = self.login
         self.realm = (realm or "").lower()
         if resolver == "**":
             resolver = ""

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -715,3 +715,15 @@ def get_username(userid, resolvername):
             username = y.getUsername(userid)
     return username
 
+
+def log_used_user(user, other_text=""):
+    """
+    This creates a log message combined of a user and another text.
+    The user information is only added, if user.login != user.used_login
+
+    :param user: A user to log
+    :type user:  User object
+    :param other_text: Some additional text
+    :return: str
+    """
+    return u"logged in as {0}. {1}".format(user.used_login, other_text) if user.used_login != user.login else other_text

--- a/privacyidea/lib/usercache.py
+++ b/privacyidea/lib/usercache.py
@@ -72,6 +72,7 @@ def get_cache_time():
     seconds = int(get_from_config(EXPIRATION_SECONDS, '0'))
     return datetime.timedelta(seconds=seconds)
 
+
 def is_cache_enabled():
     """
     :return: True if the user cache is enabled (i.e. UserCacheExpiration is non-zero)
@@ -101,20 +102,21 @@ def delete_user_cache(resolver=None, username=None, expired=None):
     return rowcount
 
 
-def add_to_cache(username, resolver, user_id):
+def add_to_cache(username, used_login, resolver, user_id):
     """
     Add the given record to the user cache, if it is enabled.
     The user cache is considered disabled if the config option
     EXPIRATION_SECONDS is set to 0.
     :param username: login name of the user
+    :param used_login: login name that was used in request
     :param resolver: resolver name of the user
     :param user_id: ID of the user in its resolver
     """
     if is_cache_enabled():
         timestamp = datetime.datetime.now()
-        record = UserCache(username, resolver, user_id, timestamp)
-        log.debug('Adding record to cache: ({!r}, {!r}, {!r}, {!r})'.format(
-            username, resolver, user_id, timestamp))
+        record = UserCache(username, used_login, resolver, user_id, timestamp)
+        log.debug('Adding record to cache: ({!r}, {!r}, {!r}, {!r}, {!r})'.format(
+            username, used_login, resolver, user_id, timestamp))
         record.save()
 
 
@@ -127,13 +129,14 @@ def retrieve_latest_entry(filter_condition):
     return UserCache.query.filter(filter_condition).order_by(UserCache.timestamp.desc()).first()
 
 
-def create_filter(username=None, resolver=None,
+def create_filter(username=None, used_login=None, resolver=None,
                   user_id=None, expired=False):
     """
     Build and return a SQLAlchemy query that searches the UserCache cache for a combination
     of username, resolver and user ID. This also takes the expiration time into account.
 
     :param username: will filter for username
+    :param used_login: will filter for used_login
     :param resolver: will filter for this resolver name
     :param user_id: will filter for this user ID
     :param expired: Can be True/False/None. If set to False will return
@@ -153,6 +156,8 @@ def create_filter(username=None, resolver=None,
 
     if username:
         conditions.append(UserCache.username == username)
+    if used_login:
+        conditions.append(UserCache.used_login == used_login)
     if resolver:
         conditions.append(UserCache.resolver == resolver)
     if user_id:
@@ -181,7 +186,7 @@ def cache_username(wrapped_function, userid, resolvername):
         username = wrapped_function(userid, resolvername)
         if username:
             # If we could figure out a user name, add the record to the cache.
-            add_to_cache(username, resolvername, userid)
+            add_to_cache(username, username, resolvername, userid)
         return username
 
 
@@ -200,7 +205,7 @@ def user_init(wrapped_function, self):
         resolvers = self.get_ordererd_resolvers()
     for resolvername in resolvers:
         # If we could figure out a resolver, we can query the user cache
-        filter_conditions = create_filter(username=self.login, resolver=resolvername)
+        filter_conditions = create_filter(used_login=self.used_login, resolver=resolvername)
         result = retrieve_latest_entry(filter_conditions)
         if result:
             # Cached user exists, retrieve information and exit early
@@ -225,7 +230,7 @@ def user_init(wrapped_function, self):
     # We need to get additional information from the userstore.
     wrapped_function(self)
     # If the user object is complete, add it to the cache.
-    if self.login and self.resolver and self.uid:
+    if self.login and self.resolver and self.uid and self.used_login:
         # We only cache complete sets!
-        add_to_cache(self.login, self.resolver, self.uid)
+        add_to_cache(self.login, self.used_login, self.resolver, self.uid)
 

--- a/privacyidea/lib/usercache.py
+++ b/privacyidea/lib/usercache.py
@@ -209,6 +209,7 @@ def user_init(wrapped_function, self):
         result = retrieve_latest_entry(filter_conditions)
         if result:
             # Cached user exists, retrieve information and exit early
+            self.login = result.username
             self.resolver = result.resolver
             self.uid = result.user_id
             return

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2485,12 +2485,14 @@ class UserCache(MethodsMixin, db.Model):
     __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("usercache_seq"), primary_key=True)
     username = db.Column(db.Unicode(64), default=u"", index=True)
+    used_login = db.Column(db.Unicode(64), default=u"", index=True)
     resolver = db.Column(db.Unicode(120), default=u'')
     user_id = db.Column(db.Unicode(320), default=u'', index=True)
     timestamp = db.Column(db.DateTime)
 
-    def __init__(self, username, resolver, user_id, timestamp):
+    def __init__(self, username, used_login, resolver, user_id, timestamp):
         self.username = username
+        self.used_login = used_login
         self.resolver = resolver
         self.user_id = user_id
         self.timestamp = timestamp

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -369,10 +369,8 @@ class APISelfserviceTestCase(MyTestCase):
 
         # Check, who is the owner of the new token!
         tokenobject = get_tokens(serial=serial)[0]
-        self.assertTrue(tokenobject.token.user_id == "1004",
-                        tokenobject.token.user_id)
-        self.assertTrue(tokenobject.token.resolver == "resolver1",
-                        tokenobject.token.resolver == "resolver1")
+        self.assertEqual(tokenobject.token.user_id, "1004")
+        self.assertEqual(tokenobject.token.resolver, "resolver1")
 
         # user can delete his own token
         with self.app.test_request_context('/token/{0!s}'.format(serial),

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -653,7 +653,7 @@ class TokenModelTestCase(MyTestCase):
         timestamp = datetime.now()
 
         # create a user in the cache
-        cached_user = UserCache(username, resolver, user_id, timestamp)
+        cached_user = UserCache(username, username, resolver, user_id, timestamp)
         self.assertTrue(cached_user)
         cached_user.save()
 
@@ -664,6 +664,14 @@ class TokenModelTestCase(MyTestCase):
         self.assertEqual(find_user.user_id, str(user_id))
         self.assertEqual(find_user.resolver, resolver)
         self.assertEqual(find_user.timestamp, timestamp)  # TODO: Sensible, or might we have a small loss of precision?
+
+        # search the user by his used_login
+        # search a user in the cache
+        find_user = UserCache.query.filter(UserCache.used_login ==
+                                           username).first()
+        self.assertTrue(find_user)
+        self.assertEqual(find_user.user_id, str(user_id))
+        self.assertEqual(find_user.resolver, resolver)
 
         # delete the user from the cache
         r = find_user.delete()

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -1925,7 +1925,6 @@ class LDAPResolverTestCase(MyTestCase):
             mock_search.assert_called_once()
 
 
-
 class BaseResolverTestCase(MyTestCase):
 
     def test_00_basefunctions(self):

--- a/tests/test_lib_usercache.py
+++ b/tests/test_lib_usercache.py
@@ -80,7 +80,7 @@ class UserCacheTestCase(MyTestCase):
         uid = "1"
 
         expiration_delta = get_cache_time()
-        r = UserCache(username, resolver, uid, datetime.now()).save()
+        r = UserCache(username, username, resolver, uid, datetime.now()).save()
         u_name = get_username(uid, resolver)
         self.assertEqual(u_name, username)
 
@@ -112,7 +112,7 @@ class UserCacheTestCase(MyTestCase):
         self._delete_realm()
 
         # manually re-add the entry from above
-        UserCache(entry.username, entry.resolver, entry.user_id, entry.timestamp).save()
+        UserCache(entry.username, entry.username, entry.resolver, entry.user_id, entry.timestamp).save()
 
         # the username is fetched from the cache
         u_name = get_username(self.uid, self.resolvername1)
@@ -151,7 +151,7 @@ class UserCacheTestCase(MyTestCase):
         self._delete_realm()
 
         # manually re-add the entry from above
-        UserCache(entry.username, entry.resolver, entry.user_id, entry.timestamp).save()
+        UserCache(entry.username, entry.username, entry.resolver, entry.user_id, entry.timestamp).save()
 
         # the username is fetched from the cache
         u_name = get_username(self.uid, self.resolvername1)
@@ -177,8 +177,8 @@ class UserCacheTestCase(MyTestCase):
 
     def test_04_delete_cache(self):
         now = datetime.now()
-        UserCache("hans1", "resolver1", "uid1", now).save()
-        UserCache("hans2", "resolver2", "uid2", now).save()
+        UserCache("hans1", "hans1", "resolver1", "uid1", now).save()
+        UserCache("hans2", "hans1", "resolver2", "uid2", now).save()
 
         r = UserCache.query.filter(UserCache.username == "hans1").first()
         self.assertTrue(r)
@@ -202,8 +202,8 @@ class UserCacheTestCase(MyTestCase):
     def test_05_multiple_entries(self):
         # two consistent entries
         now = datetime.now()
-        UserCache("hans1", "resolver1", "uid1", now - timedelta(seconds=60)).save()
-        UserCache("hans1", "resolver1", "uid1", now).save()
+        UserCache("hans1", "hans1", "resolver1", "uid1", now - timedelta(seconds=60)).save()
+        UserCache("hans1", "hans1", "resolver1", "uid1", now).save()
 
         r = UserCache.query.filter(UserCache.username == "hans1", UserCache.resolver == "resolver1")
         self.assertEquals(r.count(), 2)
@@ -214,8 +214,8 @@ class UserCacheTestCase(MyTestCase):
         r = delete_user_cache()
 
         # two inconsistent entries: most recent entry (ordered by datetime) wins
-        UserCache("hans2", "resolver1", "uid1", now).save()
-        UserCache("hans1", "resolver1", "uid1", now - timedelta(seconds=60)).save()
+        UserCache("hans2", "hans2", "resolver1", "uid1", now).save()
+        UserCache("hans1", "hans1", "resolver1", "uid1", now - timedelta(seconds=60)).save()
 
         r = UserCache.query.filter(UserCache.user_id == "uid1", UserCache.resolver == "resolver1")
         self.assertEquals(r.count(), 2)
@@ -242,7 +242,8 @@ class UserCacheTestCase(MyTestCase):
 
         # testing `User()`, but this time we add an already-expired entry to the cache
         self.assertEquals(UserCache.query.count(), 0)
-        UserCache(self.username, self.resolvername1, 'fake_uid', datetime.now() - timedelta(weeks=50)).save()
+        UserCache(self.username, self.username,
+                  self.resolvername1, 'fake_uid', datetime.now() - timedelta(weeks=50)).save()
         # cache contains an expired entry, uid is read from the resolver (we can verify
         # that the cache entry is indeed not queried as it contains 'fake_uid' instead of the correct uid)
         user = User(self.username, self.realm1, self.resolvername1)
@@ -260,9 +261,9 @@ class UserCacheTestCase(MyTestCase):
         self.assertEquals(UserCache.query.count(), 0)
         # initially populate the cache with three entries
         timestamp = datetime.now()
-        UserCache("hans1", self.resolvername1, "uid1", timestamp).save()
-        UserCache("hans2", self.resolvername1, "uid2", timestamp - timedelta(weeks=50)).save()
-        UserCache("hans3", "resolver2", "uid2", timestamp).save()
+        UserCache("hans1", "hans1", self.resolvername1, "uid1", timestamp).save()
+        UserCache("hans2", "hans2", self.resolvername1, "uid2", timestamp - timedelta(weeks=50)).save()
+        UserCache("hans3", "hans3", "resolver2", "uid2", timestamp).save()
         self.assertEquals(UserCache.query.count(), 3)
 
     def test_07_invalidate_save_resolver(self):
@@ -364,8 +365,8 @@ class UserCacheTestCase(MyTestCase):
         self.assertTrue(r >= 0)
         # populate the cache with artificial, somewhat "old", but still relevant data
         timestamp = datetime.now() - timedelta(seconds=300)
-        UserCache("hans1", "resolver1", "uid1", timestamp).save()
-        UserCache("hans2", "resolver1", "uid2", timestamp).save()
+        UserCache("hans1", "hans1", "resolver1", "uid1", timestamp).save()
+        UserCache("hans2", "hans2", "resolver1", "uid2", timestamp).save()
         # check that the cache is indeed queried
         self.assertEqual(get_username("uid1", "resolver1"), "hans1")
         self.assertEqual(User("hans2", "realm1", "resolver1").uid, "uid2")
@@ -388,7 +389,7 @@ class UserCacheTestCase(MyTestCase):
                 User("hans2", "realm1", "resolver1")
             self.assertEqual(get_username("uid3", "resolver1"), "")
             # We add another, "current" entry
-            UserCache("hans4", "resolver1", "uid4", datetime.now()).save()
+            UserCache("hans4", "hans4", "resolver1", "uid4", datetime.now()).save()
             self.assertEqual(UserCache.query.count(), 3)
             # we now remove old entries, only the newest remains
             delete_user_cache(expired=True)
@@ -452,6 +453,23 @@ class UserCacheTestCase(MyTestCase):
         delete_realm(self.sql_realm)
         delete_resolver('reso_a')
         delete_resolver('reso_b')
+
+    def test_13_cache_username(self):
+
+        self.counter = 0
+
+        def get_username(uid, resolver):
+            self.counter += 1
+            return "user1"
+
+        r = cache_username(get_username, "uid1", "reso1")
+        self.assertEqual(r, "user1")
+        self.assertEqual(self.counter, 1)
+
+        # The second call does not increase the counter, since the result is fetched from the cache
+        r = cache_username(get_username, "uid1", "reso1")
+        self.assertEqual(r, "user1")
+        self.assertEqual(self.counter, 1)
 
     def test_99_unset_config(self):
         # Test early exit!

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -531,4 +531,3 @@ class UtilsTestCase(MyTestCase):
         # Fails if the package does not exist
         with self.assertRaises(ImportError):
             get_module_class("privacyidea.lib.auditmodules.doesnotexist", "Aduit")
-


### PR DESCRIPTION
The LDAP Resolver always uses the first login attribute
as internal username. I.e. the User object is created with
the first login attribute, even if the user logs in with
the secondary (or a third...) attribute.
This way we get a consistent audit log.

The audit-info field contains the information, which login attribute
was acually used for login.

Closes #1082
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23issuecomment-447809748%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242137897%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23issuecomment-447845076%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242148271%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242183551%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242184141%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23issuecomment-448163346%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242519686%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242873741%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242875356%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242878537%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242890512%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242906151%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242909997%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242954140%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243205256%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243205768%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243210721%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243245518%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243246957%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243277225%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243277325%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23issuecomment-449037080%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243558030%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243564058%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243564352%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243564548%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243565427%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243570176%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243571766%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243573369%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243573391%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243574942%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23issuecomment-449382840%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23issuecomment-447809748%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231343%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231343%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2096.38%25%20%20%2096.38%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017300%20%20%20%2017308%20%20%20%20%20%20%20%2B8%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016674%20%20%20%2016682%20%20%20%20%20%20%20%2B8%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20626%20%20%20%20%20%20626%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/UserIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9Vc2VySWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/user.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3VzZXIucHk%3D%29%20%7C%20%6099.33%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/resolvers/LDAPIdResolver.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ%3D%3D%29%20%7C%20%6093.42%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/validate.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3ZhbGlkYXRlLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bc71da1d...6ea131a%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1343%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-17T11%3A14%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Another%20thing%3A%20I%20just%20noticed%20this%20doesn%27t%20work%20with%20the%20%60%60/auth%60%60%20endpoint%20because%20it%20writes%20the%20given%20username%20to%20the%20audit%20log%2C%20not%20%60%60user.login%60%60%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda/privacyidea/api/auth.py%23L185%5Cr%5CnShould%20we%20implement%20the%20feature%20here%20too%3F%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A27%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Another%20thing%3A%20I%20just%20noticed%20this%20doesn%27t%20work%20with%20the%20%60/auth%60%20endpoint%20because%20it%20writes%20the%20given%20username%20to%20the%20audit%20log%2C%20not%20%60user.login%60%3A%5Cr%5Cn%3E%20%5Bprivacyidea/privacyidea/api/auth.py%5D%28https%3A//github.com/privacyidea/privacyidea/blob/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda/privacyidea/api/auth.py%23L185%29%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20Line%20185%20in%20%5Bc71da1d%5D%28/privacyidea/privacyidea/commit/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda%29%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20%20g.audit_object.log%28%7B%5C%22user%5C%22%3A%20username%7D%29%20%5Cr%5Cn%3E%20%5Cr%5Cn%3E%20Should%20we%20implement%20the%20feature%20here%20too%3F%5Cr%5Cn%5Cr%5Cndone%20in%20dfbadf3a%22%2C%20%22created_at%22%3A%20%222018-12-18T09%3A57%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%2027611862%20%20should%20fix%20%2Aeverything%2A%22%2C%20%22created_at%22%3A%20%222018-12-20T15%3A32%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20opened%20%231354%20so%20I%20don%27t%20forget%20to%20add%20a%20unit%20test.%20Merging%20this%20%3Achristmas_tree%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-21T13%3A02%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f64a4c125160c988eb1d6c5b90cbaf61fa9db021%20privacyidea/api/before_after.py%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243245518%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20moved%20the%20whole%20user%20thingy%20up.%20This%20is%20%2Aonly%2A%20for%20the%20case%2C%20if%20the%20user%20is%20logged%20in.%5Cr%5CnThe%20thing%20is%2C%20that%20the%20%60%60g.logged_in_user%60%60%20does%20not%20contain%20a%20resolver%21%5Cr%5Cn%5Cr%5CnRight%20after%20this%20code%20you%20see%3A%5Cr%5Cn%5Cr%5Cn%7E%7E%7Epython%5Cr%5Cn%20%20%20%20if%20g.logged_in_user.get%28%5C%22role%5C%22%29%20%3D%3D%20%5C%22user%5C%22%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20A%20user%20is%20calling%20this%20API.%20First%20thing%20we%20do%20is%20restricting%20the%20user%20parameter.%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20...to%20restrict%20token%20view%2C%20audit%20view%20or%20token%20actions.%5Cr%5Cn%20%20%20%20%20%20%20%20request.all_data%5B%5C%22user%5C%22%5D%20%3D%20g.logged_in_user.get%28%5C%22username%5C%22%29%5Cr%5Cn%20%20%20%20%20%20%20%20request.all_data%5B%5C%22realm%5C%22%5D%20%3D%20g.logged_in_user.get%28%5C%22realm%5C%22%29%5Cr%5Cn%5Cr%5Cn%20%20%20%20try%3A%5Cr%5Cn%20%20%20%20%20%20%20%20request.User%20%3D%20get_user_from_param%28request.all_data%29%5Cr%5Cn%7E%7E%7E%5Cr%5CnThis%20is%20the%20important%20part.%20%60%60request.User%60%60%20now%20contains%20a%20complete%20User%20Object%20including%20the%20resolver%21%5Cr%5CnAnd%20after%20this%20we%20only%20work%20with%20%60%60request.User%60%60.%20So%20to%20my%20understanding%20this%20is%20totally%20fine.%22%2C%20%22created_at%22%3A%20%222018-12-20T11%3A52%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20this%20does%20not%20need%20to%20be%20change.%20Otherwise%20take%20a%20look%20at%20%20916c01da%22%2C%20%22created_at%22%3A%20%222018-12-20T13%3A50%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%2C%20I%20still%20think%20there%20is%20a%20remaining%20problem%3A%5Cr%5CnIn%20case%20the%20currently%20logged%20in%20user%27s%20role%20is%20%60%60user%60%60%2C%20we%20do%20not%20set%20%60%60request.all_data%5B%5C%22resolver%5C%22%5D%60%60%20to%20the%20user%27s%20resolver%20anymore%20%28the%20corresponding%20line%20from%20below%20was%20removed%29.%20This%20e.g.%20changes%20behavior%20of%20the%20%60%60check_base_action%60%60%20function%2C%20because%20this%20function%20uses%20%60%60request.all_data%5B%5C%22resolver%5C%22%5D%60%60%20to%20match%20policies.%20%22%2C%20%22created_at%22%3A%20%222018-12-21T11%3A29%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20must%20not%20be%20a%20problem%21%5Cr%5CnPolicies%20should/must%20not%20use%20the%20resolver%20information%20from%20the%20request%20data%21%20Because%20usually%20the%20resolver%20is%20not%20contained%20in%20the%20request%20data.%5Cr%5Cn%5Cr%5CnE.g.%20an%20admin%20enrolls%20a%20token%20to%20a%20%2Auser%2A%20%5C%22friedrich%5C%22%20in%20%2Arealm%2A%20%5C%22netknights%5C%22.%20Not%20a%20%2Auser%2A%20%5C%22friedrich%5C%22%20in%20%2Aresolver%2A%20%5C%22developers%5C%22%20in%20%2Arealm%2A%20%5C%22netknights%5C%22.%20If%20this%20worked%20before%2C%20this%20was%20a%20bad%20design%21%20%3B-%29%5Cr%5Cn%5Cr%5CnThis%20is%20why%20initially%20we%20set%20a%20user%20object%20in%20%60%60request.User%60%60.%20And%20in%20an%20ideal%20world%20imho%20this%20should%20be%20used%20afterwars.%20%28Even%20if%20it%20would%20not%20always%20be%20the%20case%29.%20%5Cr%5CnSo%20I%20would%20like%20to%20leave%20it%20that%20way%2C%20even%20if%20we%20change%20the%20behaviour%20at%20certain%20places.%20But%20this%20would%20result%20in%20a%20bad%20design%20at%20the%20other%20places.%5Cr%5Cn%5Cr%5Cn%28And%20also%2C%20the%20%60%60logged_in_user%60%60%20also%20has%20no%20componente%20%5C%22resolver%5C%22.%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-21T12%3A02%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20E.g.%20%60%60check_base_action%60%60%20actually%20uses%20the%20parameter%20%5C%22resolver%5C%22.%22%2C%20%22created_at%22%3A%20%222018-12-21T12%3A03%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20about%20it.%22%2C%20%22created_at%22%3A%20%222018-12-21T12%3A05%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20would%20suggest%20the%20following%3A%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Epython%5Cr%5Cn%20%20%20%20request.all_data%20%3D%20get_all_params%28request.values%2C%20request.data%29%5Cr%5Cn%20%20%20%20if%20g.logged_in_user.get%28%5C%22role%5C%22%29%20%3D%3D%20%5C%22user%5C%22%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20A%20user%20is%20calling%20this%20API.%20First%20thing%20we%20do%20is%20restricting%20the%20user%20parameter.%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20...to%20restrict%20token%20view%2C%20audit%20view%20or%20token%20actions.%5Cr%5Cn%20%20%20%20%20%20%20%20request.all_data%5B%5C%22user%5C%22%5D%20%3D%20g.logged_in_user.get%28%5C%22username%5C%22%29%5Cr%5Cn%20%20%20%20%20%20%20%20request.all_data%5B%5C%22realm%5C%22%5D%20%3D%20g.logged_in_user.get%28%5C%22realm%5C%22%29%5Cr%5Cn%5Cr%5Cn%20%20%20%20try%3A%5Cr%5Cn%20%20%20%20%20%20%20%20request.User%20%3D%20get_user_from_param%28request.all_data%29%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20overwrite%20or%20set%20the%20resolver%20parameter%20in%20case%20of%20a%20logged%20in%20user%5Cr%5Cn%20%20%20%20%20%20%20%20if%20g.logged_in_user.get%28%5C%22role%5C%22%29%20%3D%3D%20%5C%22user%5C%22%3A%20%20%23%23%23%20%3C%3C%3C%3C%3C%3C%20new%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20request.all_data%5B%5C%22resolver%5C%22%5D%20%3D%20request.User.resolver%5Cr%5Cn%20%20%20%20except%20AttributeError%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20Some%20endpoints%20do%20not%20need%20users%20OR%20e.g.%20the%20setPolicy%20endpoint%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20takes%20a%20list%20as%20the%20userobject%5Cr%5Cn%20%20%20%20%20%20%20%20request.User%20%3D%20None%5Cr%5Cn%20%20%20%20except%20UserError%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20In%20cases%20like%20the%20policy%20API%2C%20the%20parameter%20%5C%22user%5C%22%20is%20part%20of%20the%5Cr%5Cn%20%20%20%20%20%20%20%20%23%20policy%20and%20will%20not%20resolve%20to%20a%20user%20object%5Cr%5Cn%20%20%20%20%20%20%20%20request.User%20%3D%20User%28%29%5Cr%5Cn%7E%7E%7E%7E%5Cr%5CnOnly%20if%20the%20the%20role%20user%20is%20logged%20in%2C%20then%20we%20set%20the%20resolver.%20%5Cr%5CnThis%20might%20also%20acutally%20make%20sense%2C%20since%20it%20overwrites%20the%20resolver%2C%20in%20case%20a%20user%20would%20willingly%20set%20a%20wrong%20resolver.%20%5Cr%5Cn%28Previously%20the%20resolver%20also%20was%20only%20set%20for%20users%29%5Cr%5Cn%5Cr%5CnThe%20admin%20is%20free%20to%20choose%20the%20resolver.%22%2C%20%22created_at%22%3A%20%222018-12-21T12%3A10%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-21T12%3A36%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-21T12%3A53%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/before_after.py%3AL141-153%22%7D%2C%20%22Pull%206ea131a5f01516a2273dfa93bf7cc68ca4e1057f%20privacyidea/lib/user.py%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242137897%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Currently%2C%20if%20%60%60y.support_multiple_loginnames%20%3D%3D%20False%60%60%2C%20%60%60self.used_login%60%60%20will%20be%20%60%60%5C%22%5C%22%60%60.%20But%20in%20order%20to%20have%20%60%60_log_used_user%60%60%20return%20the%20correct%20text%2C%20shouldn%27t%20it%20%60%60self.login%60%60%3F%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A04%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20always%20you%20are%20right%21%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A08%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%2069b83c31%22%2C%20%22created_at%22%3A%20%222018-12-17T15%3A09%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-19T10%3A57%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/user.py%3AL113-123%22%7D%2C%20%22Pull%206ea131a5f01516a2273dfa93bf7cc68ca4e1057f%20privacyidea/lib/user.py%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242148271%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20tested%20it%20and%20it%20shouldn%27t%20be%20a%20big%20problem%3A%5Cr%5CnSuppose%20the%20user%20cache%20is%20enabled%20and%20a%20user%20authenticates%20with%20the%20secondary%20login%20name%20attribute.%20This%20will%20add%20a%20user%20cache%20entry%2C%20but%20with%20the%20%2Aprimary%2A%20login%20name%20attribute%20value%21%5Cr%5CnSuppose%20the%20user%20authenticates%20with%20the%20secondary%20login%20name%20attribute%20again.%20The%20user%20cache%20will%20not%20find%20an%20entry%20and%20invoke%20the%20resolver%20again%20to%20find%20the%20user.%5Cr%5Cn%5Cr%5Cn...%20so%20this%20might%20be%20a%20bit%20inefficient%20because%20the%20resolver%20is%20asked%20again%20for%20the%20second%20authentication%20request%2C%20but%20the%20audit%20log%20links%20will%20work%20correctly.%22%2C%20%22created_at%22%3A%20%222018-12-17T13%3A36%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%20faccf140%20%22%2C%20%22created_at%22%3A%20%222018-12-18T12%3A35%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-20T09%3A34%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/user.py%3AL113-123%22%7D%2C%20%22Pull%20f64a4c125160c988eb1d6c5b90cbaf61fa9db021%20privacyidea/api/before_after.py%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r243210721%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20is%20a%20bug%20here%3A%20Because%20this%20line%20is%20removed%2C%20the%20login%20name%2C%20resolver%20and%20realm%20aren%27t%20written%20to%20the%20audit%20log%20anymore%20if%20the%20current%20blueprint%20isn%27t%20%60%60token_blueprint%60%60.%22%2C%20%22created_at%22%3A%20%222018-12-20T09%3A51%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right.%20Since%20the%20code%20was%20simplified%20the%20auditlog%20is%20not%20written%20earlier.%20%5Cr%5CnSo%20we%20can%20simply%20drop%20the%20%60%60if%20%5C%22token_blueprint%60%60%20condition.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-20T11%3A58%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22all%20done%20in%20916c01da%22%2C%20%22created_at%22%3A%20%222018-12-20T13%3A49%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-21T12%3A46%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-21T12%3A53%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/before_after.py%3AL196-203%22%7D%2C%20%22Pull%20faccf14033f2e14936273c276818d06cf76fa61f%20tests/test_lib_usercache.py%20122%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242875356%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hm%2C%20I%20think%20the%20unit%20tests%20only%20cover%20the%20case%20that%20%60%60user.used_login%20%3D%3D%20user.login%60%60.%20Could%20you%20add%20another%20test%20for%20the%20case%20that%20they%20differ%3F%5Cr%5Cn...%20but%20I%20guess%20that%27s%20not%20so%20easy%20because%20the%20unittest%20uses%20the%20SQL%20resolver%20which%20doesn%27t%20support%20multiple%20login%20attributes%20%3A-/%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A02%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22True.%20I%20would%20rather%20like%20to%20refrain%20from%20doing%20this.%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A14%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/test_lib_usercache.py%3AL454-477%22%7D%2C%20%22Pull%20faccf14033f2e14936273c276818d06cf76fa61f%20privacyidea/api/auth.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242890512%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20are%20some%20endpoints%20that%20still%20write%20the%20secondary%20username%20to%20the%20audit%20log%2C%20like%20%60%60/token%60%60%20and%20%60%60/system%60%60.%20Should%20we%20fix%20that%20as%20well%3F%20Maybe%20we%20can%20do%20that%20with%20a%20few%20lines%20in%20%60%60before_after.py%60%60.%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A59%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20can%20not%20see%2C%20where%20this%20would%20happen%20in%20%60/token%60.%5Cr%5Cn%5Cr%5CnThe%20token%20endpoints%20always%20use%20%60user%20%3D%20get_user_from_param%28request.all_data%2C%20required%29%60%20to%20determine%20the%20user%20object%2C%20which%20now%20returns%20the%20primary%20login%20attribute.%5Cr%5Cn%5Cr%5CnAnd%20here%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/1082/secondary-login-attribute/privacyidea/api/before_after.py%23L176%5Cr%5Cnwe%20call%20%60get_user_from_param%60%20which%20creates%20a%20%60User%60%20Object%2C%20that%20now%20will%20contain%20the%20primary%20login.%5Cr%5Cn%5Cr%5Cn%28Besides%20that%20I%20saw%20a%20duplicate%20which%20I%20will%20remove%29%22%2C%20%22created_at%22%3A%20%222018-12-19T13%3A11%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20cleaned%20up%20some%20%60%60get_user_from_param%60%60%20in%20the%20token%20endpoint.%20This%20should%20totally%20be%20fine%21%5Cr%5Cnf64a4c12%20%22%2C%20%22created_at%22%3A%20%222018-12-19T15%3A18%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-21T13%3A01%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/api/auth.py%3AL59-66%22%7D%2C%20%22Pull%20faccf14033f2e14936273c276818d06cf76fa61f%20privacyidea/lib/usercache.py%2076%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1343%23discussion_r242906151%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22thx%21%20Done%20in%20c1ae148c%22%2C%20%22created_at%22%3A%20%222018-12-19T12%3A57%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-20T09%3A33%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/usercache.py%3AL205-212%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1343#issuecomment-447809748'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1343?src=pr&el=h1) Report
> Merging [#1343](https://codecov.io/gh/privacyidea/privacyidea/pull/1343?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1343/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1343?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1343      +/-   ##
==========================================
+ Coverage   96.38%   96.38%   +<.01%
==========================================
Files         144      144
Lines       17300    17308       +8
==========================================
+ Hits        16674    16682       +8
Misses        626      626
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1343?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/resolvers/UserIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1343/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9Vc2VySWRSZXNvbHZlci5weQ==) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/user.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1343/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3VzZXIucHk=) | `99.33% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/resolvers/LDAPIdResolver.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1343/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Jlc29sdmVycy9MREFQSWRSZXNvbHZlci5weQ==) | `93.42% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/api/validate.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1343/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3ZhbGlkYXRlLnB5) | `100% <100%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1343?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1343?src=pr&el=footer). Last update [c71da1d...6ea131a](https://codecov.io/gh/privacyidea/privacyidea/pull/1343?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Another thing: I just noticed this doesn't work with the ``/auth`` endpoint because it writes the given username to the audit log, not ``user.login``:
https://github.com/privacyidea/privacyidea/blob/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda/privacyidea/api/auth.py#L185
Should we implement the feature here too?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> > Another thing: I just noticed this doesn't work with the `/auth` endpoint because it writes the given username to the audit log, not `user.login`:
> [privacyidea/privacyidea/api/auth.py](https://github.com/privacyidea/privacyidea/blob/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda/privacyidea/api/auth.py#L185)
>
> Line 185 in [c71da1d](/privacyidea/privacyidea/commit/c71da1dabfaf3851f7e3fbbc5898f6de79e04dda)
>
>  g.audit_object.log({"user": username})
>
> Should we implement the feature here too?
done in dfbadf3a
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think 27611862  should fix *everything*
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I've opened #1354 so I don't forget to add a unit test. Merging this :christmas_tree:
- [ ] <a href='#crh-comment-Pull faccf14033f2e14936273c276818d06cf76fa61f tests/test_lib_usercache.py 122'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1343#discussion_r242875356'>File: tests/test_lib_usercache.py:L454-477</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, I think the unit tests only cover the case that ``user.used_login == user.login``. Could you add another test for the case that they differ?
... but I guess that's not so easy because the unittest uses the SQL resolver which doesn't support multiple login attributes :-/
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> True. I would rather like to refrain from doing this.
- [x] <a href='#crh-comment-Pull 6ea131a5f01516a2273dfa93bf7cc68ca4e1057f privacyidea/lib/user.py 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1343#discussion_r242137897'>File: privacyidea/lib/user.py:L113-123</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Currently, if ``y.support_multiple_loginnames == False``, ``self.used_login`` will be ``""``. But in order to have ``_log_used_user`` return the correct text, shouldn't it ``self.login``?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> As always you are right!
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in 69b83c31
- [x] <a href='#crh-comment-Pull 6ea131a5f01516a2273dfa93bf7cc68ca4e1057f privacyidea/lib/user.py 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1343#discussion_r242148271'>File: privacyidea/lib/user.py:L113-123</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I tested it and it shouldn't be a big problem:
Suppose the user cache is enabled and a user authenticates with the secondary login name attribute. This will add a user cache entry, but with the *primary* login name attribute value!
Suppose the user authenticates with the secondary login name attribute again. The user cache will not find an entry and invoke the resolver again to find the user.
... so this might be a bit inefficient because the resolver is asked again for the second authentication request, but the audit log links will work correctly.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in faccf140
- [x] <a href='#crh-comment-Pull faccf14033f2e14936273c276818d06cf76fa61f privacyidea/api/auth.py 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1343#discussion_r242890512'>File: privacyidea/api/auth.py:L59-66</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> There are some endpoints that still write the secondary username to the audit log, like ``/token`` and ``/system``. Should we fix that as well? Maybe we can do that with a few lines in ``before_after.py``.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I can not see, where this would happen in `/token`.
The token endpoints always use `user = get_user_from_param(request.all_data, required)` to determine the user object, which now returns the primary login attribute.
And here
https://github.com/privacyidea/privacyidea/blob/1082/secondary-login-attribute/privacyidea/api/before_after.py#L176
we call `get_user_from_param` which creates a `User` Object, that now will contain the primary login.
(Besides that I saw a duplicate which I will remove)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I cleaned up some ``get_user_from_param`` in the token endpoint. This should totally be fine!
f64a4c12
- [x] <a href='#crh-comment-Pull faccf14033f2e14936273c276818d06cf76fa61f privacyidea/lib/usercache.py 76'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1343#discussion_r242906151'>File: privacyidea/lib/usercache.py:L205-212</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> thx! Done in c1ae148c
- [x] <a href='#crh-comment-Pull f64a4c125160c988eb1d6c5b90cbaf61fa9db021 privacyidea/api/before_after.py 44'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1343#discussion_r243210721'>File: privacyidea/api/before_after.py:L196-203</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> There is a bug here: Because this line is removed, the login name, resolver and realm aren't written to the audit log anymore if the current blueprint isn't ``token_blueprint``.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are right. Since the code was simplified the auditlog is not written earlier.
So we can simply drop the ``if "token_blueprint`` condition.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> all done in 916c01da
- [x] <a href='#crh-comment-Pull f64a4c125160c988eb1d6c5b90cbaf61fa9db021 privacyidea/api/before_after.py 8'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1343#discussion_r243245518'>File: privacyidea/api/before_after.py:L141-153</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I moved the whole user thingy up. This is *only* for the case, if the user is logged in.
The thing is, that the ``g.logged_in_user`` does not contain a resolver!
Right after this code you see:
~~~python
if g.logged_in_user.get("role") == "user":
# A user is calling this API. First thing we do is restricting the user parameter.
# ...to restrict token view, audit view or token actions.
request.all_data["user"] = g.logged_in_user.get("username")
request.all_data["realm"] = g.logged_in_user.get("realm")
try:
request.User = get_user_from_param(request.all_data)
~~~
This is the important part. ``request.User`` now contains a complete User Object including the resolver!
And after this we only work with ``request.User``. So to my understanding this is totally fine.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think this does not need to be change. Otherwise take a look at  916c01da
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Sorry, I still think there is a remaining problem:
In case the currently logged in user's role is ``user``, we do not set ``request.all_data["resolver"]`` to the user's resolver anymore (the corresponding line from below was removed). This e.g. changes behavior of the ``check_base_action`` function, because this function uses ``request.all_data["resolver"]`` to match policies.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> This must not be a problem!
Policies should/must not use the resolver information from the request data! Because usually the resolver is not contained in the request data.
E.g. an admin enrolls a token to a *user* "friedrich" in *realm* "netknights". Not a *user* "friedrich" in *resolver* "developers" in *realm* "netknights". If this worked before, this was a bad design! ;-)
This is why initially we set a user object in ``request.User``. And in an ideal world imho this should be used afterwars. (Even if it would not always be the case).
So I would like to leave it that way, even if we change the behaviour at certain places. But this would result in a bad design at the other places.
(And also, the ``logged_in_user`` also has no componente "resolver".)
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Yes. E.g. ``check_base_action`` actually uses the parameter "resolver".
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think about it.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I would suggest the following:
~~~~python
request.all_data = get_all_params(request.values, request.data)
if g.logged_in_user.get("role") == "user":
# A user is calling this API. First thing we do is restricting the user parameter.
# ...to restrict token view, audit view or token actions.
request.all_data["user"] = g.logged_in_user.get("username")
request.all_data["realm"] = g.logged_in_user.get("realm")
try:
request.User = get_user_from_param(request.all_data)
# overwrite or set the resolver parameter in case of a logged in user
if g.logged_in_user.get("role") == "user":  ### <<<<<< new
request.all_data["resolver"] = request.User.resolver
except AttributeError:
# Some endpoints do not need users OR e.g. the setPolicy endpoint
# takes a list as the userobject
request.User = None
except UserError:
# In cases like the policy API, the parameter "user" is part of the
# policy and will not resolve to a user object
request.User = User()
~~~~
Only if the the role user is logged in, then we set the resolver.
This might also acutally make sense, since it overwrites the resolver, in case a user would willingly set a wrong resolver.
(Previously the resolver also was only set for users)
The admin is free to choose the resolver.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1343?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1343?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1343'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>