### PR TITLE
Avoid some hidden SQL queries in /validate/check

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -263,30 +263,32 @@ def check_tokeninfo(request, response):
     """
     content = json.loads(response.data)
     serial = content.get("detail", {}).get("serial")
-    tokeninfos_pol = g.policy_object.get_action_values(
-        ACTION.TOKENINFO,
-        scope=SCOPE.AUTHZ,
-        client=g.client_ip,
-        allow_white_space_in_action=True,
-        audit_data=g.audit_object.audit_data)
-    if serial and tokeninfos_pol:
-        tokens = get_tokens(serial=serial)
-        if len(tokens) == 1:
-            token_obj = tokens[0]
-            for tokeninfo_pol in tokeninfos_pol:
-                try:
-                    key, regex, _r = tokeninfo_pol.split("/")
-                    value = token_obj.get_tokeninfo(key, "")
-                    if re.search(regex, value):
-                        log.debug(u"Regular expression {0!s} "
-                                  u"matches the tokeninfo field {1!s}.".format(regex, key))
-                    else:
-                        log.info(u"Tokeninfo field {0!s} with contents {1!s} "
-                                 u"does not match {2!s}".format(key, value, regex))
-                        raise PolicyError("Tokeninfo field {0!s} with contents does not"
-                                          " match regular expression.".format(key))
-                except ValueError:
-                    log.warning(u"invalid tokeinfo policy: {0!s}".format(tokeninfo_pol))
+
+    if serial:
+        tokeninfos_pol = g.policy_object.get_action_values(
+            ACTION.TOKENINFO,
+            scope=SCOPE.AUTHZ,
+            client=g.client_ip,
+            allow_white_space_in_action=True,
+            audit_data=g.audit_object.audit_data)
+        if tokeninfos_pol:
+            tokens = get_tokens(serial=serial)
+            if len(tokens) == 1:
+                token_obj = tokens[0]
+                for tokeninfo_pol in tokeninfos_pol:
+                    try:
+                        key, regex, _r = tokeninfo_pol.split("/")
+                        value = token_obj.get_tokeninfo(key, "")
+                        if re.search(regex, value):
+                            log.debug(u"Regular expression {0!s} "
+                                      u"matches the tokeninfo field {1!s}.".format(regex, key))
+                        else:
+                            log.info(u"Tokeninfo field {0!s} with contents {1!s} "
+                                     u"does not match {2!s}".format(key, value, regex))
+                            raise PolicyError("Tokeninfo field {0!s} with contents does not"
+                                              " match regular expression.".format(key))
+                    except ValueError:
+                        log.warning(u"invalid tokeinfo policy: {0!s}".format(tokeninfo_pol))
 
     return response
 

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -262,18 +262,17 @@ def check_tokeninfo(request, response):
     :return: A new modified response
     """
     content = json.loads(response.data)
-    policy_object = g.policy_object
     serial = content.get("detail", {}).get("serial")
-    if serial:
+    tokeninfos_pol = g.policy_object.get_action_values(
+        ACTION.TOKENINFO,
+        scope=SCOPE.AUTHZ,
+        client=g.client_ip,
+        allow_white_space_in_action=True,
+        audit_data=g.audit_object.audit_data)
+    if serial and tokeninfos_pol:
         tokens = get_tokens(serial=serial)
         if len(tokens) == 1:
             token_obj = tokens[0]
-            tokeninfos_pol = policy_object.get_action_values(
-                ACTION.TOKENINFO,
-                scope=SCOPE.AUTHZ,
-                client=g.client_ip,
-                allow_white_space_in_action=True,
-                audit_data=g.audit_object.audit_data)
             for tokeninfo_pol in tokeninfos_pol:
                 try:
                     key, regex, _r = tokeninfo_pol.split("/")

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -296,10 +296,9 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
     from privacyidea.lib.token import get_tokens
     options = options or {}
     g = options.get("g")
-    if get_tokens(user=user_object, count=True) == 0 and g:
-        # We only go to passthru, if the user has no tokens!
-        clientip = options.get("clientip")
+    if g:
         policy_object = g.policy_object
+        clientip = options.get("clientip")
         pass_thru = policy_object.get_policies(action=ACTION.PASSTHRU,
                                                scope=SCOPE.AUTH,
                                                realm=user_object.realm,
@@ -308,9 +307,10 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
                                                client=clientip,
                                                active=True,
                                                sort_by_priority=True)
-        # Ensure that there are no conflicting action values within the same priority
-        policy_object.check_for_conflicts(pass_thru, "passthru")
-        if pass_thru:
+        # We only go to passthru, if the user has no tokens!
+        if pass_thru and get_tokens(user=user_object, count=True) == 0:
+            # Ensure that there are no conflicting action values within the same priority
+            policy_object.check_for_conflicts(pass_thru, "passthru")
             pass_thru_action = pass_thru[0].get("action").get("passthru")
             policy_name = pass_thru[0].get("name")
             if pass_thru_action in ["userstore", True]:

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2090,8 +2090,11 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
                                     "token is locked"), id=1007)
 
     for tokenobject in tokenobject_list:
-        log.debug("Found user with loginId {0!r}: {1!r}".format(
-                  tokenobject.user, tokenobject.get_serial()))
+        if log.isEnabledFor(logging.DEBUG):
+            # Avoid a SQL query triggered by ``tokenobject.user`` in case
+            # the log level is not DEBUG
+            log.debug("Found user with loginId {0!r}: {1!r}".format(
+                      tokenobject.user, tokenobject.get_serial()))
 
         if tokenobject.is_challenge_response(passw, user=user, options=options):
             # This is a challenge response


### PR DESCRIPTION
This PR removes the three hidden SQL queries in the /validate/check codepath mentioned in #1457.
In two cases, these queries are issued by policy functions even if there is no active matching policy.
In one case, the query is issued for a DEBUG printout.

These queries are really low-hanging fruits because optimizing them doesn't change behavior at all. Removing them might make quite a difference in case the SQL server has some latency.