### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
 # command to install dependencies
@@ -13,20 +12,22 @@ install:
   - "pip install codecov"
   - "pip install -r requirements.txt"
   - "pip install smpplib"
+
 # split the test run according to
 # http://blog.travis-ci.com/2012-11-28-speeding-up-your-tests-by-parallelizing-them/
 env:
   global:
-    - PYTHONHASHSEED=random
+    - PYTHONHASHSEED=random  # test for ordered dict use
   matrix:
     - TESTS=tests/
+
 matrix:
     allow_failures:
-       - python: 3.4
        - python: 3.5
        - python: 3.6
+
 # command to run tests
-script: "nosetests -v --with-coverage --cover-package=privacyidea $TESTS"
+script: "python -b -m pytest -v --cov=privacyidea $TESTS"
 
 after_success: 
     - codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pymysql-sa==1.0
 pyOpenSSL==18.0.0
 pyparsing==2.2.0
 pyrad==2.1
-pytest==3.6.0
+pytest==3.6.1
 pytest-cov==2.5.1
 pytest-runner==4.2
 python-dateutil==2.7.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+
+collect_ignore = []
+if sys.version_info[0] > 2:
+    collect_ignore.append("test_mod_apache.py")
+    collect_ignore.append("test_lib_smsprovider.py")
+

--- a/tests/test-migrate.sh
+++ b/tests/test-migrate.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cp tests/token-version-1.5.sqlite data.sqlite
-./manage.py db upgrade
-./manage.py addadmin -p test admin@cornelinux.de admin
-./manage.py runserver


### PR DESCRIPTION
- switch to pytest as testing framework
- use python '-b' flag to check for undesired byte conversions
- add `tests/conftest.py` to disable tests for specific python versions
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1362%23issuecomment-450748754%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1362%23discussion_r244674005%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1362%23discussion_r244775947%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1362%23discussion_r244789582%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1362%23issuecomment-450748754%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231362%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/42a210ccdba44ca1c2fdf55ad84af4d173c4bae6%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231362%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2096.64%25%20%20%2096.62%25%20%20%20-0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017291%20%20%20%2017291%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%2016711%20%20%20%2016708%20%20%20%20%20%20%20-3%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20580%20%20%20%20%20%20583%20%20%20%20%20%20%20%2B3%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6093.33%25%20%3C0%25%3E%20%28-2.5%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B42a210c...327601f%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1362%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-01T18%3A34%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20327601f13c9097bdd6c099987302b90220eb429f%20tests/conftest.py%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1362%23discussion_r244674005%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20sms%20test%20is%20excluded%3F%5Cr%5CnIs%20there%20a%20problem%2C%20why%20this%20test%20would%20not%20run%3F%22%2C%20%22created_at%22%3A%20%222019-01-02T07%3A42%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20currently%20have%20no%20working%20%60smpp%60%20library%20for%20Python%203%20thus%20the%20test%20won%27t%20even%20load.%5Cr%5CnThis%20was%20a%20mere%20example%20of%20how%20to%20exclude%20tests%20for%20specific%20Python%20versions.%20Currently%20there%20are%20several%20tests%20failing%20with%20Python%203.5/3.6%2C%20i%20have%20just%20not%20added%20all%20of%20them%20here.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-02T16%3A04%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%20see.%20These%20tests%20are%20only%20excluded%20for%20python%20ver%20%3E%202.%22%2C%20%22created_at%22%3A%20%222019-01-02T16%3A49%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/conftest.py%3AL1-8%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1362#issuecomment-450748754'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1362?src=pr&el=h1) Report
> Merging [#1362](https://codecov.io/gh/privacyidea/privacyidea/pull/1362?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/42a210ccdba44ca1c2fdf55ad84af4d173c4bae6?src=pr&el=desc) will **decrease** coverage by `0.01%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1362/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1362?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1362      +/-   ##
==========================================
- Coverage   96.64%   96.62%   -0.02%
==========================================
Files         144      144
Lines       17291    17291
==========================================
- Hits        16711    16708       -3
- Misses        580      583       +3
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1362?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1362/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `93.33% <0%> (-2.5%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1362?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1362?src=pr&el=footer). Last update [42a210c...327601f](https://codecov.io/gh/privacyidea/privacyidea/pull/1362?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [ ] <a href='#crh-comment-Pull 327601f13c9097bdd6c099987302b90220eb429f tests/conftest.py 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1362#discussion_r244674005'>File: tests/conftest.py:L1-8</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> The sms test is excluded?
Is there a problem, why this test would not run?
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> We currently have no working `smpp` library for Python 3 thus the test won't even load.
This was a mere example of how to exclude tests for specific Python versions. Currently there are several tests failing with Python 3.5/3.6, i have just not added all of them here.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK, I see. These tests are only excluded for python ver > 2.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1362?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1362?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1362'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>