### PR TITLE
Allow a deterministic installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,8 @@ setup(
                   "migrations/README",
                   "migrations/script.py.mako"]),
                 ('lib/privacyidea/migrations/versions',
-                 get_file_list("migrations/versions/"))
+                 get_file_list("migrations/versions/")),
+                ('lib/privacyidea/', ['requirements.txt'])
                 ],
     classifiers=["Framework :: Flask",
                  "License :: OSI Approved :: "


### PR DESCRIPTION
We add the requirements.txt to the privacyidea package,
so that it is possible to run

   pip install lib/privacyidea/requirements.txt

after the initial installation.

Closes #1127