### PR TITLE
Use twine to upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ VERSION=${SHORT_VERSION}
 LOCAL_SERIES=`lsb_release -a | grep Codename | cut -f2`
 SRCDIRS=deploy authmodules migrations doc tests tools privacyidea 
 SRCFILES=setup.py MANIFEST.in Makefile Changelog LICENSE pi-manage requirements.txt
+SIGNING_KEY=53E66E1D2CABEFCDB1D3B83E106164552E8D8149
 
 clean:
 	find . -name \*.pyc -exec rm {} \;
@@ -61,7 +62,10 @@ translate-server:
 
 pypi:
 	make doc-man
-	python setup.py sdist upload
+	rm -fr dist
+	python setup.py sdist
+	gpg --detach-sign -a --default-key ${SIGNING_KEY} dist/*.tar.gz
+	twine upload dist/*.tar.gz dist/*.tar.gz.asc
 
 epydoc:
 	#pydoctor --add-package privacyidea --make-html 


### PR DESCRIPTION
Using `python setup.py upload` is deprecated.
We are now using twine and we are signing the
packages with the same signing key like the
debian packages.

Closes #1376
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1391%23issuecomment-455822635%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1391%23discussion_r249436350%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1391%23discussion_r249466240%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1391%23issuecomment-455822635%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231391%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/589c0f706032f91d200251126c111dda8bf3aee3%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%231391%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2096.77%25%20%20%2096.81%25%20%20%20%2B0.03%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017240%20%20%20%2017384%20%20%20%20%20%2B144%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016684%20%20%20%2016830%20%20%20%20%20%2B146%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20556%20%20%20%20%20%20554%20%20%20%20%20%20%20-2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/authcache.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2F1dGhjYWNoZS5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policydecorators.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk%3D%29%20%7C%20%6099.49%25%20%3C0%25%3E%20%28%2B0.25%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B589c0f7...ae95149%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1391%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-19T23%3A06%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ae95149c1388d557bb532430ebc7cc35e7615d8e%20Makefile%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1391%23discussion_r249436350%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22should%20we%20add%20twine%20to%20the%20%60requirements%28-devel%29.txt%60%3F%20Or%20is%20this%20a%20%5C%22this%20runs%20only%20on%20my%20machine%5C%22%20issue%3F%22%2C%20%22created_at%22%3A%20%222019-01-21T12%3A43%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/37443810%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/plettich%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20like%20this%20kind%20of%20issue%21%20%3A-%29%5Cr%5CnWell%2C%20twine%20is%20only%20used%20if%20you%20want%20to%20upload%20the%20package%20to%20pypi.%20To%20upload%20you%20need%20an%20account%20there.%20So%20if%203rd%20persons%20would%20like%20to%20develop%20in%20this%20environment%20they%20definitively%20will%20not%20need%20twine.%22%2C%20%22created_at%22%3A%20%222019-01-21T14%3A18%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Makefile%3AL62-72%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1391#issuecomment-455822635'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1391?src=pr&el=h1) Report
> Merging [#1391](https://codecov.io/gh/privacyidea/privacyidea/pull/1391?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/589c0f706032f91d200251126c111dda8bf3aee3?src=pr&el=desc) will **increase** coverage by `0.03%`.
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1391/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1391?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master    #1391      +/-   ##
==========================================
+ Coverage   96.77%   96.81%   +0.03%
==========================================
Files         144      144
Lines       17240    17384     +144
==========================================
+ Hits        16684    16830     +146
+ Misses        556      554       -2
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1391?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/authcache.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1391/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2F1dGhjYWNoZS5weQ==) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/policydecorators.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1391/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk=) | `99.49% <0%> (+0.25%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1391/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1391?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1391?src=pr&el=footer). Last update [589c0f7...ae95149](https://codecov.io/gh/privacyidea/privacyidea/pull/1391?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull ae95149c1388d557bb532430ebc7cc35e7615d8e Makefile 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1391#discussion_r249436350'>File: Makefile:L62-72</a></b>
- <a href='https://github.com/plettich'><img border=0 src='https://avatars0.githubusercontent.com/u/37443810?v=4' height=16 width=16></a> should we add twine to the `requirements(-devel).txt`? Or is this a "this runs only on my machine" issue?
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> I like this kind of issue! :-)
Well, twine is only used if you want to upload the package to pypi. To upload you need an account there. So if 3rd persons would like to develop in this environment they definitively will not need twine.


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1391?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1391?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1391'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>