### PR TITLE
Fix token query emitted by TokenOwner migration

### DIFF
--- a/migrations/versions/48ee74b8a7c8_.py
+++ b/migrations/versions/48ee74b8a7c8_.py
@@ -84,7 +84,7 @@ def upgrade():
         bind = op.get_bind()
         session = orm.Session(bind=bind)
         # For each token, that has an owner, create a tokenowner entry
-        for token in session.query(Token).filter(Token.user_id):
+        for token in session.query(Token).filter(Token.user_id != "", Token.user_id.isnot(None)):
             token_realms = TokenRealm.query.filter(TokenRealm.token_id == token.id).all()
             realm_id = None
             if not token_realms:


### PR DESCRIPTION
The old query made the migration script miss some tokens. This also makes the pymysql warnings go away.

Closes #1464