### PR TITLE
Python3 update api tests

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -332,9 +332,9 @@ def privacyidea_error(error):
     These are not that critical exceptions.
     """
     if "audit_object" in g:
-        g.audit_object.log({"info": error.message})
+        g.audit_object.log({"info": str(error)})
         g.audit_object.finalize_log()
-    return send_error(error.message, error_code=error.id), 400
+    return send_error(str(error), error_code=error.id), 400
 
 
 # other errors
@@ -360,6 +360,6 @@ def internal_error(error):
     occurs.
     """
     if "audit_object" in g:
-        g.audit_object.log({"info": error.message})
+        g.audit_object.log({"info": str(error)})
         g.audit_object.finalize_log()
-    return send_error(error.message, error_code=-500), 500
+    return send_error(str(error), error_code=-500), 500

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -332,9 +332,9 @@ def privacyidea_error(error):
     These are not that critical exceptions.
     """
     if "audit_object" in g:
-        g.audit_object.log({"info": unicode(error)})
+        g.audit_object.log({"info": error.message})
         g.audit_object.finalize_log()
-    return send_error(unicode(error), error_code=error.id), 400
+    return send_error(error.message, error_code=error.id), 400
 
 
 # other errors
@@ -360,6 +360,6 @@ def internal_error(error):
     occurs.
     """
     if "audit_object" in g:
-        g.audit_object.log({"info": unicode(error)})
+        g.audit_object.log({"info": error.message})
         g.audit_object.finalize_log()
-    return send_error(unicode(error), error_code=-500), 500
+    return send_error(error.message, error_code=-500), 500

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -27,6 +27,7 @@ Flask endpoints.
 It also contains the error handlers.
 """
 
+import six
 from .lib.utils import (send_error, get_all_params)
 from ..lib.user import get_user_from_param
 import logging
@@ -332,9 +333,9 @@ def privacyidea_error(error):
     These are not that critical exceptions.
     """
     if "audit_object" in g:
-        g.audit_object.log({"info": str(error)})
+        g.audit_object.log({"info": six.text_type(error)})
         g.audit_object.finalize_log()
-    return send_error(str(error), error_code=error.id), 400
+    return send_error(six.text_type(error), error_code=error.id), 400
 
 
 # other errors
@@ -360,6 +361,6 @@ def internal_error(error):
     occurs.
     """
     if "audit_object" in g:
-        g.audit_object.log({"info": str(error)})
+        g.audit_object.log({"info": six.text_type(error)})
         g.audit_object.finalize_log()
-    return send_error(str(error), error_code=-500), 500
+    return send_error(six.text_type(error), error_code=-500), 500

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -208,7 +208,7 @@ def send_csv_result(obj, data_key="tokens",
     # Do the data
     for row in obj.get(data_key, {}):
         for val in row.values():
-            if isinstance(val, six.text_type):
+            if isinstance(val, six.string_types):
                 value = val.replace("\n", " ")
             else:
                 value = val

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -33,6 +33,7 @@ import pkg_resources
 import logging
 import json
 import jwt
+import six
 from flask import (jsonify,
                    current_app,
                    Response)
@@ -207,7 +208,7 @@ def send_csv_result(obj, data_key="tokens",
     # Do the data
     for row in obj.get(data_key, {}):
         for val in row.values():
-            if type(val) in [str, unicode]:
+            if isinstance(val, six.text_type):
                 value = val.replace("\n", " ")
             else:
                 value = val

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -49,6 +49,7 @@ from ..lib.policy import (set_policy,
                           enable_policy)
 from ..lib.token import get_dynamic_policy_definitions
 from ..lib.error import (ParameterError)
+from privacyidea.lib.utils import to_unicode
 from ..api.lib.prepolicy import prepolicy, check_base_action
 
 from flask import (g,
@@ -395,6 +396,9 @@ def import_policy_api(filename=None):
         file_contents = policy_file.read()
     else:  # pragma: no cover
         file_contents = policy_file
+
+    # The policy file should contain readable characters
+    file_contents = to_unicode(file_contents)
 
     if file_contents == "":
         log.error("Error loading/importing policy file. file {0!s} empty!".format(

--- a/privacyidea/api/system.py
+++ b/privacyidea/api/system.py
@@ -70,11 +70,9 @@ from privacyidea.lib.resolver import get_resolver_list
 from privacyidea.lib.realm import get_realms
 from privacyidea.lib.policy import PolicyClass, ACTION
 from privacyidea.lib.auth import get_db_admins
-from privacyidea.lib.error import HSMException
 from privacyidea.lib.crypto import geturandom, set_hsm_password, get_hsm
 from privacyidea.lib.importotp import GPGImport
-import base64
-import binascii
+from privacyidea.lib.utils import hexlify_and_unicode, b64encode_and_unicode
 
 
 log = logging.getLogger(__name__)
@@ -322,7 +320,7 @@ def rand():
     on the client side. E.g. the command line client when initializing the
     yubikey or the WebUI when creating Client API keys for the yubikey.
 
-    In this case, privacyIDEA can created the random data/keys.
+    In this case, privacyIDEA can create the random data/keys.
 
     :queryparam len: The length of a symmetric key (byte)
     :queryparam encode: The type of encoding. Can be "hex" or "b64".
@@ -334,9 +332,9 @@ def rand():
 
     r = geturandom(length=length)
     if encode == "b64":
-        res = base64.b64encode(r)
+        res = b64encode_and_unicode(r)
     else:
-        res = binascii.hexlify(r)
+        res = hexlify_and_unicode(r)
 
     g.audit_object.log({'success': res})
     return send_result(res)

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -54,9 +54,7 @@
 
 from flask import (Blueprint, request, g, current_app)
 from ..lib.log import log_with
-from .lib.utils import (optional,
-                        send_result, send_error,
-                        send_csv_result, required, get_all_params)
+from .lib.utils import optional, send_result, send_csv_result, required, getParam
 from ..lib.user import get_user_from_param
 from ..lib.token import (init_token, get_tokens_paginate, assign_token,
                          unassign_token, remove_token, enable_token,
@@ -75,7 +73,7 @@ from privacyidea.lib.error import (ParameterError, TokenAdminError)
 from privacyidea.lib.importotp import (parseOATHcsv, parseSafeNetXML,
                                        parseYubicoCSV, parsePSKCdata, GPGImport)
 import logging
-from .lib.utils import getParam
+from privacyidea.lib.utils import to_unicode
 from privacyidea.lib.policy import ACTION
 from privacyidea.lib.challenge import get_challenges_paginate
 from privacyidea.api.lib.prepolicy import (prepolicy, check_base_action,
@@ -859,6 +857,8 @@ def loadtokens_api(filename=None):
         file_contents = token_file.read()
     else:  # pragma: no cover
         file_contents = token_file
+
+    file_contents = to_unicode(file_contents)
 
     if file_contents == "":
         log.error("Error loading/importing token file. file {0!s} empty!".format(

--- a/privacyidea/lib/applications/luks.py
+++ b/privacyidea/lib/applications/luks.py
@@ -19,11 +19,11 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from privacyidea.lib.applications import MachineApplicationBase
+from privacyidea.lib.utils import hexlify_and_unicode
+from privacyidea.lib.crypto import geturandom
+from privacyidea.lib.token import get_tokens
 import logging
 log = logging.getLogger(__name__)
-from privacyidea.lib.crypto import geturandom
-import binascii
-from privacyidea.lib.token import get_tokens
 
 
 class MachineApplication(MachineApplicationBase):
@@ -62,7 +62,7 @@ class MachineApplication(MachineApplicationBase):
                 # the hmac module calculates different responses for 64 bytes.
                 if challenge is None:
                     challenge = geturandom(32)
-                    challenge_hex = binascii.hexlify(challenge)
+                    challenge_hex = hexlify_and_unicode(challenge)
                 else:
                     challenge_hex = challenge
                 ret["challenge"] = challenge_hex

--- a/privacyidea/lib/challenge.py
+++ b/privacyidea/lib/challenge.py
@@ -27,9 +27,9 @@ The method is tested in test_lib_challenges
 """
 
 import logging
+import six
 from .log import log_with
 from ..models import Challenge
-from datetime import datetime
 log = logging.getLogger(__name__)
 
 
@@ -84,7 +84,7 @@ def get_challenges_paginate(serial=None, transaction_id=None,
     sql_query = _create_challenge_query(serial=serial,
                                         transaction_id=transaction_id)
 
-    if type(sortby) in [str, unicode]:
+    if isinstance(sortby, six.string_types):
         # convert the string to a Challenge column
         cols = Challenge.__table__.columns
         sortby = cols.get(sortby)

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -397,10 +397,11 @@ def aes_encrypt_b64(key, data):
     This is used for PSKC.
 
     :param key: Encryption key (binary format)
+    :type key: bytes
     :param data: Data to encrypt
     :type data: bytes
-    :return: base64 encrypted output, containing IV
-    :rtype: bytes
+    :return: base64 encrypted output, containing IV and encrypted data
+    :rtype: str
     """
     iv = geturandom(16)
     encdata = aes_encrypt(key, iv, data)

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -71,7 +71,7 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.error import HSMException
 from privacyidea.lib.framework import (get_app_local_store, get_app_config_value,
                                        get_app_config)
-from privacyidea.lib.utils import to_unicode, to_bytes, hexlify_and_unicode
+from privacyidea.lib.utils import to_unicode, to_bytes, hexlify_and_unicode, b64encode_and_unicode
 
 if not PY2:
     long = int
@@ -404,7 +404,7 @@ def aes_encrypt_b64(key, data):
     """
     iv = geturandom(16)
     encdata = aes_encrypt(key, iv, data)
-    return base64.b64encode(iv + encdata)
+    return b64encode_and_unicode(iv + encdata)
 
 
 def aes_decrypt_b64(key, data_b64):
@@ -414,6 +414,7 @@ def aes_decrypt_b64(key, data_b64):
 
     :param key: binary key
     :param data_b64: base64 encoded data (IV + encdata)
+    :type data_b64: str
     :return: encrypted data
     """
     data_bin = base64.b64decode(data_b64)

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -632,11 +632,11 @@ def export_pskc(tokenobj_list, psk=None):
         otpkey = tokenobj.token.get_otpkey().getKey()
         try:
             if tokenobj.type.lower() in ["totp", "hotp"]:
-                encrypted_otpkey = to_unicode(aes_encrypt_b64(psk, binascii.unhexlify(otpkey)))
+                encrypted_otpkey = aes_encrypt_b64(psk, binascii.unhexlify(otpkey))
             elif tokenobj.type.lower() in ["pw"]:
-                encrypted_otpkey = to_unicode(aes_encrypt_b64(psk, otpkey))
+                encrypted_otpkey = aes_encrypt_b64(psk, otpkey)
             else:
-                encrypted_otpkey = to_unicode(aes_encrypt_b64(psk, otpkey))
+                encrypted_otpkey = aes_encrypt_b64(psk, otpkey)
         except TypeError:
             # Some keys might be odd string length
             continue

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -557,9 +557,15 @@ class GPGImport(object):
 
     def decrypt(self, input_data):
         """
-        Decrypts the input data with one of the private keys
-        :param input_data:
-        :return:
+        Decrypts the input data with one of the private keys.
+
+        Since this functionality is only used for decrypting import lists, the
+        decrypted data is assumed to be of type text und thus converted to unicode.
+
+        :param input_data: The data to decrypt
+        :type input_data: str or bytes
+        :return: The decrypted input_data
+        :rtype: str
         """
         decrypted = self.gpg.decrypt(message=input_data)
 

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -51,7 +51,8 @@ import re
 import binascii
 import base64
 import cgi
-from privacyidea.lib.utils import modhex_decode, modhex_encode, hexlify_and_unicode, to_unicode
+from privacyidea.lib.utils import (modhex_decode, modhex_encode,
+                                   hexlify_and_unicode, to_unicode, to_utf8)
 from privacyidea.lib.config import get_token_class
 from privacyidea.lib.log import log_with
 from privacyidea.lib.crypto import (aes_decrypt_b64, aes_encrypt_b64, geturandom)
@@ -59,7 +60,6 @@ from Crypto.Cipher import AES
 from bs4 import BeautifulSoup
 import traceback
 from passlib.utils.pbkdf2 import pbkdf2
-from privacyidea.lib.utils import to_utf8
 import gnupg
 
 import logging
@@ -568,7 +568,7 @@ class GPGImport(object):
                 decrypted.status, decrypted.stderr))
             raise Exception(decrypted.stderr)
 
-        return decrypted.data
+        return to_unicode(decrypted.data)
 
 
 def export_pskc(tokenobj_list, psk=None):

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -58,7 +58,8 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.apps import create_google_authenticator_url as cr_google
 from privacyidea.lib.error import ParameterError
 from privacyidea.lib.apps import create_oathtoken_url as cr_oath
-from privacyidea.lib.utils import create_img, is_true, b32encode_and_unicode
+from privacyidea.lib.utils import (create_img, is_true, b32encode_and_unicode,
+                                   hexlify_and_unicode)
 from privacyidea.lib.policydecorators import challenge_response_allowed
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.auth import ROLE
@@ -720,6 +721,7 @@ class HotpTokenClass(TokenClass):
         :type client_component: hex string
         :param options:
         :return: the new generated key as hex string
+        :rtype: str
         """
         # As /token/init has already been called before, self.hashlib
         # is already set.
@@ -738,7 +740,4 @@ class HotpTokenClass(TokenClass):
                         decoded_client_component,
                         rounds,
                         keysize)
-        return binascii.hexlify(secret)
-
-
-
+        return hexlify_and_unicode(secret)

--- a/privacyidea/lib/tokens/ocratoken.py
+++ b/privacyidea/lib/tokens/ocratoken.py
@@ -206,13 +206,12 @@ class OcraTokenClass(TokenClass):
                     "addrandomchallenge")))
             attributes["original_challenge"] = challenge
             attributes["qrcode"] = create_img(challenge)
-            challenge = to_bytes(challenge)
             if options.get("hashchallenge", "").lower() == "sha256":
-                challenge = hexlify_and_unicode(hashlib.sha256(challenge).digest())
+                challenge = hexlify_and_unicode(hashlib.sha256(to_bytes(challenge)).digest())
             elif options.get("hashchallenge", "").lower() == "sha512":
-                challenge = hexlify_and_unicode(hashlib.sha512(challenge).digest())
+                challenge = hexlify_and_unicode(hashlib.sha512(to_bytes(challenge)).digest())
             elif options.get("hashchallenge"):
-                challenge = hexlify_and_unicode(hashlib.sha1(challenge).digest())
+                challenge = hexlify_and_unicode(hashlib.sha1(to_bytes(challenge)).digest())
 
 
         # Create the challenge in the database

--- a/privacyidea/lib/tokens/ocratoken.py
+++ b/privacyidea/lib/tokens/ocratoken.py
@@ -29,13 +29,12 @@ This code is tested in tests/test_lib_tokens_tiqr.
 
 import logging
 import hashlib
-import binascii
 
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.config import get_from_config
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.log import log_with
-from privacyidea.lib.utils import create_img, hexlify_and_unicode
+from privacyidea.lib.utils import create_img, hexlify_and_unicode, to_bytes
 from privacyidea.models import Challenge
 from privacyidea.lib.user import get_user_from_param
 from privacyidea.lib.tokens.ocra import OCRASuite, OCRA
@@ -207,6 +206,7 @@ class OcraTokenClass(TokenClass):
                     "addrandomchallenge")))
             attributes["original_challenge"] = challenge
             attributes["qrcode"] = create_img(challenge)
+            challenge = to_bytes(challenge)
             if options.get("hashchallenge", "").lower() == "sha256":
                 challenge = hexlify_and_unicode(hashlib.sha256(challenge).digest())
             elif options.get("hashchallenge", "").lower() == "sha512":

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -153,7 +153,7 @@ class User(object):
         return ret
 
     def __repr__(self):
-        ret = ('User(login={0!r}, realm={1!r}, resolver={2!r})'.format(
+        ret = ("User(login='{0!s}', realm='{1!s}', resolver='{2!s}')".format(
             self.login, self.realm, self.resolver))
         return ret
 

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -142,12 +142,11 @@ class User(object):
     def __str__(self):
         ret = u"<empty user>"
         if not self.is_empty():
-            login = self.login
             # Realm and resolver should always be ASCII
             conf = u''
             if self.resolver:
                 conf = u'.{0!s}'.format(self.resolver)
-            ret = u'<{0!s}{1!s}@{2!s}>'.format(login, conf, self.realm)
+            ret = u'<{0!s}{1!s}@{2!s}>'.format(self.login, conf, self.realm)
         return ret
 
     def __repr__(self):

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -143,8 +143,6 @@ class User(object):
         ret = u"<empty user>"
         if not self.is_empty():
             login = self.login
-            if not isinstance(login, six.text_type):
-                login = login.decode('utf8')
             # Realm and resolver should always be ASCII
             conf = u''
             if self.resolver:
@@ -153,7 +151,7 @@ class User(object):
         return ret
 
     def __repr__(self):
-        ret = ("User(login='{0!s}', realm='{1!s}', resolver='{2!s}')".format(
+        ret = (u"User(login={0!r}, realm={1!r}, resolver={2!r})".format(
             self.login, self.realm, self.resolver))
         return ret
 
@@ -237,9 +235,8 @@ class User(object):
                 # We do not need to search other resolvers!
                 return True
             else:
-                log.debug("user %r not found"
-                          " in resolver %r" % (self.login,
-                                               resolvername))
+                log.debug("user {0!r} not found"
+                          " in resolver {1!r}".format(self.login, resolvername))
                 return False
 
     def get_user_identifiers(self):
@@ -359,8 +356,6 @@ class User(object):
         try:
             log.info("User %r from realm %r tries to "
                      "authenticate" % (self.login, self.realm))
-            if not isinstance(self.login, six.text_type):
-                self.login = self.login.decode('utf8')
             res = self._get_resolvers()
             # Now we know, the resolvers of this user and we can verify the
             # password
@@ -423,16 +418,15 @@ class User(object):
             attributes["password"] = password
         success = False
         try:
-            log.info("User info for user {0!r}@{1!r} about to be updated.".format(self.login, self.realm))
-            if not isinstance(self.login, six.text_type):
-                self.login = self.login.decode('utf8')
+            log.info("User info for user {0!r}@{1!r} about to "
+                     "be updated.".format(self.login, self.realm))
             res = self._get_resolvers()
             # Now we know, the resolvers of this user and we can update the
             # user
             if len(res) == 1:
                 y = get_resolver_object(self.resolver)
                 if not y.updateable:  # pragma: no cover
-                    log.warning("The resolver {0!s} is not updateable.".format(y))
+                    log.warning("The resolver {0!r} is not updateable.".format(y))
                 else:
                     uid, _rtype, _rname = self.get_user_identifiers()
                     if y.update_user(uid, attributes):
@@ -449,7 +443,7 @@ class User(object):
             elif not res:  # pragma: no cover
                 log.error("The user {0!r} exists in NO resolver.".format(self))
         except UserError as exx:  # pragma: no cover
-            log.error("Error while trying to verify the username: {0!s}".format(exx))
+            log.error("Error while trying to verify the username: {0!r}".format(exx))
 
         return success
 
@@ -464,14 +458,12 @@ class User(object):
         success = False
         try:
             log.info("User {0!r}@{1!r} about to be deleted.".format(self.login, self.realm))
-            if not isinstance(self.login, six.text_type):
-                self.login = self.login.decode('utf8')
             res = self._get_resolvers()
             # Now we know, the resolvers of this user and we can delete it
             if len(res) == 1:
                 y = get_resolver_object(self.resolver)
                 if not y.updateable:  # pragma: no cover
-                    log.warning("The resolver {0!s} is not updateable.".format(y))
+                    log.warning("The resolver {0!r} is not updateable.".format(y))
                 else:
                     uid, _rtype, _rname = self.get_user_identifiers()
                     if y.delete_user(uid):

--- a/tests/base.py
+++ b/tests/base.py
@@ -173,5 +173,18 @@ class MyTestCase(unittest.TestCase):
 
 
 class MyApiTestCase(MyTestCase):
-    def setUp(self):
-        self.authenticate()
+    @classmethod
+    def cls_auth(cls, app):
+        with app.test_request_context('/auth', data={"username": "testadmin",
+                                                     "password": "testpw"},
+                                      method='POST'):
+            res = app.full_dispatch_request()
+            assert res.status_code == 200
+            result = res.json.get("result")
+            assert result.get("status")
+            cls.at = result.get("value").get("token")
+
+    @classmethod
+    def setUpClass(cls):
+        super(MyApiTestCase, cls).setUpClass()
+        cls.cls_auth(cls.app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,6 @@ import sys
 collect_ignore = []
 if sys.version_info[0] > 2:
     collect_ignore.extend([
-        'test_api_2stepinit.py',
-        'test_api_applications.py',
-        'test_api_audit.py',
-        'test_api_clienttype.py',
-        'test_api_lib_policy.py',
-        'test_api_machines.py',
         'test_api_periodictask.py',
         'test_api_policy.py',
         'test_api_register.py',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,6 @@ import sys
 collect_ignore = []
 if sys.version_info[0] > 2:
     collect_ignore.extend([
-        'test_api_periodictask.py',
-        'test_api_policy.py',
-        'test_api_register.py',
-        'test_api_roles.py',
-        'test_api_smtpserver.py',
-        'test_api_subscriptions.py',
-        'test_api_system.py',
-        'test_api_token.py',
-        'test_api_users.py',
-        'test_api_validate.py',
         'test_lib_smsprovider.py',
         'test_mod_apache.py',
     ])

--- a/tests/test_api_2stepinit.py
+++ b/tests/test_api_2stepinit.py
@@ -7,6 +7,7 @@ import time
 
 from passlib.utils.pbkdf2 import pbkdf2
 
+from privacyidea.lib.utils import b32encode_and_unicode
 from privacyidea.lib.policy import set_policy, SCOPE, delete_policy
 from .base import MyApiTestCase
 from privacyidea.lib.tokens.HMAC import HmacOtp
@@ -53,7 +54,7 @@ class TwoStepInitTestCase(MyApiTestCase):
 
         client_component = b"VRYSECRT"
         checksum = hashlib.sha1(client_component).digest()[:4]
-        base32check_client_component = base64.b32encode(checksum + client_component).strip(b"=")
+        base32check_client_component = b32encode_and_unicode(checksum + client_component).strip("=")
 
         # Try to do a 2stepinit on a second step will raise an error
         with self.app.test_request_context('/token/init',
@@ -76,7 +77,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            data={"type": "hotp",
                                                  "2stepinit": "1",
                                                  "serial": serial,
-                                                 "otpkey": b"A" + base32check_client_component[1:],
+                                                 "otpkey": "A" + base32check_client_component[1:],
                                                  "otpkeyformat": "base32check"},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
@@ -97,7 +98,7 @@ class TwoStepInitTestCase(MyApiTestCase):
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
-                         u'matching 1 tokens, Token is disabled')
+                             u'matching 1 tokens, Token is disabled')
 
         # Now doing the correct 2nd step
         with self.app.test_request_context('/token/init',

--- a/tests/test_api_audit.py
+++ b/tests/test_api_audit.py
@@ -55,7 +55,7 @@ class APIAuditTestCase(MyApiTestCase):
             json_response = json.loads(res.data.decode('utf8'))
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
-                "count"), 9)
+                "count"), 8)
             audit_list = json_response.get("result").get("value").get("auditdata")
             audit_actions = [a for a in audit_list if a.get("action") == "GET /audit/"]
             self.assertEqual(len(audit_actions), 2)
@@ -183,7 +183,7 @@ class APIAuditTestCase(MyApiTestCase):
             # We now have 3 entries, as we added one by the search in line #43
             count = json_response.get("result").get("value").get("count")
             auditdata = json_response.get("result").get("value").get("auditdata")
-            self.assertEqual(count, 22)
+            self.assertEqual(count, 20)
 
         # delete policy
         delete_policy("audit01")

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -113,8 +113,9 @@ class APIMachinesTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertEqual(result["status"], True)
-            self.assertTrue(result["value"] >= 1)
+            self.assertEquals(result["status"], True, result)
+            self.assertGreaterEqual(result["value"]["added"], 1, result)
+            self.assertEquals(result['value']['deleted'], 0, result)
 
         # check if the options were set.
         token_obj = get_tokens(serial=serial)[0]
@@ -133,8 +134,9 @@ class APIMachinesTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertEqual(result["status"], True)
-            self.assertTrue(result["value"] >= 1)
+            self.assertEquals(result["status"], True, result)
+            self.assertEquals(result["value"]["added"], 0, result)
+            self.assertGreaterEqual(result['value']['deleted'], 1, result)
 
         # check if the options were set.
         token_obj = get_tokens(serial=serial)[0]
@@ -155,8 +157,9 @@ class APIMachinesTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertEqual(result["status"], True)
-            self.assertTrue(result["value"] >= 1)
+            self.assertEquals(result["status"], True, result)
+            self.assertGreaterEqual(result["value"]["added"], 1, result)
+            self.assertEquals(result['value']['deleted'], 0, result)
 
         # check if the options were set.
         token_obj = get_tokens(serial=serial)[0]

--- a/tests/test_api_policy.py
+++ b/tests/test_api_policy.py
@@ -1,9 +1,8 @@
+# -*- coding: utf-8 -*-
+
 import json
 from .base import MyApiTestCase
 from privacyidea.lib.policy import SCOPE, ACTION
-
-
-
 
 
 class APIPolicyTestCase(MyApiTestCase):
@@ -13,9 +12,8 @@ class APIPolicyTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue('"status": true' in res.data, res.data)
-            data = json.loads(res.data.decode('utf8'))
-            self.assertEqual(data.get("result").get("value"), [])
+            self.assertTrue(res.json['result']['status'], res.json)
+            self.assertEquals(res.json["result"]["value"], [], res.json)
 
     def test_01_set_policy(self):
         with self.app.test_request_context('/policy/pol1',
@@ -39,10 +37,8 @@ class APIPolicyTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue('"status": true' in res.data, res.data)
-            data = json.loads(res.data.decode('utf8'))
-            result = data.get("result")
-            value = result.get("value")
+            self.assertTrue(res.json['result']['status'], res.json)
+            value = res.json['result']['value']
             self.assertEqual(len(value), 1)
             pol1 = value[0]
             self.assertEqual(pol1.get("check_all_resolvers"), True)
@@ -73,10 +69,8 @@ class APIPolicyTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue('"status": true' in res.data, res.data)
-            data = json.loads(res.data.decode('utf8'))
-            result = data.get("result")
-            value = result.get("value")
+            self.assertTrue(res.json['result']['status'], res.json)
+            value = res.json['result']['value']
             self.assertEqual(len(value), 1)
             pol1 = value[0]
             self.assertEqual(pol1.get("check_all_resolvers"), False)

--- a/tests/test_api_register.py
+++ b/tests/test_api_register.py
@@ -55,8 +55,8 @@ class RegisterTestCase(MyApiTestCase):
         self. assertTrue(r > 0)
 
         added, failed = set_realm("register", resolvers=["register"])
-        self.assertTrue(added > 0)
-        self.assertEqual(len(failed), 0)
+        self.assertTrue(len(added) > 0, added)
+        self.assertEqual(len(failed), 0, failed)
 
         # create policy
         r = set_policy(name="pol2", scope=SCOPE.REGISTER,

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -22,7 +22,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue('"status": true' in res.data, res.data)
+            self.assertTrue(res.json['result']['status'], res.json)
             
     def test_00_failed_auth(self):
         with self.app.test_request_context('/system/',
@@ -39,8 +39,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            value = result.get("value")
+            value = res.json['result']['value']
             self.assertEqual(value.get("key1"),
                              "insert",
                              "This sometimes happens when test database was "
@@ -55,7 +54,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue('"key3": "update"' in res.data, res.data)
+            self.assertIn('key3', res.json['result']['value'], res.json)
 
     def test_03_set_and_del_default(self):
         with self.app.test_request_context('/system/setDefault',
@@ -117,7 +116,7 @@ class APIConfigTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertTrue('"setPolicy pol1": 1' in res.data, res.data)
+            self.assertEquals(result['value']['setPolicy pol1'], 1, res.json)
 
         # Set a policy with a more complicated client which might interfere
         # with override client
@@ -136,9 +135,9 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertTrue(result["status"] is True, result)
-            self.assertTrue('"setPolicy pol1": 1' in res.data, res.data)
+            result = res.json['result']
+            self.assertTrue(result["status"], result)
+            self.assertEquals(result['value']['setPolicy pol1'], 1, result)
         delete_privacyidea_config(SYSCONF.OVERRIDECLIENT)
 
         # setting policy with invalid name fails
@@ -181,8 +180,8 @@ class APIConfigTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             body = res.data
-            self.assertTrue('name = pol1' in body, res.data)
-            self.assertTrue("[pol1]" in body, res.data)
+            self.assertTrue(b'name = pol1' in body, res.data)
+            self.assertTrue(b"[pol1]" in body, res.data)
             
     def test_07_update_and_delete_policy(self):
         with self.app.test_request_context('/policy/pol_update_del',
@@ -817,7 +816,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue("privacyIDEA configuration documentation" in
+            self.assertTrue(b"privacyIDEA configuration documentation" in
                             res.data)
 
     def test_16_get_hsm(self):

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -54,7 +54,8 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertIn('key3', res.json['result']['value'], res.json)
+            self.assertEquals(res.json['result']['value']['key3'], 'update',
+                              res.json)
 
     def test_03_set_and_del_default(self):
         with self.app.test_request_context('/system/setDefault',

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -297,10 +297,14 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 400, res)
             result = json.loads(res.data.decode('utf8')).get("result")
             error = result.get("error")
-            self.assertEqual(error.get("message"),
-                             "ERR1103: Token already assigned to user "
-                             "User(login='cornelius', realm='realm1', "
-                             "resolver='resolver1')")
+#            self.assertEqual(error.get("message"),
+#                             "ERR1103: Token already assigned to user "
+#                             "User(login='cornelius', realm='realm1', "
+#                             "resolver='resolver1')")
+            self.assertRegexpMatches(error.get('message'),
+                                     r"ERR1103: Token already assigned to user "
+                                     r"User\(login=u?'cornelius', "
+                                     r"realm=u?'realm1', resolver=u?'resolver1'\)")
 
         # Now the user tries to assign a foreign token
         with self.app.test_request_context('/auth',

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -228,9 +228,9 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue("info" in res.data, res.data)
-            self.assertTrue("username" in res.data, res.data)
-            self.assertTrue("user_realm" in res.data, res.data)
+            self.assertTrue(b"info" in res.data, res.data)
+            self.assertTrue(b"username" in res.data, res.data)
+            self.assertTrue(b"user_realm" in res.data, res.data)
 
     def test_03_list_tokens_in_one_realm(self):
         for serial in ["S1", "S2", "S3", "S4"]:
@@ -297,8 +297,10 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 400, res)
             result = json.loads(res.data.decode('utf8')).get("result")
             error = result.get("error")
-            self.assertEqual(error.get("message"), "ERR1103: Token already assigned to user User(login=u'cornelius', "
-                                                   "realm=u'realm1', resolver=u'resolver1')")
+            self.assertEqual(error.get("message"),
+                             "ERR1103: Token already assigned to user "
+                             "User(login='cornelius', realm='realm1', "
+                             "resolver='resolver1')")
 
         # Now the user tries to assign a foreign token
         with self.app.test_request_context('/auth',
@@ -1244,12 +1246,11 @@ class APITokenTestCase(MyApiTestCase):
 
         with self.app.test_request_context('/token/init',
                                            method='POST',
-                                           data = {"genkey": 1,
-                                                   "pin": "123456"},
+                                           data={"genkey": 1,
+                                                 "pin": "123456"},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
             detail = json.loads(res.data.decode('utf8')).get("detail")
 
             serial = detail.get("serial")

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -44,8 +44,8 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertTrue('"status": true' in res.data, res.data)
-            self.assertTrue('"value": 1' in res.data, res.data)
+            self.assertTrue(res.json['result']['status'], res.json)
+            self.assertEquals(res.json['result']['value'], 1, res.json)
         
         # create realm
         realm = u"realm1"
@@ -71,22 +71,24 @@ class APIUsersTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8'))
             value = result.get("result").get("value")
-            self.assertTrue('"username": "cornelius"' in res.data, res.data)
-            self.assertTrue('"username": "corny"' in res.data, res.data)
+            unames = [x.get('username') for x in value]
+            self.assertIn("cornelius", unames, value)
+            self.assertIn("corny", unames, value)
 
         # get user list with search dict
         with self.app.test_request_context('/user/',
                                            query_string=urlencode({u"username":
-                                                           "cornelius"}),
+                                                                       "cornelius"}),
                                            method='GET',
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8'))
             value = result.get("result").get("value")
-            self.assertTrue('"username": "cornelius"' in res.data, res.data)
-            self.assertTrue('"username": "corny"' not in res.data, res.data)
-            
+            unames = [x.get('username') for x in value]
+            self.assertIn("cornelius", unames, value)
+            self.assertNotIn("corny", unames, value)
+
         # get user with a non existing realm
         with self.app.test_request_context('/user/',
                                            query_string=urlencode({"realm":
@@ -97,8 +99,9 @@ class APIUsersTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8'))
             value = result.get("result").get("value")
-            self.assertTrue('"username": "cornelius"' not in res.data, res.data)
-            self.assertTrue('"username": "corny"' not in res.data, res.data)
+            unames = [x.get('username') for x in value]
+            self.assertNotIn("cornelius", unames, value)
+            self.assertNotIn("corny", unames, value)
 
     def test_02_create_update_delete_user(self):
         realm = "sqlrealm"

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1009,8 +1009,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertTrue('"setPolicy pol_chal_resp": 1' in res.data,
-                            res.data)
+            self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
 
         serial = "CHALRESP1"
         pin = "chalresp1"
@@ -1068,8 +1067,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertTrue('"setPolicy pol_chal_resp": 1' in res.data,
-                            res.data)
+            self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
 
         serial = "CHALRESP2"
         pin = "chalresp2"
@@ -1128,8 +1126,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = json.loads(res.data.decode('utf8')).get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertTrue('"setPolicy pol_chal_resp": 1' in res.data,
-                            res.data)
+            self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
 
         serial = "CHALRESP3"
         pin = "chalresp3"
@@ -1967,7 +1964,7 @@ class ValidateAPITestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             # HTTP 204 status code signals a successful authentication
             self.assertEqual(res.status_code, 204)
-            self.assertEqual(res.data, '')
+            self.assertEqual(res.data, b'')
 
         # test authentication fails with wrong PIN
         with self.app.test_request_context('/validate/radiuscheck',
@@ -1976,7 +1973,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "wrong"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            self.assertEqual(res.data, '')
+            self.assertEqual(res.data, b'')
 
         # test authentication fails with an unknown user
         # here, we get an ordinary JSON response

--- a/tests/test_lib_applications.py
+++ b/tests/test_lib_applications.py
@@ -2,6 +2,7 @@
 This test file tests the applications definitions standalone
 lib/applications/*
 """
+import six
 from privacyidea.lib.error import ParameterError
 from .base import MyTestCase
 from privacyidea.lib.applications import MachineApplicationBase
@@ -82,8 +83,9 @@ class LUKSApplicationTestCase(MyTestCase):
                    user=user)
 
         auth_item = LUKSApplication.get_authentication_item("totp", serial)
-        self.assertEqual(len(auth_item.get("challenge")), 64)
-        self.assertEqual(len(auth_item.get("response")), 40)
+        self.assertEqual(len(auth_item.get("challenge")), 64, auth_item)
+        self.assertIsInstance(auth_item.get('challenge'), six.text_type, auth_item)
+        self.assertEqual(len(auth_item.get("response")), 40, auth_item)
 
         auth_item = LUKSApplication.get_authentication_item("totp", serial,
                                                             challenge="123456")

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -638,6 +638,6 @@ class GPGTestCase(MyTestCase):
         self.assertTrue("2F25BAF8645350BB" in pubkeys)
 
         r = GPG.decrypt(HALLO_PAYLOAD)
-        self.assertEqual(r, b"Hallo\n")
+        self.assertEqual(r, "Hallo\n")
 
         self.assertRaises(Exception, GPG.decrypt, WRONG_PAYLOAD)


### PR DESCRIPTION
This PR should fix all API testcases to make them run with Python 3

Most of the changes are just string encoding fixes.
Also the admin auth-token will now be created in the `setUpClass()` method which improves the runtime for the API testcases even further (ideally we would create one auth-token for the complete test run).
Due to this, there are  changes in `test_apt_audit.py` since we save some API calls.

Some tests were changed to use the resulting json object directly instead of searching in the data-string.

Working on #676 