### PR TITLE
Allow to concatenate challenge text in a more flexible way

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -314,7 +314,8 @@ challenge_text, challenge_text_header, challenge_test_footer
 .. index:: Challenge Text Policy
 
 Using these policies the administrator can modify the challenge texts
-of e.g. Email-Token or SMS-Token.
+of e.g. Email-Token or SMS-Token. The action *challenge_text* changes the
+challenge text in general, no matter which challenge response token is used.
 
 If the *challenge_text_header* is set and if there are more matching
 challenge response tokens, then the texts of all tokens are

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -304,3 +304,27 @@ dependent on the clients IP address and the user agent.
 .. note:: The AuthCache only works for user authentication, not for
    authentication with serials.
 
+
+.. _policy_challenge_text:
+
+
+challenge_text, challenge_text_header, challenge_test_footer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. index:: Challenge Text Policy
+
+Using these policies the administrator can modify the challenge texts
+of e.g. Email-Token or SMS-Token.
+
+If the *challenge_text_header* is set and if there are more matching
+challenge response tokens, then the texts of all tokens are
+concatenated together. Double challenge texts are reduced to one text only.
+
+The *challenge_text_header* and *challenge_text_footer* may contain HTML.
+If the *challenge_text_header* ends with an ``<ul>`` or ``<ol>``, then
+all the challenge texts are formatted as an ordered or unordered list.
+In this case the *challenge_text_footer* also should contain the closing
+tag.
+
+.. note:: The footer will only be used, if the header is also set.
+

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -782,13 +782,17 @@ def mangle_challenge_response(request, response):
     This policy decorator is used in the AUTH scope to
     decorate the /validate/check endpoint.
     It can modify the contents of the response "detail"->"message"
-    to allow a better readibilty for a challenge response text.
+    to allow a better readability for a challenge response text.
 
     :param request:
     :param response:
     :return:
     """
-    content = json.loads(response.data)
+    try:
+        content = json.loads(response.data)
+    except ValueError:
+        # This can happen with the validate/radiuscheck endpoint
+        return response
     policy_object = g.policy_object
     user_obj = request.User
 
@@ -799,7 +803,8 @@ def mangle_challenge_response(request, response):
                                                  user=user_obj.login,
                                                  realm=user_obj.realm,
                                                  resolver=user_obj.resolver,
-                                                 audit_data=g.audit_object.audit_data)
+                                                 audit_data=g.audit_object.audit_data,
+                                                 unique=True)
 
     footer_pol = policy_object.get_action_values(action=ACTION.CHALLENGETEXT_FOOTER,
                                                  scope=SCOPE.AUTH,
@@ -808,7 +813,8 @@ def mangle_challenge_response(request, response):
                                                  user=user_obj.login,
                                                  realm=user_obj.realm,
                                                  resolver=user_obj.resolver,
-                                                 audit_data=g.audit_object.audit_data)
+                                                 audit_data=g.audit_object.audit_data,
+                                                 unique=True)
 
     if header_pol:
         multi_challenge = content.get("detail", {}).get("multi_challenge")
@@ -819,7 +825,7 @@ def mangle_challenge_response(request, response):
                 footer = list(footer_pol)[0]
             # We actually have challenge response
             messages = content.get("detail", {}).get("messages") or []
-            messages = list(set(messages))
+            messages = sorted(set(messages))
             if message[-4:].lower() in ["<ol>", "<ul>"]:
                 for m in messages:
                     message += u"<li>{0!s}</li>\n".format(m)

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -87,7 +87,8 @@ from privacyidea.api.lib.postpolicy import (postpolicy,
                                             no_detail_on_fail,
                                             no_detail_on_success, autoassign,
                                             offline_info,
-                                            add_user_detail_to_response, construct_radius_response)
+                                            add_user_detail_to_response, construct_radius_response,
+                                            mangle_challenge_response)
 from privacyidea.lib.policy import PolicyClass
 from privacyidea.lib.event import EventConfiguration
 import logging
@@ -207,6 +208,7 @@ def offlinerefill():
 
 @validate_blueprint.route('/check', methods=['POST', 'GET'])
 @validate_blueprint.route('/radiuscheck', methods=['POST', 'GET'])
+@postpolicy(mangle_challenge_response, request=request)
 @postpolicy(construct_radius_response, request=request)
 @postpolicy(no_detail_on_fail, request=request)
 @postpolicy(no_detail_on_success, request=request)
@@ -460,6 +462,7 @@ def samlcheck():
 
 @validate_blueprint.route('/triggerchallenge', methods=['POST', 'GET'])
 @admin_required
+@postpolicy(mangle_challenge_response, request=request)
 @check_user_or_serial_in_request(request)
 @prepolicy(check_base_action, request, action=ACTION.TRIGGERCHALLENGE)
 @event("validate_triggerchallenge", request, g)

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -216,6 +216,8 @@ class ACTION(object):
     CACONNECTORDELETE = "caconnectordelete"
     CHALLENGERESPONSE = "challenge_response"
     CHALLENGETEXT = "challenge_text"
+    CHALLENGETEXT_HEADER = "challenge_text_header"
+    CHALLENGETEXT_FOOTER = "challenge_text_footer"
     GETCHALLENGES = "getchallenges"
     COPYTOKENPIN = "copytokenpin"
     COPYTOKENUSER = "copytokenuser"
@@ -1590,6 +1592,16 @@ def get_static_policy_definitions(scope=None):
                 'type': 'str',
                 'desc': _('Use an alternate challenge text for telling the '
                           'user to enter an OTP value.')
+            },
+            ACTION.CHALLENGETEXT_HEADER: {
+                'type': 'str',
+                'desc': _("If there are several different challenges, this text precedes the list"
+                          " of the challenge texts.")
+            },
+            ACTION.CHALLENGETEXT_FOOTER: {
+                'type': 'str',
+                'desc': _("If there are several different challenges, this text follows the list"
+                          " of the challenge texts.")
             },
             ACTION.PASSTHRU: {
                 'type': 'str',

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2048,8 +2048,9 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
                 reply_dict["multi_challenge"].append(challenge_info)
     if message_list:
         reply_dict["message"] = ", ".join(message_list)
-    # TODO: These two lines are deprecated: Add the information for the old administrative triggerchallenge
+    # The "messages" element is needed by some decorators
     reply_dict["messages"] = message_list
+    # TODO: This line is deprecated: Add the information for the old administrative triggerchallenge
     reply_dict["transaction_ids"] = [chal.get("transaction_id") for chal in reply_dict.get("multi_challenge", [])]
 
 

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -33,7 +33,8 @@ from privacyidea.api.lib.postpolicy import (check_serial, check_tokentype,
                                             offline_info, sign_response,
                                             get_webui_settings,
                                             save_pin_change,
-                                            add_user_detail_to_response)
+                                            add_user_detail_to_response,
+                                            mangle_challenge_response)
 from privacyidea.lib.token import (init_token, get_tokens, remove_token,
                                    set_realms, check_user_pass, unassign_token)
 from privacyidea.lib.user import User
@@ -2048,3 +2049,65 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # finally delete policy
         delete_policy("pol1")
         delete_policy("pol2")
+
+    def test_18_challenge_text_header(self):
+        # This looks like a validate/check request, that triggers a challenge
+        builder = EnvironBuilder(method='POST',
+                                 data={'user': "hans",
+                                       "pass": "pin"},
+                                 headers={})
+
+        env = builder.get_environ()
+        # Set the remote address so that we can filter for it
+        env["REMOTE_ADDR"] = "10.0.0.1"
+        g.client_ip = env["REMOTE_ADDR"]
+        req = Request(env)
+
+        # Set a policy for the header
+        set_policy(name="pol_header",
+                   scope=SCOPE.AUTH,
+                   action="{0!s}=These are your options:<ul>".format(ACTION.CHALLENGETEXT_HEADER))
+        # Set a policy for the footer
+        set_policy(name="pol_footer",
+                   scope=SCOPE.AUTH,
+                   action="{0!s}=Happy authenticating!".format(ACTION.CHALLENGETEXT_FOOTER))
+        g.policy_object = PolicyClass()
+
+        req.all_data = {
+            "user": "hans",
+            "pass": "pin"}
+        req.User = User()
+
+        # We do an html list
+        res = {"jsonrpc": "2.0",
+               "result": {"status": True,
+                          "value": False},
+               "version": "privacyIDEA test",
+               "id": 1,
+               "detail": {"message": "enter the HOTP from your email, "
+                                     "enter the HOTP from your email, "
+                                     "enter the TOTP from your SMS",
+                          "messages": ["enter the HOTP from your email",
+                                       "enter the HOTP from your email",
+                                       "enter the TOTP from your SMS"],
+                          "multi_challenge": ["chal1", "chal2", "chal3"]}}
+        resp = jsonify(res)
+
+        r = mangle_challenge_response(req, resp)
+        message = r.json.get("detail", {}).get("message")
+        self.assertEqual(message, "These are your options:<ul><li>enter the TOTP from your SMS</li>\n<li>enter the HOTP from your email</li>\nHappy authenticating!")
+
+        # We do no html list
+        set_policy(name="pol_header",
+                   scope=SCOPE.AUTH,
+                   action="{0!s}=These are your options:".format(ACTION.CHALLENGETEXT_HEADER))
+        g.policy_object = PolicyClass()
+        resp = jsonify(res)
+
+        r = mangle_challenge_response(req, resp)
+        message = r.json.get("detail", {}).get("message")
+        self.assertTrue("<ul><li>" not in message, message)
+        self.assertEqual(message, "These are your options:\nenter the TOTP from your SMS, enter the HOTP from your email\nHappy authenticating!")
+
+        delete_policy("pol_header")
+        delete_policy("pol_footer")

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -2095,7 +2095,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
 
         r = mangle_challenge_response(req, resp)
         message = r.json.get("detail", {}).get("message")
-        self.assertEqual(message, "These are your options:<ul><li>enter the TOTP from your SMS</li>\n<li>enter the HOTP from your email</li>\nHappy authenticating!")
+        self.assertEqual(message, "These are your options:<ul><li>enter the HOTP from your email</li>\n<li>enter the TOTP from your SMS</li>\nHappy authenticating!")
 
         # We do no html list
         set_policy(name="pol_header",
@@ -2107,7 +2107,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         r = mangle_challenge_response(req, resp)
         message = r.json.get("detail", {}).get("message")
         self.assertTrue("<ul><li>" not in message, message)
-        self.assertEqual(message, "These are your options:\nenter the TOTP from your SMS, enter the HOTP from your email\nHappy authenticating!")
+        self.assertEqual(message, "These are your options:\nenter the HOTP from your email, enter the TOTP from your SMS\nHappy authenticating!")
 
         delete_policy("pol_header")
         delete_policy("pol_footer")


### PR DESCRIPTION
In case of multi_challenge, double challenge texts will be removed.
The list of the challenge texts can have an additional footer and
header.
It may contain HTML to format an ordered or unordered list.

Closes #1384