### PR TITLE
Migrate migration scripts to Python 3

### DIFF
--- a/migrations/versions/19f727d285e2_.py
+++ b/migrations/versions/19f727d285e2_.py
@@ -25,9 +25,9 @@ def upgrade():
         sa.UniqueConstraint('timestamp', 'stats_key', name='msix_1'),
         mysql_row_format='DYNAMIC'
         )
-    except Exception, exx:
-        print "Could not add table for monitoring stats!"
-        print exx
+    except Exception as exx:
+        print("Could not add table for monitoring stats!")
+        print(exx)
 
 
 def downgrade():

--- a/migrations/versions/204d8d4f351e_.py
+++ b/migrations/versions/204d8d4f351e_.py
@@ -19,9 +19,9 @@ def upgrade():
         # As we defined 'priority' to be non-NULLable, we supply a server_default value of 1
         # here to set the priority of all existing policies to 1.
         op.add_column('policy', sa.Column('priority', sa.Integer(), nullable=False, server_default='1'))
-    except Exception, exx:
-        print "Could not add column 'priority' to table 'policy'."
-        print exx
+    except Exception as exx:
+        print("Could not add column 'priority' to table 'policy'.")
+        print(exx)
 
 def downgrade():
     op.drop_column('policy', 'priority')

--- a/migrations/versions/20969b4cbf06_.py
+++ b/migrations/versions/20969b4cbf06_.py
@@ -20,7 +20,7 @@ def upgrade():
         op.add_column('token', sa.Column('revoked', sa.Boolean(),
                                          default=False))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Column revoked already exists.")
         else:
             print(exx)
@@ -32,7 +32,7 @@ def upgrade():
         op.add_column('token', sa.Column('locked', sa.Boolean(),
                                          default=False))
     except (OperationalError, ProgrammingError)  as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Column locked already exists.")
         else:
             print(exx)

--- a/migrations/versions/20969b4cbf06_.py
+++ b/migrations/versions/20969b4cbf06_.py
@@ -20,7 +20,7 @@ def upgrade():
         op.add_column('token', sa.Column('revoked', sa.Boolean(),
                                          default=False))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Column revoked already exists.")
         else:
             print(exx)
@@ -32,7 +32,7 @@ def upgrade():
         op.add_column('token', sa.Column('locked', sa.Boolean(),
                                          default=False))
     except (OperationalError, ProgrammingError)  as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Column locked already exists.")
         else:
             print(exx)

--- a/migrations/versions/2181294eed0b_.py
+++ b/migrations/versions/2181294eed0b_.py
@@ -19,7 +19,7 @@ def upgrade():
     try:
         op.add_column('policy', sa.Column('condition', sa.Integer(), nullable=False))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Column condition already exists.")
         else:
             print(exx)

--- a/migrations/versions/2181294eed0b_.py
+++ b/migrations/versions/2181294eed0b_.py
@@ -19,7 +19,7 @@ def upgrade():
     try:
         op.add_column('policy', sa.Column('condition', sa.Integer(), nullable=False))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Column condition already exists.")
         else:
             print(exx)

--- a/migrations/versions/239995464c48_.py
+++ b/migrations/versions/239995464c48_.py
@@ -21,7 +21,7 @@ def upgrade():
                                                 sa.Unicode(length=255),
                                                 nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Table 'radiusserver' already exists.")
         else:
             print(exx)

--- a/migrations/versions/239995464c48_.py
+++ b/migrations/versions/239995464c48_.py
@@ -21,7 +21,7 @@ def upgrade():
                                                 sa.Unicode(length=255),
                                                 nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Table 'radiusserver' already exists.")
         else:
             print(exx)

--- a/migrations/versions/2551ee982544_.py
+++ b/migrations/versions/2551ee982544_.py
@@ -20,7 +20,7 @@ def upgrade():
         op.add_column('tokeninfo', sa.Column('Type', sa.Unicode(length=100),
                                              nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Column tokeninfo already exists.")
         else:
             print("Column already exists")

--- a/migrations/versions/2551ee982544_.py
+++ b/migrations/versions/2551ee982544_.py
@@ -20,7 +20,7 @@ def upgrade():
         op.add_column('tokeninfo', sa.Column('Type', sa.Unicode(length=100),
                                              nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Column tokeninfo already exists.")
         else:
             print("Column already exists")

--- a/migrations/versions/2ac117d0a6f5_.py
+++ b/migrations/versions/2ac117d0a6f5_.py
@@ -30,7 +30,7 @@ def upgrade():
         sa.PrimaryKeyConstraint('id')
         )
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Column smtpserver already exists.")
         else:
             print(exx)

--- a/migrations/versions/2ac117d0a6f5_.py
+++ b/migrations/versions/2ac117d0a6f5_.py
@@ -30,7 +30,7 @@ def upgrade():
         sa.PrimaryKeyConstraint('id')
         )
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Column smtpserver already exists.")
         else:
             print(exx)

--- a/migrations/versions/2c9430cfc66b_.py
+++ b/migrations/versions/2c9430cfc66b_.py
@@ -49,9 +49,9 @@ def upgrade():
         sa.UniqueConstraint('periodictask_id', 'key', name='ptoix_1'),
         mysql_row_format='DYNAMIC'
         )
-    except Exception, exx:
-        print "Could not add tables for periodic tasks!"
-        print exx
+    except Exception as exx:
+        print("Could not add tables for periodic tasks!")
+        print(exx)
 
 
 def downgrade():

--- a/migrations/versions/37e6b49fc686_.py
+++ b/migrations/versions/37e6b49fc686_.py
@@ -43,7 +43,7 @@ def upgrade():
         op.create_index(op.f('ix_subscription_application'), 'subscription', ['application'], unique=False)
         op.create_index(op.f('ix_subscription_id'), 'subscription', ['id'], unique=False)
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Table subscription already exists.")
         else:
             print("Table subscription exists")

--- a/migrations/versions/37e6b49fc686_.py
+++ b/migrations/versions/37e6b49fc686_.py
@@ -43,7 +43,7 @@ def upgrade():
         op.create_index(op.f('ix_subscription_application'), 'subscription', ['application'], unique=False)
         op.create_index(op.f('ix_subscription_id'), 'subscription', ['id'], unique=False)
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Table subscription already exists.")
         else:
             print("Table subscription exists")

--- a/migrations/versions/3ae3c668f444_.py
+++ b/migrations/versions/3ae3c668f444_.py
@@ -28,7 +28,7 @@ def upgrade():
         sa.UniqueConstraint('eventhandler_id', 'Key', name='ehcix_1')
         )
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Table eventhandlercondition already exists.")
         else:
             print("Table already exists")

--- a/migrations/versions/3ae3c668f444_.py
+++ b/migrations/versions/3ae3c668f444_.py
@@ -28,7 +28,7 @@ def upgrade():
         sa.UniqueConstraint('eventhandler_id', 'Key', name='ehcix_1')
         )
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Table eventhandlercondition already exists.")
         else:
             print("Table already exists")

--- a/migrations/versions/3c6e9dd7fbac_.py
+++ b/migrations/versions/3c6e9dd7fbac_.py
@@ -30,7 +30,7 @@ def upgrade():
         op.create_index(op.f('ix_clientapplication_id'), 'clientapplication', ['id'], unique=False)
         op.create_index(op.f('ix_clientapplication_ip'), 'clientapplication', ['ip'], unique=False)
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Table clientapplication already exists.")
         else:
             print("Table already exists")

--- a/migrations/versions/3c6e9dd7fbac_.py
+++ b/migrations/versions/3c6e9dd7fbac_.py
@@ -30,7 +30,7 @@ def upgrade():
         op.create_index(op.f('ix_clientapplication_id'), 'clientapplication', ['id'], unique=False)
         op.create_index(op.f('ix_clientapplication_ip'), 'clientapplication', ['ip'], unique=False)
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Table clientapplication already exists.")
         else:
             print("Table already exists")

--- a/migrations/versions/3f7e8583ea2_.py
+++ b/migrations/versions/3f7e8583ea2_.py
@@ -21,7 +21,7 @@ def upgrade():
             length=64), default=u""))
         op.add_column('eventhandler', sa.Column('active', sa.Boolean(), nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Columns name and active already exist.")
         else:
             print("Columns name and active already exist.")

--- a/migrations/versions/3f7e8583ea2_.py
+++ b/migrations/versions/3f7e8583ea2_.py
@@ -21,7 +21,7 @@ def upgrade():
             length=64), default=u""))
         op.add_column('eventhandler', sa.Column('active', sa.Boolean(), nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Columns name and active already exist.")
         else:
             print("Columns name and active already exist.")

--- a/migrations/versions/4023571658f8_.py
+++ b/migrations/versions/4023571658f8_.py
@@ -33,7 +33,7 @@ def upgrade():
         op.create_index(op.f('ix_passwordreset_username'), 'passwordreset',
                         ['username'], unique=False)
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Table passwordreset already exists.")
         else:
             print(exx)

--- a/migrations/versions/4023571658f8_.py
+++ b/migrations/versions/4023571658f8_.py
@@ -33,7 +33,7 @@ def upgrade():
         op.create_index(op.f('ix_passwordreset_username'), 'passwordreset',
                         ['username'], unique=False)
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Table passwordreset already exists.")
         else:
             print(exx)

--- a/migrations/versions/449903fb6e35_.py
+++ b/migrations/versions/449903fb6e35_.py
@@ -29,7 +29,7 @@ def upgrade():
         sa.UniqueConstraint('identifier')
         )
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Table 'radiusserver' already exists.")
         else:
             print(exx)

--- a/migrations/versions/449903fb6e35_.py
+++ b/migrations/versions/449903fb6e35_.py
@@ -29,7 +29,7 @@ def upgrade():
         sa.UniqueConstraint('identifier')
         )
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Table 'radiusserver' already exists.")
         else:
             print(exx)

--- a/migrations/versions/4d9178fa8336_.py
+++ b/migrations/versions/4d9178fa8336_.py
@@ -21,7 +21,7 @@ def upgrade():
                                           sa.Unicode(length=256),
                                           nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Column adminrealm already exists.")
         else:
             print(exx)

--- a/migrations/versions/4d9178fa8336_.py
+++ b/migrations/versions/4d9178fa8336_.py
@@ -21,7 +21,7 @@ def upgrade():
                                           sa.Unicode(length=256),
                                           nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Column adminrealm already exists.")
         else:
             print(exx)

--- a/migrations/versions/50adc980d625_.py
+++ b/migrations/versions/50adc980d625_.py
@@ -38,7 +38,7 @@ def upgrade():
         sa.UniqueConstraint('eventhandler_id', 'Key', name='ehoix_1')
         )
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Table 'eventhandler' already exists.")
         else:
             print(exx)

--- a/migrations/versions/50adc980d625_.py
+++ b/migrations/versions/50adc980d625_.py
@@ -38,7 +38,7 @@ def upgrade():
         sa.UniqueConstraint('eventhandler_id', 'Key', name='ehoix_1')
         )
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Table 'eventhandler' already exists.")
         else:
             print(exx)

--- a/migrations/versions/5402fd96fbca_.py
+++ b/migrations/versions/5402fd96fbca_.py
@@ -37,7 +37,7 @@ def upgrade():
         )
         op.create_index(op.f('ix_smsgatewayoption_gateway_id'), 'smsgatewayoption', ['gateway_id'], unique=False)
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Table smsgateway already exists.")
         else:
             print("Table already exists")

--- a/migrations/versions/5402fd96fbca_.py
+++ b/migrations/versions/5402fd96fbca_.py
@@ -37,7 +37,7 @@ def upgrade():
         )
         op.create_index(op.f('ix_smsgatewayoption_gateway_id'), 'smsgatewayoption', ['gateway_id'], unique=False)
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Table smsgateway already exists.")
         else:
             print("Table already exists")

--- a/migrations/versions/e5cbeb7c177_.py
+++ b/migrations/versions/e5cbeb7c177_.py
@@ -20,7 +20,7 @@ def upgrade():
         op.add_column('resolverrealm', sa.Column('priority', sa.Integer(),
                                                  nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.args[0].lower().startswith("duplicate column name"):
+        if "duplicate column name" in str(exx.orig).lower():
             print("Good. Column priority already exists.")
         else:
             print(exx)

--- a/migrations/versions/e5cbeb7c177_.py
+++ b/migrations/versions/e5cbeb7c177_.py
@@ -20,7 +20,7 @@ def upgrade():
         op.add_column('resolverrealm', sa.Column('priority', sa.Integer(),
                                                  nullable=True))
     except (OperationalError, ProgrammingError, InternalError) as exx:
-        if exx.orig.message.lower().startswith("duplicate column name"):
+        if exx.orig.args[0].lower().startswith("duplicate column name"):
             print("Good. Column priority already exists.")
         else:
             print(exx)


### PR DESCRIPTION
The necessary changes are due to the "new" ``except ... as`` syntax, and due to the missing ``message`` attribute for Exceptions. The alternative ``args[0]`` should work under both Python 2 and 3. 