### PR TITLE
Update smpplib to run with Python 3

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -1,5 +1,22 @@
 # Update Notes
 
+## Update from 2.23 to 3.0
+
+A lot of changes will be introduced in privacyIDEA 3.0, most notably the
+Python 3 compatibility.
+
+* Package dependencies:
+  * Removed packages:
+    * matplotlib
+    * pandas
+  * Added packages:
+    * cryptography (2.4.2)
+  * Updated packages:
+    * smpplib (0.1 -> 2.0)
+    * pytest (3.6.0 -> 3.6.1)
+    * requests (2.18.4 -> 2.20.0)
+
+
 ## Update from 2.22 to 2.23
 
 * An additional dependency python-croniter was added.

--- a/privacyidea/lib/smsprovider/SmppSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmppSMSProvider.py
@@ -83,19 +83,19 @@ class SmppSMSProvider(ISMSProvider):
         client = None
         error_message = None 
         try:
-            client = smpplib.client.Client(smsc_host.encode("ascii"),
-                                           smsc_port.encode("ascii"))
+            client = smpplib.client.Client(smsc_host,
+                                           smsc_port)
             client.connect()
-            r = client.bind_transmitter(system_id=sys_id.encode("ascii"),
-                                        password=passwd.encode("ascii"))
+            r = client.bind_transmitter(system_id=sys_id,
+                                        password=passwd)
             log.debug("bind_transmitter returns {0!r}".format(r))
             r = client.send_message(source_addr_ton=s_addr_ton,
                                     source_addr_npi=s_addr_npi,
-                                    source_addr=s_addr.encode("ascii"),
+                                    source_addr=s_addr,
                                     dest_addr_ton=d_addr_ton,
                                     dest_addr_npi=d_addr_npi,
-                                    destination_addr=phone.encode("ascii"),
-                                    short_message=message.encode("ascii"))
+                                    destination_addr=phone,
+                                    short_message=message)
             log.debug("send_message returns {0!r}".format(r))
 
         except Exception as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ redis==2.10.6
 requests==2.20.0
 responses==0.9.0
 six==1.11.0
-smpplib==0.1
+smpplib==2.0
 snowballstemmer==1.2.1
 Sphinx==1.7.5
 sphinxcontrib-httpdomain==1.6.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,5 @@ if sys.version_info[0] > 2:
         'test_api_token.py',
         'test_api_users.py',
         'test_api_validate.py',
-        'test_lib_smsprovider.py',
         'test_mod_apache.py',
     ])

--- a/tests/smppmock.py
+++ b/tests/smppmock.py
@@ -35,10 +35,7 @@ except ImportError:
 import inspect
 from collections import namedtuple, Sequence, Sized
 from functools import update_wrapper
-if six.PY2:
-    from smpplib.client import ConnectionError
-else:
-    from smpplib.exceptions import ConnectionError
+from smpplib.exceptions import ConnectionError
 
 
 Call = namedtuple('Call', ['request', 'response'])

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -172,7 +172,7 @@ class SmtpSMSTestCase(MyTestCase):
     def test_02_simple_config_success(self):
         smtpmock.setdata(response={"recp@example.com": (200, "OK")})
         r = self.simple_provider.submit_message("123456", "Hello")
-        self.assertRaises(r)
+        self.assertTrue(r)
 
     @smtpmock.activate
     def test_03_simple_config_fail(self):


### PR DESCRIPTION
The recent update of [python-smpplib](https://github.com/python-smpplib/python-smpplib) to version 2.0 makes it possible to run with Python 2 and 3.
Only small changes were required to make the smsprovider test cases work with Python 2 and 3.

The new [smpplib](https://pypi.org/project/smpplib/) package on pypi should be compatible with version 0.1 (https://github.com/pypa/warehouse/issues/5122)

Working on #676 