### PR TITLE
Fix occasionally failing LDAP resolver test

### DIFF
--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -1468,7 +1468,11 @@ class LDAPResolverTestCase(MyTestCase):
         # resolver but alice will be found in the other resolver.
         ldap3mock.setLDAPDirectory(LDAPDirectory_small)
         y = LDAPResolver()
-        y.loadConfig({'LDAPURI': 'ldap://localhost',
+        # We add :789 to the LDAPURI in order to force a unused resolver ID.
+        # If we omit it, the test occasionally fails because of leftover
+        # cache entries from a resolver with the same resolver ID
+        # that was instantiated in the test_api_validate.py tests.
+        y.loadConfig({'LDAPURI': 'ldap://localhost:789',
                       'LDAPBASE': 'o=test',
                       'BINDDN': 'cn=manager,ou=example,o=test',
                       'BINDPW': 'ldaptest',


### PR DESCRIPTION
An admittedly quick-and-dirty fix. :-) In the long run, we should avoid using a global variable for the LDAP cache anyway. See #1477.