### PR TITLE
Python 3 compatibility for tools

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -76,7 +76,7 @@ from privacyidea.lib.caconnector import (get_caconnector_list,
                                          save_caconnector)
 from privacyidea.app import create_app
 from privacyidea.lib.auth import ROLE
-from flask_script import Manager, Command
+from flask_script import Manager, Command, Option
 from privacyidea.app import db
 from flask_migrate import MigrateCommand
 # Wee need to import something, so that the models will be created.
@@ -163,8 +163,9 @@ def create_crl(ca, force=False):
 
 
 @ca_manager.option('name', help='The name of the new CA')
-@ca_manager.option('-t', '--type', help='The type of the new CA. The default '
-                                        'is "local"')
+@ca_manager.option('-t', '--type',
+                   help='The type of the new CA. The default is "local"',
+                   dest='catype')
 def create(name, catype='local'):
     """
     Create a new CA connector. In case of the "localca" also the directory
@@ -252,7 +253,7 @@ def create(directory="/var/lib/privacyidea/backup/",
     CONF_DIR = conf_dir
     DATE = datetime.datetime.now().strftime("%Y%m%d-%H%M")
     BASE_NAME = "privacyidea-backup"
-    
+
     call(["mkdir", "-p", directory])
     # set correct owner, if possible
     if os.geteuid() == 0:
@@ -331,11 +332,11 @@ def restore(backup_file):
     p = Popen(["tar", "-ztf", backup_file], stdout=PIPE)
     std_out, err_out = p.communicate()
     for line in std_out.split("\n"):
-        if re.search("/pi.cfg$", line):
+        if re.search(r"/pi.cfg$", line):
             config_file = "/{0!s}".format(line.strip())
-        elif re.search("\.sql", line):
+        elif re.search(r"\.sql", line):
             sqlfile = "/{0!s}".format(line.strip())
-        elif re.search("/enckey", line):
+        elif re.search(r"/enckey", line):
             enckey_contained = True
 
     if not config_file:
@@ -522,7 +523,7 @@ def dropdb(dropit=None):
 
 
 @manager.command
-def validate(user, password, realm=None, client=None):
+def validate(user, password, realm=None):
     """
     Do an authentication request
     """
@@ -844,32 +845,40 @@ def create_internal(name):
     metadata.create_all(engine)
 
 
-@resolver_manager.option('-v',
-                         help="Verbose output - also print the configuration of the resolvers.",
-                         dest="verbose", action="store_true")
-def list(verbose):
+# unfortunately it is not possible in flask_script to add a command with a
+# different name and options. So we create an appropriate command class.
+class ListResolver(Command):
     """
-    list the available resolvers and the type.
+    Command class to list the available resolvers and the type.
     """
-    from privacyidea.lib.resolver import get_resolver_list
-    resolver_list = get_resolver_list()
+    option_list = (
+        Option('-v', '--verbose',
+               help="Verbose output - also print the configuration of the resolvers.",
+               dest="verbose", action="store_true"),
+    )
 
-    if not verbose:
-        for (name, resolver) in resolver_list.items():
-            print("{0!s:16} - ({1!s})".format(name, resolver.get("type")))
-    else:
-        for (name, resolver) in resolver_list.items():
-            print("{0!s:16} - ({1!s})".format(name, resolver.get("type")))
-            print("."*32)
-            data = resolver.get("data", {})
-            for (k, v) in data.items():
-                if k.lower() in ["bindpw", "password"]:
-                    v = "xxxxx"
-                print("{0!s:>24}: {1!r}".format(k, v))
-            print("")
+    def run(self, verbose=False):
+        from privacyidea.lib.resolver import get_resolver_list
+        resolver_list = get_resolver_list()
+
+        if not verbose:
+            for (name, resolver) in resolver_list.items():
+                print("{0!s:16} - ({1!s})".format(name, resolver.get("type")))
+        else:
+            for (name, resolver) in resolver_list.items():
+                print("{0!s:16} - ({1!s})".format(name, resolver.get("type")))
+                print("."*32)
+                data = resolver.get("data", {})
+                for (k, v) in data.items():
+                    if k.lower() in ["bindpw", "password"]:
+                        v = "xxxxx"
+                    print("{0!s:>24}: {1!r}".format(k, v))
+                print("")
 
 
-@realm_manager.command
+resolver_manager.add_command('list', ListResolver)
+
+
 def list_realms():
     """
     list the available realms

--- a/pi-manage
+++ b/pi-manage
@@ -125,7 +125,8 @@ def create_keys():
     """
     Create new encryption keys on the HSM. Be sure to first setup the HSM module, the PKCS11
     module and the slot/password for the given HSM in your pi.cfg.
-    Set the variables PI_HSM_MODULE, PI_HSM_MODULE_MODULE, PI_HSM_MODULE_SLOT, PI_HSM_MODULE_PASSWORD.
+    Set the variables PI_HSM_MODULE, PI_HSM_MODULE_MODULE, PI_HSM_MODULE_SLOT,
+                      PI_HSM_MODULE_PASSWORD.
     """
     hsm_object = create_hsm_object(app.config)
     r = hsm_object.create_keys()
@@ -135,15 +136,20 @@ def create_keys():
     print("PI_HSM_MODULE_KEY_LABEL_VALUE = '{0}'".format(r.get("value")))
 
 
-@ca_manager.command
-def list(verbose=False):
-    l = get_caconnector_list()
-    for ca in l:
+def list_ca(verbose=False):
+    """
+    List the Certificate Authorities.
+    """
+    lst = get_caconnector_list()
+    for ca in lst:
         print("{ca!s} (type {typ!s})".format(ca=ca.get("connectorname"),
                                              typ=ca.get("type")))
         if verbose:
-            for k, v in ca.get("data").iteritems():
+            for (k, v) in ca.get("data").items():
                 print("\t{key!s:20}: {value!s}".format(key=k, value=v))
+
+
+ca_manager.add_command('list', Command(list_ca))
 
 
 @ca_manager.command
@@ -159,7 +165,7 @@ def create_crl(ca, force=False):
 @ca_manager.option('name', help='The name of the new CA')
 @ca_manager.option('-t', '--type', help='The type of the new CA. The default '
                                         'is "local"')
-def create(name, type):
+def create(name, catype='local'):
     """
     Create a new CA connector. In case of the "localca" also the directory
     structure, the openssl.cnf and the key pair is created.
@@ -169,10 +175,10 @@ def create(name, type):
         print("A CA connector with the name '{0!s}' already exists.".format(
             name))
         sys.exit(1)
-    if not type:
-        type = "local"
-    print("Creating CA connector of type {0!s}.".format(type))
-    ca_class = get_caconnector_class(type)
+    if not catype:
+        catype = "local"
+    print("Creating CA connector of type {0!s}.".format(catype))
+    ca_class = get_caconnector_class(catype)
     ca_params = ca_class.create_ca(name)
     r = save_caconnector(ca_params)
     if r:
@@ -198,12 +204,14 @@ def add(username, email=None, password=None):
     print('Admin {0} was registered successfully.'.format(username))
 
 
-@admin_manager.command
-def list():
+def list_admins():
     """
     List all administrators.
     """
     list_db_admin()
+
+
+admin_manager.add_command('list', Command(list_admins))
 
 
 @admin_manager.command
@@ -279,14 +287,14 @@ def create(directory="/var/lib/privacyidea/backup/",
     enc_file = app.config.get("PI_ENCFILE")
 
     backup_call = ["tar", "-zcf",
-          backup_file, CONF_DIR, sqlfile]
+                   backup_file, CONF_DIR, sqlfile]
     if not enckey:
         # Exclude enckey from backup
         backup_call.append("--exclude={0!s}".format(enc_file))
 
     call(backup_call)
     os.unlink(sqlfile)
-    os.chmod(backup_file, 0600)
+    os.chmod(backup_file, 0o600)
 
 
 def _write_mysql_defaults(filename, username, password):
@@ -303,7 +311,7 @@ def _write_mysql_defaults(filename, username, password):
 user={0!s}
 password={1!s}""".format(username, password))
 
-    os.chmod(filename, 0600)
+    os.chmod(filename, 0o600)
     # set correct owner, if possible
     if os.geteuid() == 0:
         directory_stat = os.stat(os.path.dirname(filename))
@@ -373,9 +381,9 @@ def restore(backup_file):
         # Rewriting database
         print("Restoring database.")
         call("mysql --defaults-file=%s -h %s %s < %s" % (defaults_file,
-                                                          datahost,
-                                                          database,
-                                                          sqlfile), shell=True)
+                                                         datahost,
+                                                         database,
+                                                         sqlfile), shell=True)
         os.unlink(sqlfile)
     else:
         print("unsupported SQL syntax: %s" % sqltype)
@@ -423,7 +431,7 @@ def create_enckey():
     """
     If the key of the given configuration does not exist, it will be created
     """
-    print
+    print()
     filename = app.config.get("PI_ENCFILE")
     if os.path.isfile(filename):
         print("The file \n\t%s\nalready exist. We do not overwrite it!" %
@@ -433,7 +441,7 @@ def create_enckey():
         f.write(DefaultSecurityModule.random(96))
 
     print("Encryption key written to %s" % filename)
-    os.chmod(filename, 0400)
+    os.chmod(filename, 0o400)
     print("The file permission of %s was set to 400!" % filename)
     print("Please ensure, that it is owned by the right user.   ")
 
@@ -480,7 +488,7 @@ def create_audit_keys(keysize=2048):
 
     print("Signing keys written to %s and %s" %
           (filename, app.config.get("PI_AUDIT_KEY_PUBLIC")))
-    os.chmod(filename, 0400)
+    os.chmod(filename, 0o400)
     print("The file permission of %s was set to 400!" % filename)
     print("Please ensure, that it is owned by the right user.")
 
@@ -538,6 +546,9 @@ class CommandOutsideRequestContext(Command):
     def __call__(self, app=None, *args, **kwargs):
         return self.run(*args, **kwargs)
 
+    def run(self, *arg, **kwargs):
+        pass
+
 
 def profile(length=30, profile_dir=None):
     """
@@ -549,6 +560,7 @@ def profile(length=30, profile_dir=None):
     app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[length],
                                       profile_dir=profile_dir)
     app.run()
+
 
 # If flask_script's `Command` is used here instead of `CommandOutsideRequestContext`,
 # the request context will persist over requests. Thus, `g` is not
@@ -572,13 +584,13 @@ except TypeError:
 @manager.option('--chunksize', help="Delete entries in chunks of the given size "
                                     "to avoid deadlocks")
 @audit_manager.option('--highwatermark', '--hw', help="If entries exceed this value, "
-                                                "old entries are deleted.")
+                                                      "old entries are deleted.")
 @audit_manager.option('--lowwatermark', '--lw', help="Keep this number of entries.")
 @audit_manager.option('--age', help="Delete audit entries older than these number "
-                              "of days.")
+                                    "of days.")
 @audit_manager.option('--config', help="Read config from the specified yaml file.")
 @audit_manager.option('--dryrun', help="Do not actually delete, only show "
-                                 "what would be done.", action="store_true")
+                                       "what would be done.", action="store_true")
 @audit_manager.option('--chunksize', help="Delete entries in chunks of the given size "
                                           "to avoid deadlocks")
 def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
@@ -623,8 +635,8 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
         print("Cleaning up with age: %s. %s" % (age, audit_db_uri))
     else:
         print("Cleaning up with high: %s, low: %s. %s" % (highwatermark,
-                                                      lowwatermark,
-                                                      audit_db_uri))
+                                                          lowwatermark,
+                                                          audit_db_uri))
 
     engine = create_engine(audit_db_uri)
     # create a configured "Session" class
@@ -633,12 +645,12 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
     metadata.create_all(engine)
     if config:
         with open(config, 'r') as f:
-            Config = yaml.load(f)
+            yml_config = yaml.load(f)
         auditlogs = session.query(LogEntry).all()
         delete_list = []
         for log in auditlogs:
             print("investigating log entry {0!s}".format(log.id))
-            for rule in Config:
+            for rule in yml_config:
                 age = int(rule.get("rotate"))
                 rotate_date = datetime.datetime.now() - datetime.timedelta(days=age)
 
@@ -646,7 +658,8 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
                 for key in rule.keys():
                     if key not in ["rotate"]:
                         search_value = rule.get(key)
-                        print(" + searching for {0!r} in {1!s}".format(search_value, getattr(LogEntry, key)))
+                        print(" + searching for {0!r} in {1!s}".format(search_value,
+                                                                       getattr(LogEntry, key)))
                         audit_value = getattr(log, key) or ""
                         m = re.search(search_value, audit_value)
                         if m:
@@ -668,10 +681,12 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
                     # skip all other rules and go to the next log entry
                     break
         if dryrun:
-            print("If you only would let me I would clean up {0!s} entries!".format(len(delete_list)))
+            print("If you only would let me I would clean up "
+                  "{0!s} entries!".format(len(delete_list)))
         else:
             print("Cleaning up {0!s} entries.".format(len(delete_list)))
-            delete_matching_rows(session, LogEntry.__table__, LogEntry.id.in_(delete_list), chunksize)
+            delete_matching_rows(session, LogEntry.__table__,
+                                 LogEntry.id.in_(delete_list), chunksize)
     elif age:
         now = datetime.datetime.now() - datetime.timedelta(days=age)
         print("Deleting entries older than {0!s}".format(now))
@@ -684,6 +699,7 @@ def rotate_audit(highwatermark=10000, lowwatermark=5000, age=0, config=None,
             print("{0!s} entries deleted.".format(r))
     else:
         count = session.query(LogEntry.id).count()
+        last_id = 0
         for l in session.query(LogEntry.id).order_by(desc(LogEntry.id)).limit(1):
             last_id = l[0]
         print("The log audit log has %i entries, the last one is %i" % (count,
@@ -771,6 +787,7 @@ def create_internal(name):
     database = "/".join(sqlelements[3:])
     username = ""
     password = ""
+    host = ""
     # determine host and user
     hostparts = user_pw_host.split("@")
     if len(hostparts) > 2:
@@ -827,7 +844,8 @@ def create_internal(name):
     metadata.create_all(engine)
 
 
-@resolver_manager.option('-v', help="Verbose output - also print the configuration of the resolvers.",
+@resolver_manager.option('-v',
+                         help="Verbose output - also print the configuration of the resolvers.",
                          dest="verbose", action="store_true")
 def list(verbose):
     """
@@ -837,14 +855,14 @@ def list(verbose):
     resolver_list = get_resolver_list()
 
     if not verbose:
-        for name, resolver in resolver_list.iteritems():
+        for (name, resolver) in resolver_list.items():
             print("{0!s:16} - ({1!s})".format(name, resolver.get("type")))
     else:
-        for name, resolver in resolver_list.iteritems():
+        for (name, resolver) in resolver_list.items():
             print("{0!s:16} - ({1!s})".format(name, resolver.get("type")))
             print("."*32)
             data = resolver.get("data", {})
-            for k, v in data.iteritems():
+            for (k, v) in data.items():
                 if k.lower() in ["bindpw", "password"]:
                     v = "xxxxx"
                 print("{0!s:>24}: {1!r}".format(k, v))
@@ -852,15 +870,18 @@ def list(verbose):
 
 
 @realm_manager.command
-def list():
+def list_realms():
     """
     list the available realms
     """
     from privacyidea.lib.realm import get_realms
     realm_list = get_realms()
-    for name, realm_data in realm_list.iteritems():
+    for (name, realm_data) in realm_list.items():
         resolvernames = [x.get("name") for x in realm_data.get("resolver")]
         print("%16s: %s" % (name, resolvernames))
+
+
+realm_manager.add_command('list', Command(list_realms))
 
 
 @realm_manager.command
@@ -877,20 +898,24 @@ def create(name, resolver):
 
 # Event interface
 
-@event_manager.command
-def list():
+
+def list_events():
     """
     List events
     """
-    E = EventConfiguration()
-    events = E.events
+    conf = EventConfiguration()
+    events = conf.events
     print("{0:7} {4:4} {1:30}\t{2:20}\t{3}".format("Active", "Name", "Module", "Action", "ID"))
     print(90*"=")
     for event in events:
         print("[{0!s:>5}] {4:4} {1:30}\t{2:20}\t{3}".format(event.get("active"),
-                                                 event.get("name")[0:30],
-                                         event.get("handlermodule"),
-                                         event.get("action"),event.get("id"),))
+                                                            event.get("name")[0:30],
+                                                            event.get("handlermodule"),
+                                                            event.get("action"), event.get("id"),))
+
+
+event_manager.add_command('list', Command(list_events))
+
 
 @event_manager.command
 def enable(eid):
@@ -899,6 +924,7 @@ def enable(eid):
     """
     r = enable_event(eid)
     print(r)
+
 
 @event_manager.command
 def disable(eid):
@@ -917,6 +943,7 @@ def delete(eid):
     r = delete_event(eid)
     print(r)
 
+
 @event_manager.command
 def e_export(filename=None):
     """
@@ -924,14 +951,15 @@ def e_export(filename=None):
     """
     import pprint
     pp = pprint.PrettyPrinter(indent=4)
-    E = EventConfiguration()
-    events = E.events
+    conf = EventConfiguration()
+    events = conf.events
     event_str = pp.pformat(events)
     if filename:
         with open(filename, "w") as f:
             f.write(event_str)
     else:
         print(event_str)
+
 
 @event_manager.command
 def e_import(filename, cleanup=False):
@@ -942,8 +970,8 @@ def e_import(filename, cleanup=False):
     """
     if cleanup:
         print("Cleanup old events.")
-        E = EventConfiguration()
-        events = E.events
+        conf = EventConfiguration()
+        events = conf.events
         for event in events:
             name = event.get("name")
             r = delete_event(event.get("id"))
@@ -966,18 +994,20 @@ def e_import(filename, cleanup=False):
 
 # Policy interface
 
-@policy_manager.command
-def list():
+def list_policies():
     """
     list the policies
     """
-    P = PolicyClass()
-    policies = P.get_policies()
+    pol_cls = PolicyClass()
+    policies = pol_cls.get_policies()
     print("Active \t Name \t Scope")
     print(40*"=")
     for policy in policies:
         print("%s \t %s \t %s" % (policy.get("active"), policy.get("name"),
                                   policy.get("scope")))
+
+
+policy_manager.add_command('list', Command(list_policies))
 
 
 @policy_manager.command
@@ -1015,8 +1045,8 @@ def p_export(filename=None):
     """
     import pprint
     pp = pprint.PrettyPrinter(indent=4)
-    P = PolicyClass()
-    policies = P.get_policies()
+    pol_cls = PolicyClass()
+    policies = pol_cls.get_policies()
     pol_str = pp.pformat(policies)
     if filename:
         with open(filename, 'w') as f:
@@ -1034,8 +1064,8 @@ def p_import(filename, cleanup=False):
     """
     if cleanup:
         print("Cleanup old policies.")
-        P = PolicyClass()
-        policies = P.get_policies()
+        pol_cls = PolicyClass()
+        policies = pol_cls.get_policies()
         for policy in policies:
             name = policy.get("name")
             r = delete_policy(name)
@@ -1053,7 +1083,7 @@ def p_import(filename, cleanup=False):
                        check_all_resolvers=policy.get(
                            "check_all_resolvers", False),
                        client=policy.get("client"),
-                       #condition=policy.get("condition"),
+                       # condition=policy.get("condition"),
                        realm=policy.get("realm"),
                        resolver=policy.get("resolver"),
                        scope=policy.get("scope"),
@@ -1079,7 +1109,7 @@ def create(name, scope, action, filename=None):
 
             params = ast.literal_eval(contents)
 
-            if params.get("scope") and params.get("scope")!=scope:
+            if params.get("scope") and params.get("scope") != scope:
                 print("Found scope '{0!s}' in file, will use that instead of "
                       "'{1!s}'.".format(params.get("scope"), scope))
             else:
@@ -1087,13 +1117,13 @@ def create(name, scope, action, filename=None):
                       "{0!s}.".format(scope))
                 params["scope"] = scope
 
-            if params.get("action") and params.get("action")!=action:
+            if params.get("action") and params.get("action") != action:
                 print("Found action in file: '{0!s}', will use that instead "
                       "of: '{1!s}'.".format(params.get("action"), action))
             else:
                 print("action not defined in file, will use the cli value "
                       "{0!s}.".format(action))
-                params["action"]=action
+                params["action"] = action
 
             r = set_policy(name, scope=params.get("scope"),
                            action=params.get("action"),
@@ -1108,7 +1138,7 @@ def create(name, scope, action, filename=None):
                                "check_all_resolvers", False))
             return r
 
-        except Exception:
+        except Exception as _e:
             print("Unexpected error: {0!s}".format(sys.exc_info()[1]))
 
     else:

--- a/tools/creategoogleauthenticator-file
+++ b/tools/creategoogleauthenticator-file
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  2016-05-25 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -20,7 +20,7 @@ emergency = []
 for _ in range(5):
     emergency.append(''.join(random.choice(string.digits) for _ in range(8)))
 
-print """{seed}
+print("""{seed}
 " RATE_LIMIT 3 30
 " WINDOW_SIZE 17
 " DISALLOW_REUSE
@@ -31,4 +31,4 @@ print """{seed}
 {emergency[2]}
 {emergency[3]}
 {emergency[4]}
-""".format(seed=seed, emergency=emergency)
+""".format(seed=seed, emergency=emergency))

--- a/tools/getgooglecodes
+++ b/tools/getgooglecodes
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  2016-05-25 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -46,6 +46,3 @@ for user in os.listdir("/home/"):
             sys.stderr.write("--- Only TOTP Token suppported at the moment!\n")
     except IOError:
         sys.stderr.write("-- Nothing for user {0}\n".format(user))
-
-
-

--- a/tools/privacyidea-convert-base32.py
+++ b/tools/privacyidea-convert-base32.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  2018-07-27 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -33,11 +33,11 @@ for line in content:
     secret = values[1]
     try:
         secret = binascii.hexlify(base64.b32decode(secret))
-    except TypeError:
+    except (TypeError, binascii.Error):
         sys.stderr.write("Error converting secret of serial {0}.\n".format(serial))
         continue
 
-    print("{0}, {1}".format(serial, secret), end='')
+    print("{0}, {1}".format(serial, secret.decode('utf8')), end='')
 
     if args.type:
         print(", {0}".format(args.type), end='')

--- a/tools/privacyidea-create-ad-users
+++ b/tools/privacyidea-create-ad-users
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # 2015-10-12 Cornelius Kölbel <cornelius@privacyidea.org>
 #            Rewrite to LDAP3
 #
-VERSION = '0.2'
+__version__ = '0.2'
 
 import sys
 from getopt import getopt, GetoptError
@@ -15,6 +15,7 @@ import getpass
 #OBJECT_CLASSES = ['top', "posixAccount", 'inetOrgPerson']
 # ObjectClass for AD
 OBJECT_CLASSES = ['top', "person", 'inetOrgPerson', "user"]
+
 
 def usage():
     print('''
@@ -51,7 +52,7 @@ def main():
         opts, args = getopt(sys.argv[1:], "f:u:b:d:", ["file="])
 
     except GetoptError:
-        print "There is an error in your parameter syntax:"
+        print("There is an error in your parameter syntax:")
         usage()
         sys.exit(1)
 

--- a/tools/privacyidea-create-certificate
+++ b/tools/privacyidea-create-certificate
@@ -1,77 +1,82 @@
-#!/usr/bin/python
-VERSION = '0.1'
-import os, sys
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
 from getopt import getopt, GetoptError
-import ConfigParser
 from subprocess import call
 
-CONFIG_FILE="/etc/apache2/sites-available/privacyidea"
+__version__ = '0.1'
+CONFIG_FILE = "/etc/apache2/sites-available/privacyidea"
+
 
 def usage():
-    print  '''
+    print('''
     Parameter:
     -f <apache config file> (Default: %s)
     -h : help
-    ''' % CONFIG_FILE
+    ''' % CONFIG_FILE)
 
 
 def create_keys(file):
-	print "Creating certificate..."
-	'''
-	Read
+    print("Creating certificate...")
+    '''
+    Read
     SSLCertificateFile    /etc/ssl/certs/privacyideaserver.pem
     SSLCertificateKeyFile /etc/ssl/private/privacyideaserver.key
-	'''
-	key=None
-	cert=None
-	f =	open(file, 'r')
-	for l in f:
-		if l.strip()[:18] == "SSLCertificateFile":
-			cert=l.split()[1]
-		elif l.strip()[:21] == "SSLCertificateKeyFile":
-			key=l.split()[1]
-	f.close()
-	
-	if key and cert:
-		command = "openssl req -x509 -newkey rsa:2048 -keyout %s -out %s -days 1000 -subj /CN=privacyideaserver -nodes" % (key, cert)
-		r = call(command, shell=True)
-		if r == 0:
-			print "created key and cert..."
-			os.chmod(key, 0x400)
-		else:
-			print "Failed to create key and cert: %i" % r
-			sys.exit(r)
-	
-	else:
-		print "Could not find key and cert!"
-		print "key: %s" % key
-		print "cert: %s" % cert
-		sys.exit(2)
+    '''
+    key = None
+    cert = None
+    f = open(file, 'r')
+    for l in f:
+        if l.strip()[:18] == "SSLCertificateFile":
+            cert = l.split()[1]
+        elif l.strip()[:21] == "SSLCertificateKeyFile":
+            key = l.split()[1]
+    f.close()
+
+    if key and cert:
+        command = "openssl req -x509 -newkey rsa:2048 -keyout %s -out %s " \
+                  "-days 1000 -subj /CN=privacyideaserver -nodes" % (key, cert)
+        r = call(command, shell=True)
+        if r == 0:
+            print("created key and cert...")
+            os.chmod(key, 0x400)
+        else:
+            print("Failed to create key and cert: %i" % r)
+            sys.exit(r)
+
+    else:
+        print("Could not find key and cert!")
+        print("key: %s" % key)
+        print("cert: %s" % cert)
+        sys.exit(2)
 
 
 def main():
 
-    file = CONFIG_FILE
+    fname = CONFIG_FILE
     try:
         opts, args = getopt(sys.argv[1:], "f:", ["file="])
 
     except GetoptError:
-        print "There is an error in your parameter syntax:"
+        print("There is an error in your parameter syntax:")
         usage()
         sys.exit(1)
 
     for opt, arg in opts:
         if opt in ('-f', '--file'):
-            file = arg
+            fname = arg
         elif opt in ('-h', '--help'):
             usage()
             sys.exit(1)
 
-    if file:
-        create_keys(file)
+    if fname:
+        create_keys(fname)
     else:
         usage()
         sys.exit(2)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/privacyidea-create-pwidresolver-user
+++ b/tools/privacyidea-create-pwidresolver-user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #  privacyIDEA is a fork of LinOTP
 #  May 08, 2014 Cornelius Kölbel
@@ -9,36 +9,33 @@
 #  contact:  http://www.linotp.org
 #            http://www.lsexperts.de
 #            linotp@lsexperts.de
-'''
+"""
   Description:  This tool generates lines for a PasswdIdResolver user file
-                 
+
   Dependencies: ./.
-                
 
-'''
+"""
 
-VERSION = '0.1'
-import os, sys
+import sys
 from getopt import getopt, GetoptError
 import getpass
 import crypt
-import pprint
 import random
 
+__version__ = '0.1'
 
 
 def usage():
-    print  '''
+    print('''
     Parameter:
     -u username
     -i uid (numerical)
     -p password
     -d description
-    '''
+    ''')
 
 
 def main():
-
     user = ""
     password = ""
     uid = ""
@@ -48,18 +45,18 @@ def main():
         opts, args = getopt(sys.argv[1:], "u:i:p:hd:", ["help"])
 
     except GetoptError:
-        print "There is an error in your parameter syntax:"
+        print("There is an error in your parameter syntax:")
         usage()
         sys.exit(1)
 
     for opt, arg in opts:
-        if opt in ('-u'):
+        if opt in ('-u',):
             user = arg
-        elif opt in ('-i'):
+        elif opt in ('-i',):
             uid = arg
-        elif opt in ('-p'):
+        elif opt in ('-p',):
             password = arg
-        elif opt in ('-d'):
+        elif opt in ('-d',):
             description = arg
         elif opt in ('-h', '--help'):
             usage()
@@ -77,12 +74,13 @@ def main():
     home = ""
     shell = ""
     print("%s:%s:%s:%s:%s:%s:%s" % (user,
-                encryptedPW,
-                uid,
-                gid,
-                description,
-                home,
-                shell))
+                                    encryptedPW,
+                                    uid,
+                                    gid,
+                                    description,
+                                    home,
+                                    shell))
+
 
 if __name__ == '__main__':
     main()

--- a/tools/privacyidea-create-sqlidresolver-user
+++ b/tools/privacyidea-create-sqlidresolver-user
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  privacyIDEA is a fork of LinOTP
@@ -11,30 +11,29 @@
 #  contact:  http://www.linotp.org
 #            http://www.lsexperts.de
 #            linotp@lsexperts.de
-'''
+"""
   Description:  This tool generates passwords for the sql resolver
-                 
+
   Dependencies: ./.
-                
 
-'''
 
-VERSION = '0.1'
-import os, sys
+"""
+
+import sys
 from getopt import getopt, GetoptError
 import getpass
 import crypt
-import pprint
 import random
 
+__version__ = '0.1'
 
 
 def usage():
-    print  '''
+    print('''
     Parameter:
     -u username 
     -p password
-    '''
+    ''')
 
 
 def main():
@@ -42,19 +41,18 @@ def main():
     user = ""
     password = ""
 
-
     try:
         opts, args = getopt(sys.argv[1:], "u:p:h", ["help"])
 
     except GetoptError:
-        print "There is an error in your parameter syntax:"
+        print("There is an error in your parameter syntax:")
         usage()
         sys.exit(1)
 
     for opt, arg in opts:
-        if opt in ('-u'):
+        if opt in ('-u',):
             user = arg
-        elif opt in ('-p'):
+        elif opt in ('-p',):
             password = arg
         elif opt in ('-h', '--help'):
             usage()
@@ -69,6 +67,7 @@ def main():
     encryptedPW = crypt.crypt(password, salt)
 
     print("|%s|%s|%s|" % (user, encryptedPW, salt))
+
 
 if __name__ == '__main__':
     main()

--- a/tools/privacyidea-cron
+++ b/tools/privacyidea-cron
@@ -31,13 +31,14 @@ import json
 from datetime import datetime
 
 import dateutil
-from flask_script import Manager
+from flask_script import Manager, Command
 
 from privacyidea.app import create_app
 from privacyidea.lib.config import get_privacyidea_node
-from privacyidea.lib.periodictask import get_scheduled_periodic_tasks, set_periodic_task_last_run, \
-    get_periodic_task_by_name, \
-    execute_task, get_periodic_tasks
+from privacyidea.lib.periodictask import (get_scheduled_periodic_tasks,
+                                          execute_task, get_periodic_tasks,
+                                          get_periodic_task_by_name,
+                                          set_periodic_task_last_run)
 
 warnings.simplefilter("ignore")
 
@@ -87,11 +88,12 @@ def run_task_on_node(ptask, node):
         result = False
     if result:
         current_time = datetime.now(dateutil.tz.tzlocal())
-        print_stdout(u'Task {!r} on node {!r} exited successfully. Noting this in the database ...'.format(
-            ptask["name"], node))
+        print_stdout(u'Task {!r} on node {!r} exited successfully. Noting this '
+                     u'in the database ...'.format(ptask["name"], node))
         set_periodic_task_last_run(ptask["id"], node, current_time)
     else:
-        print_stderr(u'Task {!r} on node {!r} did not run successfully.'.format(ptask["name"], node))
+        print_stderr(u'Task {!r} on node {!r} did not run '
+                     u'successfully.'.format(ptask["name"], node))
         print_stderr(u'This unsuccessful run is not recorded in the database.')
     return result
 
@@ -114,8 +116,7 @@ def run_manually(node_string, task_name):
     run_task_on_node(ptask, node)
 
 
-@manager.command
-def list():
+def list_tasks():
     """
     Show a list of available tasks that could be run.
     """
@@ -134,8 +135,12 @@ def list():
     print_stdout(u"=" * 120)
     for ptask in get_periodic_tasks():
         print_stdout(line_format.format(node_list=u', '.join(ptask["nodes"]),
-                                 options_json=json.dumps(ptask["options"]),
-                                 **ptask))
+                                        options_json=json.dumps(ptask["options"]),
+                                        **ptask))
+
+
+# add the list_tasks() function as flask command 'list'
+manager.add_command('list', Command(list_tasks))
 
 
 @manager.option("-d", "--dryrun",

--- a/tools/privacyidea-decrypt-safeword.py
+++ b/tools/privacyidea-decrypt-safeword.py
@@ -4,6 +4,7 @@
 # (c) Cornelius Kölbel
 # Info: http://www.privacyidea.org
 
+from __future__ import print_function
 import argparse
 import re
 from Crypto.Cipher import AES, DES
@@ -55,4 +56,3 @@ with open(args.file, 'r') as f:
 
 for token in all_tokens:
     print("{0!s}, {1!s}".format(token.get("serial"), token.get("seed")))
-

--- a/tools/privacyidea-expired-users
+++ b/tools/privacyidea-expired-users
@@ -115,13 +115,6 @@ def expire(realm=None, attribute_name=ATTRIBUTE_NAME,
     :return:
     """
     utc_now = datetime.datetime.utcnow()
-    # Active directory starts at 1.1.1601 ;-)
-    elapsed_time = utc_now - MS_AD_START
-    total_seconds = elapsed_time.total_seconds()
-    # convert this to (100 nanoseconds)
-    # 1 sec == 10^9 nano secs == 10^7 * (100 nano secs)
-    multiplyer = 10 ** 7
-    total_100_nano_secs = multiplyer * total_seconds
     params = {"accountExpires": "1"}
     if realm:
         params["realm"] = realm
@@ -178,6 +171,5 @@ def expire(realm=None, attribute_name=ATTRIBUTE_NAME,
 
 
 if __name__ == '__main__':
-    print
+    print()
     manager.run()
-

--- a/tools/privacyidea-export-linotp-counter.py
+++ b/tools/privacyidea-export-linotp-counter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  2018-05-27 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -14,14 +14,13 @@ values of the tokens in the new privacyIDEA installation.
 
 
 import argparse
-import sys
 from sqlalchemy import create_engine
 from sqlalchemy import Table, MetaData, Column
 from sqlalchemy import Integer, Unicode, Boolean
 from sqlalchemy.sql import select
 
 metadata = MetaData()
-linotp_token_table = Table('Token',metadata,
+linotp_token_table = Table('Token', metadata,
                            Column('LinOtpTokenId', Integer(), primary_key=True, nullable=False),
                            Column(
                                'LinOtpTokenDesc', Unicode(80), default=u''),
@@ -87,7 +86,8 @@ def get_linotp_uri(config_file):
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("-c", "--config", help="LinOTP config file. We only need the SQLALCHEMY_DATABASE_URI.",
+parser.add_argument("-c", "--config",
+                    help="LinOTP config file. We only need the SQLALCHEMY_DATABASE_URI.",
                     required=True)
 args = parser.parse_args()
 

--- a/tools/privacyidea-fix-access-rights
+++ b/tools/privacyidea-fix-access-rights
@@ -1,56 +1,57 @@
-#!/usr/bin/python
-VERSION = '0.1'
-import os, sys
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+__version__ = '0.1'
+import sys
 from getopt import getopt, GetoptError
-import ConfigParser
 from subprocess import call
-import ast
+
 
 def usage():
-    print '''
+    print('''
     Parameter:
     -f <pi.cfg file>
     -u <privacyidea user>
     -h : help
-    '''
+    ''')
 
 
 def fix_rights(file, user):
 
     # READ the configs
-    conf = {}
-    execfile(file, conf)
+    conf = {'__file__': file}
+    exec(compile(open(file).read(), file, 'exec'), conf)
 
     # Create the user
     try:
         call("/usr/sbin/adduser  --system %s" % user, shell=True)
-        print "Created user %s" % user
-    except Exception, e:
-        print "Failed to create user %s: %s" % (user, str(e))
+        print("Created user %s" % user)
+    except Exception as e:
+        print("Failed to create user %s: %s" % (user, str(e)))
 
     # fix the file itself!
     try:
         call("chmod 640 %s" % file, shell=True)
         call("chown %s:%s %s" % (user, "root", file), shell=True)
-        print "Fixed access rights for %s" % file
-    except Exception, e:
-        print "Failed to fix access rights for %s" % file
+        print("Fixed access rights for %s" % file)
+    except Exception as _e:
+        print("Failed to fix access rights for %s" % file)
 
     # Fix the encryption file
     try:
         call("chmod 400 %s" % conf.get("PI_ENCFILE"), shell=True)
         call("chown %s %s" % (user, conf.get("PI_ENCFILE")), shell=True)
-        print "Fixed access rights for %s" % conf.get("PI_ENCFILE")
-    except Exception, e:
-        print "Failed to fix access rights for %s" % conf.get("PI_ENCFILE")
+        print("Fixed access rights for %s" % conf.get("PI_ENCFILE"))
+    except Exception as _e:
+        print("Failed to fix access rights for %s" % conf.get("PI_ENCFILE"))
 
     # fix the audit key
     try:
         call("chmod 400 %s" % conf.get("PI_AUDIT_KEY_PRIVATE"), shell=True)
         call("chown %s %s" % (user, conf.get("PI_AUDIT_KEY_PRIVATE")), shell=True)
-        print "Fixed access rights for %s" % conf.get("PI_AUDIT_KEY_PRIVATE")
-    except Exception, e:
-        print "Failed to fix access rights for %s" % conf.get("PI_AUDIT_KEY_PRIVATE")
+        print("Fixed access rights for %s" % conf.get("PI_AUDIT_KEY_PRIVATE"))
+    except Exception as _e:
+        print("Failed to fix access rights for %s" % conf.get("PI_AUDIT_KEY_PRIVATE"))
 
     # TODO: logfile
 
@@ -63,7 +64,7 @@ def main():
         opts, args = getopt(sys.argv[1:], "f:u:h", ["file=", "user=", "help"])
 
     except GetoptError:
-        print "There is an error in your parameter syntax:"
+        print("There is an error in your parameter syntax:")
         usage()
         sys.exit(1)
 
@@ -81,6 +82,7 @@ def main():
     else:
         usage()
         sys.exit(2)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/privacyidea-get-serial
+++ b/tools/privacyidea-get-serial
@@ -67,9 +67,9 @@ def byotp(otp=None, type=None, serial="", window=10, unassigned=False,
     :param assigned: If set, searches only assigned tokens
     :return: The serial number of the token
     """
-    print
+    print()
     if not assigned and not unassigned:
-        assigned=None
+        assigned = None
     count = get_tokens(tokentype=type, serial_wildcard="*{0!s}*".format(
             serial), assigned=assigned, count=True)
     print("Searching in {0!s} tokens.".format(count))
@@ -83,7 +83,7 @@ def byotp(otp=None, type=None, serial="", window=10, unassigned=False,
     else:
         print("No token found.")
 
-if __name__ == '__main__':
-    print
-    manager.run()
 
+if __name__ == '__main__':
+    print()
+    manager.run()

--- a/tools/privacyidea-pip-update
+++ b/tools/privacyidea-pip-update
@@ -5,6 +5,7 @@ from subprocess import call, check_output
 import getopt
 import sys
 import os
+from six.moves import input
 
 # We follow the hint at https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program to invoke pip.
 PIP_EXECUTABLE = [sys.executable, '-m', 'pip']

--- a/tools/privacyidea-pip-update
+++ b/tools/privacyidea-pip-update
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-from __future__ import print_function
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import pipes
 from subprocess import call, check_output
 import getopt
@@ -15,7 +15,8 @@ def usage():
 privacyidea-pip-update
 
     -f, --force      force the update
-    -s, --skipstamp  skip the stamping of the database. Use this, if you know your DB has the correct version.
+    -s, --skipstamp  skip the stamping of the database. Use this, if you know
+                     your DB has the correct version.
     -n, --noschema   do not run the schema update.
     -h, --help       show this help
     """)
@@ -30,8 +31,8 @@ def get_installed_packages():
     pip_output = check_output(PIP_EXECUTABLE + ["freeze", "--local", "--all"])
     for line in pip_output.splitlines():
         line = line.strip()
-        if "==" in line:
-            package_name = line.split("==", 1)[0]
+        if b"==" in line:
+            package_name = line.split(b"==", 1)[0]
             packages.append(package_name)
     return packages
 
@@ -85,9 +86,10 @@ def main():
         update()
     else:
         answer = False
+        res = 'n'
         while not answer:
-            res = raw_input("Do you really want to update your "
-                            "python environment and the DB schema? (y/N)")
+            res = input("Do you really want to update your "
+                        "python environment and the DB schema? (y/N)")
             answer = res.lower() in ['y', 'n', '']
 
         if res.lower() == 'y':

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -49,6 +49,7 @@ import os
 import string
 import subprocess
 from functools import wraps
+from six.moves import input
 
 import sqlalchemy
 import sys
@@ -134,17 +135,17 @@ manager.add_option('-i', '--instance', dest='instance', required=False,
                    help='Location of the privacyIDEA instance (defaults to ~/.privacyidea)')
 
 
-def read_credentials(file):
+def read_credentials(fobj):
     """
     read username and password from a file. This could be sys.stdin.
 
     The first line specifies the username, the second line specifies the password.
 
-    :param file: a Python file object
+    :param fobj: a Python file object
     :return: a tuple (user, password)
     """
-    username = file.readline().strip()
-    password = file.readline().strip()
+    username = fobj.readline().strip()
+    password = fobj.readline().strip()
     return username, password
 
 

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -254,7 +254,8 @@ There are two possibilities to create a resolver:
     print()
     print('Configuration is complete. You can now configure privacyIDEA in '
           'the web browser by running')
-    print("  privacyidea-standalone -i '{}' configure".format(instance_dir.encode('string-escape')))
+    print("  privacyidea-standalone -i '{}' "
+          "configure".format(instance_dir.encode('unicode-escape')))
 
 
 @manager.option('-r', '--response', dest='show_response', action='store_true',

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -110,10 +110,8 @@ def require_instance(f):
     def deco(*args, **kwargs):
         config_file = os.path.join(manager.app.instance_directory, 'pi.cfg')
         if not os.path.exists(config_file):
-            raise RuntimeError(
-                "{!r} does not exist! Create a new instance using ``privacyidea-standalone create``.".format(
-                    config_file
-                ))
+            raise RuntimeError("{!r} does not exist! Create a new instance using"
+                               " ``privacyidea-standalone create``.".format(config_file))
         return f(*args, **kwargs)
     return deco
 
@@ -125,10 +123,14 @@ class Configure(Server):
     def __call__(self, *args, **kwargs):
         Server.__call__(self, *args, **kwargs)
 
+    def run(self):
+        pass
+
 
 manager = Manager(_app_factory, with_default_commands=False, description=__doc__)
 manager.add_command("configure", Configure())
-manager.add_option('-i', '--instance', dest='instance', required=False, default=os.path.expanduser('~/.privacyidea'),
+manager.add_option('-i', '--instance', dest='instance', required=False,
+                   default=os.path.expanduser('~/.privacyidea'),
                    help='Location of the privacyIDEA instance (defaults to ~/.privacyidea)')
 
 
@@ -174,13 +176,13 @@ def choice(question, choices, case_insensitive=True):
     :return: a value of ``choices``
     """
     while True:
-        answer = raw_input(question)
+        answer = input(question)
         if case_insensitive:
             answer = answer.lower()
         if answer in choices:
             return choices[answer]
         else:
-            print '{!r} is not a valid answer.'.format(answer)
+            print('{!r} is not a valid answer.'.format(answer))
 
 
 def yesno(question, default):
@@ -220,17 +222,19 @@ def create():
     invoke_pi_manage(['create_audit_keys'], pi_cfg)
     invoke_pi_manage(['createdb'], pi_cfg)
 
-    print
-    print 'Please enter a password for the new admin `super`.'
+    print()
+    print('Please enter a password for the new admin `super`.')
     invoke_pi_manage(['admin', 'add', 'super'], pi_cfg)
 
     # create users
     if yesno('Would you like to create a default resolver and realm (Y/n)? ', True):
-        print 'There are two possibilities to create a resolver:'
-        print ' 1) We can create a table in the privacyIDEA SQLite database to store the users.'
-        print '    You can add users via the privacyIDEA Web UI.'
-        print ' 2) We can create a resolver that contains the users from /etc/passwd'
-        print
+        print("""
+There are two possibilities to create a resolver:
+ 1) We can create a table in the privacyIDEA SQLite database to store the users.
+    You can add users via the privacyIDEA Web UI.
+ 2) We can create a resolver that contains the users from /etc/passwd
+""")
+        print()
         create_sql_resolver = choice('Please choose (default=1): ', {
             '1': True,
             '2': False,
@@ -241,13 +245,15 @@ def create():
         else:
             with NamedTemporaryFile(delete=False) as f:
                 f.write('{"fileName": "/etc/passwd"}')
-            invoke_pi_manage(['resolver', 'create', 'defresolver', 'passwdresolver', f.name], pi_cfg)
+            invoke_pi_manage(['resolver', 'create', 'defresolver', 'passwdresolver', f.name],
+                             pi_cfg)
             os.unlink(f.name)
         invoke_pi_manage(['realm', 'create', 'defrealm', 'defresolver'], pi_cfg)
 
-    print
-    print 'Configuration is complete. You can now configure privacyIDEA in the web browser by running'
-    print "  privacyidea-standalone -i '{}' configure".format(instance_dir.encode('string-escape'))
+    print()
+    print('Configuration is complete. You can now configure privacyIDEA in '
+          'the web browser by running')
+    print("  privacyidea-standalone -i '{}' configure".format(instance_dir.encode('string-escape')))
 
 
 @manager.option('-r', '--response', dest='show_response', action='store_true',
@@ -267,7 +273,7 @@ def check(show_response=False):
     exitcode = 255
     try:
         with manager.app.test_request_context('/validate/check', method='POST',
-                                      data={'user': user, 'pass': password}):
+                                              data={'user': user, 'pass': password}):
             response = manager.app.full_dispatch_request()
             data = json.loads(response.data)
             result = data['result']
@@ -276,9 +282,9 @@ def check(show_response=False):
             else:
                 exitcode = 1
             if show_response:
-                print response.data
-    except Exception, e:
-        print repr(e)
+                print(response.data)
+    except Exception as e:
+        print(repr(e))
     sys.exit(exitcode)
 
 

--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -46,6 +46,14 @@ from flask_script.commands import InvalidCommand
 from privacyidea.lib.policy import ACTION
 from privacyidea.lib.utils import parse_legacy_time
 from privacyidea.lib.importotp import export_pskc
+from privacyidea.lib.token import (get_tokens, remove_token, enable_token,
+                                   unassign_token, import_token)
+from privacyidea.app import create_app
+from flask_script import Manager
+import re
+import sys
+
+__version__ = "0.1"
 
 ALLOWED_ACTIONS = ["disable", "delete", "unassign", "mark", "export", "listuser"]
 
@@ -99,19 +107,11 @@ Actions:
    https://stackoverflow.com/questions/4545661/unicodedecodeerror-when-redirecting-to-file
 
 """.format("|".join(ALLOWED_ACTIONS))
-from privacyidea.lib.token import (get_tokens, remove_token, enable_token,
-                                   unassign_token, import_token, get_tokens_paginated_generator)
-from privacyidea.app import create_app
-from flask_script import Manager
-import re
-import sys
-
-__version__ = "0.1"
-
 
 
 app = create_app(config_name='production', silent=True)
 manager = Manager(app)
+
 
 def _try_convert_to_integer(given_value_string):
     try:
@@ -120,10 +120,10 @@ def _try_convert_to_integer(given_value_string):
         raise InvalidCommand('Not an integer: {}'.format(given_value_string))
 
 
-def _compare_greater_than(key, given_value_string):
+def _compare_greater_than(_key, given_value_string):
     """
-    :return: a function which returns True if its parameter (converted to an integer) is greater than
-    *given_value_string* (converted to an integer).
+    :return: a function which returns True if its parameter (converted to an integer)
+             is greater than *given_value_string* (converted to an integer).
     """
     given_value = _try_convert_to_integer(given_value_string)
 
@@ -135,10 +135,10 @@ def _compare_greater_than(key, given_value_string):
     return comparator
 
 
-def _compare_less_than(key, given_value_string):
+def _compare_less_than(_key, given_value_string):
     """
-    :return: a function which returns True if its parameter (converted to an integer) is less than
-    *given_value_string* (converted to an integer).
+    :return: a function which returns True if its parameter (converted to an integer)
+             is less than *given_value_string* (converted to an integer).
     """
     given_value = _try_convert_to_integer(given_value_string)
 
@@ -175,7 +175,7 @@ def _try_convert_to_datetime(given_value_string):
 def _compare_after(key, given_value_string):
     """
     :return: a function which returns True if its parameter (converted to a datetime) occurs after
-    *given_value_string* (converted to a datetime).
+             *given_value_string* (converted to a datetime).
     """
     given_value = _try_convert_to_datetime(given_value_string)
 
@@ -190,7 +190,7 @@ def _compare_after(key, given_value_string):
 def _compare_before(key, given_value_string):
     """
     :return: a function which returns True if its parameter (converted to a datetime) occurs before
-    *given_value_string* (converted to a datetime).
+             *given_value_string* (converted to a datetime).
     """
     given_value = _try_convert_to_datetime(given_value_string)
 
@@ -202,7 +202,7 @@ def _compare_before(key, given_value_string):
     return comparator
 
 
-def _compare_regex(key, given_regex):
+def _compare_regex(_key, given_regex):
     def comparator(value):
         return re.search(given_regex, value)
     return comparator
@@ -215,10 +215,11 @@ def build_tokenvalue_filter(key,
                             tokeninfo_value_after,
                             tokeninfo_value_before):
     """
-    Build and return a token value filter, which is a list of comparator functions. Each comparator function
-    takes a tokeninfo value and returns True if the user-defined criterion matches.
-    The filter matches a record if *all* comparator functions return True, i.e. if the conjunction of
-    all comparators returns True.
+    Build and return a token value filter, which is a list of comparator functions.
+    Each comparator function takes a tokeninfo value and returns True if the
+    user-defined criterion matches.
+    The filter matches a record if *all* comparator functions return True, i.e.
+    if the conjunction of all comparators returns True.
     :param key: user-supplied --tokeninfo-key= value
     :param tokeninfo_value: user-supplied --tokeninfo-value= value
     :param tokeninfo_value_greater_than: user-supplied --tokeninfo-value-greater-than= value
@@ -227,18 +228,18 @@ def build_tokenvalue_filter(key,
     :param tokeninfo_value_before: user-supplied --tokeninfo-value-before= value
     :return: list of functions
     """
-    filter = []
+    tvfilter = []
     if tokeninfo_value:
-        filter.append(_compare_regex(key, tokeninfo_value))
+        tvfilter.append(_compare_regex(key, tokeninfo_value))
     if tokeninfo_value_greater_than:
-        filter.append(_compare_greater_than(key, tokeninfo_value_greater_than))
+        tvfilter.append(_compare_greater_than(key, tokeninfo_value_greater_than))
     if tokeninfo_value_less_than:
-        filter.append(_compare_less_than(key, tokeninfo_value_less_than))
+        tvfilter.append(_compare_less_than(key, tokeninfo_value_less_than))
     if tokeninfo_value_after:
-        filter.append(_compare_after(key, tokeninfo_value_after))
+        tvfilter.append(_compare_after(key, tokeninfo_value_after))
     if tokeninfo_value_before:
-        filter.append(_compare_before(key, tokeninfo_value_before))
-    return filter
+        tvfilter.append(_compare_before(key, tokeninfo_value_before))
+    return tvfilter
 
 
 def _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
@@ -309,9 +310,8 @@ def export_token_data(token_list):
     """
     tokens = []
     for token_obj in token_list:
-        token_data = []
-        token_data.append(u"{0!s}".format(token_obj.token.serial))
-        token_data.append(u"{0!s}".format(token_obj.token.tokentype))
+        token_data = [u"{0!s}".format(token_obj.token.serial),
+                      u"{0!s}".format(token_obj.token.tokentype)]
         if token_obj.user:
             token_data.append(u"{0!s}".format(token_obj.user.info.get("username", "")))
             token_data.append(u"{0!s}".format(token_obj.user.info.get("givenname", "")))
@@ -330,7 +330,6 @@ def export_user_data(token_list):
     :return:
     """
     users = {}
-    userlist = {}
     for token_obj in token_list:
         if token_obj.user:
             uid = u"{0!s}|{1!s}|{2!s}|{3!s}|{4!s}".format(
@@ -356,14 +355,18 @@ def export_user_data(token_list):
 @manager.option('--active', help='True|False|None')
 @manager.option('--tokeninfo-value', metavar='REGEX', help='The tokeninfo value to match')
 @manager.option('--tokeninfo-value-greater-than', metavar='INTEGER',
-                help='Interpret tokeninfo values as integers and match only if they are greater than the given integer')
+                help='Interpret tokeninfo values as integers and match only if they are '
+                     'greater than the given integer')
 @manager.option('--tokeninfo-value-less-than', metavar='INTEGER',
-                help='Interpret tokeninfo values as integers and match only if they are smaller than the given integer')
+                help='Interpret tokeninfo values as integers and match only if they are '
+                     'smaller than the given integer')
 @manager.option('--tokeninfo-value-after', metavar='DATETIME',
-                help='Interpret tokeninfo values as datetimes, match only if they occur after the given '
+                help='Interpret tokeninfo values as datetimes, match only if they occur '
+                     'after the given '
                      'ISO 8601 datetime')
 @manager.option('--tokeninfo-value-before', metavar='DATETIME',
-                help='Interpret tokeninfo values as datetimes, match only if they occur before the given '
+                help='Interpret tokeninfo values as datetimes, match only if they occur '
+                     'before the given '
                      ' ISO 8601 datetime')
 @manager.option('--tokeninfo-key', help='The tokeninfo key to match')
 @manager.option('--orphaned',
@@ -376,9 +379,10 @@ def export_user_data(token_list):
 @manager.option('--set-description', help='')
 @manager.option('--set-tokeninfo-key', help='')
 @manager.option('--set-tokeninfo-value', help='')
-@manager.option('--sum', help='In case of the action "listuser", this switch specifies if the output'
-                              ' should only contain the number of tokens owned by the user.',
-                dest='sum', action='store_true')
+@manager.option('--sum', help='In case of the action "listuser", this switch specifies if '
+                              'the output should only contain the number of tokens owned '
+                              'by the user.',
+                dest='sum_tokens', action='store_true')
 @manager.option('--csv', dest='csv', action='store_true',
                 help='In case of a simple find, the output is written as CSV instead of the '
                      'formatted output.')
@@ -388,7 +392,7 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
          tokeninfo_value_greater_than, tokeninfo_value_less_than,
          tokeninfo_value_after, tokeninfo_value_before,
          orphaned, tokentype, serial, description, action, set_description,
-         set_tokeninfo_key, set_tokeninfo_value, sum, csv, chunksize):
+         set_tokeninfo_key, set_tokeninfo_value, sum_tokens, csv, chunksize):
     """
     finds all tokens which match the conditions
     """
@@ -399,15 +403,15 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
             sys.exit(1)
     if chunksize is not None:
         chunksize = int(chunksize)
-    filter = build_tokenvalue_filter(tokeninfo_key,
-                                     tokeninfo_value,
-                                     tokeninfo_value_greater_than,
-                                     tokeninfo_value_less_than,
-                                     tokeninfo_value_after,
-                                     tokeninfo_value_before)
+    tvfilter = build_tokenvalue_filter(tokeninfo_key,
+                                       tokeninfo_value,
+                                       tokeninfo_value_greater_than,
+                                       tokeninfo_value_less_than,
+                                       tokeninfo_value_after,
+                                       tokeninfo_value_before)
     generator = _get_tokenlist(last_auth, assigned, active, tokeninfo_key,
-                    filter, orphaned, tokentype, serial,
-                    description, chunksize)
+                               tvfilter, orphaned, tokentype, serial,
+                               description, chunksize)
     if chunksize is not None:
         sys.stderr.write("+ Reading tokens from database in chunks of {}...\n".format(chunksize))
     else:
@@ -434,20 +438,21 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
                     ))
 
         elif action == "listuser":
-            if not sum:
+            if not sum_tokens:
                 tokens = export_token_data(tlist)
                 for token in tokens:
                     print(u",".join([u"'{0!s}'".format(x) for x in token]))
             else:
                 users = export_user_data(tlist)
-                for user, tokens in users.iteritems():
+                for user, tokens in users.items():
                     print(u"{0!s},{1!s}".format(user, len(tokens)))
 
         elif action == "export":
             key, token_num, soup = export_pskc(tlist)
             sys.stderr.write("\n{0!s} tokens exported.\n".format(token_num))
             sys.stderr.write("\nThis is the AES encryption key of the token seeds.\n"
-                             "You need this key to import the tokens again:\n\n\t{0!s}\n\n".format(key))
+                             "You need this key to import the "
+                             "tokens again:\n\n\t{0!s}\n\n".format(key))
             print("{0!s}".format(soup))
         else:
             for token_obj in tlist:
@@ -485,19 +490,18 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
                 help='The AES encryption key.')
 def loadtokens(pskc, preshared_key_hex):
     from privacyidea.lib.importotp import parsePSKCdata
-    from privacyidea.lib.token import init_token, TOKENKIND
 
     with open(pskc, 'r') as pskcfile:
         file_contents = pskcfile.read()
 
-    TOKENS = parsePSKCdata(file_contents, preshared_key_hex)
+    tokens = parsePSKCdata(file_contents, preshared_key_hex)
     success = 0
     failed = 0
     failed_tokens = []
-    for serial in TOKENS:
+    for serial in tokens:
         try:
             print("Importing token {0!s}".format(serial))
-            import_token(serial, TOKENS[serial])
+            import_token(serial, tokens[serial])
             success = success + 1
         except Exception as e:
             failed = failed + 1
@@ -509,5 +513,3 @@ def loadtokens(pskc, preshared_key_hex):
 
 if __name__ == '__main__':
     manager.run()
-
-

--- a/tools/privacyidea-update-counter.py
+++ b/tools/privacyidea-update-counter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  2018-05-27 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -49,13 +49,17 @@ def read_counter_file(import_file):
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("-c", "--config", help="privacyIDEA config file. We only need the SQLALCHEMY_DATABASE_URI.",
+parser.add_argument("-c", "--config",
+                    help="privacyIDEA config file. We only need the SQLALCHEMY_DATABASE_URI.",
                     required=True)
-parser.add_argument('file', help='The CSV file with the updated counters. The file should contain one serial and '
-                                 'counter per line split by a comma. You can specify "-" to read from stdin.',
+parser.add_argument('file',
+                    help='The CSV file with the updated counters. The file should contain one '
+                         'serial and counter per line split by a comma. '
+                         'You can specify "-" to read from stdin.',
                     type=argparse.FileType())
-parser.add_argument("-i", "--increase-only", help="Only update the token counter, if the new counter value"
-                                                  "is bigger than the existing in the database.",
+parser.add_argument("-i", "--increase-only",
+                    help="Only update the token counter, if the new counter value "
+                         "is bigger than the existing in the database.",
                     action='store_const', const=True)
 args = parser.parse_args()
 
@@ -92,7 +96,7 @@ for count in counters:
 
 privacyidea_session.commit()
 
-print
+print()
 print("{0!s:6} tokens processed.".format(processed))
 print("{0!s:6} counters updated.".format(updated))
 print("{0!s:6} tokens not found.".format(not_found))

--- a/tools/privacyidea-usercache-cleanup
+++ b/tools/privacyidea-usercache-cleanup
@@ -39,13 +39,12 @@ This script deletes expired entries from the user cache.
 """
 __version__ = "0.1"
 
-from privacyidea.lib.token import get_tokens, remove_token, enable_token
-from privacyidea.lib.policy import ACTION
 from privacyidea.app import create_app
 from flask_script import Manager
 
 app = create_app(config_name='production', silent=True)
 manager = Manager(app)
+
 
 def _get_expired_entries():
     """
@@ -54,15 +53,18 @@ def _get_expired_entries():
     filter_condition = create_filter(expired=True)
     return UserCache.query.filter(filter_condition).order_by(UserCache.timestamp.desc()).all()
 
+
 LIST_FORMAT = '{:<5} {:<10} {:<10} {:<30} {:<10}'
 
 
 @manager.command
 def delete(noaction=False):
     """
-    Delete all cache entries that are considered expired according to the UserCacheExpiration configuration setting.
+    Delete all cache entries that are considered expired according to the
+    UserCacheExpiration configuration setting.
     If the user cache is disabled, no entries are deleted.
-    If '--noaction' is passed, expired cache entries are listed, but not actually deleted.
+    If '--noaction' is passed, expired cache entries are listed, but not
+    actually deleted.
     """
     if not get_cache_time():
         print('User cache is disabled, not doing anything.')
@@ -87,6 +89,6 @@ def delete(noaction=False):
         else:
             print("'--noaction' was passed, not doing anything.")
 
+
 if __name__ == '__main__':
     manager.run()
-

--- a/tools/ssha.py
+++ b/tools/ssha.py
@@ -1,4 +1,33 @@
 #!/usr/bin/env python
-import base64, getpass, hashlib, os
-salt = os.urandom(8) # edit the length as you see fit
-print '{SSHA}' + base64.b64encode(hashlib.sha1(getpass.getpass() + salt).digest() + salt)
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import base64
+import getpass
+import hashlib
+import os
+
+
+def get_hash(passwd, salt):
+    """
+    Calculate a sha1 hash of a password with salt.
+
+    :param passwd: The password
+    :type passwd: string
+    :param salt: The salt
+    :type salt: bytestring
+    :return: string
+
+    lets see if doctest works:
+
+    >>> print(get_hash('test', b'test'))
+    {SSHA}Uau5Y2B43vv4iNhFenx2+FyPEUx0ZXN0
+
+    """
+    h = hashlib.sha1(passwd.encode('utf8') + salt).digest()
+    return '{SSHA}' + base64.b64encode(h + salt).decode('utf8')
+
+
+if __name__ == '__main__':
+    salt = os.urandom(8)  # edit the length as you see fit
+    print(get_hash(getpass.getpass(), salt))


### PR DESCRIPTION
The python based tools should now be able to run with python 2 and python 3.

Changes include print statement vs. print function, literal octal
representation, iteration of dict items and differences in the except
clause.

Cosmetics:
- Fix the shebang to use `/usr/bin/env python` in order to execute the
  correct python version in a virtual environment
- Add content type description if it was missing
- Add a whole lot of wrapping and indenting
- Rename some variables/functions to avoid overwriting python internals
- Cleanup of imports

Working on #676