### PR TITLE
Fix tokenowner migration script for tokens with multiple realms 

### DIFF
--- a/migrations/versions/48ee74b8a7c8_.py
+++ b/migrations/versions/48ee74b8a7c8_.py
@@ -89,9 +89,9 @@ def upgrade():
             if not token_realms:
                 sys.stderr.write(u"{serial!s}, {userid!s}, {resolver!s}, "
                                  u"Error while migrating token assignment. "
-                                 u"This token has no realm assignments!".format(serial=token.serial,
-                                                                                userid=token.user_id,
-                                                                                resolver=token.resolver))
+                                 u"This token has no realm assignments!\n".format(serial=token.serial,
+                                                                                  userid=token.user_id,
+                                                                                  resolver=token.resolver))
             elif len(token_realms) == 1:
                 realm_id = token_realms[0].realm_id
             elif len(token_realms) > 1:
@@ -133,8 +133,8 @@ def upgrade():
                                 found_realm_ids.append(token_realm.realm.id)
                                 found_realm_names.append(token_realm.realm.name)
                         if len(found_realm_ids) > 1:
-                            sys.stderr.write(u"{serial!s}, {userid!s}, {resolver!s}, "
-                                             u"Your realm configuration for the token is not distinct!. "
+                            sys.stderr.write(u"{serial!s}, {userid!s}, {resolver!s}, Can not assign token. "
+                                             u"Your realm configuration for the token is not distinct! "
                                              u"The tokenowner could be in multiple realms! "                                  
                                              u"The token is assigned to the following realms and the resolver is also "
                                              u"contained in these realm IDs: {realms!s}.\n".format(serial=token.serial,

--- a/migrations/versions/48ee74b8a7c8_.py
+++ b/migrations/versions/48ee74b8a7c8_.py
@@ -149,10 +149,11 @@ def upgrade():
                                              u"realms, to which the token is assigned!\n".format(serial=token.serial,
                                                                                                  userid=token.user_id,
                                                                                                  resolver=token.resolver))
-
-            to = TokenOwner(token_id=token.id, user_id=token.user_id,
-                            resolver=token.resolver, realm_id=realm_id)
-            session.add(to)
+            # If we could not figure out a tokenowner realm, we skip the token assignment.
+            if realm_id is not None:
+                to = TokenOwner(token_id=token.id, user_id=token.user_id,
+                                resolver=token.resolver, realm_id=realm_id)
+                session.add(to)
         session.commit()
 
         # Now we drop the columns


### PR DESCRIPTION
See #1485: Due to a query typo, the migration script aborted whenever it encountered a token with multiple realms. This PR fixes the issue. Also, this fixes various error messages.

Finally, with this PR, the migration script does not create ``TokenOwner`` entries with ``realm=NULL`` anymore. If the token owner realm cannot be uniquely identified, the migration script does not create a ``TokenOwner`` entry at all.