### PR TITLE
Make triggerchallenge HTTP response consistent

### DIFF
--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2014,18 +2014,18 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
                 challenge_info["attributes"] = attributes
                 challenge_info["serial"] = token_obj.token.serial
                 # If exist, add next pin and next password change
-                next_pin = token_list[0].get_tokeninfo(
+                next_pin = token_obj.get_tokeninfo(
                         "next_pin_change")
                 if next_pin:
                     challenge_info["next_pin_change"] = next_pin
                     challenge_info["pin_change"] = \
-                        token_list[0].is_pin_change()
-                next_passw = token_list[0].get_tokeninfo(
+                        token_obj.is_pin_change()
+                next_passw = token_obj.get_tokeninfo(
                         "next_password_change")
                 if next_passw:
                     challenge_info["next_password_change"] = next_passw
                     challenge_info["password_change"] = \
-                        token_list[0].is_pin_change(
+                        token_obj.is_pin_change(
                             password=True)
                 reply_dict.update(challenge_info)
                 reply_dict["multi_challenge"].append(challenge_info)

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1985,6 +1985,57 @@ def check_user_pass(user, passw, options=None):
     return res, reply_dict
 
 
+def create_challenges_from_tokens(token_list, reply_dict, options=None):
+    """
+    Get a list of active tokens and create challenges for these tokens.
+    The reply_dict is modified accordingly. The transaction_id and
+    the messages are added to the reply_dict.
+
+    :param token_list: The list of the token objects, that can do challenge response
+    :param reply_dict: The dictionary that is passed to the API response
+    :param options: Additional options. Passed from the upper layer
+    :return: None
+    """
+    options = options or {}
+    reply_dict["multi_challenge"] = []
+    transaction_id = None
+    message_list = []
+    for token_obj in token_list:
+        # Check if the max auth is succeeded
+        if token_obj.check_all(message_list):
+            r_chal, message, transaction_id, attributes = \
+                token_obj.create_challenge(
+                    transactionid=transaction_id, options=options)
+            # Add the reply to the response
+            message_list.append(message)
+            reply_dict["message"] = ", ".join(message_list)
+            if r_chal:
+                challenge_info = {}
+                challenge_info["transaction_id"] = transaction_id
+                challenge_info["attributes"] = attributes
+                challenge_info["serial"] = token_obj.token.serial
+                # If exist, add next pin and next password change
+                next_pin = token_list[0].get_tokeninfo(
+                        "next_pin_change")
+                if next_pin:
+                    challenge_info["next_pin_change"] = next_pin
+                    challenge_info["pin_change"] = \
+                        token_list[0].is_pin_change()
+                next_passw = token_list[0].get_tokeninfo(
+                        "next_password_change")
+                if next_passw:
+                    challenge_info["next_password_change"] = next_passw
+                    challenge_info["password_change"] = \
+                        token_list[0].is_pin_change(
+                            password=True)
+                for k, v in challenge_info.items():
+                    reply_dict[k] = v
+                reply_dict["multi_challenge"].append(challenge_info)
+    # TODO: These two lines are deprecated: Add the information for the old administrative triggerchallenge
+    reply_dict["messages"] = message_list
+    reply_dict["transaction_ids"] = [chal.get("transaction_id") for chal in reply_dict.get("multi_challenge", [])]
+
+
 @log_with(log)
 @libpolicy(reset_all_user_tokens)
 def check_token_list(tokenobject_list, passw, user=None, options=None, allow_reset_all_tokens=False):
@@ -2179,40 +2230,7 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         if len(active_challenge_token) == 0:
             reply_dict["message"] = "No active challenge response token found"
         else:
-            reply_dict["multi_challenge"] = []
-            transaction_id = None
-            message_list = []
-            for token_obj in active_challenge_token:
-                # Check if the max auth is succeeded
-                if token_obj.check_all(message_list):
-                    r_chal, message, transaction_id, attributes = \
-                        token_obj.create_challenge(
-                            transactionid=transaction_id, options=options)
-                    # Add the reply to the response
-                    message_list.append(message)
-                    reply_dict["message"] = ", ".join(message_list)
-                    if r_chal:
-                        challenge_info = {}
-                        challenge_info["transaction_id"] = transaction_id
-                        challenge_info["attributes"] = attributes
-                        challenge_info["serial"] = token_obj.token.serial
-                        # If exist, add next pin and next password change
-                        next_pin = challenge_request_token_list[0].get_tokeninfo(
-                                "next_pin_change")
-                        if next_pin:
-                            challenge_info["next_pin_change"] = next_pin
-                            challenge_info["pin_change"] = \
-                                challenge_request_token_list[0].is_pin_change()
-                        next_passw = challenge_request_token_list[0].get_tokeninfo(
-                                "next_password_change")
-                        if next_passw:
-                            challenge_info["next_password_change"] = next_passw
-                            challenge_info["password_change"] = \
-                                challenge_request_token_list[0].is_pin_change(
-                                    password=True)
-                        for k, v in challenge_info.items():
-                            reply_dict[k] = v
-                        reply_dict["multi_challenge"].append(challenge_info)
+            create_challenges_from_tokens(active_challenge_token, reply_dict, options)
 
     elif pin_matching_token_list:
         # We did not find a valid token and no challenge.

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2008,7 +2008,6 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
                     transactionid=transaction_id, options=options)
             # Add the reply to the response
             message_list.append(message)
-            reply_dict["message"] = ", ".join(message_list)
             if r_chal:
                 challenge_info = {}
                 challenge_info["transaction_id"] = transaction_id
@@ -2028,9 +2027,10 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
                     challenge_info["password_change"] = \
                         token_list[0].is_pin_change(
                             password=True)
-                for k, v in challenge_info.items():
-                    reply_dict[k] = v
+                reply_dict.update(challenge_info)
                 reply_dict["multi_challenge"].append(challenge_info)
+    if message_list:
+        reply_dict["message"] = ", ".join(message_list)
     # TODO: These two lines are deprecated: Add the information for the old administrative triggerchallenge
     reply_dict["messages"] = message_list
     reply_dict["transaction_ids"] = [chal.get("transaction_id") for chal in reply_dict.get("multi_challenge", [])]

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2218,7 +2218,8 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
                     tokenobject.reset()
                     # We have one successful authentication, so we bail out
                     break
-                else:
+                else:  # pragma: no cover
+                    # usually check_challenge response would return "False" in case of inactive tokens
                     reply_dict["message"] = "Challenge matches, but token is inactive."
                     log.info("Received a valid response to a "
                              "challenge for inactive token {0!s}".format(tokenobject.token.serial))

--- a/privacyidea/static/components/token/controllers/tokenChallengesController.js
+++ b/privacyidea/static/components/token/controllers/tokenChallengesController.js
@@ -44,4 +44,7 @@ myApp.controller("tokenChallengesController", function ($scope,
     // initialize
     $scope.get();
 
+    // listen to the reload broadcast
+    $scope.$on("piReload", $scope.get);
+
 });

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -104,7 +104,6 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
         TokenFactory.enable(serial, $scope.get);
     };
 
-
     if ($location.path() === "/token/list") {
         $scope.get();
     }
@@ -122,9 +121,16 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
     if ($scope.pin_change) {
         $location.path("/pinchange");
     }
-
+    
     // listen to the reload broadcast
-    $scope.$on("piReload", $scope.get);
+    $scope.$on("piReload", function() {
+        /* Due to the parameter "live_search" in the get function
+        we can not bind the get-function to piReload below. This
+        will break in Chrome, would work in Firefox.
+        So we need this wrapper function
+        */
+        $scope.get();
+    });
 
 });
 

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -788,9 +788,50 @@ class TokenTestCase(MyTestCase):
         # enable the token again
         hotp_tokenobject.enable(True)
 
+        # Set HOTP as challenge response
+        set_policy("check_token_list_CR", scope=SCOPE.AUTH, action="{0!s}=HOTP".format(
+            ACTION.CHALLENGERESPONSE))
+
+        hotp_tokenobject.add_tokeninfo("next_pin_change", u"{0!s}".format(datetime.datetime(2019, 1, 7, 0, 0)))
+        hotp_tokenobject.add_tokeninfo("next_password_change", u"{0!s}".format(datetime.datetime(2019, 1, 7, 0, 0)))
+
+        # Now the HOTP is a valid C/R token
+        res, reply = check_token_list(tokenobject_list, "hotppin")
+        self.assertFalse(res)
+        self.assertTrue("multi_challenge" in reply)
+        transaction_id = reply.get("transaction_id")
+        res, reply = check_token_list(tokenobject_list, "481090", options={"transaction_id": transaction_id})
+        self.assertTrue(res)
+
+        # Create a challenge, but deactivate the token in the meantime:
+        hotp_tokenobject.token.counter = 9
+        hotp_tokenobject.save()
+        res, reply = check_token_list(tokenobject_list, "hotppin")
+        self.assertFalse(res)
+        self.assertTrue("multi_challenge" in reply)
+        transaction_id = reply.get("transaction_id")
+        # deactivate token
+        hotp_tokenobject.enable(False)
+        hotp_tokenobject.save()
+        res, reply = check_token_list(tokenobject_list, "481090", options={"transaction_id": transaction_id})
+        self.assertFalse(res)
+
+        # Have a challenge response token, but it is disabled.
+        hotp_tokenobject.token.counter = 9
+        hotp_tokenobject.save()
+        res, reply = check_token_list(tokenobject_list, "hotppin")
+        self.assertFalse(res)
+        self.assertFalse("multi_challenge" in reply)
+        self.assertEqual(reply.get("message"), "No active challenge response token found")
+
+        hotp_tokenobject.enable()
+        hotp_tokenobject.save()
+        delete_policy("check_token_list_CR")
+
     def test_35_check_serial_pass(self):
         hotp_tokenobject = get_tokens(serial="hotptoken")[0]
         hotp_tokenobject.set_pin("hotppin")
+        hotp_tokenobject.token.count = 10
         hotp_tokenobject.save()
 
         with self.assertRaises(ResourceNotFoundError):


### PR DESCRIPTION
The endpoints /validate/check and /validate/triggerchallenge
are able to trigger a challenge. They where not consisitent.
Now both endpoints return the same JSON, when a challenge is triggered.
If there are several C/R tokens, only ONE transaction_id is created,
which makes it easier for the calling application.

Closes #1353
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23issuecomment-449427658%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244763912%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244792086%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244793000%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244793195%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244793673%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244829091%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244829167%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244829850%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244830740%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244956427%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244956513%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244958596%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244961974%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23issuecomment-451110314%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r245695587%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23issuecomment-451977597%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23issuecomment-452001054%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23issuecomment-449427658%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231355%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/42a210ccdba44ca1c2fdf55ad84af4d173c4bae6%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6087.5%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231355%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2096.64%25%20%20%2096.64%25%20%20%20-0.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017291%20%20%20%2017288%20%20%20%20%20%20%20-3%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2016711%20%20%20%2016708%20%20%20%20%20%20%20-3%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20580%20%20%20%20%20%20580%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/api/validate.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvYXBpL3ZhbGlkYXRlLnB5%29%20%7C%20%60100%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6094.95%25%20%3C86.2%25%3E%20%28%2B0.02%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B42a210c...4169b9b%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1355%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-21T16%3A04%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%20now%20understand%20what%20this%20PR%20is%20doing%20and%20I%20think%20it%20is%20a%20sensible%20change%20%3A%29%20Some%20points%3A%5Cr%5Cn%2A%20I%20think%20it%20would%20be%20nice%20to%20have%20some%20unit%20tests%20%281%29%20to%20improve%20the%20diff%20coverage%20%282%29%20and%20for%20the%20new%20/validate/triggerchallenge%20behavior%20in%20which%20only%20one%20transaction%20ID%20is%20generated.%20I%20can%20also%20look%20into%20this%20if%20you%20want.%5Cr%5Cn%2A%20I%20don%27t%20really%20like%20the%20structure%20of%20the%20JSON%20response%20that%20results%20from%20adding%20the%20challenge%20info%20to%20the%20detail%20dict%3A%5Cr%5Cnhttps%3A//github.com/privacyidea/privacyidea/blob/6bd173a5ce7a7fa148c99bb28e0f1391345e1f3e/privacyidea/lib/token.py%23L2030%5Cr%5Cnbecause%20the%20values%20of%20%60%60serial%60%60%20and%20%60%60attributes%60%60%20depend%20on%20the%20order%20of%20tokens%20in%20%60%60token_list%60%60%2C%20and%20I%20think%20we%20don%27t%20have%20a%20defined%20order%20there.%20%20But%20I%20see%20your%20point%20about%20backwards%20compatibility%2C%20so%20we%20can%20keep%20that.%5Cr%5Cn%2A%20We%20should%20decide%20whether%20to%20merge%20this%20into%20%60%60branch-2.23%60%60%20or%20%60%60master%60%60.%20If%20we%20want%20to%20include%20this%20in%20a%20potential%20maintenance%20release%2C%20we%20could%20first%20merge%20it%20to%20%60%60branch-2.23%60%60%20and%20merge%20%60%60branch-2.23%60%60%20into%20%60%60master%60%60%20afterwards.%22%2C%20%22created_at%22%3A%20%222019-01-03T10%3A51%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cr%5Cn%3E%20%2A%20I%20think%20it%20would%20be%20nice%20to%20have%20some%20unit%20tests%20%281%29%20to%20improve%20the%20diff%20coverage%20%282%29%20and%20for%20the%20new%20/validate/triggerchallenge%20behavior%20in%20which%20only%20one%20transaction%20ID%20is%20generated.%20I%20can%20also%20look%20into%20this%20if%20you%20want.%5Cr%5Cn%5Cr%5CnWill%20take%20a%20look%20at%20it.%5Cr%5Cn%5Cr%5Cn%3E%20%2A%20We%20should%20decide%20whether%20to%20merge%20this%20into%20%60branch-2.23%60%20or%20%60master%60.%20If%20we%20want%20to%20include%20this%20in%20a%20potential%20maintenance%20release%2C%20we%20could%20first%20merge%20it%20to%20%60branch-2.23%60%20and%20merge%20%60branch-2.23%60%20into%20%60master%60%20afterwards.%5Cr%5Cn%5Cr%5CnI%20also%20thought%20about%20adding%20it%20to%20either%20a%20release%202.23.4%20%282.24%29.%5Cr%5CnEither%20by%20cherry%20picking%20or%20by%20merging%20the%20brach-2.23%20back%20in%20master%20%28Phew%2C%20not%20sure%20if%20this%20will%20work%29.%5Cr%5Cn%5Cr%5CnAs%20there%20are%20also%20some%20other%20changes%2C%20we%20might%20want%20to%20add%20to%20a%202.23.4%20cherry%20picking%20might%20be%20attractive%3F%20Lets%20talk%20about%20this%20later.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-07T15%3A44%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20%23e2f788a8%20I%20added%20some%20tests%20for%20the%20code%20%2AI%20touched%2A.%20No%20tests%20for%20line%20I%20did%20%2Anot%2A%20touch.%22%2C%20%22created_at%22%3A%20%222019-01-07T16%3A50%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204169b9b850bdc3c99c0e651c45127171975dbb64%20privacyidea/lib/token.py%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244793000%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yes%2C%20will%20do.%22%2C%20%22created_at%22%3A%20%222019-01-02T17%3A00%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%2017bdb171%22%2C%20%22created_at%22%3A%20%222019-01-02T19%3A27%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222019-01-03T10%3A20%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL1985-2042%22%7D%2C%20%22Pull%204169b9b850bdc3c99c0e651c45127171975dbb64%20privacyidea/lib/token.py%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244763912%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20we%20move%20this%20line%20to%20the%20very%20end%20of%20the%20function%20for%20the%20sake%20of%20clarity%3F%5Cr%5Cn%5Cr%5CnInitially%2C%20I%20was%20confused%20because%20I%20thought%20this%20line%20overwrites%20the%20messages%20from%20the%20tokens%20at%20the%20beginning%20of%20%60%60token_list%60%60%2C%20but%20it%20actually%20doesn%27t%2C%20because%20new%20messages%20are%20appended%20to%20the%20end%20of%20%60%60message_list%60%60%20in%20each%20iteration.%22%2C%20%22created_at%22%3A%20%222019-01-02T15%3A24%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20we%20can%20do%20this.%5Cr%5CnWill%20do.%22%2C%20%22created_at%22%3A%20%222019-01-02T16%3A57%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%2017bdb171%22%2C%20%22created_at%22%3A%20%222019-01-02T19%3A27%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222019-01-03T10%3A28%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL1985-2042%22%7D%2C%20%22Pull%204169b9b850bdc3c99c0e651c45127171975dbb64%20privacyidea/lib/token.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244793673%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Independent%20of%20merging%20this%20into%20master%20or%202.23%2C%20I%20want%20to%20keep%20this%20for%20now%2C%20for%20backward%20compatibility.%20We%20can%20not%20asure%20that%20all%20plugins%20will%20update%20the%20transaction_ids%20immediately.%20%22%2C%20%22created_at%22%3A%20%222019-01-02T17%3A03%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20just%20one%20more%20thought%3A%20If%20I%20understand%20correctly%2C%20all%20challenges%20will%20now%20have%20the%20same%20transaction%20ID%2C%20e.g.%20for%20three%20challenges%20we%20have%20the%20following%20detail%3A%5Cr%5Cn%60%60%60json%5Cr%5Cn%20%20%20%20...%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22transaction_ids%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%2204049536927188455149%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%2204049536927188455149%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%2204049536927188455149%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%5D%5Cr%5Cn%20%20%20%20%7D%2C%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnShould%20we%20keep%20this%20as%20it%20is%2C%20or%20should%20we%20modify%20%60%60transaction_id%60%60%20to%20only%20contain%20unique%20IDs%3F%20i.e.%5Cr%5Cn%60%60%60json%5Cr%5Cn%20%20%20%20...%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22transaction_ids%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%2204049536927188455149%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%5D%5Cr%5Cn%20%20%20%20%7D%2C%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222019-01-03T10%3A41%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5C%22No%5C%22%20for%20the%20sake%20of%20backward%20compatibility%20%3B-%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-07T15%3A39%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL1985-2042%22%7D%2C%20%22Pull%204169b9b850bdc3c99c0e651c45127171975dbb64%20privacyidea/lib/token.py%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1355%23discussion_r244793195%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20do%20not%20know.%20I%20will%20have%20to%20check%20this.%20Depends%20on%20the%20reset-pin%20policies.%22%2C%20%22created_at%22%3A%20%222019-01-02T17%3A01%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Currently%3A%20If%20there%20are%20more%20tokens%2C%20then%20the%20pin-change%20information%20in%20the%20top%20level%20details%20branch%20will%20be%20the%20info%20of%20the%20first%20token.%5Cr%5CnIf%20we%20change%20it%3A%20the%20info%20in%20the%20top%20level%20branch%20will%20be%20this%20of%20the%20last%20token.%5Cr%5Cn%5Cr%5CnBut%3A%20If%20we%20change%20this%2C%20then%20the%20multi_challenge%20branch%20will%20contain%20the%20correct%20pin-change%20info%20for%20each%20token.%5Cr%5CnSo%20I%20think%20it%20makes%20sense%20to%20change%20this.%22%2C%20%22created_at%22%3A%20%222019-01-02T19%3A29%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20in%206bd173a5%22%2C%20%22created_at%22%3A%20%222019-01-02T19%3A33%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222019-01-03T10%3A20%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/lib/token.py%3AL1985-2042%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1355#issuecomment-449427658'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1355?src=pr&el=h1) Report
> Merging [#1355](https://codecov.io/gh/privacyidea/privacyidea/pull/1355?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/42a210ccdba44ca1c2fdf55ad84af4d173c4bae6?src=pr&el=desc) will **decrease** coverage by `<.01%`.
> The diff coverage is `87.5%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1355/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1355?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1355      +/-   ##
==========================================
- Coverage   96.64%   96.64%   -0.01%
==========================================
Files         144      144
Lines       17291    17288       -3
==========================================
- Hits        16711    16708       -3
Misses        580      580
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1355?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/api/validate.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1355/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvYXBpL3ZhbGlkYXRlLnB5) | `100% <100%> (ø)` | :arrow_up: |
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1355/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `94.95% <86.2%> (+0.02%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1355?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1355?src=pr&el=footer). Last update [42a210c...4169b9b](https://codecov.io/gh/privacyidea/privacyidea/pull/1355?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> OK, I now understand what this PR is doing and I think it is a sensible change :) Some points:
* I think it would be nice to have some unit tests (1) to improve the diff coverage (2) and for the new /validate/triggerchallenge behavior in which only one transaction ID is generated. I can also look into this if you want.
* I don't really like the structure of the JSON response that results from adding the challenge info to the detail dict:
https://github.com/privacyidea/privacyidea/blob/6bd173a5ce7a7fa148c99bb28e0f1391345e1f3e/privacyidea/lib/token.py#L2030
because the values of ``serial`` and ``attributes`` depend on the order of tokens in ``token_list``, and I think we don't have a defined order there.  But I see your point about backwards compatibility, so we can keep that.
* We should decide whether to merge this into ``branch-2.23`` or ``master``. If we want to include this in a potential maintenance release, we could first merge it to ``branch-2.23`` and merge ``branch-2.23`` into ``master`` afterwards.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> > * I think it would be nice to have some unit tests (1) to improve the diff coverage (2) and for the new /validate/triggerchallenge behavior in which only one transaction ID is generated. I can also look into this if you want.
Will take a look at it.
> * We should decide whether to merge this into `branch-2.23` or `master`. If we want to include this in a potential maintenance release, we could first merge it to `branch-2.23` and merge `branch-2.23` into `master` afterwards.
I also thought about adding it to either a release 2.23.4 (2.24).
Either by cherry picking or by merging the brach-2.23 back in master (Phew, not sure if this will work).
As there are also some other changes, we might want to add to a 2.23.4 cherry picking might be attractive? Lets talk about this later.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> In #e2f788a8 I added some tests for the code *I touched*. No tests for line I did *not* touch.
- [ ] <a href='#crh-comment-Pull 4169b9b850bdc3c99c0e651c45127171975dbb64 privacyidea/lib/token.py 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1355#discussion_r244793673'>File: privacyidea/lib/token.py:L1985-2042</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Independent of merging this into master or 2.23, I want to keep this for now, for backward compatibility. We can not asure that all plugins will update the transaction_ids immediately.
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> OK, just one more thought: If I understand correctly, all challenges will now have the same transaction ID, e.g. for three challenges we have the following detail:
```json
...
"transaction_ids": [
"04049536927188455149",
"04049536927188455149",
"04049536927188455149"
]
},
```
Should we keep this as it is, or should we modify ``transaction_id`` to only contain unique IDs? i.e.
```json
...
"transaction_ids": [
"04049536927188455149"
]
},
```
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> "No" for the sake of backward compatibility ;-)
- [x] <a href='#crh-comment-Pull 4169b9b850bdc3c99c0e651c45127171975dbb64 privacyidea/lib/token.py 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1355#discussion_r244763912'>File: privacyidea/lib/token.py:L1985-2042</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Could we move this line to the very end of the function for the sake of clarity?
Initially, I was confused because I thought this line overwrites the messages from the tokens at the beginning of ``token_list``, but it actually doesn't, because new messages are appended to the end of ``message_list`` in each iteration.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I think we can do this.
Will do.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in 17bdb171
- [x] <a href='#crh-comment-Pull 4169b9b850bdc3c99c0e651c45127171975dbb64 privacyidea/lib/token.py 47'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1355#discussion_r244793000'>File: privacyidea/lib/token.py:L1985-2042</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Yes, will do.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in 17bdb171
- [x] <a href='#crh-comment-Pull 4169b9b850bdc3c99c0e651c45127171975dbb64 privacyidea/lib/token.py 34'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1355#discussion_r244793195'>File: privacyidea/lib/token.py:L1985-2042</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I do not know. I will have to check this. Depends on the reset-pin policies.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Currently: If there are more tokens, then the pin-change information in the top level details branch will be the info of the first token.
If we change it: the info in the top level branch will be this of the last token.
But: If we change this, then the multi_challenge branch will contain the correct pin-change info for each token.
So I think it makes sense to change this.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done in 6bd173a5


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1355?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1355?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1355'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>