### PR TITLE
Use reset_all_user_token for challenge response tokens

### DIFF
--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -703,7 +703,7 @@ def reset_all_user_tokens(wrapped_function, *args, **kwds):
             action=ACTION.RESETALLTOKENS,
             scope=SCOPE.AUTH,
             realm=token_owner.login if token_owner else None,
-            resolver=token_owner.login if token_owner else None,
+            resolver=token_owner.resolver if token_owner else None,
             user=token_owner.realm if token_owner else None,
             client=clientip, active=True,
             audit_data=g.audit_object.audit_data)

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -677,3 +677,45 @@ def config_lost_token(wrapped_function, *args, **kwds):
 
     return wrapped_function(*args, **kwds)
 
+
+def reset_all_user_tokens(wrapped_function, *args, **kwds):
+    """
+    Resets all tokens if the corresponding policy is set.
+
+    :param token: The successful token, the tokenowner is used to find policies.
+    :param tokenobject_list: The list of all the tokens of the user
+    :param options: options dictionary containing g.
+    :return: None
+    """
+    tokenobject_list = args[0]
+    options = kwds.get("options") or {}
+    g = options.get("g")
+    allow_reset = kwds.get("allow_reset_all_tokens")
+
+    r = wrapped_function(*args, **kwds)
+
+    # A successful authentication was done
+    if r[0] and g and allow_reset:
+        clientip = options.get("clientip")
+        policy_object = g.policy_object
+        token_owner = tokenobject_list[0].user
+        reset_all = policy_object.get_policies(
+            action=ACTION.RESETALLTOKENS,
+            scope=SCOPE.AUTH,
+            realm=token_owner.login if token_owner else None,
+            resolver=token_owner.login if token_owner else None,
+            user=token_owner.realm if token_owner else None,
+            client=clientip, active=True,
+            audit_data=g.audit_object.audit_data)
+        if reset_all:
+            log.debug("Reset failcounter of all tokens of {0!s}".format(
+                token_owner))
+            for tok_obj_reset in tokenobject_list:
+                try:
+                    tok_obj_reset.reset()
+                except Exception:
+                    log.debug(
+                        "registration token does not exist anymore and "
+                        "cannot be reset.")
+
+    return r

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1924,7 +1924,8 @@ def check_serial_pass(serial, passw, options=None):
     tokenobject = get_one_token(serial=serial)
     res, reply_dict = check_token_list([tokenobject], passw,
                                        user=tokenobject.user,
-                                       options=options)
+                                       options=options,
+                                       allow_reset_all_tokens=True)
 
     return res, reply_dict
 
@@ -1978,7 +1979,8 @@ def check_user_pass(user, passw, options=None):
         tokenobject = tokenobject_list[0]
         res, reply_dict = check_token_list(tokenobject_list, passw,
                                            user=tokenobject.user,
-                                           options=options)
+                                           options=options,
+                                           allow_reset_all_tokens=True)
 
     return res, reply_dict
 

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1987,7 +1987,7 @@ def check_user_pass(user, passw, options=None):
 
 @log_with(log)
 @libpolicy(reset_all_user_tokens)
-def check_token_list(tokenobject_list, passw, user=None, options=None, allow_reset_all_tokens=True):
+def check_token_list(tokenobject_list, passw, user=None, options=None, allow_reset_all_tokens=False):
     """
     this takes a list of token objects and tries to find the matching token
     for the given passw. It also tests,
@@ -2002,8 +2002,8 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
     :param passw: the provided passw (mostly pin+otp)
     :param user: the identified use - as class object
     :param options: additional parameters, which are passed to the token
-    :param allow_reset_all_tokens: If set to false, the policy reset_all_user_tokens does not have
-        any effect. It is used by the decorator.
+    :param allow_reset_all_tokens: If set to True, the policy reset_all_user_tokens is evaluated to
+        reset all user tokens accordingly. Note: This parameter is used in the decorator.
 
     :return: tuple of success and optional response
     :rtype: (bool, dict)

--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -450,7 +450,7 @@ h={h}
                                     prefix))
             return res, opt
 
-        (res, opt) = check_token_list(token_list, passw)
+        (res, opt) = check_token_list(token_list, passw, allow_reset_all_tokens=True)
         return res, opt
 
     @log_with(log)

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -1530,7 +1530,7 @@ class TokenFailCounterTestCase(MyTestCase):
         options = {"g": g}
 
         check_token_list([token1, token2], pin1, user=user,
-                         options=options)
+                         options=options, allow_reset_all_tokens=True)
 
         self.assertEqual(token1.token.failcount, 0)
         self.assertEqual(token2.token.failcount, 0)
@@ -1547,7 +1547,8 @@ class TokenFailCounterTestCase(MyTestCase):
         self.assertEqual(token1.token.failcount, 1)
         self.assertEqual(token2.token.failcount, 2)
 
-        check_token_list([token1, token2], pin1, options=options)
+        check_token_list([token1, token2], pin1, options=options,
+                         allow_reset_all_tokens=True)
 
         self.assertEqual(token1.token.failcount, 0)
         self.assertEqual(token2.token.failcount, 0)


### PR DESCRIPTION
The policy reset_all_user_tokens now also works
with challenge response tokens. If a successful challenge
was given, the failcounter of all tokens are reset.

For this we move the reset_all logic to a decorator.

Closes #1348
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243214862%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243220956%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243221957%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23issuecomment-448972864%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243290573%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243290647%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243294139%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243294872%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23issuecomment-448972864%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231349%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/2f14e9b7c2004236bf06b01d2e6b8bb771d7ffba%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6090.9%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231349%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2096.37%25%20%20%2096.37%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017315%20%20%20%2017322%20%20%20%20%20%20%20%2B7%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016687%20%20%20%2016694%20%20%20%20%20%20%20%2B7%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20628%20%20%20%20%20%20628%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/yubikeytoken.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy95dWJpa2V5dG9rZW4ucHk%3D%29%20%7C%20%6097.61%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6094.92%25%20%3C100%25%3E%20%28%2B0.15%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policydecorators.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk%3D%29%20%7C%20%6099.22%25%20%3C89.47%25%3E%20%28-0.78%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B2f14e9b...29d95af%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1349%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-20T11%3A52%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c823f096c45c50fff52f5bcf6031ad09bb16a94b%20privacyidea/lib/policydecorators.py%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243214862%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22shouldn%27t%20that%20be%20%60%60token_owner.resolver%60%60%3F%22%2C%20%22created_at%22%3A%20%222018-12-20T10%3A03%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22yes.%20thx.%22%2C%20%22created_at%22%3A%20%222018-12-20T10%3A24%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%20bd97b66b%22%2C%20%22created_at%22%3A%20%222018-12-20T10%3A27%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-20T14%3A30%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/policydecorators.py%3AL677-722%22%7D%2C%20%22Pull%2029d95afc56a4a79f469bc7dbb6dd43cce8b04ab3%20privacyidea/lib/token.py%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1349%23discussion_r243290573%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20we%20set%20the%20default%20value%20of%20%60%60allow_reset_all_tokens%60%60%20to%20False%3F%20The%20default%20value%20specified%20here%20does%20not%20affect%20the%20behavior%20anyway%20because%20it%20is%20unused%20in%20%60%60check_token_list%60%60.%20But%20the%20implementation%20of%20%60%60reset_all_user_tokens%60%60%20does%20not%20reset%20tokens%20if%20the%20parameter%20is%20unspecified%2C%20so%20having%20a%20default%20value%20of%20%60%60True%60%60%20here%20is%20misleading.%22%2C%20%22created_at%22%3A%20%222018-12-20T14%3A29%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right.%20Usually%20it%20would%20not%20be%20what%20you%20wanted.%20But%20it%20is%20acutally%20how%20it%20works.%5Cr%5CnDone%20in%20e78da4cb%22%2C%20%22created_at%22%3A%20%222018-12-20T14%3A39%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222018-12-20T14%3A41%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL1979-1994%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1349#issuecomment-448972864'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1349?src=pr&el=h1) Report
> Merging [#1349](https://codecov.io/gh/privacyidea/privacyidea/pull/1349?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/2f14e9b7c2004236bf06b01d2e6b8bb771d7ffba?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `90.9%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1349/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1349?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1349      +/-   ##
==========================================
+ Coverage   96.37%   96.37%   +<.01%
==========================================
Files         144      144
Lines       17315    17322       +7
==========================================
+ Hits        16687    16694       +7
Misses        628      628
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1349?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/yubikeytoken.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1349/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy95dWJpa2V5dG9rZW4ucHk=) | `97.61% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1349/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `94.92% <100%> (+0.15%)` | :arrow_up: |
| [privacyidea/lib/policydecorators.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1349/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk=) | `99.22% <89.47%> (-0.78%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1349?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1349?src=pr&el=footer). Last update [2f14e9b...29d95af](https://codecov.io/gh/privacyidea/privacyidea/pull/1349?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull c823f096c45c50fff52f5bcf6031ad09bb16a94b privacyidea/lib/policydecorators.py 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1349#discussion_r243214862'>File: privacyidea/lib/policydecorators.py:L677-722</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> shouldn't that be ``token_owner.resolver``?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> yes. thx.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in bd97b66b
- [x] <a href='#crh-comment-Pull 29d95afc56a4a79f469bc7dbb6dd43cce8b04ab3 privacyidea/lib/token.py 44'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1349#discussion_r243290573'>File: privacyidea/lib/token.py:L1979-1994</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Can we set the default value of ``allow_reset_all_tokens`` to False? The default value specified here does not affect the behavior anyway because it is unused in ``check_token_list``. But the implementation of ``reset_all_user_tokens`` does not reset tokens if the parameter is unspecified, so having a default value of ``True`` here is misleading.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You are right. Usually it would not be what you wanted. But it is acutally how it works.
Done in e78da4cb


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1349?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1349?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1349'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>