### PR TITLE
Allow to not check SSL for push token

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1299,6 +1299,8 @@ def pushtoken_add_config(request, action):
         )
         if len(ssl_verify) == 1:
             request.all_data[PUSH_ACTION.SSL_VERIFY] = list(ssl_verify)[0]
+        else:
+            request.all_data[PUSH_ACTION.SSL_VERIFY] = "1"
 
 
 def u2ftoken_verify_cert(request, action):

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1254,7 +1254,7 @@ def pushtoken_add_config(request, action):
     This is a token specific wrapper for push token for the endpoint
     /token/init
     According to the policy scope=SCOPE.ENROLL,
-    action=TTL or action=REGISTRATION_URL the parameters are added to the
+    action=SSL_VERIFY_NO or action=FIREBASE_CONFIG the parameters are added to the
     enrollment step.
     :param request:
     :param action:
@@ -1271,7 +1271,7 @@ def pushtoken_add_config(request, action):
             token_resolver = user_object.resolver
         else:
             token_realm = token_resolver = token_user = None
-        # Get the TTL and the Registration URL from the configs
+        # Get the firebase configuration from the policies
         firebase_config = g.policy_object.get_action_values(
             action=PUSH_ACTION.FIREBASE_CONFIG,
             scope=SCOPE.ENROLL,
@@ -1286,6 +1286,19 @@ def pushtoken_add_config(request, action):
         else:
             raise PolicyError("Missing enrollment policy for push token: {0!s}".format(PUSH_ACTION.FIREBASE_CONFIG))
 
+        # Get the sslverify definition from the policies
+        ssl_verify = g.policy_object.get_action_values(
+            action=PUSH_ACTION.SSL_VERIFY,
+            scope=SCOPE.ENROLL,
+            realm=token_realm,
+            user=token_user,
+            resolver=token_resolver,
+            client=g.client_ip,
+            audit_data=g.audit_object.audit_data,
+            unique=True
+        )
+        if len(ssl_verify) == 1:
+            request.all_data[PUSH_ACTION.SSL_VERIFY] = list(ssl_verify)[0]
 
 
 def u2ftoken_verify_cert(request, action):

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1254,7 +1254,7 @@ def pushtoken_add_config(request, action):
     This is a token specific wrapper for push token for the endpoint
     /token/init
     According to the policy scope=SCOPE.ENROLL,
-    action=SSL_VERIFY_NO or action=FIREBASE_CONFIG the parameters are added to the
+    action=SSL_VERIFY or action=FIREBASE_CONFIG the parameters are added to the
     enrollment step.
     :param request:
     :param action:

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -47,7 +47,7 @@ optional = True
 required = False
 
 
-def getParam(param, key, optional=True, default=None, allow_empty=True):
+def getParam(param, key, optional=True, default=None, allow_empty=True, allowed_values=None):
     """
     returns a parameter from the request parameters.
     
@@ -62,6 +62,8 @@ def getParam(param, key, optional=True, default=None, allow_empty=True):
                     contained in the param.
     :param allow_empty: Set to False is the parameter is a string and is
         not allowed to be empty
+    :param allowed_values: A list of allowed values. If another value is given,
+        then the default value is returned
     :type allow_empty: bool
     
     :return: the value (literal) of the parameter if exists or nothing
@@ -78,6 +80,9 @@ def getParam(param, key, optional=True, default=None, allow_empty=True):
 
     if not allow_empty and ret == "":
         raise ParameterError("Parameter {0!r} must not be empty".format(key), id=905)
+
+    if allowed_values and ret not in allowed_values:
+            ret = default
 
     return ret
 

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -323,7 +323,7 @@ class PushTokenClass(TokenClass):
         user = user or User()
         tokenlabel = params.get("tokenlabel", "<s>")
         tokenissuer = params.get("tokenissuer", "privacyIDEA")
-        sslverify = params.get(PUSH_ACTION.SSL_VERIFY, "1")
+        sslverify = getParam(params, PUSH_ACTION.SSL_VERIFY, allowed_values=["0", "1"], default="1")
         # Add rollout state the response
         response_detail['rollout_state'] = self.token.rollout_state
 
@@ -493,6 +493,7 @@ class PushTokenClass(TokenClass):
         sslverify = get_action_values_from_options(SCOPE.AUTH,
                                                    PUSH_ACTION.SSL_VERIFY,
                                                    options) or "1"
+        sslverify = getParam({"sslverify": sslverify}, "sslverify", allowed_values=["0", "1"], default="1")
 
         attributes = None
         data = None

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1347,7 +1347,15 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
             "type": "push"}
         pushtoken_add_config(req, "init")
         self.assertEqual(req.all_data.get(PUSH_ACTION.FIREBASE_CONFIG), "some-fb-config")
-        self.assertEqual(None, req.all_data.get(PUSH_ACTION.SSL_VERIFY))
+        self.assertEqual("1", req.all_data.get(PUSH_ACTION.SSL_VERIFY))
+
+        # the request tries to inject a rogue value, but we assure sslverify=1
+        g.policy_object = PolicyClass()
+        req.all_data = {
+            "type": "push",
+            "sslverify": "rogue"}
+        pushtoken_add_config(req, "init")
+        self.assertEqual("1", req.all_data.get(PUSH_ACTION.SSL_VERIFY))
 
         # set sslverify="0"
         set_policy(name="push_pol2",
@@ -1362,6 +1370,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
 
         # finally delete policy
         delete_policy("push_pol")
+        delete_policy("push_pol2")
 
 
 class PostPolicyDecoratorTestCase(MyApiTestCase):

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1347,6 +1347,18 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
             "type": "push"}
         pushtoken_add_config(req, "init")
         self.assertEqual(req.all_data.get(PUSH_ACTION.FIREBASE_CONFIG), "some-fb-config")
+        self.assertEqual(None, req.all_data.get(PUSH_ACTION.SSL_VERIFY))
+
+        # set sslverify="0"
+        set_policy(name="push_pol2",
+                   scope=SCOPE.ENROLL,
+                   action="{0!s}=0".format(PUSH_ACTION.SSL_VERIFY))
+        g.policy_object = PolicyClass()
+        req.all_data = {
+            "type": "push"}
+        pushtoken_add_config(req, "init")
+        self.assertEqual(req.all_data.get(PUSH_ACTION.FIREBASE_CONFIG), "some-fb-config")
+        self.assertEqual("0", req.all_data.get(PUSH_ACTION.SSL_VERIFY))
 
         # finally delete policy
         delete_policy("push_pol")

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -15,3 +15,13 @@ class UtilsTestCase(MyApiTestCase):
         self.assertEqual(s, "")
 
         self.assertRaises(ParameterError, getParam, {"serial": ""}, "serial", optional=False, allow_empty=False)
+
+        # check for allowed values
+        v = getParam({"sslverify": "0"}, "sslverify", allowed_values=["0", "1"], default="1")
+        self.assertEqual("0", v)
+
+        v = getParam({"sslverify": "rogue value"}, "sslverify", allowed_values=["0", "1"], default="1")
+        self.assertEqual("1", v)
+
+        v = getParam({}, "sslverify", allowed_values=["0", "1"], default="1")
+        self.assertEqual("1", v)

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -362,7 +362,7 @@ class PushTokenTestCase(MyTestCase):
             # check the signature in the payload!
             data = payload.get("message").get("data")
 
-            sign_string = u"{nonce}|{url}|{serial}|{question}|{title}".format(**data)
+            sign_string = u"{nonce}|{url}|{serial}|{question}|{title}|{sslverify}".format(**data)
             token_obj = get_tokens(serial=data.get("serial"))[0]
             pem_pubkey = token_obj.get_tokeninfo(PUBLIC_KEY_SERVER)
             pubkey_obj = load_pem_public_key(to_bytes(pem_pubkey), backend=default_backend())


### PR DESCRIPTION
An enrollment policy and auth policy can define,
if the smartphone does not need to verify the SSL
certificte.

Closes #1534