### PR TITLE
Set mysql_row_format=DYNAMIC for tokenowner table

### DIFF
--- a/migrations/versions/48ee74b8a7c8_.py
+++ b/migrations/versions/48ee74b8a7c8_.py
@@ -71,7 +71,8 @@ def upgrade():
         sa.Column('realm_id', sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(['realm_id'], ['realm.id'], ),
         sa.ForeignKeyConstraint(['token_id'], ['token.id'], ),
-        sa.PrimaryKeyConstraint('id')
+        sa.PrimaryKeyConstraint('id'),
+        mysql_row_format='DYNAMIC'
         )
         op.create_index(op.f('ix_tokenowner_resolver'), 'tokenowner', ['resolver'], unique=False)
         op.create_index(op.f('ix_tokenowner_user_id'), 'tokenowner', ['user_id'], unique=False)

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -1056,6 +1056,7 @@ class TokenOwner(MethodsMixin, db.Model):
     A token can be assigned to several users.
     """
     __tablename__ = 'tokenowner'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer(), Sequence("tokenowner_seq"), primary_key=True)
     token_id = db.Column(db.Integer(), db.ForeignKey('token.id'))
     resolver = db.Column(db.Unicode(120), default=u'', index=True)


### PR DESCRIPTION
Otherwise, we cannot create an index on user_id using the utf8mb4 charset on MariaDB 10.0.36.

We already talked about the row format of the tokenowner table [here](https://github.com/privacyidea/privacyidea/pull/1368/files#r257252508), but as it turns out, I had a slight misconception: In the ``utf8mb4`` charset, every character in ``user_id`` actually takes 4 bytes, which means that the index on ``user_id`` requires a column size of ``320 * 4 = 1280`` bytes, which exceeds the limit of 767 size.

Thus, ``pi-manage createdb`` fails on my Ubuntu 16.04 with MariaDB 10.0.36:
```
sqlalchemy.exc.OperationalError: (_mysql_exceptions.OperationalError) (1709, 'Index column size too large. The maximum column size is 767 bytes.') [SQL: u'CREATE INDEX ix_tokenowner_user_id ON tokenowner (user_id)'] (Background on this error at: http://sqlalche.me/e/e3q8)
```
Likewise, he migration script cannot create the index and prints
```
(_mysql_exceptions.OperationalError) (1709, 'Index column size too large. The maximum column size is 767 bytes.') [SQL: u'CREATE INDEX ix_tokenowner_user_id ON tokenowner (user_id)'] (Background on this error at: http://sqlalche.me/e/e3q8)
```
... but this message is suppressed by ``privacyidea-schema-upgrade``.

So this PR sets ``mysql_row_format=DYNAMIC`` for the tokenowner table to fix this issue.