### PR TITLE
Remove authentication for testing libs

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -142,10 +142,7 @@ class MyTestCase(unittest.TestCase):
         db.session.remove()
         db.drop_all()
         cls.app_context.pop()
-        
-    def setUp(self):
-        self.authenticate()
-        
+
     def authenticate(self):
         with self.app.test_request_context('/auth',
                                            data={"username": "testadmin",
@@ -173,3 +170,8 @@ class MyTestCase(unittest.TestCase):
             role = result.get("value").get("role")
             self.assertTrue(role == "user", result)
             self.assertEqual(result.get("value").get("realm"), "realm1")
+
+
+class MyApiTestCase(MyTestCase):
+    def setUp(self):
+        self.authenticate()

--- a/tests/test_api_2stepinit.py
+++ b/tests/test_api_2stepinit.py
@@ -8,11 +8,11 @@ import time
 from passlib.utils.pbkdf2 import pbkdf2
 
 from privacyidea.lib.policy import set_policy, SCOPE, delete_policy
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.tokens.HMAC import HmacOtp
 
 
-class TwoStepInitTestCase(MyTestCase):
+class TwoStepInitTestCase(MyApiTestCase):
     """
     test the 2stepinit process.
     

--- a/tests/test_api_applications.py
+++ b/tests/test_api_applications.py
@@ -4,10 +4,10 @@ api/applications.py
 """
 
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 
 
-class APIApplicationsResolverTestCase(MyTestCase):
+class APIApplicationsResolverTestCase(MyApiTestCase):
 
     def test_get_applications(self):
         with self.app.test_request_context('/application/',

--- a/tests/test_api_audit.py
+++ b/tests/test_api_audit.py
@@ -1,5 +1,5 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.policy import set_policy, SCOPE, ACTION, delete_policy
 from privacyidea.models import Audit
 import datetime
@@ -12,7 +12,7 @@ PWFILE = "tests/testdata/passwords"
 POLICYFILE = "tests/testdata/policy.cfg"
 POLICYEMPTY = "tests/testdata/policy_empty_file.cfg"
 
-class APIAuditTestCase(MyTestCase):
+class APIAuditTestCase(MyApiTestCase):
 
     def test_00_get_audit(self):
         with self.app.test_request_context('/audit/',

--- a/tests/test_api_caconnector.py
+++ b/tests/test_api_caconnector.py
@@ -2,12 +2,12 @@
 This testcase is used to test the REST API  in api/caconnector.py
 to create, update, delete CA connectors.
 """
-from .base import MyTestCase
+from .base import MyApiTestCase
 import json
 from privacyidea.lib.caconnector import get_caconnector_list, save_caconnector
 
 
-class CAConnectorTestCase(MyTestCase):
+class CAConnectorTestCase(MyApiTestCase):
 
     def test_01_fail_without_auth(self):
         # creation fails without auth

--- a/tests/test_api_clienttype.py
+++ b/tests/test_api_clienttype.py
@@ -1,9 +1,9 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.clientapplication import save_clientapplication
 
 
-class APIClienttypeTestCase(MyTestCase):
+class APIClienttypeTestCase(MyApiTestCase):
 
     def test_00_get_client(self):
         save_clientapplication("1.2.3.4", "PAM")

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -1,10 +1,10 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 from . import smtpmock
 from privacyidea.lib.config import set_privacyidea_config
 
 
-class APIEventsTestCase(MyTestCase):
+class APIEventsTestCase(MyApiTestCase):
 
     def test_01_crud_events(self):
 

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -6,7 +6,7 @@ The api.lib.policy.py depends on lib.policy and on flask!
 from __future__ import print_function
 import json
 
-from .base import (MyTestCase, PWFILE)
+from .base import (MyApiTestCase, PWFILE)
 
 from privacyidea.lib.policy import (set_policy, delete_policy,
                                     PolicyClass, SCOPE, ACTION, REMOTE_USER,
@@ -70,7 +70,7 @@ SSHKEY = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDO1rx366cmSSs/89j" \
          "jPw== corny@schnuck"
 
 
-class PrePolicyDecoratorTestCase(MyTestCase):
+class PrePolicyDecoratorTestCase(MyApiTestCase):
 
     def test_01_check_token_action(self):
         g.logged_in_user = {"username": "admin1",
@@ -1314,7 +1314,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         delete_policy("sms1")
 
 
-class PostPolicyDecoratorTestCase(MyTestCase):
+class PostPolicyDecoratorTestCase(MyApiTestCase):
 
     def test_01_check_tokentype(self):
         # http://werkzeug.pocoo.org/docs/0.10/test/#environment-building

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -2,13 +2,13 @@
 """
 This tests the file api.lib.utils
 """
-from .base import MyTestCase
+from .base import MyApiTestCase
 
 from privacyidea.api.lib.utils import (getParam)
 from privacyidea.lib.error import ParameterError
 
 
-class UtilsTestCase(MyTestCase):
+class UtilsTestCase(MyApiTestCase):
 
     def test_01_getParam(self):
         s = getParam({"serial": ""}, "serial", optional=False, allow_empty=True)

--- a/tests/test_api_machineresolver.py
+++ b/tests/test_api_machineresolver.py
@@ -1,9 +1,9 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 
 HOSTSFILE = "tests/testdata/hosts"
 
-class APIMachineResolverTestCase(MyTestCase):
+class APIMachineResolverTestCase(MyApiTestCase):
 
     # Resolvers
     def test_01_pretestresolver(self):

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -5,7 +5,7 @@ to fetch machine information and to attach token to machines
 import passlib
 
 from privacyidea.lib.user import User
-from .base import MyTestCase
+from .base import MyApiTestCase
 import json
 from privacyidea.lib.token import init_token, get_tokens
 from privacyidea.lib.machine import attach_token
@@ -30,7 +30,7 @@ SSHKEY = "ssh-rsa " \
 OTPKEY = "3132333435363738393031323334353637383930"
 
 
-class APIMachinesTestCase(MyTestCase):
+class APIMachinesTestCase(MyApiTestCase):
 
     serial2 = "ser1"
     serial3 = "UBOM12345"

--- a/tests/test_api_monitoring.py
+++ b/tests/test_api_monitoring.py
@@ -1,12 +1,12 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.monitoringstats import write_stats
 from privacyidea.lib.tokenclass import AUTH_DATE_FORMAT
 import datetime
 from flask import current_app
 
 
-class APIMonitoringTestCase(MyTestCase):
+class APIMonitoringTestCase(MyApiTestCase):
 
     def test_01_get_stats(self):
 

--- a/tests/test_api_periodictask.py
+++ b/tests/test_api_periodictask.py
@@ -9,10 +9,10 @@ import mock
 from dateutil.parser import parse as parse_timestamp
 
 from privacyidea.lib.periodictask import TASK_MODULES
-from tests.base import MyTestCase
+from tests.base import MyApiTestCase
 
 
-class APIPeriodicTasksTestCase(MyTestCase):
+class APIPeriodicTasksTestCase(MyApiTestCase):
     @contextmanager
     def mock_task_module(self):
         """

--- a/tests/test_api_policy.py
+++ b/tests/test_api_policy.py
@@ -1,12 +1,12 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.policy import SCOPE, ACTION
 
 
 
 
 
-class APIPolicyTestCase(MyTestCase):
+class APIPolicyTestCase(MyApiTestCase):
     def test_00_get_policy(self):
         with self.app.test_request_context('/policy/',
                                            method='GET',

--- a/tests/test_api_privacyideaserver.py
+++ b/tests/test_api_privacyideaserver.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from .base import MyTestCase
+from .base import MyApiTestCase
 import json
 import responses
 
 
-class PrivacyIDEAServerTestCase(MyTestCase):
+class PrivacyIDEAServerTestCase(MyApiTestCase):
     """
     test the api.privacyideaserver endpoints
     """

--- a/tests/test_api_radiusserver.py
+++ b/tests/test_api_radiusserver.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .base import MyTestCase
+from .base import MyApiTestCase
 import json
 from . import radiusmock
 from privacyidea.lib.config import set_privacyidea_config
@@ -7,7 +7,7 @@ from privacyidea.lib.radiusserver import delete_radius
 DICT_FILE = "tests/testdata/dictionary"
 
 
-class RADIUSServerTestCase(MyTestCase):
+class RADIUSServerTestCase(MyApiTestCase):
     """
     test the api.radiusserver endpoints
     """

--- a/tests/test_api_register.py
+++ b/tests/test_api_register.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.realm import set_realm
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.policy import SCOPE, ACTION, set_policy
 from privacyidea.lib.resolvers.SQLIdResolver import IdResolver as SQLResolver
 import json
@@ -13,7 +13,7 @@ from privacyidea.lib.user import User
 from privacyidea.lib.error import ERROR
 
 
-class RegisterTestCase(MyTestCase):
+class RegisterTestCase(MyApiTestCase):
     """
     test the api.register and api.recover endpoints
     """

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -5,7 +5,7 @@ selfservice) on the REST API.
 implementation is contained in api/auth.py, api/token.py api/audit.py
 """
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.error import (TokenAdminError, UserError)
 from privacyidea.lib.token import (get_tokens, remove_token, enable_token,
                                    assign_token, unassign_token)
@@ -19,7 +19,7 @@ from privacyidea.lib.policy import ACTION, SCOPE, set_policy, delete_policy
 PWFILE = "tests/testdata/passwords"
 
 
-class APIAuthTestCase(MyTestCase):
+class APIAuthTestCase(MyApiTestCase):
     """
     This tests some side functionalities of the /auth API.
     """
@@ -145,7 +145,7 @@ class APIAuthTestCase(MyTestCase):
         delete_policy("realmadmin")
 
 
-class APIAuthChallengeResponse(MyTestCase):
+class APIAuthChallengeResponse(MyApiTestCase):
 
     def setUp(self):
         self.setUp_user_realms()
@@ -183,7 +183,7 @@ class APIAuthChallengeResponse(MyTestCase):
             self.assertEqual(data.get("result").get("value").get("username"), "selfservice")
 
 
-class APISelfserviceTestCase(MyTestCase):
+class APISelfserviceTestCase(MyApiTestCase):
 
     my_serial = "myToken"
     foreign_serial = "notMyToken"

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -1,8 +1,8 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 
 
-class APISmsGatewayTestCase(MyTestCase):
+class APISmsGatewayTestCase(MyApiTestCase):
 
     def test_01_crud_smsgateway(self):
 

--- a/tests/test_api_smtpserver.py
+++ b/tests/test_api_smtpserver.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from .base import MyTestCase
+from .base import MyApiTestCase
 import json
 from . import smtpmock
 
 
-class SMTPServerTestCase(MyTestCase):
+class SMTPServerTestCase(MyApiTestCase):
     """
     test the api.smtpserver endpoints
     """

--- a/tests/test_api_subscriptions.py
+++ b/tests/test_api_subscriptions.py
@@ -1,10 +1,10 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 
 SUB_FILE = "tests/testdata/test.sub"
 
 
-class APISubscriptionsTestCase(MyTestCase):
+class APISubscriptionsTestCase(MyApiTestCase):
 
     def test_01_crud_subscription(self):
         # Load Subscription file

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 
 from privacyidea.lib.policy import PolicyClass
 from privacyidea.lib.config import (set_privacyidea_config,
@@ -14,7 +14,7 @@ POLICYFILE = "tests/testdata/policy.cfg"
 POLICYEMPTY = "tests/testdata/policy_empty_file.cfg"
 
 
-class APIConfigTestCase(MyTestCase):
+class APIConfigTestCase(MyApiTestCase):
 
     def test_00_get_empty_config(self):
         with self.app.test_request_context('/system/',

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1,4 +1,4 @@
-from .base import MyTestCase
+from .base import MyApiTestCase
 import json
 import os
 import datetime
@@ -84,7 +84,7 @@ oysLynYXZkm0wFudTV04K0aKlMJTp/G96sJOtw1yqrkZSe0rNVcDs9vo+HAoMWO/
 XZp8nprZvJuk6/QIRpadjRkv4NElZ2oNu6a8mtaO38xxnfQm4FEMbm5p+4tM
 -----END CERTIFICATE REQUEST-----"""
 
-class APITokenTestCase(MyTestCase):
+class APITokenTestCase(MyApiTestCase):
 
     def _create_temp_token(self, serial):
         with self.app.test_request_context('/token/init',
@@ -1537,7 +1537,7 @@ class APITokenTestCase(MyTestCase):
         remove_token("goog1")
         delete_policy("imgurl")
 
-class API00TokenPerformance(MyTestCase):
+class API00TokenPerformance(MyApiTestCase):
 
     token_count = 21
 

--- a/tests/test_api_ttype.py
+++ b/tests/test_api_ttype.py
@@ -1,5 +1,5 @@
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.user import (User)
 from privacyidea.lib.tokens.totptoken import HotpTokenClass
 from privacyidea.models import (Token)
@@ -14,7 +14,7 @@ from privacyidea.lib.error import (ParameterError, UserError)
 PWFILE = "tests/testdata/passwords"
 
 
-class TtypeAPITestCase(MyTestCase):
+class TtypeAPITestCase(MyApiTestCase):
     """
     test the api.ttype endpoints
     """

--- a/tests/test_api_u2f.py
+++ b/tests/test_api_u2f.py
@@ -1,4 +1,4 @@
-from .base import MyTestCase
+from .base import MyApiTestCase
 import json
 import binascii
 from privacyidea.lib.token import assign_token, remove_token
@@ -22,7 +22,7 @@ OTPKEY2 = "010fe88d31948c0c2e3258a4b0f7b11956a258ef"
 OTPVALUES2 = ["551536", "703671", "316522", "413789"]
 
 
-class APIU2fTestCase(MyTestCase):
+class APIU2fTestCase(MyApiTestCase):
 
     serial = "U2F001"
 

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from .base import MyTestCase
+from .base import MyApiTestCase
 import json
 from privacyidea.lib.resolver import (save_resolver)
 from privacyidea.lib.realm import (set_realm)
@@ -8,7 +8,7 @@ from six.moves.urllib.parse import urlencode
 PWFILE = "tests/testdata/passwd"
 
 
-class APIUsersTestCase(MyTestCase):
+class APIUsersTestCase(MyApiTestCase):
 
     parameters = {'Driver': 'sqlite',
                   'Server': '/tests/testdata/',

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from six.moves.urllib.parse import urlencode
 import json
-from .base import MyTestCase
+from .base import MyApiTestCase
 from privacyidea.lib.user import (User)
 from privacyidea.lib.tokens.totptoken import HotpTokenClass
 from privacyidea.models import (Token, Challenge, AuthCache)
@@ -89,7 +89,7 @@ OTPs = ["755224",
         "399871",
         "520489"]
 
-class AuthorizationPolicyTestCase(MyTestCase):
+class AuthorizationPolicyTestCase(MyApiTestCase):
     """
     This tests the catch all resolvers and resolvers which also contain the
     user.
@@ -242,7 +242,7 @@ class AuthorizationPolicyTestCase(MyTestCase):
             self.assertTrue(result.get("value"))
 
 
-class DisplayTANTestCase(MyTestCase):
+class DisplayTANTestCase(MyApiTestCase):
 
     def test_00_run_complete_workflow(self):
         # This is a standard workflow of a display TAN token.
@@ -332,7 +332,7 @@ class DisplayTANTestCase(MyTestCase):
         remove_token("ocra1234")
 
 
-class AValidateOfflineTestCase(MyTestCase):
+class AValidateOfflineTestCase(MyApiTestCase):
     """
     Test api.validate endpoints that are responsible for offline auth.
     """
@@ -535,7 +535,7 @@ class AValidateOfflineTestCase(MyTestCase):
                              u"ERR905: Token is not an offline token or refill token is incorrect")
 
 
-class ValidateAPITestCase(MyTestCase):
+class ValidateAPITestCase(MyApiTestCase):
     """
     test the api.validate endpoints
     """
@@ -2418,14 +2418,14 @@ class ValidateAPITestCase(MyTestCase):
             self.assertFalse(result.get("value"))
 
 
-class AChallengeResponse(MyTestCase):
+class AChallengeResponse(MyApiTestCase):
 
     serial = "hotp1"
     serial_email = "email1"
     serial_sms= "sms1"
 
     def setUp(self):
-        MyTestCase.setUp(self)
+        super(AChallengeResponse, self).setUp()
         self.setUp_user_realms()
 
     def setup_sms_gateway(self):
@@ -2871,10 +2871,10 @@ class AChallengeResponse(MyTestCase):
         remove_token(self.serial_sms)
 
 
-class TriggeredPoliciesTestCase(MyTestCase):
+class TriggeredPoliciesTestCase(MyApiTestCase):
 
     def setUp(self):
-        MyTestCase.setUp(self)
+        super(TriggeredPoliciesTestCase, self).setUp()
         self.setUp_user_realms()
 
     def test_00_two_policies(self):

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -2339,6 +2339,8 @@ class UserNotificationTestCase(MyTestCase):
         notified anymore, since the email also does not exist in the
         userstore anymore.
         """
+        # Create admin authentication token
+        self.authenticate()
         # Create our realm and resolver
         parameters = {'resolver': "notify_resolver",
                       "type": "sqlresolver",

--- a/tests/test_lib_lifecycle.py
+++ b/tests/test_lib_lifecycle.py
@@ -9,6 +9,10 @@ from .base import MyTestCase
 
 
 class LifecycleTestCase(MyTestCase):
+    # Create admin authentication token for each testcase
+    def setUp(self):
+        self.authenticate()
+
     def test_01_register_finalizer(self):
         finalizer1 = mock.MagicMock()
         finalizer2 = mock.MagicMock()

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -806,6 +806,7 @@ class LibPolicyTestCase(MyTestCase):
         self.assertEqual(token2.token.failcount, 2)
 
         g.policy_object = PolicyClass()
+        g.audit_object = FakeAudit()
         options = {"g": g}
 
         r = reset_all_user_tokens(self.fake_check_token_list,

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -13,7 +13,7 @@ getTokens4UserOrSerial
 gettokensoftype
 getToken....
 """
-from .base import MyTestCase
+from .base import MyTestCase, FakeAudit
 from privacyidea.lib.user import (User)
 from privacyidea.lib.tokenclass import TokenClass, TOKENKIND
 from privacyidea.lib.tokens.totptoken import TotpTokenClass
@@ -1614,6 +1614,7 @@ class TokenFailCounterTestCase(MyTestCase):
         self.assertEqual(token2.token.failcount, 2)
 
         g.policy_object = PolicyClass()
+        g.audit_object = FakeAudit()
         options = {"g": g}
 
         check_token_list([token1, token2], pin1, user=user,

--- a/tests/test_resolver_realm.py
+++ b/tests/test_resolver_realm.py
@@ -1,11 +1,10 @@
-import unittest
+# -*- coding: utf-8 -*-
+
 import json
-from privacyidea.app import create_app
 from privacyidea.models import (Resolver,
                                 ResolverConfig,
-                                Realm,
                                 db)
-from .base import MyTestCase
+from .base import MyTestCase, MyApiTestCase
 
 
 class ResolverModelTestCase(MyTestCase):
@@ -29,7 +28,7 @@ class ResolverModelTestCase(MyTestCase):
         self.assertTrue(r1.rtype=="passwdresolver", r1.rtype)
 
 
-class APIResolverTestCase(MyTestCase):
+class APIResolverTestCase(MyApiTestCase):
     '''
     Test the resolver on the API level
     '''


### PR DESCRIPTION
The `setUp()` of the base test case created an admin token request which
slowed down the startup of the tests. Most of the library tests don't need
an admin authentication token since they don't talk to the API.
Therefore a new base class for the API test cases ([MyApiTestCase](https://github.com/privacyidea/privacyidea/blob/c60f6db40cd9bbfd60568eac6d8979bc23ff1272/tests/base.py#L175)) creates the authentication token in its `setUp()` function.

This reduces the test run time by about a half. Time to add Python 3.7 to the test matrix :-)