### PR TITLE
Rework crypto layer

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -405,12 +405,14 @@ def encrypt_enckey(encfile):
 
     The result can be piped to a new enckey file.
     """
+    # TODO we just print out a string here and assume, the user pipes it into a file.
+    #      Maybe we should write the file here so we know what is in there
     password = getpass()
     password2 = getpass(prompt='Confirm: ')
     if password != password2:
         import sys
         sys.exit('Error: passwords do not match.')
-    with open(encfile, "r") as f:
+    with open(encfile, "rb") as f:
         enckey = f.read()
     res = DefaultSecurityModule.password_encrypt(enckey, password)
     print(res)

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -49,7 +49,7 @@ from flask import (Blueprint,
                    g)
 from .lib.utils import (send_result, get_all_params,
                         verify_auth_token)
-from ..lib.crypto import geturandom, init_hsm
+from privacyidea.lib.crypto import geturandom, init_hsm, hexlify_and_unicode
 from ..lib.error import AuthError, ERROR
 from ..lib.auth import verify_db_admin, db_admin_exist
 import jwt
@@ -65,7 +65,7 @@ from privacyidea.lib.realm import get_default_realm
 from privacyidea.api.lib.postpolicy import postpolicy, get_webui_settings
 from privacyidea.api.lib.prepolicy import is_remote_user_allowed
 from privacyidea.api.lib.utils import getParam
-from privacyidea.lib.utils import get_client_ip, hexlify_and_unicode
+from privacyidea.lib.utils import get_client_ip
 from privacyidea.lib.config import get_from_config, SYSCONF, update_config_object
 from privacyidea.lib import _
 import logging
@@ -278,7 +278,6 @@ def get_auth_token():
                                                   g.client_ip)
     else:
         import os
-        import binascii
         nonce = hexlify_and_unicode(os.urandom(20))
         rights = []
         menus = []

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -65,7 +65,7 @@ from privacyidea.lib.realm import get_default_realm
 from privacyidea.api.lib.postpolicy import postpolicy, get_webui_settings
 from privacyidea.api.lib.prepolicy import is_remote_user_allowed
 from privacyidea.api.lib.utils import getParam
-from privacyidea.lib.utils import get_client_ip
+from privacyidea.lib.utils import get_client_ip, hexlify_and_unicode
 from privacyidea.lib.config import get_from_config, SYSCONF, update_config_object
 from privacyidea.lib import _
 import logging
@@ -279,7 +279,7 @@ def get_auth_token():
     else:
         import os
         import binascii
-        nonce = binascii.hexlify(os.urandom(20))
+        nonce = hexlify_and_unicode(os.urandom(20))
         rights = []
         menus = []
 
@@ -293,7 +293,7 @@ def get_auth_token():
                         "authtype": authtype,
                         "exp": datetime.utcnow() + validity,
                         "rights": rights},
-                       secret)
+                       secret).decode('utf8')
 
     # Add the role to the response, so that the WebUI can make decisions
     # based on this (only show selfservice, not the admin part)

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -48,7 +48,6 @@ from .error import HSMException
 import binascii
 import six
 import ctypes
-from Crypto.Hash import SHA as SHA1
 from Crypto.Hash import SHA256 as HashFunc
 from Crypto.Cipher import AES
 from Crypto.PublicKey import RSA
@@ -92,7 +91,7 @@ class SecretObj(object):
 
     def compare(self, key):
         bhOtpKey = binascii.unhexlify(key)
-        enc_otp_key = encrypt(bhOtpKey, self.iv)
+        enc_otp_key = _to_bytes(encrypt(bhOtpKey, self.iv))
         return enc_otp_key == self.val
 
     def hmac_digest(self, data_input, hash_algo):
@@ -146,7 +145,7 @@ def _to_bytes(s):
     :rtype: bytes
     """
     if isinstance(s, six.text_type):
-        return s.encode('utf8')
+        s = s.encode('utf8')
     return s
 
 
@@ -154,12 +153,12 @@ def _to_unicode(s):
     """
     decode a byte string to unicode using utf8
     :param s: string to decode to utf8
-    :type s: bytes
+    :type s: bytes or str
     :return: the utf-8 decoded string s
     :rtype: str
     """
     if isinstance(s, bytes):
-        return s.decode('utf8')
+        s = s.decode('utf8')
     return s
 
 
@@ -167,11 +166,13 @@ def hexlify_and_unicode(s):
     """
 
     :param s: string to hexlify
-    :type s: bytes
+    :type s: bytes or str
     :return: hexlified string converted to unicode
-    :rtype: unicode
+    :rtype: str
     """
-    return _to_unicode(binascii.hexlify(s))
+
+    res = _to_unicode(binascii.hexlify(_to_bytes(s)))
+    return res
 
 
 @log_with(log, log_entry=False, log_exit=False)
@@ -297,7 +298,7 @@ def encryptPassword(password):
 def encryptPin(cryptPin):
     """
     :param cryptPin: the pin to encrypt
-    :type cryptPin: bytes, str, unicode
+    :type cryptPin: bytes or str
     :return: the encrypted pin
     :rtype: str
     """
@@ -383,13 +384,14 @@ def decrypt(input, iv, id=0):
     :type  input: bytes
     :param iv:    initialisation vector
     :type  iv:    bytes
-    :param id:    contains the id of which key of the keyset should be used
+    :param id:    contains the key id of the keyset which should be used
     :type  id:    int
     :return:      decrypted buffer
     :rtype: bytes
     '''
     hsm = get_hsm()
-    return hsm.decrypt(input, iv, id)
+    res = hsm.decrypt(input, iv, id)
+    return res
 
 
 @log_with(log, log_exit=False)

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -52,7 +52,6 @@ from Crypto.Hash import SHA as SHA1
 from Crypto.Hash import SHA256 as HashFunc
 from Crypto.Cipher import AES
 from Crypto.PublicKey import RSA
-import os
 import base64
 try:
     from Crypto.Signature import pkcs1_15
@@ -75,33 +74,6 @@ pver = float(int(ma) + int(mi) * 0.1)
 
 log = logging.getLogger(__name__)
 
-c_hash = {'sha1': SHA1,
-          'sha256': HashFunc}
-
-try:
-    from Crypto.Hash import SHA224
-    c_hash['sha224'] = SHA224
-except:  # pragma: no cover
-    log.warning('Your system does not support Crypto SHA224 hash algorithm')
-
-try:
-    from Crypto.Hash import SHA384
-    c_hash['sha384'] = SHA384
-except:  # pragma: no cover
-    log.warning('Your system does not support Crypto SHA384 hash algorithm')
-
-try:
-    from Crypto.Hash import SHA512
-    c_hash['sha512'] = SHA512
-except:  # pragma: no cover
-    log.warning('Your system does not support Crypto SHA512 hash algorithm')
-
-
-# constant - later taken from the env?
-CONFIG_KEY = 1
-TOKEN_KEY = 2
-VALUE_KEY = 3
-
 
 class SecretObj(object):
     def __init__(self, val, iv, preserve=True):
@@ -111,8 +83,8 @@ class SecretObj(object):
         self.preserve = preserve
 
     def getKey(self):
-        log.warn('Requesting secret key '
-                 '- verify the usage scope and zero + free ')
+        log.warning('Requesting secret key '
+                    '- verify the usage scope and zero + free ')
         return decrypt(self.val, self.iv)
 
     def getPin(self):
@@ -121,7 +93,7 @@ class SecretObj(object):
     def compare(self, key):
         bhOtpKey = binascii.unhexlify(key)
         enc_otp_key = encrypt(bhOtpKey, self.iv)
-        return (enc_otp_key == self.val)
+        return enc_otp_key == self.val
 
     def hmac_digest(self, data_input, hash_algo):
         self._setupKey_()
@@ -147,13 +119,6 @@ class SecretObj(object):
         self._clearKey_(preserve=self.preserve)
         return msg_bin
 
-# This is never used. So we will remove it.
-#    def encryptPin(self):
-#        self._setupKey_()
-#        res = encryptPin(self.bkey)
-#        self._clearKey_(preserve=self.preserve)
-#        return res
-
     def _setupKey_(self):
         if self.bkey is None:
             akey = decrypt(self.val, self.iv)
@@ -171,88 +136,6 @@ class SecretObj(object):
     def __del__(self):
         self._clearKey_()
         
-# This is never used. It would be used for something like:
-# with SecretObj:
-#    ....
-#    def __enter__(self):
-#        self._clearKey_()
-#
-#    def __exit__(self, typ, value, traceback):
-#        self._clearKey_()
-
-
-# def check(st):
-#     """
-#     calculate the checksum of st
-#     :param st: input string
-#     :return: the checksum code as 2 hex bytes
-#     """
-#     summ = 0
-#     arry = bytearray(st)
-#     for x in arry:
-#         summ = summ ^ x
-#     res = str(hex(summ % 256))[2:]
-#     if len(res) < 2:
-#         res = '0' * (2 - len(res)) + res
-#     return res.upper()
-
-#
-# def kdf2(sharesecret, nonce,
-#          activationcode, length,
-#          iterations=10000,
-#          digest='SHA256', macmodule=HMAC, checksum=True):
-#     '''
-#     key derivation function
-#
-#     - takes the shared secret, an activation code and a nonce to generate a
-#          new key
-#     - the last 4 btyes (8 chars) of the nonce is the salt
-#     - the last byte    (2 chars) of the activation code are the checksum
-#     - the activation code mitght contain '-' signs for grouping char blocks
-#        aabbcc-ddeeff-112233-445566
-#
-#     :param sharedsecret:    hexlified binary value
-#     :param nonce:           hexlified binary value
-#     :param activationcode:  base32 encoded value
-#
-#     '''
-#     digestmodule = c_hash.get(digest.lower(), None)
-#
-#     byte_len = 2
-#     salt_len = 8 * byte_len
-#
-#     salt = u'' + nonce[-salt_len:]
-#     bSalt = binascii.unhexlify(salt)
-#     activationcode = activationcode.replace('-', '')
-#
-#     acode = activationcode
-#     if checksum is True:
-#         acode = str(activationcode)[:-2]
-#
-#     try:
-#         bcode = base64.b32decode(acode)
-#
-#     except Exception as exx:
-#         error = "Error during decoding activationcode %r: %r" % (acode, exx)
-#         log.error(error)
-#         raise Exception(error)
-#
-#     if checksum is True:
-#         checkCode = str(activationcode[-2:])
-#         veriCode = str(check(bcode)[-2:])
-#         if checkCode != veriCode:
-#             raise Exception('[crypt:kdf2] activation code checksum error!! '
-#                             ' [%s]%s:%s' % (acode, veriCode, checkCode))
-#
-#     activ = binascii.hexlify(bcode)
-#     passphrase = u'' + sharesecret + activ + nonce[:-salt_len]
-#     #keyStream = PBKDF2(binascii.unhexlify(passphrase),
-#     #                   bSalt, iterations=iterations,
-#     #                   digestmodule=digestmodule)
-#     #key = keyStream.read(length)
-#     key = pbkdf2_sha256(binascii.unhexlify(passphrase),
-#                         salt=bSalt, rounds=iterations)
-#     return key
 
 def _to_bytes(s):
     """
@@ -267,12 +150,36 @@ def _to_bytes(s):
     return s
 
 
+def _to_unicode(s):
+    """
+    decode a byte string to unicode using utf8
+    :param s: string to decode to utf8
+    :type s: bytes
+    :return: the utf-8 decoded string s
+    :rtype: str
+    """
+    if isinstance(s, bytes):
+        return s.decode('utf8')
+    return s
+
+
+def hexlify_and_unicode(s):
+    """
+
+    :param s: string to hexlify
+    :type s: bytes
+    :return: hexlified string converted to unicode
+    :rtype: unicode
+    """
+    return _to_unicode(binascii.hexlify(s))
+
+
 @log_with(log, log_entry=False, log_exit=False)
 def hash(val, seed, algo=None):
     """
 
     :param val: value to hash
-    :type val: bytes, str, unicode
+    :type val: bytes or str or unicode
     :param seed: seed for the hash
     :type seed: bytes, str, unicode
     :param algo:
@@ -283,25 +190,37 @@ def hash(val, seed, algo=None):
     m = sha256()
     m.update(_to_bytes(val))
     m.update(_to_bytes(seed))
-    return binascii.hexlify(m.digest()).decode('utf8')
+    return hexlify_and_unicode(m.digest())
 
 
-def hash_with_pepper(password, rounds=10023, salt_size=10):
+def hash_with_pepper(password):
     """
     Hash function to hash with salt and pepper. The pepper is read from
     "PI_PEPPER" from pi.cfg.
 
     Is used with admins and passwordReset
 
-    :return: Hash string
+    :param password: the password to hash
+    :type password: str
+    :return: hashed password string
+    :rtype: str
     """
     key = get_app_config_value("PI_PEPPER", "missing")
-    pw_dig = passlib.hash.pbkdf2_sha512.encrypt(key + password, rounds=rounds,
-                                                salt_size=salt_size)
+    pw_dig = passlib.hash.pbkdf2_sha512.hash(key + password)
     return pw_dig
 
 
 def verify_with_pepper(passwordhash, password):
+    """
+    verify the password hash with the given password and pepper
+
+    :param passwordhash: the passwordhash
+    :type passwordhash: str
+    :param password: the password to verify
+    :type password: str
+    :return: whether the password matches the hash
+    :rtype: bool
+    """
     # get the password pepper
     password = password or ""
     key = get_app_config_value("PI_PEPPER", "missing")
@@ -358,10 +277,16 @@ def set_hsm_password(password):
 
 @log_with(log, log_entry=False)
 def encryptPassword(password):
-    from privacyidea.lib.utils import to_utf8
+    """
+    Encrypt given password with hsm
+    :param password: the password
+    :type password: bytes or str
+    :return: the encrypted password
+    :rtype: bytes
+    """
     hsm = get_hsm()
     try:
-        ret = hsm.encrypt_password(to_utf8(password))
+        ret = hsm.encrypt_password(_to_bytes(password))
     except Exception as exx:  # pragma: no cover
         log.warning(exx)
         ret = "FAILED TO ENCRYPT PASSWORD!"
@@ -377,7 +302,7 @@ def encryptPin(cryptPin):
     :rtype: str
     """
     hsm = get_hsm()
-    return hsm.encrypt_pin(_to_bytes(cryptPin)).decode('utf8')
+    return _to_unicode(hsm.encrypt_pin(_to_bytes(cryptPin)))
 
 
 @log_with(log, log_exit=False)
@@ -390,6 +315,9 @@ def decryptPassword(cryptPass, convert_unicode=False):
     :param convert_unicode: If true, interpret the decrypted password as an UTF-8 string
                             and convert it to unicode. If an error occurs here,
                             the original bytestring is returned.
+    :type convert_unicode: bool
+    :return: the decrypted password
+    :rtype: str or bytes
     """
     # NOTE: Why do we have the ``convert_unicode`` parameter?
     # Up until now, this always returned bytestrings. However, this breaks
@@ -398,17 +326,16 @@ def decryptPassword(cryptPass, convert_unicode=False):
     # takes unicode strings!). But always returning unicode might break
     # other call sites of ``decryptPassword``. So we add the
     # keyword argument to avoid breaking compatibility.
-    from privacyidea.lib.utils import to_unicode
     hsm = get_hsm()
     try:
         ret = hsm.decrypt_password(cryptPass)
-    except Exception as exx:  # pragma: no cover
+    except Exception as exx:
         log.warning(exx)
         ret = FAILED_TO_DECRYPT_PASSWORD
     try:
         if convert_unicode:
-            ret = to_unicode(ret)
-    except Exception as exx:  # pragma: no cover
+            ret = _to_unicode(ret)
+    except Exception as exx:
         log.warning(exx)
         # just keep ``ret`` as a bytestring in that case
     return ret
@@ -424,7 +351,7 @@ def decryptPin(cryptPin):
     :rtype: str
     """
     hsm = get_hsm()
-    return hsm.decrypt_pin(_to_bytes(cryptPin)).decode('utf8')
+    return _to_unicode(hsm.decrypt_pin(_to_bytes(cryptPin)))
 
 
 @log_with(log, log_entry=False)
@@ -433,18 +360,18 @@ def encrypt(data, iv, id=0):
     encrypt a variable from the given input with an initialisation vector
 
     :param data: buffer, which contains the value
-    :type  data: bytes
+    :type  data: bytes or str
     :param iv:   initialisation vector
-    :type  iv:   bytes
-    :param id:   contains the id of which key of the keyset should be used
+    :type  iv:   bytes or str
+    :param id:   contains the key id of the keyset which should be used
     :type  id:   int
-    :return:     encryted and hexlified data
+    :return:     encrypted and hexlified data
     :rtype: str
 
     '''
     hsm = get_hsm()
     ret = hsm.encrypt(_to_bytes(data), _to_bytes(iv), id)
-    return binascii.hexlify(ret).decode('utf8')
+    return hexlify_and_unicode(ret)
 
 
 @log_with(log, log_exit=False)
@@ -453,17 +380,16 @@ def decrypt(input, iv, id=0):
     decrypt a variable from the given input with an initialiation vector
 
     :param input: buffer, which contains the crypted value
-    :type  input: buffer of bytes
-    :param iv:    initilaitation vector
-    :type  iv:    buffer (20 bytes random)
+    :type  input: bytes
+    :param iv:    initialisation vector
+    :type  iv:    bytes
     :param id:    contains the id of which key of the keyset should be used
     :type  id:    int
-    :return:      decryted buffer
-
+    :return:      decrypted buffer
+    :rtype: bytes
     '''
     hsm = get_hsm()
-    ret = hsm.decrypt(input, iv, id)
-    return ret
+    return hsm.decrypt(input, iv, id)
 
 
 @log_with(log, log_exit=False)
@@ -472,17 +398,18 @@ def aes_decrypt(key, iv, cipherdata, mode=AES.MODE_CBC):
     Decrypts the given cipherdata with the key/iv.
 
     :param key: The encryption key
-    :type key: binary string
+    :type key: bytes
     :param iv: The initialization vector
-    :type iv: binary string
+    :type iv: bytes
     :param cipherdata: The cipher text
     :type cipherdata: binary string
     :param mode: The AES MODE
     :return: plain text in binary data
+    :rtype: bytes
     """
     aes = AES.new(key, mode, iv)
     output = aes.decrypt(cipherdata)
-    padding = ord(output[-1])
+    padding = six.indexbytes(output, len(output) - 1)
     # remove padding
     output = output[0:-padding]
     return output
@@ -496,15 +423,16 @@ def aes_encrypt(key, iv, data, mode=AES.MODE_CBC):
     :type key: binary string
     :param iv: The initialization vector
     :type iv: binary string
-    :param cipherdata: The cipher text
-    :type cipherdata: binary string
+    :param data: The cipher text
+    :type data: bytes
     :param mode: The AES MODE
     :return: plain text in binary data
+    :rtype: bytes
     """
     aes = AES.new(key, mode, iv)
     # pad data
     num_pad = aes.block_size - (len(data) % aes.block_size)
-    data = data + chr(num_pad) * num_pad
+    data = data + six.int2byte(num_pad) * num_pad
     output = aes.encrypt(data)
     return output
 
@@ -517,7 +445,9 @@ def aes_encrypt_b64(key, data):
 
     :param key: Encryption key (binary format)
     :param data: Data to encrypt
+    :type data: bytes
     :return: base64 encrypted output, containing IV
+    :rtype: bytes
     """
     iv = geturandom(16)
     encdata = aes_encrypt(key, iv, data)
@@ -558,7 +488,7 @@ def geturandom(length=20, hex=False):
     ret = hsm.random(length)
         
     if hex:
-        ret = binascii.hexlify(ret).decode('utf8')
+        ret = _to_unicode(binascii.hexlify(ret))
     return ret
 
 # some random functions based on geturandom #################################
@@ -713,8 +643,8 @@ def zerome(bufferObject):
     '''
     clear a string value from memory
 
-    :param string: the string variable, which should be cleared
-    :type  string: string or key buffer
+    :param bufferObject: the string variable, which should be cleared
+    :type  bufferObject: string or key buffer
 
     :return:    - nothing -
     '''

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2018-12-19 Paul Lettich <paul.lettich@netknights.it>
+#             Change public functions to accept and return unicode
 #  2017-11-24 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Use HSM for iv in aes_encrypt
 #  2017-10-17 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -34,6 +36,11 @@
 """
 contains all crypto functions.
 Security module functions are contained under lib/security/
+
+The encrypt/decrypt functions for PINs and passwords accept bytes as well
+as unicode strings. They always return a hexlified unicode string.
+The functions which encrypt/decrypt arbitrary data return bytes and let the
+calling function handle the data.
 
 This lib.cryto is tested in tests/test_lib_crypto.py
 """
@@ -381,16 +388,16 @@ def decrypt(input, iv, id=0):
     decrypt a variable from the given input with an initialiation vector
 
     :param input: buffer, which contains the crypted value
-    :type  input: bytes
+    :type  input: bytes or str
     :param iv:    initialisation vector
-    :type  iv:    bytes
+    :type  iv:    bytes or str
     :param id:    contains the key id of the keyset which should be used
     :type  id:    int
     :return:      decrypted buffer
     :rtype: bytes
     '''
     hsm = get_hsm()
-    res = hsm.decrypt(input, iv, id)
+    res = hsm.decrypt(_to_bytes(input), _to_bytes(iv), id)
     return res
 
 

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -369,7 +369,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         return key_labels
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     logging.basicConfig()
     log.setLevel(logging.INFO)
     # log.setLevel(logging.DEBUG)

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -270,17 +270,17 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         """
         return self._decrypt_value(crypt_pin, TOKEN_KEY)
 
-    def encrypt_password(self, password):
+    def encrypt_password(self, passwd):
         """
         Encrypt the given password with the CONFIG_KEY an a random IV.
 
-        :param password: The password that is to be encrypted
-        :param password: byte string
+        :param passwd: The password that is to be encrypted
+        :type passwd: bytes
 
         :return: encrypted data - leading iv, separated by the ':'
-        :rtype: byte string
+        :rtype: bytes
         """
-        return self._encrypt_value(password, CONFIG_KEY)
+        return self._encrypt_value(passwd, CONFIG_KEY)
 
     def encrypt_pin(self, pin):
         """
@@ -302,18 +302,18 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         returns as string with leading iv, separated by ':'
 
         :param value: the value that is to be encrypted
-        :param value: byte string
+        :param value: bytes
 
         :param key_id: slot of the key array
         :type key_id: int
 
         :return: encrypted data with leading iv and separator ':'
-        :rtype: byte string
+        :rtype: bytes
         """
         iv = self.random(16)
         v = self.encrypt(value, iv, key_id)
 
-        return ':'.join([binascii.hexlify(x) for x in [iv, v]])
+        return b':'.join([binascii.hexlify(x) for x in [iv, v]])
 
     def _decrypt_value(self, crypt_value, key_id):
         """
@@ -321,15 +321,15 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         - used one slot id to encrypt a string with leading iv, separated by ':'
 
         :param crypt_value: the the value that is to be decrypted
-        :param crypt_value: byte string
+        :param crypt_value: bytes
 
         :param  key_id: slot of the key array
         :type   key_id: int
 
         :return: decrypted data
-        :rtype:  byte string
+        :rtype:  bytes
         """
-        (iv, data) = [binascii.unhexlify(x) for x in crypt_value.split(':')]
+        (iv, data) = [binascii.unhexlify(x) for x in crypt_value.split(b':')]
 
         return self.decrypt(data, iv, key_id)
 

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -34,17 +34,7 @@ HSM that is connected via PKCS11. This alternate version relies on AES keys.
 
 log = logging.getLogger(__name__)
 
-TOKEN_KEY = 0
-CONFIG_KEY = 1
-VALUE_KEY = 2
-
 MAX_RETRIES = 5
-
-mapping = {
-    'token':  TOKEN_KEY,
-    'config': CONFIG_KEY,
-    'value':  VALUE_KEY
-}
 
 try:
     import PyKCS11
@@ -86,7 +76,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
 
         label_prefix = config.get("key_label", "privacyidea")
         self.key_labels = {}
-        for k in ['token', 'config', 'value']:
+        for k in self.mapping:
             l = config.get(("key_label_{0!s}".format(k)))
             l = ('{0!s}_{1!s}'.format(label_prefix, k)) if l is None else l
             self.key_labels[k] = l
@@ -157,13 +147,13 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         log.debug("Logging on to '{}'".format(slotinfo.slotDescription))
         self.session.login(self.password)
 
-        for k in ['token', 'config', 'value']:
+        for k in self.mapping:
             label = self.key_labels[k]
             objs = self.session.findObjects([(PyKCS11.CKA_CLASS, PyKCS11.CKO_SECRET_KEY),
                                              (PyKCS11.CKA_LABEL, label)])
             log.debug("Loading '{}' key with label '{}'".format(k, label))
-            if objs != []:
-                self.key_handles[mapping[k]] = objs[0]
+            if objs:
+                self.key_handles[self.mapping[k]] = objs[0]
 
         # self.session.logout()
         log.debug("Successfully setup the security module.")
@@ -192,7 +182,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         # convert the array of the random integers to a string
         return int_list_to_bytestring(r_integers)
 
-    def encrypt(self, data, iv, key_id=TOKEN_KEY):
+    def encrypt(self, data, iv, key_id=SecurityModule.TOKEN_KEY):
         """
 
         :rtype: bytes
@@ -218,7 +208,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
 
         return int_list_to_bytestring(r)
 
-    def decrypt(self, data, iv, key_id=TOKEN_KEY):
+    def decrypt(self, data, iv, key_id=SecurityModule.TOKEN_KEY):
         """
 
         :rtype bytes
@@ -255,7 +245,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         :return: decrypted data
         :rtype: byte string
         """
-        return self._decrypt_value(crypt_pass, CONFIG_KEY)
+        return self._decrypt_value(crypt_pass, self.CONFIG_KEY)
 
     def decrypt_pin(self, crypt_pin):
         """
@@ -268,7 +258,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         :return: decrypted data
         :rtype: byte string
         """
-        return self._decrypt_value(crypt_pin, TOKEN_KEY)
+        return self._decrypt_value(crypt_pin, self.TOKEN_KEY)
 
     def encrypt_password(self, passwd):
         """
@@ -280,7 +270,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         :return: encrypted data - leading iv, separated by the ':'
         :rtype: bytes
         """
-        return self._encrypt_value(passwd, CONFIG_KEY)
+        return self._encrypt_value(passwd, self.CONFIG_KEY)
 
     def encrypt_pin(self, pin):
         """
@@ -292,7 +282,7 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         :return: encrypted data - leading iv, separated by the ':'
         :rtype: byte string
         """
-        return self._encrypt_value(pin, TOKEN_KEY)
+        return self._encrypt_value(pin, self.TOKEN_KEY)
 
     ''' base methods for pin and password '''
     def _encrypt_value(self, value, key_id):
@@ -342,7 +332,8 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
         :return: a dictionary of the created key labels
         """
         # We need a new read/write session
-        session = self.pkcs11.openSession(self.slot, PyKCS11.CKF_SERIAL_SESSION | PyKCS11.CKF_RW_SESSION)
+        session = self.pkcs11.openSession(self.slot,
+                                          PyKCS11.CKF_SERIAL_SESSION | PyKCS11.CKF_RW_SESSION)
         # We need to logout, otherwise we get CKR_USER_ALREADY_LOGGED_IN
         session.logout()
         session.login(self.password)

--- a/privacyidea/lib/security/default.py
+++ b/privacyidea/lib/security/default.py
@@ -173,7 +173,7 @@ class DefaultSecurityModule(SecurityModule):
             raise HSMException("no secret file defined: PI_ENCFILE!")
 
         # We determine, if the file is encrypted.
-        with open(config.get("file")) as f:
+        with open(config.get("file"), 'rb') as f:
             cipher = f.read()
 
         if len(cipher) > 100:
@@ -227,7 +227,7 @@ class DefaultSecurityModule(SecurityModule):
 
         else:
             # Only read the key with the slot_id
-            with open(self.secFile) as f:
+            with open(self.secFile, 'rb') as f:
                 for _i in range(0, slot_id + 1):
                     secret = f.read(32)
 
@@ -290,17 +290,17 @@ class DefaultSecurityModule(SecurityModule):
         security module methods: encrypt
 
         :param data: the data that is to be encrypted
-        :type data: byte string
+        :type data: bytes
 
         :param iv: initialisation vector
-        :type iv: random bytes
+        :type iv: bytes
 
         :param slot_id: slot of the key array. The key file contains 96
             bytes, which are made up of 3 32byte keys.
         :type slot_id: int
 
         :return: encrypted data
-        :rtype:  byte string
+        :rtype:  bytes
         """
         if self.is_ready is False:
             raise HSMException('setup of security module incomplete')
@@ -308,9 +308,9 @@ class DefaultSecurityModule(SecurityModule):
         key = self._get_secret(slot_id)
         # convert input to ascii, so we can securely append bin data
         input_data = binascii.b2a_hex(data)
-        input_data += u"\x01\x02"
+        input_data += b"\x01\x02"
         padding = (16 - len(input_data) % 16) % 16
-        input_data += padding * "\0"
+        input_data += padding * b"\0"
         aes = AES.new(key, AES.MODE_CBC, iv)
 
         res = aes.encrypt(input_data)
@@ -377,16 +377,16 @@ class DefaultSecurityModule(SecurityModule):
         Decrypt the given data with the key from the key slot
 
         :param input_data: the to be decrypted data
-        :type input_data: byte string
+        :type input_data: bytes
 
         :param iv: initialisation vector (salt)
-        :type iv: random bytes
+        :type iv: bytes
 
         :param slot_id: slot of the key array
         :type slot_id: int
 
         :return: decrypted data
-        :rtype: byte string
+        :rtype: bytes
         """
         if self.is_ready is False:
             raise HSMException('setup of security module incomplete')
@@ -394,7 +394,7 @@ class DefaultSecurityModule(SecurityModule):
         key = self._get_secret(slot_id)
         aes = AES.new(key, AES.MODE_CBC, iv)
         output = aes.decrypt(input_data)
-        eof = output.rfind(u"\x01\x02")
+        eof = output.rfind(b"\x01\x02")
         if eof >= 0:
             output = output[:eof]
 
@@ -476,7 +476,7 @@ class DefaultSecurityModule(SecurityModule):
         iv = self.random(16)
         v = self.encrypt(value, iv, slot_id)
 
-        cipher_value = binascii.hexlify(iv) + ':' + binascii.hexlify(v)
+        cipher_value = binascii.hexlify(iv) + b':' + binascii.hexlify(v)
         return cipher_value
 
     def _decrypt_value(self, crypt_value, slot_id):
@@ -494,7 +494,7 @@ class DefaultSecurityModule(SecurityModule):
         :rtype:  byte string
         """
         # split at ":"
-        pos = crypt_value.find(':')
+        pos = crypt_value.find(b':')
         bIV = crypt_value[:pos]
         bData = crypt_value[pos + 1:]
 

--- a/privacyidea/lib/security/pkcs11.py
+++ b/privacyidea/lib/security/pkcs11.py
@@ -163,7 +163,7 @@ class PKCS11SecurityModule(SecurityModule):  # pragma: no cover
         return self.decrypt(crypt_pin)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
 
     module = "/usr/local/lib/opensc-pkcs11.so"
     #module = "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so"

--- a/privacyidea/lib/security/pkcs11.py
+++ b/privacyidea/lib/security/pkcs11.py
@@ -175,25 +175,25 @@ if __name__ == "__main__":
     cleartext = "Hello there!"
     cipher = p.encrypt(cleartext)
     text = p.decrypt(cipher)
-    print text
+    print(text)
     assert(text == cleartext)
 
     cleartext = "Hello, this is a really long text and so and and so on..."
     cipher = p.encrypt(cleartext)
     text = p.decrypt(cipher)
-    print text
+    print(text)
     assert (text == cleartext)
 
     # password
     password = "topSekr3t"
     crypted = p.encrypt_password(password)
     text = p.decrypt_password(crypted)
-    print text
+    print(text)
     assert(text == password)
 
     # pin
     password = "topSekr3t"
     crypted = p.encrypt_pin(password)
     text = p.decrypt_pin(crypted)
-    print text
+    print(text)
     assert (text == password)

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1327,7 +1327,7 @@ def set_pin_so(serial, so_pin, user=None):
     :param serial: The serial number of the token (exact)
     :type serial: basestring
     :param so_pin: The Security Officer PIN
-    :type so_ping: basestring
+    :type so_pin: basestring
     :return: The number of SO PINs set. (usually 1)
     :rtype: int
     """

--- a/privacyidea/lib/tokens/tantoken.py
+++ b/privacyidea/lib/tokens/tantoken.py
@@ -141,7 +141,7 @@ class TanTokenClass(PaperTokenClass):
             # Get a 4 byte salt from the crypto module
             salt = geturandom(SALT_LENGTH, hex=True)
             # Now we add all TANs to the tokeninfo of this token.
-            hashed_tan = binascii.hexlify(hash(tanvalue, salt))
+            hashed_tan = hash(tanvalue, salt)
             self.add_tokeninfo("tan.tan{0!s}".format(tankey),
                                "{0}:{1}".format(salt, hashed_tan))
 
@@ -165,7 +165,7 @@ class TanTokenClass(PaperTokenClass):
         for tankey, tanvalue in tans.items():
             if tankey.startswith("tan.tan"):
                 salt, tan = tanvalue.split(":")
-                if tan == binascii.hexlify(hash(anOtpVal,salt)):
+                if tan == hash(anOtpVal, salt):
                     self.del_tokeninfo(tankey)
                     return 1
 

--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -163,8 +163,12 @@ def to_unicode(s, encoding="utf-8"):
     """
     converts a value to unicode if it is of type str.
     
-    :param s: The utf-8 encoded str 
+    :param s: the str to decode
+    :type s: bytes, str
+    :param encoding: the encoding to use (default utf8)
+    :type encoding: str
     :return: unicode string
+    :rtype: str
     """
     if type(s) == str:
         s = s.decode(encoding)
@@ -1257,14 +1261,3 @@ def get_module_class(package_name, class_name, check_method=None):
         raise NameError(u"Class AttributeError: {0}.{1} "
                         u"instance has no attribute '{2}'".format(package_name, class_name, check_method))
     return klass
-
-
-def hexlify_and_unicode(s):
-    """
-
-    :param s: string to hexlify
-    :type s: bytes
-    :return: hexlified string converted to unicode
-    :rtype: unicode
-    """
-    return binascii.hexlify(s).decode('utf8')

--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -26,6 +26,7 @@ This is the library with base functions for privacyIDEA.
 
 This module is tested in tests/test_lib_utils.py
 """
+import six
 import logging
 from importlib import import_module
 
@@ -572,8 +573,7 @@ def reload_db(timestamp, db_ts):
 
     :return: bool
     """
-    rdb = False
-    internal_timestamp = None
+    internal_timestamp = ''
     if timestamp:
         internal_timestamp = timestamp.strftime("%s")
     rdb = False
@@ -1089,12 +1089,16 @@ def convert_column_to_unicode(value):
     """
     Helper function for models. If ``value`` is None or a unicode object, do nothing.
     Otherwise, convert it to a unicode object.
+    :param value: the string to convert
+    :type value: str
     :return: a unicode object or None
     """
-    if value is None or isinstance(value, unicode):
+    if value is None or isinstance(value, six.text_type):
         return value
+    elif isinstance(value, bytes):
+        return value.decode('utf8')
     else:
-        return unicode(value)
+        return six.text_type(value)
 
 
 def convert_timestamp_to_utc(timestamp):
@@ -1253,3 +1257,14 @@ def get_module_class(package_name, class_name, check_method=None):
         raise NameError(u"Class AttributeError: {0}.{1} "
                         u"instance has no attribute '{2}'".format(package_name, class_name, check_method))
     return klass
+
+
+def hexlify_and_unicode(s):
+    """
+
+    :param s: string to hexlify
+    :type s: bytes
+    :return: hexlified string converted to unicode
+    :rtype: unicode
+    """
+    return binascii.hexlify(s).decode('utf8')

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -43,18 +43,18 @@ from datetime import datetime, timedelta
 from dateutil.tz import tzutc
 from json import loads, dumps
 from flask_sqlalchemy import SQLAlchemy
-from .lib.crypto import (encrypt,
-                         encryptPin,
-                         decryptPin,
-                         geturandom,
-                         hash,
-                         SecretObj,
-                         get_rand_digit_str)
-
+from privacyidea.lib.crypto import (encrypt,
+                                    encryptPin,
+                                    decryptPin,
+                                    geturandom,
+                                    hash,
+                                    SecretObj,
+                                    get_rand_digit_str,
+                                    hexlify_and_unicode)
 from sqlalchemy import and_
 from sqlalchemy.schema import Sequence
 from .lib.log import log_with
-from privacyidea.lib.utils import is_true, convert_column_to_unicode, hexlify_and_unicode
+from privacyidea.lib.utils import is_true, convert_column_to_unicode
 
 log = logging.getLogger(__name__)
 
@@ -340,6 +340,14 @@ class Token(MethodsMixin, db.Model):
         return secret
 
     def set_hashed_pin(self, pin):
+        """
+        Set the pin of the token in hashed format
+
+        :param pin: the pin to hash
+        :type pin: str
+        :return: the hashed pin
+        :rtype: str
+        """
         seed = geturandom(16)
         self.pin_seed = hexlify_and_unicode(seed)
         self.pin_hash = hash(pin, seed)

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -36,6 +36,7 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import binascii
+import six
 import logging
 from datetime import datetime, timedelta
 
@@ -53,7 +54,7 @@ from .lib.crypto import (encrypt,
 from sqlalchemy import and_
 from sqlalchemy.schema import Sequence
 from .lib.log import log_with
-from .lib.utils import is_true, convert_column_to_unicode
+from privacyidea.lib.utils import is_true, convert_column_to_unicode, hexlify_and_unicode
 
 log = logging.getLogger(__name__)
 
@@ -248,8 +249,9 @@ class Token(MethodsMixin, db.Model):
         Also avoids running into errors, if the data is a None Type.
 
         :param data: a string from the database
-        :type data: usually a string
+        :type data: str
         :return: a stripped string
+        :rtype: str
         """
         if data:
             data = data.strip()
@@ -259,13 +261,12 @@ class Token(MethodsMixin, db.Model):
     @log_with(log)
     def set_otpkey(self, otpkey, reset_failcount=True):
         iv = geturandom(16)
-        enc_otp_key = encrypt(otpkey, iv)
-        self.key_enc = unicode(binascii.hexlify(enc_otp_key))
+        self.key_enc = encrypt(otpkey, iv)
         length = len(self.key_enc)
         if length > Token.key_enc.property.columns[0].type.length:
             log.error("Key {0!s} exceeds database field {1:d}!".format(self.serial,
                                                              length))
-        self.key_iv = unicode(binascii.hexlify(iv))
+        self.key_iv = hexlify_and_unicode(iv)
         self.count = 0
         if reset_failcount is True:
             self.failcount = 0
@@ -315,9 +316,8 @@ class Token(MethodsMixin, db.Model):
     @log_with(log)
     def set_user_pin(self, userPin):
         iv = geturandom(16)
-        enc_userPin = encrypt(userPin, iv)
-        self.user_pin = unicode(binascii.hexlify(enc_userPin))
-        self.user_pin_iv = unicode(binascii.hexlify(iv))
+        self.user_pin = encrypt(userPin, iv)
+        self.user_pin_iv = hexlify_and_unicode(iv)
 
     @log_with(log)
     def get_otpkey(self):
@@ -341,8 +341,8 @@ class Token(MethodsMixin, db.Model):
 
     def set_hashed_pin(self, pin):
         seed = geturandom(16)
-        self.pin_seed = unicode(binascii.hexlify(seed))
-        self.pin_hash = unicode(binascii.hexlify(hash(pin, seed)))
+        self.pin_seed = hexlify_and_unicode(seed)
+        self.pin_hash = hash(pin, seed)
         return self.pin_hash
 
     def get_hashed_pin(self, pin):
@@ -351,15 +351,18 @@ class Token(MethodsMixin, db.Model):
         Fix for working with MS SQL servers
         MS SQL servers sometimes return a '<space>' when the
         column is empty: ''
+
+        :param pin: the pin to hash
+        :type pin: str
+        :return: hashed pin with current pin_seed
+        :rtype: str
         """
         seed_str = self._fix_spaces(self.pin_seed)
         seed = binascii.unhexlify(seed_str)
         hPin = hash(pin, seed)
-        log.debug("hPin: {0!s}, pin: {1!r}, seed: {2!s}".format(
-            binascii.hexlify(hPin),
-            pin,
-            self.pin_seed))
-        return binascii.hexlify(hPin)
+        log.debug("hPin: {0!s}, pin: {1!r}, seed: {2!s}".format(hPin, pin,
+                                                                self.pin_seed))
+        return hPin
     
     def check_hashed_pin(self, pin):
         hp = self.get_hashed_pin(pin)
@@ -369,7 +372,7 @@ class Token(MethodsMixin, db.Model):
     def set_description(self, desc):
         if desc is None:
             desc = ""
-        self.description = unicode(desc)
+        self.description = convert_column_to_unicode(desc)
         return self.description
 
     def set_pin(self, pin, hashed=True):
@@ -382,7 +385,9 @@ class Token(MethodsMixin, db.Model):
         if hashed is True:
             self.set_hashed_pin(upin)
             log.debug("setPin(HASH:{0!r})".format(self.pin_hash))
-        elif hashed is False:
+        else:
+            if isinstance(pin, six.text_type):
+                upin = upin.encode('utf8')
             self.pin_hash = "@@" + encryptPin(upin)
             log.debug("setPin(ENCR:{0!r})".format(self.pin_hash))
         return self.pin_hash
@@ -429,7 +434,7 @@ class Token(MethodsMixin, db.Model):
         ret = False
         if pin is None:
             pin = self.pin_hash
-        if (pin.startswith("@@") is True):
+        if pin.startswith("@@"):
             ret = True
         return ret
 
@@ -447,10 +452,9 @@ class Token(MethodsMixin, db.Model):
         :rtype : None
         """
         iv = geturandom(16)
-        enc_soPin = encrypt(soPin, iv)
-        self.so_pin = unicode(binascii.hexlify(enc_soPin))
-        self.so_pin_iv = unicode(binascii.hexlify(iv))
-        return (self.so_pin, self.so_pin_iv)
+        self.so_pin = encrypt(soPin, iv)
+        self.so_pin_iv = hexlify_and_unicode(iv)
+        return self.so_pin, self.so_pin_iv
 
     def __unicode__(self):
         return self.serial
@@ -719,6 +723,7 @@ class Admin(db.Model):
         db.session.commit()
 
 
+@six.python_2_unicode_compatible
 class Config(TimestampMethodsMixin, db.Model):
     """
     The config table holds all the system configuration in key value pairs.
@@ -737,13 +742,13 @@ class Config(TimestampMethodsMixin, db.Model):
 
     @log_with(log)
     def __init__(self, Key, Value, Type=u'', Description=u''):
-        self.Key = unicode(Key)
+        self.Key = convert_column_to_unicode(Key)
         self.Value = convert_column_to_unicode(Value)
-        self.Type = unicode(Type)
-        self.Description = unicode(Description)
+        self.Type = convert_column_to_unicode(Type)
+        self.Description = convert_column_to_unicode(Description)
 
-    def __unicode__(self):
-        return "<{0!s} ({1!s})>".format(self.Key, self.Type)
+    def __str__(self):
+        return u"<{0!s} ({1!s})>".format(self.Key, self.Type)
 
     def save(self):
         db.session.add(self)
@@ -963,10 +968,10 @@ class ResolverConfig(TimestampMethodsMixin, db.Model):
                                        .filter_by(name=resolver)\
                                        .first()\
                                        .id
-        self.Key = unicode(Key)
+        self.Key = convert_column_to_unicode(Key)
         self.Value = convert_column_to_unicode(Value)
-        self.Type = unicode(Type)
-        self.Description = unicode(Description)
+        self.Type = convert_column_to_unicode(Type)
+        self.Description = convert_column_to_unicode(Description)
 
     def save(self):
         c = ResolverConfig.query.filter_by(resolver_id=self.resolver_id,
@@ -1133,6 +1138,7 @@ class PasswordReset(MethodsMixin, db.Model):
                                         timedelta(seconds=expiration_seconds)
 
 
+@six.python_2_unicode_compatible
 class Challenge(MethodsMixin, db.Model):
     """
     Table for handling of the generic challenges.
@@ -1191,7 +1197,7 @@ class Challenge(MethodsMixin, db.Model):
         if type(data) in [dict, list]:
             self.data = dumps(data)
         else:
-            self.data = unicode(data)
+            self.data = convert_column_to_unicode(data)
 
     def get_data(self):
         data = {}
@@ -1205,10 +1211,10 @@ class Challenge(MethodsMixin, db.Model):
         return self.session
 
     def set_session(self, session):
-        self.session = unicode(session)
+        self.session = convert_column_to_unicode(session)
 
     def set_challenge(self, challenge):
-        self.challenge = unicode(challenge)
+        self.challenge = convert_column_to_unicode(challenge)
     
     def get_challenge(self):
         return self.challenge
@@ -1256,11 +1262,9 @@ class Challenge(MethodsMixin, db.Model):
         descr['expiration'] = self.expiration
         return descr
 
-    def __unicode__(self):
+    def __str__(self):
         descr = self.get()
-        return "{0!s}".format(unicode(descr))
-
-    __str__ = __unicode__
+        return u"{0!s}".format(descr)
 
 
 def cleanup_challenges():
@@ -1312,7 +1316,7 @@ class Policy(TimestampMethodsMixin, db.Model):
                  active=True, scope="", action="", realm="", adminrealm="",
                  resolver="", user="", client="", time="", condition=0, priority=1,
                  check_all_resolvers=False):
-        if type(active) in [str, unicode]:
+        if isinstance(active, six.string_types):
             active = is_true(active.lower())
         self.name = name
         self.action = action

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -265,7 +265,7 @@ class Token(MethodsMixin, db.Model):
         length = len(self.key_enc)
         if length > Token.key_enc.property.columns[0].type.length:
             log.error("Key {0!s} exceeds database field {1:d}!".format(self.serial,
-                                                             length))
+                                                                       length))
         self.key_iv = hexlify_and_unicode(iv)
         self.count = 0
         if reset_failcount is True:
@@ -394,8 +394,6 @@ class Token(MethodsMixin, db.Model):
             self.set_hashed_pin(upin)
             log.debug("setPin(HASH:{0!r})".format(self.pin_hash))
         else:
-            if isinstance(pin, six.text_type):
-                upin = upin.encode('utf8')
             self.pin_hash = "@@" + encryptPin(upin)
             log.debug("setPin(ENCR:{0!r})".format(self.pin_hash))
         return self.pin_hash
@@ -436,7 +434,7 @@ class Token(MethodsMixin, db.Model):
         else:
             otp = passwd[:self.otplen]
             pin = passwd[self.otplen:]
-        return(True, pin, otp)
+        return True, pin, otp
 
     def is_pin_encrypted(self, pin=None):
         ret = False

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -36,18 +36,18 @@ class TokenModelTestCase(MyTestCase):
         # Add configuration to the resolver
         conf = ResolverConfig(r.id, "fileName", "tests/testdata/passwd")
         conf.save()
-        
+
         # Read Resolver
         r1 = Resolver.query.filter_by(name="resolver1").first()
         self.assertTrue(r1.rtype == "passwdresolver", r1.rtype)
-        
+
         realm = Realm("realm1")
         realm.save()
         # Put the resolver into the realm
         rrealm = ResolverRealm(resolver_name="resolver1",
                                realm_name="realm1")
         rrealm.save()
-    
+
     def test_00_create_token(self):
         otpkey = "1234567890"
         t1 = Token(serial="serial1",
@@ -57,28 +57,40 @@ class TokenModelTestCase(MyTestCase):
         t1.set_hashed_pin("1234")
         t1.otplen = 6
         tid = t1.save()
-        
+
         userpin = "HalloDuda"
         t1.set_user_pin(userpin)
         t1.save()
-        
+
         pin_object = t1.get_user_pin()
-        self.assertTrue(pin_object.getPin() == userpin)
-        
+        self.assertTrue(pin_object.getPin() == userpin.encode('utf8'))
+
         t = Token.query.filter_by(id=tid).first()
         self.assertTrue(len(t.pin_hash) > 0)
         self.assertTrue(len(t.user_pin) > 0)
-        
+
         otpObj = t.get_otpkey()
-        self.assertTrue(otpObj.getKey() == otpkey)
+        self.assertTrue(otpObj.getKey() == otpkey.encode('utf8'))
         count = t.count
         self.assertTrue(count == 0)
-        
+
         up = t.get_user_pin()
-        self.assertTrue(up.getPin() == userpin)
-        
+        self.assertTrue(up.getPin() == userpin.encode('utf8'))
+
         self.assertTrue(t.check_hashed_pin("1234"))
-        
+
+        t.set_user_pin(b'HalloDuDa')
+        self.assertTrue(t.get_user_pin().getPin() == b'HalloDuDa')
+
+        t.set_user_pin(u'HelloWörld')
+        self.assertTrue(t.get_user_pin().getPin().decode('utf8') == u'HelloWörld')
+
+        t.set_hashed_pin(b'1234')
+        self.assertTrue(t.check_hashed_pin(b'1234'))
+
+        t.set_hashed_pin(u'HelloWörld')
+        self.assertTrue(t.check_hashed_pin(u'HelloWörld'))
+
         # Delete the token
         t1.delete()
         t = Token.query.filter_by(id=tid).first()
@@ -96,7 +108,7 @@ class TokenModelTestCase(MyTestCase):
         # resolver=resolver1
         # realm=realm1
         otpkey = "123456"
-        
+
         # create token and also assign the user and realm
         tneu = Token(serial="serial2",
                      otpkey=otpkey,
@@ -113,12 +125,12 @@ class TokenModelTestCase(MyTestCase):
             if realm_entry.realm.name == "realm1":
                 realm_found = True
         self.assertTrue(realm_found)
-        
+
         # set the pin in a hashed way
         t2.set_pin("thepin")
         t2.save()
         r = t2.check_pin("wrongpin")
-        self.assertTrue(r is False)
+        self.assertFalse(r)
         r = t2.check_pin("thepin")
         self.assertTrue(r)
 
@@ -140,27 +152,35 @@ class TokenModelTestCase(MyTestCase):
         r = t2.check_pin("thepin")
         self.assertTrue(r)
         pin = t2.get_pin()
-        self.assertTrue(pin == "thepin")
-        
+        self.assertEqual("thepin", pin)
+
         # set the so pin
         (enc, iv) = t2.set_so_pin("topsecret")
         self.assertTrue(len(enc) > 0)
         self.assertTrue(len(iv) > 0)
-        
+
+        (enc, iv) = t2.set_so_pin(b"topsecret")
+        self.assertTrue(enc)
+        self.assertTrue(iv)
+
+        (enc, iv) = t2.set_so_pin(u"topsecrät")
+        self.assertTrue(enc)
+        self.assertTrue(iv)
+
         # get token information
         token_dict = t2.get()
         self.assertTrue(type(token_dict) == dict)
         self.assertTrue(token_dict.get("resolver") == "resolver1")
         # THe realm list is contained in realms
         self.assertTrue("realm1" in token_dict.get("realms"))
-        
+
         resolver = t2.get("resolver")
         self.assertTrue(resolver == "resolver1")
-        
+
         # retrieve a value, that does not exist
         nonexist = t2.get("nonexist")
         self.assertTrue(nonexist is None)
-        
+
         # setting normal values
         t2.count_window = 100
         t2.otplen = 8
@@ -176,15 +196,15 @@ class TokenModelTestCase(MyTestCase):
         self.assertTrue(t3.info_list[0].Value == "value")
         t3info = t3.get_info()
         self.assertTrue(t3.get_info().get("info") == "value")
-        
+
         # test the string represenative
         s = "{0!s}".format(t3)
         self.assertTrue(s == "serial2")
-        
+
         # update token type
         t2.update_type("totp")
         self.assertTrue(t2.get("tokentype") == "totp")
-        
+
         old_key = t2.key_enc
         old_pin = t2.pin_hash
         t2.update_token(description="New Text", otpkey="1234",
@@ -193,7 +213,15 @@ class TokenModelTestCase(MyTestCase):
         # The key has changed
         self.assertTrue(t2.key_enc != old_key)
         self.assertTrue(t2.pin_hash != old_pin)
-        
+
+        t2.set_otpkey(b'12345')
+        self.assertEqual(b'12345', t2.get_otpkey().getKey(), t2)
+        t2.failcount = 5
+        t2.set_otpkey(u'Hellö', reset_failcount=True)
+        self.assertTrue(t2.failcount == 0, t2)
+        self.assertEqual(u'Hellö', t2.get_otpkey().getKey().decode('utf8'), t2)
+
+        # TODO set description empty
         # delete the token
         ret = t2.delete()
         self.assertTrue(ret)
@@ -204,32 +232,32 @@ class TokenModelTestCase(MyTestCase):
     def test_02_config_model(self):
         c = Config("splitRealm", True,
                    Type="string", Description="something")
-        
+
         cid = c.save()
         self.assertTrue(cid == "splitRealm", cid)
         self.assertTrue(u"{0!s}".format(c) == "<splitRealm (string)>", c)
-        
+
         # delete the config
         config = Config.query.filter_by(Key="splitRealm").first()
         self.assertTrue(config.delete() == "splitRealm")
         q = Config.query.filter_by(Key="splitRealm").all()
         # the list is empty
         self.assertTrue(len(q) == 0, q)
-        
+
     def test_03_create_and_delete_realm(self):
         realmname = "realm23"
         r = Realm(realmname)
         r.save()
-        
+
         qr = Realm.query.filter_by(name=realmname).first()
         self.assertTrue(qr.name == realmname)
-        
+
         # delete realm
         qr.delete()
         # no realm left
         q = Realm.query.filter_by(name=realmname).all()
         self.assertTrue(len(q) == 0)
-    
+
     def test_04_update_resolver_config(self):
         resolvername = "resolver2"
         r = Resolver(resolvername, "passwdresolver")
@@ -254,7 +282,7 @@ class TokenModelTestCase(MyTestCase):
         # check that config is empty
         q = ResolverConfig.query.filter_by(resolver_id=rid).all()
         self.assertTrue(len(q) == 0, q)
-        
+
     def test_05_get_set_realm(self):
         t1 = Token(serial="serial1123")
         t1.save()
@@ -331,7 +359,7 @@ class TokenModelTestCase(MyTestCase):
                         len(db_realm.resolver_list))
         # delete the realm
         db_realm.delete()
-    
+
     def test_11_policy(self):
         p = Policy("pol1", active="true",
                    scope="selfservice", action="action1",
@@ -340,12 +368,12 @@ class TokenModelTestCase(MyTestCase):
         self.assertTrue(p.action == "action1", p)
         self.assertTrue("action1" in p.get().get("action"), p)
         self.assertTrue("action1" in p.get("action"), p)
-        
+
         p2 = Policy("pol1", active="false",
                     scope="selfservice", action="action1",
                     realm="*")
         self.assertFalse(p2.active, p2.active)
-        
+
         # update
         self.assertTrue(p.user == "", p.user)
         p.user = "cornelius"
@@ -359,12 +387,12 @@ class TokenModelTestCase(MyTestCase):
         p3 = Policy("pol3", active="false", scope="admin",
                     adminrealm='superuser', action="*")
         self.assertEqual(p3.adminrealm, "superuser")
-        
+
     def test_12_challenge(self):
         c = Challenge("S123456")
         self.assertTrue(len(c.transaction_id) == 20, c.transaction_id)
         self.assertTrue(len(c.get_transaction_id()) == 20, c.transaction_id)
-        
+
         c.set_data("some data")
         self.assertTrue(c.data == "some data", c.data)
         self.assertTrue(c.get_data() == "some data", c.data)
@@ -374,11 +402,11 @@ class TokenModelTestCase(MyTestCase):
         self.assertTrue(c.get_session() == "session", c.session)
         c.set_challenge("challenge")
         self.assertTrue(c.get_challenge() == "challenge", c.challenge)
-        
+
         self.assertTrue("otp_received" in "{0!s}".format(c), "{0!s}".format(c))
         self.assertTrue("transaction_id" in "{0!s}".format(c), "{0!s}".format(c))
         self.assertTrue("timestamp" in "{0!s}".format(c), "{0!s}".format(c))
-        
+
         # test with timestamp=True, which results in something like this:
         timestamp = '2014-11-29 21:56:43.057293'
         self.assertTrue(len(c.get(True).get("timestamp")) == len(timestamp),
@@ -392,10 +420,10 @@ class TokenModelTestCase(MyTestCase):
         # create the machineresolver and a config entry
         mr = MachineResolver("mr1", "mrtype1")
         mr_id = mr.save()
-        self.assertTrue(mr_id > 0, mr_id)
+        self.assertTrue(mr_id > 0, mr)
         mrc = MachineResolverConfig(resolver="mr1", Key="key1", Value="value1")
-        mrc.save()
-        self.assertTrue(mrc > 0)
+        mrc_id = mrc.save()
+        self.assertTrue(mrc_id > 0, mrc)
         # check that the config entry exist
         db_mrconf = MachineResolverConfig.query.filter(
             MachineResolverConfig.resolver_id == mr_id).first()
@@ -403,8 +431,8 @@ class TokenModelTestCase(MyTestCase):
 
         # add a config value by ID
         mrc = MachineResolverConfig(resolver_id=mr_id, Key="key2", Value="v2")
-        mrc.save()
-        self.assertTrue(mrc > 0)
+        mrc_id = mrc.save()
+        self.assertTrue(mrc_id > 0)
         # update config
         MachineResolverConfig(resolver_id=mr_id, Key="key2",
                               Value="new value").save()

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -3,17 +3,18 @@
 This test file tests the lib.crypto and lib.security.default
 """
 from mock import call
+import binascii
 
 from privacyidea.lib.error import HSMException
 from .base import MyTestCase
 # need to import pkcs11mock before PyKCS11, because it may be replaced by a mock module
 from .pkcs11mock import PKCS11Mock
 from privacyidea.lib.crypto import (encryptPin, encryptPassword, decryptPin,
-                                    decryptPassword, urandom,
-                                    get_rand_digit_str, geturandom,
-                                    get_alphanum_str,
-                                    hash_with_pepper, verify_with_pepper, aes_encrypt_b64, aes_decrypt_b64, get_hsm,
-                                    init_hsm, set_hsm_password)
+                                    decryptPassword, urandom, get_rand_digit_str,
+                                    geturandom, get_alphanum_str, hash_with_pepper,
+                                    verify_with_pepper, aes_encrypt_b64, aes_decrypt_b64,
+                                    get_hsm, init_hsm, set_hsm_password, hash,
+                                    encrypt, decrypt)
 from privacyidea.lib.security.default import (SecurityModule,
                                               DefaultSecurityModule)
 from privacyidea.lib.security.aeshsm import AESHardwareSecurityModule
@@ -65,13 +66,13 @@ class SecurityModuleTestCase(MyTestCase):
         text = hsm.decrypt(cipher, b"iv12345678901234")
         self.assertTrue(text == b"data", text)
 
-        cipher = hsm.encrypt_pin("data")
+        cipher = hsm.encrypt_pin(b"data")
         text = hsm.decrypt_pin(cipher)
-        self.assertTrue(text == "data", text)
+        self.assertTrue(text == b"data", text)
 
-        cipher = hsm.encrypt_password("data")
+        cipher = hsm.encrypt_password(b"data")
         text = hsm.decrypt_password(cipher)
-        self.assertTrue(text == "data", text)
+        self.assertTrue(text == b"data", text)
 
     def test_06_password_encrypt_decrypt(self):
         res = DefaultSecurityModule.password_encrypt("secrettext", "password1")
@@ -81,7 +82,7 @@ class SecurityModuleTestCase(MyTestCase):
             "8cac15585ed2fbab05bd2b1ea2cc44b"), res)
 
         res = DefaultSecurityModule.password_decrypt(res, "password1")
-        self.assertTrue(res == "secrettext", res)
+        self.assertTrue(res == b"secrettext", res)
 
         # encrypt and decrypt binary data like the enckey
         enckey = geturandom(96)
@@ -145,9 +146,9 @@ class CryptoTestCase(MyTestCase):
         self.assertTrue(pin == "test", (r, pin))
 
     def test_01_encrypt_decrypt_pass(self):
-        r = encryptPassword("passwörd")
+        r = encryptPassword(u"passwörd".encode('utf8'))
         pin = decryptPassword(r)
-        self.assertTrue(pin == "passwörd", (r, pin))
+        self.assertEqual(pin, u"passwörd".encode('utf8'))
 
         r = encryptPassword(u"passwörd")
         pin = decryptPassword(r, convert_unicode=True)
@@ -155,16 +156,19 @@ class CryptoTestCase(MyTestCase):
 
         r = encryptPassword(u"passwörd")
         pin = decryptPassword(r, convert_unicode=False)
-        self.assertEqual(pin, "passwörd")
+        self.assertEqual(pin, u"passwörd".encode('utf8'))
 
         # error path returns the bytestring
-        r = encryptPassword(b"\x01\x02\x03\x04")
-        self.assertEqual(decryptPassword(r, convert_unicode=True), b"\x01\x02\x03\x04")
+        bs = b"\x01\x02\x03\x04\xff"
+        r = encryptPassword(bs)
+        self.assertEqual(decryptPassword(r, convert_unicode=True), bs)
+
+        self.assertEqual(decryptPassword('test'), 'FAILED TO DECRYPT PASSWORD!')
 
     def test_02_encrypt_decrypt_eas_base64(self):
         import os
         key = os.urandom(16)
-        data = "This is so secret!"
+        data = b"This is so secret!"
         s = aes_encrypt_b64(key, data)
         d = aes_decrypt_b64(key, s)
         self.assertEqual(data, d)
@@ -178,6 +182,29 @@ class CryptoTestCase(MyTestCase):
         s = aes_encrypt_b64(key, otp_seed)
         d = aes_decrypt_b64(key, s)
         self.assertEqual(otp_seed, d)
+
+    def test_03_hash(self):
+        import os
+        val = os.urandom(16)
+        seed = os.urandom(16)
+        h1 = hash(val, seed)
+        self.assertEqual(h1, hash(val, seed))
+        seed2 = os.urandom(16)
+        self.assertNotEqual(h1, hash(val, seed2))
+
+    def test_04_encrypt_decrypt_data(self):
+        import os
+        data = os.urandom(50)
+        iv = os.urandom(16)
+        c = encrypt(data, iv)
+        # verify
+        d = decrypt(binascii.unhexlify(c), iv)
+        self.assertEqual(data, d)
+
+        s = u"Encryption Text with unicode chars: äöü"
+        c = encrypt(s, iv)
+        d = decrypt(binascii.unhexlify(c), iv)
+        self.assertEqual(s, d.decode('utf8'))
 
 
 class RandomTestCase(MyTestCase):
@@ -231,7 +258,6 @@ class RandomTestCase(MyTestCase):
     def test_06_hash_pepper(self):
         h = hash_with_pepper("superPassword")
         self.assertTrue("$pbkdf2"in h, h)
-        self.assertTrue("$10023"in h, h)
 
         r = verify_with_pepper(h, "superPassword")
         self.assertEqual(r, True)
@@ -271,10 +297,10 @@ class AESHardwareSecurityModuleTestCase(MyTestCase):
             self.assertIs(hsm.session, pkcs11.session_mock)
 
             # mock just returns \x00\x01... for random values
-            self.assertEqual(hsm.random(4), "\x00\x01\x02\x03")
+            self.assertEqual(hsm.random(4), b"\x00\x01\x02\x03")
             pkcs11.session_mock.generateRandom.assert_called_once_with(4)
 
-            password = "topSekr3t" * 16
+            password = b"topSekr3t" * 16
             crypted = hsm.encrypt_password(password)
             # to generate the IV
             pkcs11.session_mock.generateRandom.assert_called_with(16)
@@ -304,7 +330,7 @@ class AESHardwareSecurityModuleTestCase(MyTestCase):
             ])
 
             # simulate that encryption succeeds after five tries
-            password = "topSekr3t" * 16
+            password = b"topSekr3t" * 16
             with pkcs11.simulate_failure(pkcs11.session_mock.encrypt, 5):
                 encrypted = hsm.encrypt_password(password)
                 # the session has been opened initially, and five times after that
@@ -318,7 +344,7 @@ class AESHardwareSecurityModuleTestCase(MyTestCase):
 
             # simulate that random generation succeeds after five tries
             with pkcs11.simulate_failure(pkcs11.session_mock.generateRandom, 5):
-                self.assertEqual(hsm.random(4), "\x00\x01\x02\x03")
+                self.assertEqual(hsm.random(4), b"\x00\x01\x02\x03")
                 self.assertEqual(pkcs11.mock.openSession.mock_calls, [call(slot=1)] * 16)
 
     def test_04_fail_encrypt(self):
@@ -338,7 +364,7 @@ class AESHardwareSecurityModuleTestCase(MyTestCase):
             ])
 
             # simulate that encryption still fails after five tries
-            password = "topSekr3t" * 16
+            password = b"topSekr3t" * 16
             with pkcs11.simulate_failure(pkcs11.session_mock.encrypt, 6):
                 with self.assertRaises(HSMException):
                     hsm.encrypt_password(password)
@@ -361,7 +387,7 @@ class AESHardwareSecurityModuleTestCase(MyTestCase):
             ])
 
             # encryption+decryption succeeds once
-            password = "topSekr3t" * 16
+            password = b"topSekr3t" * 16
             crypted = hsm.encrypt_password(password)
             text = hsm.decrypt_password(crypted)
             self.assertEqual(text, password)

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -61,9 +61,9 @@ class SecurityModuleTestCase(MyTestCase):
         config = current_app.config
         hsm = DefaultSecurityModule({"file": config.get("PI_ENCFILE")})
 
-        cipher = hsm.encrypt("data", "iv12345678901234")
-        text = hsm.decrypt(cipher, "iv12345678901234")
-        self.assertTrue(text == "data", text)
+        cipher = hsm.encrypt(b"data", b"iv12345678901234")
+        text = hsm.decrypt(cipher, b"iv12345678901234")
+        self.assertTrue(text == b"data", text)
 
         cipher = hsm.encrypt_pin("data")
         text = hsm.decrypt_pin(cipher)

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -14,7 +14,7 @@ from privacyidea.lib.crypto import (encryptPin, encryptPassword, decryptPin,
                                     geturandom, get_alphanum_str, hash_with_pepper,
                                     verify_with_pepper, aes_encrypt_b64, aes_decrypt_b64,
                                     get_hsm, init_hsm, set_hsm_password, hash,
-                                    encrypt, decrypt)
+                                    encrypt, decrypt, _to_bytes, _to_unicode)
 from privacyidea.lib.security.default import (SecurityModule,
                                               DefaultSecurityModule)
 from privacyidea.lib.security.aeshsm import AESHardwareSecurityModule
@@ -205,6 +205,14 @@ class CryptoTestCase(MyTestCase):
         c = encrypt(s, iv)
         d = decrypt(binascii.unhexlify(c), iv)
         self.assertEqual(s, d.decode('utf8'))
+
+    def test_05_encode_decode(self):
+        b_str = b'Hello World'
+        self.assertEqual(_to_unicode(b_str), b_str.decode('utf8'))
+        u_str = u'Hello Wörld'
+        self.assertEqual(_to_unicode(u_str), u_str)
+        self.assertEqual(_to_bytes(b_str), b_str)
+        self.assertEqual(_to_bytes(u_str), u_str.encode('utf8'))
 
 
 class RandomTestCase(MyTestCase):


### PR DESCRIPTION
Working on the crypto layer to improve the interfaces.
Changed the signature of some function to accept/return (hexlified) unicode strings where appropriate. Some functions still accept/return bytes since they are called from several places with unclear code paths.
This is more a basis for discussion...
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23issuecomment-448224570%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242568047%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242568962%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242570208%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242571330%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242574458%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242576131%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242863162%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242866936%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242871600%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242878631%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242879108%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242885620%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242886233%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242886669%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242886735%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242888659%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242889194%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242891459%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242925406%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242983497%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242983640%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242988048%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242988098%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242988305%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242989058%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242989067%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242989742%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242989953%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243199440%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23issuecomment-448927537%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243203386%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23issuecomment-448931604%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243237209%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243263678%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243283119%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243287485%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243287759%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243311709%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243312338%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243315255%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243315954%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243556356%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243556409%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r243556422%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23issuecomment-448224570%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231345%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/2f14e9b7c2004236bf06b01d2e6b8bb771d7ffba%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6093.75%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231345%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2096.37%25%20%20%2096.36%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017315%20%20%20%2017312%20%20%20%20%20%20%20-3%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2016687%20%20%20%2016683%20%20%20%20%20%20%20-4%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20628%20%20%20%20%20%20629%20%20%20%20%20%20%20%2B1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6094.76%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/security/aeshsm.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2Flc2hzbS5weQ%3D%3D%29%20%7C%20%6038.09%25%20%3C%5Cu00f8%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/security/pkcs11.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L3BrY3MxMS5weQ%3D%3D%29%20%7C%20%600%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/api/auth.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL2F1dGgucHk%3D%29%20%7C%20%6099.11%25%20%3C100%25%3E%20%28-0.01%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/utils.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5%29%20%7C%20%6096.85%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/security/default.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2RlZmF1bHQucHk%3D%29%20%7C%20%6097.84%25%20%3C100%25%3E%20%28-0.54%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/tantoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90YW50b2tlbi5weQ%3D%3D%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/crypto.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2NyeXB0by5weQ%3D%3D%29%20%7C%20%6095.16%25%20%3C96.66%25%3E%20%28-0.39%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/models.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5%29%20%7C%20%6098.82%25%20%3C97.05%25%3E%20%28-0.08%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20...%20and%20%5B1%20more%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345/diff%3Fsrc%3Dpr%26el%3Dtree-more%29%20%7C%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B2f14e9b...d709698%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1345%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-18T13%3A41%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20fine%20with%20my%20comments%21%5Cr%5CnIf%20Friedrich%20is%20fine%20with%20his%20points%2C%20I%20think%20this%20can%20be%20merged.%22%2C%20%22created_at%22%3A%20%222018-12-20T09%3A15%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20still%20have%20some%20open%20comments%20--%20but%20we%20could%20also%20keep%20them%20in%20mind%20for%20a%20subsequent%20PR%20to%20get%20this%20merged%3F%22%2C%20%22created_at%22%3A%20%222018-12-20T09%3A29%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/lib/crypto.py%20203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242568962%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22would%20it%20make%20sense%20and%20be%20safe%20to%20do%5Cr%5Cn%7E%7E%7Epython%5Cr%5Cnreturn%20_to_unicode%28binascii.hexlify%28_to_bytes%28s%29%29%29%5Cr%5Cn%7E%7E%7E%5Cr%5Cn%3F%22%2C%20%22created_at%22%3A%20%222018-12-18T14%3A56%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22sure%2C%20I%27ll%20fix%20it.%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A16%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%20in%20d709698%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A26%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A40%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/crypto.py%3AL136-227%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/lib/crypto.py%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242568047%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20know%2C%20this%20is%20a%20new%20one%3A%20But%20it%20might%20make%20sense%20to%20define%20the%20CONFIG_KEY%3B%20TOKEN_KEY%20here%20and%20import%20them%20in%20e.g.%20lib/security/aeshsm.py%20...%20so%20that%20we%20do%20not%20need%20to%20redefine%20the%20%60%60int%60%60s%20in%20all%20files.%22%2C%20%22created_at%22%3A%20%222018-12-18T14%3A54%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20was%20thinking%20about%20that%2C%20too.%5Cr%5CnUnfortunately%20they%20are%20mixed%20up%3A%5Cr%5Cnin%20%60lib/crypto.py%60%3A%5Cr%5Cn%60CONFIG_KEY%20%3D%201%5Cr%5CnTOKEN_KEY%20%3D%202%5Cr%5CnVALUE_KEY%20%3D%203%60%5Cr%5Cn%5Cr%5Cnin%20%60lib/security/aeshsm.py%60%3A%5Cr%5Cn%60TOKEN_KEY%20%3D%200%5Cr%5CnCONFIG_KEY%20%3D%201%5Cr%5CnVALUE_KEY%20%3D%202%60%5Cr%5Cn%5Cr%5Cnand%20in%20%60lib/security/default.py%60%3A%5Cr%5Cn%60TOKEN_KEY%20%3D%200%5Cr%5CnCONFIG_KEY%20%3D%201%5Cr%5CnVALUE_KEY%20%3D%202%5Cr%5CnDEFAULT_KEY%20%3D%203%60%5Cr%5Cn%5Cr%5CnI%27ll%20check%20the%20code%20and%20fix%20it.%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A14%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%20in%20d7096985c2a6f8f0e5f15a5388da587ee7e289b1%5Cr%5CnThere%20are%20also%20the%20functions%20%5B%60encrypt%28%29%60%5D%28https%3A//github.com/privacyidea/privacyidea/blob/f0e71aec27513c032ce0bdfb63956e705fab849f/privacyidea/lib/crypto.py%23L358%29%20and%20%5B%60decrypt%28%29%60%5D%28https%3A//github.com/privacyidea/privacyidea/blob/f0e71aec27513c032ce0bdfb63956e705fab849f/privacyidea/lib/crypto.py%23L378%29%20in%20%60crypto.py%60%20which%20pass%20the%20slot%20id%2C%20but%20it%20is%20actually%20unused.%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A26%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A37%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-20T09%3A13%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/crypto.py%3AL74-80%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/lib/security/default.py%20112%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242863162%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20wasn%27t%20really%20aware%20of%20this%20method%20%3A-%29%20But%20I%20see%20it%27s%20used%20to%20encrypt%20encryption%20keys%20with%20a%20password%20in%20%60%60encrypt_enckey%60%60%20in%20%60%60pi-manage%60%60.%20I%20think%20encryption%20keys%20are%20just%20bytes.%20What%20do%20you%20think%20about%20making%20%60%60password_encrypt%60%60%20take%20bytes%20and%20return%20bytes%2C%20and%20%60%60password_decrypt%60%60%20take%20bytes%20and%20return%20bytes%2C%20in%20order%20to%20make%20it%20consistent%20with%20the%20other%20methods%20of%20%60%60DefaultSecurityModule%60%60%3F%5Cr%5Cn%5Cr%5CnAlso%2C%20I%20think%20we%27ll%20need%20to%20change%20%60%60encrypt_enckey%60%60%20in%20%60%60pi-manage%60%60%3A%20it%20reads%20the%20enckey%20file%20using%20%60%60open%28encfile%2C%20%5C%22r%5C%22%29%60%60%20which%20I%20think%20will%20break%20in%20Python%203%3F%22%2C%20%22created_at%22%3A%20%222018-12-19T10%3A25%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20stumbled%20upon%20this%20as%20well%2C%20we%20need%20to%20distinguish%20between%20functions%20that%20expect/return%20strings%20%28hashing%2C%20encrypting/decrypting%20passwords/pins%29%20and%20functions%20which%20handle%20arbitrary%20%28binary%29%20data.%20I%20am%20on%20it.%5Cr%5Cn%5Cr%5CnAnd%20there%20are%20several%20%60open%28%29%60%20calls%20which%20need%20to%20be%20changed%20to%20read%20the%20data%20in%20binary%20format.%20I%27ll%20fix%20them%20along%20the%20way.%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A52%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20all%20a%20little%20tricky%3A%20%60encrypt_enckey%60%20in%20%60pi-manage%60%20reads%20in%20an%20encKey%20file%20%28which%20should%20be%20binary%29%20and%20prints%20out%20a%20string%20%28hexlified%20iv%20and%20hexlified%20encrypted%20data%29.%5Cr%5CnThis%20string%20will%20be%20read%20in%20by%20%60_get_secret%28%29%60%20in%20the%20%60DefaultSecurityModule%60%20which%20then%20calls%20%60password_decrypt%60%20with%20the%20given%20string.%5Cr%5CnI%20am%20not%20really%20sure%20how%20we%20should%20handle%20things%20here.%5Cr%5CnWe%20are%20going%20to%20rewrite%20these%20parts%20anyway%20when%20we%20switch%20to%20a%20different%20crypto-library%20%28AES%2C%20padding%2C%20etc...%29%2C%20so%20maybe%20we%20should%20keep%20it%20that%20way%20for%20now%20and%20keep%20this%20in%20mind%20for%20the%20next%20rewrite.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-20T13%3A04%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20adding%20a%20TODO%20at%20those%20functions%20should%20be%20fine.%22%2C%20%22created_at%22%3A%20%222018-12-20T14%3A07%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-20T14%3A21%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/security/default.py%3AL325-352%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/lib/security/default.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242574458%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22if%20we%20use%20the%20functions%20%60_to_bytes%60%20and%20%60_to_unicode%60%20outside%20of%20the%20original%20module%20I%20think%20we%20should%20calls%20them%20%60to_bytes%60%20and%20%60to_unicode%60.%22%2C%20%22created_at%22%3A%20%222018-12-18T15%3A10%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tried%20to%20keep%20these%20functions%20to%20the%20crypto.py%20module...%20I%27ll%20check%20if%20the%20import%20can%20be%20avoided.%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A45%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20they%27ll%20be%20useful%20for%20porting%20other%20modules.%20At%20least%20%60%60hexlify_and_unicode%60%60%20might%20be%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-12-19T12%3A03%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22One%20Problem%20is%2C%20if%20we%20define%20something%20in%20%60lib/utils.py%60%20we%20can%27t%20use%20it%20in%20%60lib/crypto.py%60%20since%20the%20%60crypto%60%20module%20is%20imported%20into%20%60utils%60...%5Cr%5CnI%20would%20prefer%20if%20the%20%60utils%60%20module%20would%20not%20import%20any%20privacyIDEA%20specific%20modules%20so%20that%20we%20can%20import%20it%20everywhere.%5Cr%5CnWe%20could%20%20move%20the%20functions%20that%20make%20use%20of%20the%20%60crypto%60%20module%20%28specifically%20%60urandom%28%29%60%20and%20%60geturandom%28%29%60%29%20into%20the%20%60crypto%60%20module%2C%20but%20i%20would%20like%20to%20do%20that%20in%20a%20different%20PR.%22%2C%20%22created_at%22%3A%20%222018-12-20T11%3A20%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20a%20privacyIDEA-independent%20utils%20module%20would%20be%20nice%21%20But%20doing%20this%20in%20another%20PR%20is%20probably%20a%20good%20idea.%22%2C%20%22created_at%22%3A%20%222018-12-20T14%3A20%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Right.%20The%20utils%20was%20ment%20to%20run%20independent%20of%20anything%20privacyidea%20specific.%22%2C%20%22created_at%22%3A%20%222018-12-20T15%3A28%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-20T15%3A35%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/security/default.py%3AL43-54%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/lib/crypto.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242576131%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20add%20some%20information%20to%20the%20doc%20string%20of%20this%20module%2C%20that%20parameter%20of%20functions%20are%20expected%20as%20a%20certain%20type%20and%20functions%20in%20this%20module%20usually%20return%20a%20certain%20type%20%28is%20it%20hexlified%20byte%20string%3F%29%22%2C%20%22created_at%22%3A%20%222018-12-18T15%3A14%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22on%20it.%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A45%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-20T15%3A26%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/crypto.py%3AL46-58%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/lib/crypto.py%20245%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242570208%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Where%20is%20the%20salt%20and%20the%20rounds%20gone%3F%20%28OK%2C%20obviously%20we%20might%20drop%20passlib%20anyways%20later%20in%20favour%20for%20cryptography%29%22%2C%20%22created_at%22%3A%20%222018-12-18T14%3A59%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20documentation%20recommends%20keeping%20the%20default%20values.%20I%20am%20not%20sure%20what%20we%20would%20gain%20%28in%20our%20case%20even%20reducing%20the%20number%20of%20%60rounds%60%20and%20the%20%60salt_size%60%20compared%20to%20the%20default%29.%5Cr%5CnI%20would%20prefer%20sticking%20with%20the%20default%20since%20%27they%20know%20best%27...%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A40%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20probably%20right.%20I%20also%20think%20the%20parameters%20where%20not%20used%20externally.%20We%20added%20them%20to%20be%20able%20to%20allow%20someone%20who%20%5C%22thinks%20he%20knows%20better%5C%22%2C%20to%20more%20easily%20adapt%20this.%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A41%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A42%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/crypto.py%3AL136-227%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/lib/crypto.py%20373%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242571330%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20used%20this%20step%20before%20the%20%60%60return%60%60%20since%20it%20was%20easier%20to%20debug.%20What%20do%20you%20tink%3F%20%22%2C%20%22created_at%22%3A%20%222018-12-18T15%3A02%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20it%20is%20more%20%27pythonic%27%20but%20You%20are%20right%2C%20debugging%20is%20easier%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A43%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%20in%20d709698%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A37%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A40%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/crypto.py%3AL326-378%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/lib/crypto.py%20367%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242871600%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hm%2C%20I%20see%20why%20you%20changed%20%60%60encrypt%60%60%20to%20return%20a%20hexstring%2C%20and%20I%20think%20that%20makes%20sense.%20But%20I%20think%20it%27s%20unfortunate%20that%20%60%60encrypt%60%60%20and%20%60%60decrypt%60%60%20are%20not%20inverses%20anymore%20%28because%20%60%60decrypt%60%60%20expects%20bytes%29.%5Cr%5CnMaybe%20we%20can%20keep%20the%20old%20%60%60encrypt%60%60/%60%60decrypt%60%60%20operating%20on%20bytes%2C%20and%20add%20a%20new%20%60%60encrypt_and_hexlify%60%60%3F%20But%20maybe%20there%27s%20a%20better%20way%20to%20fix%20it.%22%2C%20%22created_at%22%3A%20%222018-12-19T10%3A50%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20i%20don%27t%20like%20this%20either.%20I%27ll%20look%20into%20the%20usage%20of%20these%20functions%20again%2C%20maybe%20there%20is%20a%20better%20approach.%22%2C%20%22created_at%22%3A%20%222018-12-19T14%3A00%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40fredreichbier%20%3A%20%40plettich%20added%20a%20docstring%2C%20so%20that%20we%20can%20handle%20this%20later%20with%20issue%20%23337%22%2C%20%22created_at%22%3A%20%222018-12-20T15%3A37%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20can%20fix%20this%20in%20a%20later%20PR.%22%2C%20%22created_at%22%3A%20%222018-12-21T11%3A22%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-21T11%3A22%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/crypto.py%3AL326-378%22%7D%2C%20%22Pull%20f0e71aec27513c032ce0bdfb63956e705fab849f%20privacyidea/models.py%20134%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1345%23discussion_r242866936%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Correct%20me%20if%20I%27m%20wrong%2C%20but%20can%27t%20we%20remove%20this%20because%20%60%60encryptPin%60%60%20will%20call%20%60%60_to_bytes%28%29%60%60%20anyway%3F%22%2C%20%22created_at%22%3A%20%222018-12-19T10%3A37%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20need%20for%20correction%20%3A-%29%22%2C%20%22created_at%22%3A%20%222018-12-19T11%3A54%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%20in%20d709698%22%2C%20%22created_at%22%3A%20%222018-12-19T16%3A38%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-20T09%3A27%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-21T11%3A21%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/models.py%3AL393-402%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#issuecomment-448224570'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1345?src=pr&el=h1) Report
> Merging [#1345](https://codecov.io/gh/privacyidea/privacyidea/pull/1345?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/2f14e9b7c2004236bf06b01d2e6b8bb771d7ffba?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `93.75%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1345?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1345      +/-   ##
==========================================
- Coverage   96.37%   96.36%   -0.01%
==========================================
Files         144      144
Lines       17315    17312       -3
==========================================
- Hits        16687    16683       -4
- Misses        628      629       +1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1345?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `94.76% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/security/aeshsm.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2Flc2hzbS5weQ==) | `38.09% <ø> (ø)` | :arrow_up: |
| [privacyidea/lib/security/pkcs11.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L3BrY3MxMS5weQ==) | `0% <0%> (ø)` | :arrow_up: |
| [privacyidea/api/auth.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL2F1dGgucHk=) | `99.11% <100%> (-0.01%)` | :arrow_down: |
| [privacyidea/lib/utils.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3V0aWxzLnB5) | `96.85% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/lib/security/default.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3NlY3VyaXR5L2RlZmF1bHQucHk=) | `97.84% <100%> (-0.54%)` | :arrow_down: |
| [privacyidea/lib/tokens/tantoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy90YW50b2tlbi5weQ==) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/crypto.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2NyeXB0by5weQ==) | `95.16% <96.66%> (-0.39%)` | :arrow_down: |
| [privacyidea/models.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbW9kZWxzLnB5) | `98.82% <97.05%> (-0.08%)` | :arrow_down: |
| ... and [1 more](https://codecov.io/gh/privacyidea/privacyidea/pull/1345/diff?src=pr&el=tree-more) | |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1345?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1345?src=pr&el=footer). Last update [2f14e9b...d709698](https://codecov.io/gh/privacyidea/privacyidea/pull/1345?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I am fine with my comments!
If Friedrich is fine with his points, I think this can be merged.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I still have some open comments -- but we could also keep them in mind for a subsequent PR to get this merged?
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/lib/crypto.py 41'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242568047'>File: privacyidea/lib/crypto.py:L74-80</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I know, this is a new one: But it might make sense to define the CONFIG_KEY; TOKEN_KEY here and import them in e.g. lib/security/aeshsm.py ... so that we do not need to redefine the ``int``s in all files.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> I was thinking about that, too.
Unfortunately they are mixed up:
in `lib/crypto.py`:
`CONFIG_KEY = 1
TOKEN_KEY = 2
VALUE_KEY = 3`
in `lib/security/aeshsm.py`:
`TOKEN_KEY = 0
CONFIG_KEY = 1
VALUE_KEY = 2`
and in `lib/security/default.py`:
`TOKEN_KEY = 0
CONFIG_KEY = 1
VALUE_KEY = 2
DEFAULT_KEY = 3`
I'll check the code and fix it.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> fixed in d7096985c2a6f8f0e5f15a5388da587ee7e289b1
There are also the functions [`encrypt()`](https://github.com/privacyidea/privacyidea/blob/f0e71aec27513c032ce0bdfb63956e705fab849f/privacyidea/lib/crypto.py#L358) and [`decrypt()`](https://github.com/privacyidea/privacyidea/blob/f0e71aec27513c032ce0bdfb63956e705fab849f/privacyidea/lib/crypto.py#L378) in `crypto.py` which pass the slot id, but it is actually unused.
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/lib/crypto.py 203'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242568962'>File: privacyidea/lib/crypto.py:L136-227</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> would it make sense and be safe to do
~~~python
return _to_unicode(binascii.hexlify(_to_bytes(s)))
~~~
?
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> sure, I'll fix it.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> fixed in d709698
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/lib/crypto.py 245'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242570208'>File: privacyidea/lib/crypto.py:L136-227</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Where is the salt and the rounds gone? (OK, obviously we might drop passlib anyways later in favour for cryptography)
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> The documentation recommends keeping the default values. I am not sure what we would gain (in our case even reducing the number of `rounds` and the `salt_size` compared to the default).
I would prefer sticking with the default since 'they know best'...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are probably right. I also think the parameters where not used externally. We added them to be able to allow someone who "thinks he knows better", to more easily adapt this.
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/lib/crypto.py 373'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242571330'>File: privacyidea/lib/crypto.py:L326-378</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I used this step before the ``return`` since it was easier to debug. What do you tink?
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> I think it is more 'pythonic' but You are right, debugging is easier :-)
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> fixed in d709698
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/lib/security/default.py 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242574458'>File: privacyidea/lib/security/default.py:L43-54</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> if we use the functions `_to_bytes` and `_to_unicode` outside of the original module I think we should calls them `to_bytes` and `to_unicode`.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> I tried to keep these functions to the crypto.py module... I'll check if the import can be avoided.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Maybe they'll be useful for porting other modules. At least ``hexlify_and_unicode`` might be :-)
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> One Problem is, if we define something in `lib/utils.py` we can't use it in `lib/crypto.py` since the `crypto` module is imported into `utils`...
I would prefer if the `utils` module would not import any privacyIDEA specific modules so that we can import it everywhere.
We could  move the functions that make use of the `crypto` module (specifically `urandom()` and `geturandom()`) into the `crypto` module, but i would like to do that in a different PR.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Yes, a privacyIDEA-independent utils module would be nice! But doing this in another PR is probably a good idea.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Right. The utils was ment to run independent of anything privacyidea specific.
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/lib/crypto.py 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242576131'>File: privacyidea/lib/crypto.py:L46-58</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Please add some information to the doc string of this module, that parameter of functions are expected as a certain type and functions in this module usually return a certain type (is it hexlified byte string?)
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> on it.
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/lib/security/default.py 112'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242863162'>File: privacyidea/lib/security/default.py:L325-352</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> I wasn't really aware of this method :-) But I see it's used to encrypt encryption keys with a password in ``encrypt_enckey`` in ``pi-manage``. I think encryption keys are just bytes. What do you think about making ``password_encrypt`` take bytes and return bytes, and ``password_decrypt`` take bytes and return bytes, in order to make it consistent with the other methods of ``DefaultSecurityModule``?
Also, I think we'll need to change ``encrypt_enckey`` in ``pi-manage``: it reads the enckey file using ``open(encfile, "r")`` which I think will break in Python 3?
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> I stumbled upon this as well, we need to distinguish between functions that expect/return strings (hashing, encrypting/decrypting passwords/pins) and functions which handle arbitrary (binary) data. I am on it.
And there are several `open()` calls which need to be changed to read the data in binary format. I'll fix them along the way.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> This is all a little tricky: `encrypt_enckey` in `pi-manage` reads in an encKey file (which should be binary) and prints out a string (hexlified iv and hexlified encrypted data).
This string will be read in by `_get_secret()` in the `DefaultSecurityModule` which then calls `password_decrypt` with the given string.
I am not really sure how we should handle things here.
We are going to rewrite these parts anyway when we switch to a different crypto-library (AES, padding, etc...), so maybe we should keep it that way for now and keep this in mind for the next rewrite.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think adding a TODO at those functions should be fine.
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/models.py 134'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242866936'>File: privacyidea/models.py:L393-402</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Correct me if I'm wrong, but can't we remove this because ``encryptPin`` will call ``_to_bytes()`` anyway?
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> No need for correction :-)
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> fixed in d709698
- [x] <a href='#crh-comment-Pull f0e71aec27513c032ce0bdfb63956e705fab849f privacyidea/lib/crypto.py 367'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1345#discussion_r242871600'>File: privacyidea/lib/crypto.py:L326-378</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Hm, I see why you changed ``encrypt`` to return a hexstring, and I think that makes sense. But I think it's unfortunate that ``encrypt`` and ``decrypt`` are not inverses anymore (because ``decrypt`` expects bytes).
Maybe we can keep the old ``encrypt``/``decrypt`` operating on bytes, and add a new ``encrypt_and_hexlify``? But maybe there's a better way to fix it.
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> Yes, i don't like this either. I'll look into the usage of these functions again, maybe there is a better approach.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @fredreichbier : @plettich added a docstring, so that we can handle this later with issue #337
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> We can fix this in a later PR.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1345?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1345?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1345'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>