### PR TITLE
Allow to set a custom login text

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,11 @@
+Version 3.0, 2019-03-xx
+
+  Changes:
+  * When logging in to the webui the client IP is only determined by
+    X-Forwarded-For if the orinigal (REMOTE_ADDR) is allowed to overwrite the client ip.
+    (Side effect of #1392)
+
+
 Version 2.23.3, 2018-10-26
 
   Fixes:

--- a/Changelog
+++ b/Changelog
@@ -2,7 +2,7 @@ Version 3.0, 2019-03-xx
 
   Changes:
   * When logging in to the webui the client IP is only determined by
-    X-Forwarded-For if the orinigal (REMOTE_ADDR) is allowed to overwrite the client ip.
+    X-Forwarded-For if the original (REMOTE_ADDR) is allowed to overwrite the client ip.
     (Side effect of #1392)
 
 

--- a/doc/policies/webui.rst
+++ b/doc/policies/webui.rst
@@ -280,3 +280,14 @@ Buttons for actions that a user is not allowed to perform, are hidden instead of
 being disabled.
 
 (Since privacyIDEA 2.24)
+
+login_text
+~~~~~~~~~~
+
+type: str
+
+This way the text "Please sign in" on the login dialog can be changed. Since the policy can
+also depend on the IP address of the client, you can also choose different login texts depending
+on from where a user tries to log in.
+
+(Since privacyIDEA 3.0)

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -316,6 +316,7 @@ class ACTION(object):
     CUSTOM_BASELINE = "custom_baseline"
     STATISTICSREAD = "statistics_read"
     STATISTICSDELETE = "statistics_delete"
+    LOGIN_TEXT = "login_text"
 
 
 class GROUP(object):
@@ -1701,6 +1702,10 @@ def get_static_policy_definitions(scope=None):
                     'to the Web UI. Defaults to "userstore"'),
                 'value': [LOGINMODE.USERSTORE, LOGINMODE.PRIVACYIDEA,
                           LOGINMODE.DISABLE],
+            },
+            ACTION.LOGIN_TEXT: {
+                'type': 'str',
+                'desc': _('An alternative text to display on the WebUI login dialog instead of "Please sign in".')
             },
             ACTION.SEARCH_ON_ENTER: {
                 'type': 'bool',

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -60,6 +60,8 @@ angular.module("privacyideaApp")
     //debug: console.log($scope.piRealms);
     obj = angular.element(document.querySelector('#LOGO'));
     $scope.piLogo = obj.val();
+    obj = angular.element(document.querySelector('#LOGIN_TEXT'));
+    $scope.piLoginText= obj.val();
     // Check if registration is allowed
     $scope.registrationAllowed = false;
     RegisterFactory.status(function (data) {

--- a/privacyidea/static/components/login/views/login.html
+++ b/privacyidea/static/components/login/views/login.html
@@ -39,13 +39,18 @@
             </translate>
         </div>
 
+
+
         <div class="container">
-            <form name="formSignin" class="form-signin" role="form" novalidate>
-                <div class="text-center">
+            <div class="text-center">
                     <img ng-src="{{ instanceUrl }}/static/css/{{ piLogo }}"
                          width="90px">
                 </div>
-                <h2 class="form-signin-heading" translate>Please sign in</h2>
+            <div class="text-center">
+                <h2 ng-hide="piLoginText" class="form-signin-heading" translate>Please sign in</h2>
+                <h2 ng-show="piLoginText" class="form-signin-heading">{{ piLoginText }}</h2>
+            </div>
+            <form name="formSignin" class="form-signin" role="form" novalidate>
                 <label for="username" class="sr-only" translate>Username</label>
                 <input name="username" id="username"
                        class="form-control round-top"

--- a/privacyidea/static/templates/index.html
+++ b/privacyidea/static/templates/index.html
@@ -15,6 +15,7 @@
 <input type=hidden id="REALMS" value="{{ realms }}">
 <input type=hidden id="LOGO" value="{{ logo }}">
 <input type=hidden id="EXTERNAL_LINKS" value="{{ external_links }}">
+<input type=hidden id="LOGIN_TEXT" value="{{ login_text }}">
 
 <!-- Include baseline -->
 

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -38,6 +38,8 @@ from privacyidea.lib.error import HSMException
 from privacyidea.lib.realm import get_realms
 from privacyidea.lib.policy import PolicyClass, ACTION, SCOPE
 from privacyidea.lib.subscriptions import subscription_status
+from privacyidea.lib.utils import get_client_ip
+from privacyidea.lib.config import get_from_config, SYSCONF
 
 DEFAULT_THEME = "/static/contrib/css/bootstrap-theme.css"
 
@@ -81,8 +83,8 @@ def single_page_application():
     # Depending on displaying the realm dropdown, we fill realms or not.
     policy_object = PolicyClass()
     realms = ""
-    client_ip = request.access_route[0] if request.access_route else \
-        request.remote_addr
+    client_ip = get_client_ip(request,
+                              get_from_config(SYSCONF.OVERRIDECLIENT))
     realm_dropdown = policy_object.get_policies(action=ACTION.REALMDROPDOWN,
                                                 scope=SCOPE.WEBUI,
                                                 client=client_ip,

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -134,6 +134,17 @@ def single_page_application():
     else:
         customization_baseline_file = "templates/baseline.html"
 
+    login_text = policy_object.get_action_values(
+        allow_white_space_in_action=True,
+        action=ACTION.LOGIN_TEXT,
+        scope=SCOPE.WEBUI,
+        client=client_ip, unique=True
+    )
+    if len(login_text) and list(login_text)[0] and sub_state not in [1, 2]:
+        login_text = list(login_text)[0]
+    else:
+        login_text = ""
+
     return render_template("index.html", instance=instance,
                            backendUrl=backend_url,
                            browser_lang=browser_lang,
@@ -146,5 +157,6 @@ def single_page_application():
                            customization_baseline_file=customization_baseline_file,
                            realms=realms,
                            external_links=external_links,
+                           login_text=login_text,
                            logo=logo)
 

--- a/tests/test_ui_login.py
+++ b/tests/test_ui_login.py
@@ -48,3 +48,12 @@ class LoginUITestCase(MyTestCase):
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue("/static/mytemplates/nonexist_base.html" in res.data)
             self.assertTrue("/static/mytemplates/nonexist_menu.html" in res.data)
+
+    def test_05_custom_login_text(self):
+        set_policy("logtext", scope=SCOPE.WEBUI,
+                   action="{0!s}=Go for it!".format(ACTION.LOGIN_TEXT))
+        with self.app.test_request_context('/',
+                                           method='GET'):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            self.assertTrue("Go for it!" in res.data)


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23issuecomment-456081344%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r251787269%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r251864438%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r251864583%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r252310086%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r252314364%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r252583640%22%2C%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r252583675%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23issuecomment-456081344%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%231392%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/commit/589c0f706032f91d200251126c111dda8bf3aee3%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.03%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%6080%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392/graphs/tree.svg%3Fwidth%3D650%26token%3D7nHLZki60B%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%231392%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%2096.77%25%20%20%2096.8%25%20%20%20%2B0.03%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20144%20%20%20%20%20144%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%2017240%20%20%2017389%20%20%20%20%20%2B149%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%2016684%20%20%2016834%20%20%20%20%20%2B150%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20556%20%20%20%20%20555%20%20%20%20%20%20%20-1%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bprivacyidea/lib/policy.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ%3D%3D%29%20%7C%20%6099.4%25%20%3C100%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/webui/login.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvd2VidWkvbG9naW4ucHk%3D%29%20%7C%20%6088.52%25%20%3C75%25%3E%20%28-0.95%25%29%60%20%7C%20%3Aarrow_down%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/authcache.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL2F1dGhjYWNoZS5weQ%3D%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/policydecorators.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk%3D%29%20%7C%20%6099.49%25%20%3C0%25%3E%20%28%2B0.25%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Bprivacyidea/lib/tokens/u2f.py%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392/diff%3Fsrc%3Dpr%26el%3Dtree%23diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk%3D%29%20%7C%20%6095.83%25%20%3C0%25%3E%20%28%2B1.66%25%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5B589c0f7...13c1fb2%5D%28https%3A//codecov.io/gh/privacyidea/privacyidea/pull/1392%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-21T13%3A52%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2013c1fb28152865770638d7e07a212f34c8357cd4%20privacyidea/webui/login.py%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r251864438%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hm%2C%20interesting.%20Why%20didn%27t%20we%20use%20get_client_ip%20in%20the%20first%20place%3F%5Cr%5Cn%28I%20know%2C%20because%20we%20did%20only%20allow%20the%20X-Forwarded-For%20for%20/validate/%20requests%20till%20now%29.%5Cr%5Cn%5Cr%5CnSo%20if%20we%20would%20use%20%60%60get_client_ip%60%60%20in%20line%2084%2C%20then%20the%20admin%20would%20have%20to%20allow%20the%20proxy%20to%20overwrite%20the%20client.%5Cr%5CnI%20think%20this%20would%20be%20ok.%20%5Cr%5CnHowever%2C%20would%20change%20the%20behaviour%20-%20worth%20noting%20in%20the%20changelog...%22%2C%20%22created_at%22%3A%20%222019-01-29T14%3A50%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222019-01-30T15%3A39%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222019-01-31T09%3A08%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/webui/login.py%3AL134-151%22%7D%2C%20%22Pull%2013c1fb28152865770638d7e07a212f34c8357cd4%20privacyidea/webui/login.py%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/privacyidea/pull/1392%23discussion_r251787269%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20add%20a%20unit%20test%20for%20this%20code%20path%3F%20Maybe%20just%20something%20simple%2C%20e.g.%20changing%20the%20login%20text%20to%20%5C%22Hello%20there%5C%22%20and%20checking%20if%20%5C%22Hello%20there%5C%22%20is%20part%20of%20the%20returned%20HTML.%22%2C%20%22created_at%22%3A%20%222019-01-29T11%3A06%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK.%20Will%20do.%22%2C%20%22created_at%22%3A%20%222019-01-29T14%3A50%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222019-01-30T15%3A48%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20thanks%21%22%2C%20%22created_at%22%3A%20%222019-01-31T09%3A08%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/28243%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fredreichbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20privacyidea/webui/login.py%3AL134-151%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1392#issuecomment-456081344'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1392?src=pr&el=h1) Report
> Merging [#1392](https://codecov.io/gh/privacyidea/privacyidea/pull/1392?src=pr&el=desc) into [master](https://codecov.io/gh/privacyidea/privacyidea/commit/589c0f706032f91d200251126c111dda8bf3aee3?src=pr&el=desc) will **increase** coverage by `0.03%`.
> The diff coverage is `80%`.
[![Impacted file tree graph](https://codecov.io/gh/privacyidea/privacyidea/pull/1392/graphs/tree.svg?width=650&token=7nHLZki60B&height=150&src=pr)](https://codecov.io/gh/privacyidea/privacyidea/pull/1392?src=pr&el=tree)
```diff
@@            Coverage Diff            @@
##           master   #1392      +/-   ##
=========================================
+ Coverage   96.77%   96.8%   +0.03%
=========================================
Files         144     144
Lines       17240   17389     +149
=========================================
+ Hits        16684   16834     +150
+ Misses        556     555       -1
```
| [Impacted Files](https://codecov.io/gh/privacyidea/privacyidea/pull/1392?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [privacyidea/lib/policy.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1392/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeS5weQ==) | `99.4% <100%> (ø)` | :arrow_up: |
| [privacyidea/webui/login.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1392/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvd2VidWkvbG9naW4ucHk=) | `88.52% <75%> (-0.95%)` | :arrow_down: |
| [privacyidea/lib/authcache.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1392/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL2F1dGhjYWNoZS5weQ==) | `100% <0%> (ø)` | :arrow_up: |
| [privacyidea/lib/policydecorators.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1392/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3BvbGljeWRlY29yYXRvcnMucHk=) | `99.49% <0%> (+0.25%)` | :arrow_up: |
| [privacyidea/lib/tokens/u2f.py](https://codecov.io/gh/privacyidea/privacyidea/pull/1392/diff?src=pr&el=tree#diff-cHJpdmFjeWlkZWEvbGliL3Rva2Vucy91MmYucHk=) | `95.83% <0%> (+1.66%)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1392?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/privacyidea/privacyidea/pull/1392?src=pr&el=footer). Last update [589c0f7...13c1fb2](https://codecov.io/gh/privacyidea/privacyidea/pull/1392?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- [x] <a href='#crh-comment-Pull 13c1fb28152865770638d7e07a212f34c8357cd4 privacyidea/webui/login.py 11'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1392#discussion_r251787269'>File: privacyidea/webui/login.py:L134-151</a></b>
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> Could you add a unit test for this code path? Maybe just something simple, e.g. changing the login text to "Hello there" and checking if "Hello there" is part of the returned HTML.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> OK. Will do.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done
- <a href='https://github.com/fredreichbier'><img border=0 src='https://avatars2.githubusercontent.com/u/28243?v=4' height=16 width=16></a> :+1: thanks!
- [x] <a href='#crh-comment-Pull 13c1fb28152865770638d7e07a212f34c8357cd4 privacyidea/webui/login.py 8'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/privacyidea/pull/1392#discussion_r251864438'>File: privacyidea/webui/login.py:L134-151</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Hm, interesting. Why didn't we use get_client_ip in the first place?
(I know, because we did only allow the X-Forwarded-For for /validate/ requests till now).
So if we would use ``get_client_ip`` in line 84, then the admin would have to allow the proxy to overwrite the client.
I think this would be ok.
However, would change the behaviour - worth noting in the changelog...
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> done


<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1392?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/privacyidea/pull/1392?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/privacyidea/pull/1392'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>