### PR TITLE
Patch for Integer userids when using SQLIdResolver

### DIFF
--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -39,6 +39,7 @@ from privacyidea.lib.resolvers.UserIdResolver import UserIdResolver
 
 from sqlalchemy import and_
 from sqlalchemy import create_engine
+from sqlalchemy import Integer
 from sqlalchemy.orm import sessionmaker, scoped_session
 
 import traceback
@@ -336,8 +337,7 @@ class IdResolver (UserIdResolver):
 
         try:
             conditions = []
-            column = self.map.get("userid")
-            conditions.append(getattr(self.TABLE, column).like(userId))
+            conditions.append(self._get_userid_filter(userId))
             conditions = self._append_where_filter(conditions, self.TABLE,
                                                    self.where)
             filter_condition = and_(*conditions)
@@ -351,6 +351,13 @@ class IdResolver (UserIdResolver):
             log.error("Could not get the userinformation: {0!r}".format(exx))
 
         return userinfo
+    
+    def _get_userid_filter(self, userId):
+        column = getattr(self.TABLE, self.map.get("userid"))
+        if isinstance(column.type, Integer):
+            return column == userId
+        else:
+            return column.like(userId)
 
     def getUsername(self, userId):
         """
@@ -720,8 +727,7 @@ class IdResolver (UserIdResolver):
         res = True
         try:
             conditions = []
-            column = self.map.get("userid")
-            conditions.append(getattr(self.TABLE, column).like(uid))
+            conditions.append(self._get_userid_filter(uid))
             conditions = self._append_where_filter(conditions, self.TABLE,
                                                    self.where)
             filter_condition = and_(*conditions)

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -514,6 +514,14 @@ class SQLResolverTestCase(MyTestCase):
 
         # rid1 != rid4, because the pool size has changed
         self.assertNotEqual(rid1, rid4)
+    
+    def test_08_noninteger_userid(self):
+        y = SQLResolver()
+        y.loadConfig(self.parameters)
+        y.map["userid"] = "username"
+        user = "cornelius"
+        user_id = y.getUserId(user)
+        self.assertTrue(user_id == 3, user_id)
 
     def test_99_testconnection_fail(self):
         y = SQLResolver()

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -520,8 +520,8 @@ class SQLResolverTestCase(MyTestCase):
         y.loadConfig(self.parameters)
         y.map["userid"] = "username"
         user = "cornelius"
-        user_id = y.getUserId(user)
-        self.assertTrue(user_id == 3, user_id)
+        user_info = y.getUserInfo(user)
+        self.assertEqual(user_info.get("id"), "cornelius")      
 
     def test_99_testconnection_fail(self):
         y = SQLResolver()


### PR DESCRIPTION
SQLIdResolver currently assumes all userId's will work with the sqlalchemy `like` filter.   This breaks Postgres when the userId is an Integer as Postgres does not allow Integers to be compared with string operators.  This patch defines a new private method that determines if the appropriate filter to build should use the `like` pragram or the direct equivalency pragram of sqlalchemy and return that filter for addition in the conditions array.  Replaced both instances of the `like` assumption that mattered with a call to this function. works as expected for my use case.
See https://github.com/privacyidea/privacyidea/issues/1513 for more info.

Closes #1513 