### PR TITLE
Make yubikey tests run with Python 3

### DIFF
--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -56,8 +56,8 @@ import logging
 from privacyidea.lib.log import log_with
 from privacyidea.lib.policydecorators import challenge_response_allowed
 from privacyidea.lib.tokenclass import TokenClass
-from privacyidea.lib.utils import modhex_decode
-from privacyidea.lib.utils import checksum
+from privacyidea.lib.utils import (modhex_decode, hexlify_and_unicode, checksum,
+                                   to_bytes, b64encode_and_unicode)
 import binascii
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.api.lib.utils import getParam
@@ -97,8 +97,8 @@ def yubico_api_signature(data, api_key):
     data_string = data_string.strip("&")
     api_key_bin = base64.b64decode(api_key)
     # generate the signature
-    h = hmac.new(api_key_bin, data_string, sha1).digest()
-    h_b64 = base64.b64encode(h)
+    h = hmac.new(api_key_bin, to_bytes(data_string), sha1).digest()
+    h_b64 = b64encode_and_unicode(h)
     return h_b64
 
 
@@ -263,15 +263,16 @@ class YubikeyTokenClass(TokenClass):
             return -4
 
         msg_bin = secret.aes_decrypt(otp_bin)
-        msg_hex = binascii.hexlify(msg_bin)
+        msg_hex = hexlify_and_unicode(msg_bin)
 
         # The checksum is a CRC-16 (16-bit ISO 13239 1st complement) that
         # occupies the last 2 bytes of the decrypted OTP value. Calculating the
         # CRC-16 checksum of the whole decrypted OTP should give a fixed
         # residual
         # of 0xf0b8 (see Yubikey-Manual - Chapter 6: Implementation details).
-        log.debug("calculated checksum (61624): {0!r}".format(checksum(msg_hex)))
-        if checksum(msg_hex) != 0xf0b8:  # pragma: no cover
+        crc16 = checksum(msg_bin)
+        log.debug("calculated checksum (61624): {0!r}".format(crc16))
+        if crc16 != 0xf0b8:  # pragma: no cover
             log.warning("CRC checksum for token {0!r} failed".format(serial))
             return -3
 

--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -286,9 +286,17 @@ def modhex_decode(m):
 
 
 def checksum(msg):
+    """
+    Calculate CRC-16 (16-bit ISO 13239 1st complement) checksum.
+    (see Yubikey-Manual - Chapter 6: Implementation details)
+
+    :param msg: input byte string for crc calculation
+    :type msg: bytes
+    :return: crc16 checksum of msg
+    :rtype: int
+    """
     crc = 0xffff
-    for i in range(0, len(msg) // 2):
-        b = int(msg[i * 2] + msg[(i * 2) + 1], 16)
+    for b in six.iterbytes(msg):
         crc = crc ^ (b & 0xff)
         for _j in range(0, 8):
             n = crc & 1
@@ -296,6 +304,18 @@ def checksum(msg):
             if n != 0:
                 crc = crc ^ 0x8408
     return crc
+
+
+def b64encode_and_unicode(s):
+    """
+    Base64-encode a str (which is first encoded to UTF-8)
+    or a byte string and return the result as a str.
+    :param s: str or bytes to base32-encode
+    :type s: str or bytes
+    :return: base32-encoded string converted to unicode
+    :rtype: str
+    """
+    return to_unicode(base64.b64encode(to_bytes(s)))
 
 
 def decode_base32check(encoded_data, always_upper=True):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,6 @@ if sys.version_info[0] > 2:
         'test_lib_tokens_remote.py',
         'test_lib_tokens_tiqr.py',
         'test_lib_tokens_u2f.py',
-        'test_lib_tokens_yubico.py',
-        'test_lib_tokens_yubikey.py',
         'test_mod_apache.py',
         'test_resolver_realm.py',
         'test_ui_certificate.py',


### PR DESCRIPTION
- create a `b64encode_and_unicode()` function to automatically convert the
  result of a `b64encode()` call to a unicode string
- update crc checksum calculation to work with Python 2 and 3

Working on #676 