### PR TITLE
Set SQLALCHEMY_TRACK_MODIFICATIONS = False

### DIFF
--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -18,6 +18,7 @@ class Config(object):
     PI_LOGLEVEL = 9
     CACHE_TYPE = "simple"
     PI_EXTERNAL_LINKS = True
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
     # PI_GNUPG_HOME = "gpg"
     # PI_LOGO = "otherlogo.png"
     # PI_AUDIT_SQL_URI = sqlite://


### PR DESCRIPTION
We all know and love this scary warning:
```
$ ./pi-manage policy p_export       
/home/fred/privacyidea/privacyidea/venv/lib/python2.7/site-packages/flask_sqlalchemy/__init__.py:794: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
  'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
```

According to [this SO answer](https://stackoverflow.com/a/33790196) we only need the option ``SQLALCHEMY_TRACK_MODIFICATIONS = True`` if we use the Flask-SQLAlchemy event system. I can't think of a location where we do that, and grepping for ``models_committed`` gives no results either.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1344?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1344'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>