### PR TITLE
Remove tokeclass function that was never used

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1298,19 +1298,6 @@ class TokenClass(object):
 
         return response_detail
 
-    def get_QRimage_data(self, response_detail):
-        """
-        FIXME: Do we really use this?
-        """
-        url = None
-        hparam = {}
-
-        if response_detail is not None and 'googleurl' in response_detail:
-            url = response_detail.get('googleurl')
-            hparam['alt'] = url
-
-        return url, hparam
-
     # challenge interfaces starts here
     @challenge_response_allowed
     def is_challenge_request(self, passw, user=None, options=None):

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -493,8 +493,6 @@ class TokenBaseTestCase(MyTestCase):
         self.assertTrue("otpkey" not in token.token.get_info(),
                         token.token.get_info())
 
-        token.get_QRimage_data({"googleurl": "hotp://"})
-        self.assertRaises(Exception, token.set_init_details, "unvalid value")
         token.set_init_details({"detail1": "value1"})
         self.assertTrue("detail1" in token.get_init_details(),
                         token.get_init_details())

--- a/tests/test_lib_tokens_daplug.py
+++ b/tests/test_lib_tokens_daplug.py
@@ -387,12 +387,7 @@ class DaplugTokenTestCase(MyTestCase):
         self.assertTrue("img" in otpkey, otpkey)
         self.assertTrue("googleurl" in detail, detail)
         # some other stuff.
-        r = token.get_QRimage_data({"googleurl": detail.get("googleurl").get(
-            "value")})
-        self.assertEqual(r[0],
-                         'otpauth://daplug/SE123456?secret=CERDGRCVMZ3YRGIA'
-                         '&digits=6&issuer=privacyIDEA')
-        self.assertRaises(Exception, token.set_init_details, "unvalid value")
+        self.assertRaises(Exception, token.set_init_details, "invalid value")
         token.set_init_details({"detail1": "value1"})
         self.assertTrue("detail1" in token.get_init_details(),
                         token.get_init_details())

--- a/tests/test_lib_tokens_hotp.py
+++ b/tests/test_lib_tokens_hotp.py
@@ -393,11 +393,7 @@ class HOTPTokenTestCase(MyTestCase):
         self.assertTrue("img" in otpkey, otpkey)
         self.assertTrue("googleurl" in detail, detail)
         # some other stuff.
-        r = token.get_QRimage_data({"googleurl": detail.get("googleurl").get(
-            "value")})
-        self.assertTrue('otpauth://hotp/SE123456?secret=CERDGRCVMZ3YRGIA'
-                        '&counter=1' in r[0], r[0])
-        self.assertRaises(Exception, token.set_init_details, "unvalid value")
+        self.assertRaises(Exception, token.set_init_details, "invalid value")
         token.set_init_details({"detail1": "value1"})
         self.assertTrue("detail1" in token.get_init_details(),
                         token.get_init_details())

--- a/tests/test_lib_tokens_motp.py
+++ b/tests/test_lib_tokens_motp.py
@@ -129,7 +129,7 @@ class MotpTokenTestCase(MyTestCase):
         motpurl = detail.get("motpurl").get("value")
         self.assertTrue(motpurl == 'motp://privacyidea:mylabel?'
                         'secret=11223344556677889900', motpurl)
-        self.assertRaises(Exception, token.set_init_details, "unvalid value")
+        self.assertRaises(Exception, token.set_init_details, "invalid value")
         token.set_init_details({"detail1": "value1"})
         self.assertTrue("detail1" in token.get_init_details(),
                         token.get_init_details())

--- a/tests/test_lib_tokens_totp.py
+++ b/tests/test_lib_tokens_totp.py
@@ -347,11 +347,7 @@ class TOTPTokenTestCase(MyTestCase):
         self.assertTrue("img" in otpkey, otpkey)
         self.assertTrue("googleurl" in detail, detail)
         # some other stuff.
-        r = token.get_QRimage_data({"googleurl": detail.get("googleurl").get(
-            "value")})
-        self.assertEqual(r[0], 'otpauth://totp/SE123456?secret=CERDGRCVMZ3YRGIA'
-                         '&period=30&digits=6&issuer=privacyIDEA')
-        self.assertRaises(Exception, token.set_init_details, "unvalid value")
+        self.assertRaises(Exception, token.set_init_details, "invalid value")
         token.set_init_details({"detail1": "value1"})
         self.assertTrue("detail1" in token.get_init_details(),
                         token.get_init_details())


### PR DESCRIPTION
The function get_QRImage was never used.
So we remove it.

Closes #1367