### PR TITLE
Add oauth depenency

### DIFF
--- a/deploy/debian-ubuntu/control
+++ b/deploy/debian-ubuntu/control
@@ -9,7 +9,7 @@ Package: python-privacyidea
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-flask-migrate, python-qrcode, python-netaddr,
  python-pyrad, python-yaml, python-configobj, python-bs4, python-pandas, python-matplotlib, python-ecdsa, python-gnupg, python-openssl,
- python-dateutil, python-croniter
+ python-dateutil, python-croniter, python-oauth2client
 Replaces: privacyidea (<< 2.0)
 Breaks: privacyidea (<< 2.0)
 X-Python-Version: >= 2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ mock==2.0.0
 netaddr==0.7.19
 nose==1.3.7
 numpy==1.14.3
+oauth2client>=2.0.1
 passlib==1.7.1
 Pillow==5.1.0
 psycopg2>=2.6

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ install_requires = ["Flask>=0.10.1",
                     "python-gnupg>=0.3.8",
                     "defusedxml>=0.4.1",
                     "flask-babel>=0.9",
-                    "croniter>=0.3.8"
+                    "croniter>=0.3.8",
+                    "oauth2client>=2.0.1"
                     ]
 
 # For python 2.6 we need additional dependency importlib


### PR DESCRIPTION
We need the python-oauth2client for the Firebase SMS provder a.k.a. Push
Token.

This is also available on Ubuntu 16.04 for python 2.7.
The version in Ubuntu 14.04 is too old.
But users with 14.04 should upgrade to 16.04 anyways.