### PR TITLE
Python 3 migration: Fix policy/policydecorator tests

### DIFF
--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -28,6 +28,7 @@
 contains Errors and Exceptions
 """
 
+import six
 from privacyidea.lib import _
 import logging
 log = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ class ERROR:
     PARAMETER = 905
 
 
+@six.python_2_unicode_compatible
 class privacyIDEAError(Exception):
 
     def __init__(self, description=u"privacyIDEAError!", id=10):
@@ -69,16 +71,10 @@ class privacyIDEAError(Exception):
     def getDescription(self):
         return self.message
 
-    def __unicode__(self):
-        pstr = u"ERR%d: %r"
-        if type(self.message) in [str, unicode]:
-            pstr = u"ERR%d: %s"
-        return pstr % (self.id, self.message)
-
     def __str__(self):
         pstr = u"ERR%d: %r"
-        if type(self.message) in [str, unicode]:
-            pstr = "ERR%d: %s"
+        if isinstance(self.message, six.string_types):
+            pstr = u"ERR%d: %s"
 
         ### if we have here unicode, we might fail with conversion error
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,6 @@ if sys.version_info[0] > 2:
         'test_lib_importotp.py',
         'test_lib_machines.py',
         'test_lib_machinetokens.py',
-        'test_lib_policydecorator.py',
-        'test_lib_policy.py',
         'test_lib_recovery.py',
         'test_lib_smsprovider.py',
         'test_lib_subscriptions.py',

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -740,16 +740,16 @@ class PolicyTestCase(MyTestCase):
 
         # this chooses email2, because it has the highest priority
         P = PolicyClass()
-        self.assertEqual(P.get_action_values(action="emailtext", scope=SCOPE.AUTH,
-                                             unique=True, allow_white_space_in_action=True).keys(),
+        self.assertEqual(list(P.get_action_values(action="emailtext", scope=SCOPE.AUTH,
+                                                  unique=True, allow_white_space_in_action=True).keys()),
                          ["text 2"])
 
         delete_policy("email2")
         P.reload_from_db()
 
         # with email2 gone, this chooses email1
-        self.assertEqual(P.get_action_values(action="emailtext", scope=SCOPE.AUTH,
-                                             unique=True, allow_white_space_in_action=True).keys(),
+        self.assertEqual(list(P.get_action_values(action="emailtext", scope=SCOPE.AUTH,
+                                                  unique=True, allow_white_space_in_action=True).keys()),
                          ["text 1"])
 
         # if we now add another policy with priority 77, we get no conflict
@@ -757,8 +757,8 @@ class PolicyTestCase(MyTestCase):
         set_policy(name="email4", scope=SCOPE.AUTH, action="emailtext=text 4", priority=77)
         P.reload_from_db()
 
-        self.assertEqual(P.get_action_values(action="emailtext", scope=SCOPE.AUTH,
-                                             unique=True, allow_white_space_in_action=True).keys(),
+        self.assertEqual(list(P.get_action_values(action="emailtext", scope=SCOPE.AUTH,
+                                                  unique=True, allow_white_space_in_action=True).keys()),
                          ["text 1"])
 
         # but we get a conflict if we change the priority of email4 to 4
@@ -783,8 +783,8 @@ class PolicyTestCase(MyTestCase):
         set_policy(name="email4", priority=3)
         P.reload_from_db()
 
-        self.assertEqual(P.get_action_values(action="emailtext", scope=SCOPE.AUTH,
-                                             unique=True, allow_white_space_in_action=True).keys(),
+        self.assertEqual(list(P.get_action_values(action="emailtext", scope=SCOPE.AUTH,
+                                                  unique=True, allow_white_space_in_action=True).keys()),
                          ["text 4"])
 
         # now we have
@@ -822,10 +822,10 @@ class PolicyTestCase(MyTestCase):
 
         # this reduces the action values to unique values
         P = PolicyClass()
-        self.assertEqual(P.get_action_values(scope=SCOPE.AUTH, action="emailtext").keys(),
+        self.assertEqual(list(P.get_action_values(scope=SCOPE.AUTH, action="emailtext").keys()),
                          ["text 1"])
         # this is allowed if the policies agree
-        self.assertEqual(P.get_action_values(scope=SCOPE.AUTH, action="emailtext", unique=True).keys(),
+        self.assertEqual(list(P.get_action_values(scope=SCOPE.AUTH, action="emailtext", unique=True).keys()),
                          ["text 1"])
 
         set_policy(name="email2", action="emailtext='text 2'")


### PR DESCRIPTION
Some small changes to fix the remaining failing tests in ``test_lib_policy.py`` and ``test_lib_policydecorator.py``.