### PR TITLE
Fix --chunksize parameter of token janitor

### DIFF
--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -318,7 +318,7 @@ def get_tokens_paginated_generator(tokentype=None, realm=None, assigned=None, us
 def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
                serial=None, serial_wildcard=None, active=None, resolver=None, rollout_state=None,
                count=False, revoked=None, locked=None, tokeninfo=None,
-               maxfail=None, psize=None, page=1):
+               maxfail=None):
     """
     (was getTokensOfType)
     This function returns a list of token objects of a
@@ -364,14 +364,7 @@ def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
     :type tokeninfo: dict
     :param maxfail: If only tokens should be returned, which failcounter
         reached maxfail
-    :param psize: The number of returned tokens can be restricted by using the parameter psize.
-        Pagination then is used.
-    :type psize: int
-    :param page: If pagination is used, this is the page to get
-    :type page: int
-
     :return: A list of tokenclasses (lib.tokenclass).
-        In case of pagination a tuple of count, prev, next, token_list
     :rtype: list
     """
     token_list = []
@@ -393,25 +386,6 @@ def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
     # Decide, what we are supposed to return
     if count is True:
         ret = sql_query.count()
-    elif psize:
-        # We return a paginated list of token objects.
-        pagination = sql_query.paginate(page, per_page=psize,
-                                        error_out=False)
-        count = pagination.total
-        prev = None
-        if pagination.has_prev:
-            prev = page - 1
-        next = None
-        if pagination.has_next:
-            next = page + 1
-        for token in pagination.items:
-            tokenobject = create_tokenclass_object(token)
-            if isinstance(tokenobject, TokenClass):
-                # A database token, that has a non existing type, will
-                # return None, and not a TokenClass. We do not want to
-                # add None to our list
-                token_list.append(tokenobject)
-        ret = count, prev, next, token_list
     else:
         # Return a simple, flat list of tokenobjects
         for token in sql_query.all():

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -186,19 +186,6 @@ class TokenTestCase(MyTestCase):
         tokenobject_list = get_tokens(serial_wildcard="*")
         self.assertEqual(len(tokenobject_list), 4)
 
-        # test pagination
-        count, prev, next, tokenobject_list = get_tokens(serial_wildcard="*", psize=2, page=1)
-        self.assertEqual(count, 4)
-        self.assertEqual(prev, None)
-        self.assertEqual(next, 2)
-        self.assertEqual(len(tokenobject_list), 2)
-
-        count, prev, next, tokenobject_list = get_tokens(serial_wildcard="*", psize=2, page=2)
-        self.assertEqual(count, 4)
-        self.assertEqual(prev, 1)
-        self.assertEqual(next, None)
-        self.assertEqual(len(tokenobject_list), 2)
-
     def test_03_get_token_type(self):
         ttype = get_token_type("hotptoken")
         self.assertTrue(ttype == "hotp", ttype)

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -53,7 +53,8 @@ from privacyidea.lib.token import (create_tokenclass_object,
                                    get_tokens_paginate,
                                    set_validity_period_end,
                                    set_validity_period_start, remove_token, delete_tokeninfo,
-                                   import_token, get_one_token, get_tokens_from_serial_or_user)
+                                   import_token, get_one_token, get_tokens_from_serial_or_user,
+                                   get_tokens_paginated_generator)
 
 from privacyidea.lib.error import (TokenAdminError, ParameterError,
                                    privacyIDEAError, ResourceNotFoundError)
@@ -1398,6 +1399,54 @@ class TokenTestCase(MyTestCase):
         with self.assertRaises(ResourceNotFoundError):
             get_tokens_from_serial_or_user(serial="S1", user=shadow)
         unassign_token(serial=None, user=user)
+
+    def test_55_get_tokens_paginated_generator(self):
+        def flatten_tokens(l):
+            return [token.token.id for l2 in l for token in l2]
+
+        # serial72 token has invalid type. Check behavior and remove it.
+        self.assertEquals(list(get_tokens_paginated_generator(serial_wildcard="serial*")), [[]])
+        Token.query.filter_by(serial="serial72").delete()
+
+        all_matching_tokens = get_tokens(serial_wildcard="S*")
+        lists1 = list(get_tokens_paginated_generator(serial_wildcard="S*"))
+        self.assertEquals(len(lists1), 1)
+        self.assertEquals(len(lists1[0]), 6)
+        lists2 = list(get_tokens_paginated_generator(serial_wildcard="S*", psize=2))
+        self.assertEquals(len(lists2), 3)
+        self.assertEquals(len(lists2[0]), 2)
+        self.assertEquals(len(lists2[1]), 2)
+        self.assertEquals(len(lists2[2]), 2)
+        lists3 = list(get_tokens_paginated_generator(serial_wildcard="S*", psize=3))
+        self.assertEquals(len(lists3), 2)
+        self.assertEquals(len(lists3[0]), 3)
+        self.assertEquals(len(lists3[1]), 3)
+        lists4 = list(get_tokens_paginated_generator(serial_wildcard="S*", psize=4))
+        self.assertEquals(len(lists4), 2)
+        self.assertEquals(len(lists4[0]), 4)
+        self.assertEquals(len(lists4[1]), 2)
+        lists5 = list(get_tokens_paginated_generator(serial_wildcard="S*", psize=6))
+        self.assertEquals(len(lists5), 1)
+        self.assertEquals(len(lists5[0]), 6)
+        self.assertEquals(set([t.token.id for t in all_matching_tokens]), set(flatten_tokens(lists1)))
+        self.assertEquals(flatten_tokens(lists1), flatten_tokens(lists2))
+        self.assertEquals(flatten_tokens(lists2), flatten_tokens(lists3))
+        self.assertEquals(flatten_tokens(lists3), flatten_tokens(lists4))
+        self.assertEquals(flatten_tokens(lists4), flatten_tokens(lists5))
+
+        lists6 = list(get_tokens_paginated_generator(serial_wildcard="*DOESNOTEXIST*"))
+        self.assertEquals(lists6, [])
+
+    def test_56_get_tokens_paginated_generator_removal(self):
+        all_serials = set(t.token.serial for t in get_tokens(serial_wildcard="S*"))
+        # Test proper behavior if a matching token is deleted while paginating
+        gen = get_tokens_paginated_generator(serial_wildcard="S*", psize=3)
+        list1 = next(gen)
+        remove_token(list1[0].token.serial)
+        list2 = next(gen)
+        # Check that we did not miss any tokens
+        self.assertEquals(set(t.token.serial for t in list1 + list2), all_serials)
+
 
 class TokenFailCounterTestCase(MyTestCase):
     """

--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -100,7 +100,7 @@ Actions:
 
 """.format("|".join(ALLOWED_ACTIONS))
 from privacyidea.lib.token import (get_tokens, remove_token, enable_token,
-                                   unassign_token, import_token)
+                                   unassign_token, import_token, get_tokens_paginated_generator)
 from privacyidea.app import create_app
 from flask_script import Manager
 import re
@@ -242,9 +242,7 @@ def build_tokenvalue_filter(key,
 
 
 def _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
-                   tokeninfo_value_filter, orphaned, tokentype, serial, description, psize, page):
-    tlist = []
-    filter_tokentype = None
+                   tokeninfo_value_filter, orphaned, tokentype, serial, description, chunksize):
     filter_active = None
     filter_assigned = None
 
@@ -253,48 +251,48 @@ def _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
     if active is not None:
         filter_active = active.lower() == "true"
 
-    count, prev, next, tokenobj_list = get_tokens(tokentype=tokentype,
-                                                  active=filter_active,
-                                                  assigned=filter_assigned,
-                                                  page=page,
-                                                  psize=psize)
+    generator = get_tokens_paginated_generator(tokentype=tokentype,
+                                                active=filter_active,
+                                                assigned=filter_assigned,
+                                                psize=chunksize)
+    for tokenobj_list in generator:
+        filtered_list = []
+        sys.stderr.write("++ Creating token object list.\n")
+        tok_count = 0
+        tok_found = 0
+        for token_obj in tokenobj_list:
+            sys.stderr.write('{0} Tokens processed / {1} Tokens found\r'.format(tok_count, tok_found))
+            sys.stderr.flush()
+            tok_count += 1
+            if last_auth and token_obj.check_last_auth_newer(last_auth):
+                continue
+            if serial and not re.search(serial, token_obj.token.serial):
+                continue
+            if description and not re.search(description,
+                                             token_obj.token.description):
+                continue
+            if tokeninfo_value_filter and tokeninfo_key:
+                value = token_obj.get_tokeninfo(tokeninfo_key)
+                # if the tokeninfo key is not even set, it does not match the filter
+                if value is None:
+                    continue
+                # suppose not all comparator functions return True
+                # => at least one comparator function returns False
+                # => at least one user-supplied criterion does not match
+                # => the token object does not match the user-supplied criteria
+                if not all(comparator(value) for comparator in tokeninfo_value_filter):
+                    continue
+            if orphaned and not token_obj.is_orphaned():
+                continue
 
-    sys.stderr.write("++ Creating token object list.\n")
-    tok_count = 0
-    tok_found = 0
-    for token_obj in tokenobj_list:
-        sys.stderr.write('{0} Tokens processed / {1} Tokens found\r'.format(tok_count, tok_found))
+            tok_found += 1
+            # if everything matched, we append the token object
+            filtered_list.append(token_obj)
+
+        sys.stderr.write('{0} Tokens processed / {1} Tokens found\r\n'.format(tok_count, tok_found))
+        sys.stderr.write("++ Token object list created.\n")
         sys.stderr.flush()
-        tok_count += 1
-        if last_auth and token_obj.check_last_auth_newer(last_auth):
-            continue
-        if serial and not re.search(serial, token_obj.token.serial):
-            continue
-        if description and not re.search(description,
-                                         token_obj.token.description):
-            continue
-        if tokeninfo_value_filter and tokeninfo_key:
-            value = token_obj.get_tokeninfo(tokeninfo_key)
-            # if the tokeninfo key is not even set, it does not match the filter
-            if value is None:
-                continue
-            # suppose not all comparator functions return True
-            # => at least one comparator function returns False
-            # => at least one user-supplied criterion does not match
-            # => the token object does not match the user-supplied criteria
-            if not all(comparator(value) for comparator in tokeninfo_value_filter):
-                continue
-        if orphaned and not token_obj.is_orphaned():
-            continue
-
-        tok_found += 1
-        # if everything matched, we append the token object
-        tlist.append(token_obj)
-
-    sys.stderr.write('{0} Tokens processed / {1} Tokens found\r\n'.format(tok_count, tok_found))
-    sys.stderr.write("++ Token object list created.\n")
-    sys.stderr.flush()
-    return count, prev, next, tlist
+        yield filtered_list
 
 
 def export_token_data(token_list):
@@ -394,20 +392,18 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
                 ", ".join(["'{0!s}'".format(x) for x in ALLOWED_ACTIONS])
             ))
             sys.exit(1)
+    chunksize = int(chunksize)
     filter = build_tokenvalue_filter(tokeninfo_key,
                                      tokeninfo_value,
                                      tokeninfo_value_greater_than,
                                      tokeninfo_value_less_than,
                                      tokeninfo_value_after,
                                      tokeninfo_value_before)
-
-    next = 1
-    chunksize = int(chunksize)
-    while next:
-        sys.stderr.write("+ Reading tokens in chunk from database...\n")
-        _, _, next, tlist = _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
-                                                    filter, orphaned, tokentype, serial,
-                                                    description, chunksize, next)
+    generator = _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
+                    filter, orphaned, tokentype, serial,
+                    description, chunksize)
+    sys.stderr.write("+ Reading tokens in chunk from database...\n")
+    for tlist in generator:
         sys.stderr.write("+ Tokens read. Starting action.\n")
         if not action:
             if not csv:

--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -251,11 +251,16 @@ def _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
     if active is not None:
         filter_active = active.lower() == "true"
 
-    generator = get_tokens_paginated_generator(tokentype=tokentype,
-                                                active=filter_active,
-                                                assigned=filter_assigned,
-                                                psize=chunksize)
-    for tokenobj_list in generator:
+    if chunksize is not None:
+        iterable = get_tokens_paginated_generator(tokentype=tokentype,
+                                                  active=filter_active,
+                                                  assigned=filter_assigned,
+                                                  psize=chunksize)
+    else:
+        iterable = [get_tokens(tokentype=tokentype,
+                               active=filter_active,
+                               assigned=filter_assigned)]
+    for tokenobj_list in iterable:
         filtered_list = []
         sys.stderr.write("++ Creating token object list.\n")
         tok_count = 0
@@ -377,7 +382,7 @@ def export_user_data(token_list):
 @manager.option('--csv', dest='csv', action='store_true',
                 help='In case of a simple find, the output is written as CSV instead of the '
                      'formatted output.')
-@manager.option('--chunksize', default=1000,
+@manager.option('--chunksize', default=None,
                 help='Read tokens from the database in smaller chunks to perform operations.')
 def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
          tokeninfo_value_greater_than, tokeninfo_value_less_than,
@@ -392,7 +397,8 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
                 ", ".join(["'{0!s}'".format(x) for x in ALLOWED_ACTIONS])
             ))
             sys.exit(1)
-    chunksize = int(chunksize)
+    if chunksize is not None:
+        chunksize = int(chunksize)
     filter = build_tokenvalue_filter(tokeninfo_key,
                                      tokeninfo_value,
                                      tokeninfo_value_greater_than,
@@ -402,7 +408,10 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
     generator = _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
                     filter, orphaned, tokentype, serial,
                     description, chunksize)
-    sys.stderr.write("+ Reading tokens in chunk from database...\n")
+    if chunksize is not None:
+        sys.stderr.write("+ Reading tokens from database in chunks of {}...\n".format(chunksize))
+    else:
+        sys.stderr.write("+ Reading tokens from database...\n")
     for tlist in generator:
         sys.stderr.write("+ Tokens read. Starting action.\n")
         if not action:


### PR DESCRIPTION
This PR
* adds a new function ``get_tokens_paginated_generator`` that implements the improved pagination approach suggested by @plettich in #1323.
* makes the token janitor use this function to fetch tokens instead of the ``Pagination``-based pagination of ``get_tokens``. This fixes #1322.
* removes the ``Pagination``-based pagination feature from ``get_tokens`` because it isn't used anymore (besides the tests).
* makes chunked queries optional in the token janitor. Queries are now *not* chunked by default. This is because users might not want to use chunked queries, e.g. in the case of ``--action export``. If we use chunked queries there, we get a different PSKC file and a different encryption key for each chunk.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1364%23issuecomment-451155429%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1364%23issuecomment-451155429%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231364%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/b837f39e9f229a9ede001f2ecc004e5060c08645%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Adecrease%2A%2A%20coverage%20by%20%600.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60100%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231364%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Coverage%20%20%2096.64%25%20%20%2096.63%25%20%20%20-0.02%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017291%20%20%20%2017293%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%2016711%20%20%20%2016711%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20580%20%20%20%20%20%20582%20%20%20%20%20%20%20%2B2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/token.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5%29%20%7C%20%6094.93%25%20%3C100%25%3E%20%28%2B0.01%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6094.16%25%20%3C0%25%3E%20%28-1.67%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bb837f39...a3f7d05%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1364%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-03T14%3A17%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1364#issuecomment-451155429'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1364?src=pr&el=h1) Report
> Merging [#1364](https://codecov.io/gh/privacyidea/privacyidea/pull/1364?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/b837f39e9f229a9ede001f2ecc004e5060c08645?src=pr&el=desc) will **decrease** coverage by `0.01%`.
> The diff coverage is `100%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1364/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1364?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1364      +/-   ##
==========================================
- Coverage   96.64%   96.63%   -0.02%
==========================================
Files         144      144
Lines       17291    17293       +2
==========================================
Hits        16711    16711
- Misses        580      582       +2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1364?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/token.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1364/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2VuLnB5) | `94.93% <100%> (+0.01%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1364/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `94.16% <0%> (-1.67%)` | :arrow_down: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1364?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1364?src=pr&el=footer). Last update [b837f39...a3f7d05](https://codecov.io/gh/privacyidea/privacyidea/pull/1364?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1364?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1364?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1364'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>