### PR TITLE
Add token resync status to audit log

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -613,7 +613,7 @@ def resync_api(serial=None):
     otp2 = getParam(request.all_data, "otp2", required)
 
     res = resync_token(serial, otp1, otp2, user=user)
-    g.audit_object.log({"success": True})
+    g.audit_object.log({"success": bool(res)})
     return send_result(res)
 
 


### PR DESCRIPTION
The result of a token resync is now added to the audit log.

Fixes #1416