### PR TITLE
Restore correct datetime formatting in audit logs

### DIFF
--- a/privacyidea/static/components/audit/controllers/auditControllers.js
+++ b/privacyidea/static/components/audit/controllers/auditControllers.js
@@ -25,11 +25,12 @@
 myApp.controller("auditController", function (AuditFactory, $scope,
                                               $stateParams, $http,
                                               AuthFactory, instanceUrl,
-                                              $location) {
+                                              $location, gettextCatalog) {
     $scope.params = {sortorder: "desc",
                      page_size: 10,
                      page: 1};
     $scope.instanceUrl = instanceUrl;
+    $scope.dateFormat = gettextCatalog.getString("M/d/yy HH:mm:ss");
 
     // If the state is called with some filter values
     if ($stateParams.serial) {


### PR DESCRIPTION
This commit re-adds time information to the Audit log WebUI view.
By accident we removed the ``dateFormat`` variable in d2c62aba983694d5c393c85532d9ccfcf6ba84cf, which causes Angular to fallback to formatting datetimes without dates.