### PR TITLE
Fix Unicode error in audit log

### DIFF
--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -488,7 +488,7 @@ class Audit(AuditBase):
                 #  audit_entry, we will get issues when packing the response.
                 log.warning('Could not verify log entry! We get invalid values '
                             'from the database, please check the encoding.')
-                log.debug('{0!s'.format(traceback.format_exc()))
+                log.debug('{0!s}'.format(traceback.format_exc()))
 
         is_not_missing = self._check_missing(int(audit_entry.id))
         # is_not_missing = True

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2513,26 +2513,26 @@ class Audit(MethodsMixin, db.Model):
     __table_args__ = {'mysql_row_format': 'DYNAMIC'}
     id = db.Column(db.Integer, Sequence("audit_seq"), primary_key=True)
     date = db.Column(db.DateTime)
-    signature = db.Column(db.String(audit_column_length.get("signature")))
-    action = db.Column(db.String(audit_column_length.get("action")))
+    signature = db.Column(db.Unicode(audit_column_length.get("signature")))
+    action = db.Column(db.Unicode(audit_column_length.get("action")))
     success = db.Column(db.Integer)
-    serial = db.Column(db.String(audit_column_length.get("serial")))
-    token_type = db.Column(db.String(audit_column_length.get("token_type")))
-    user = db.Column(db.String(audit_column_length.get("user")), index=True)
-    realm = db.Column(db.String(audit_column_length.get("realm")))
-    resolver = db.Column(db.String(audit_column_length.get("resolver")))
+    serial = db.Column(db.Unicode(audit_column_length.get("serial")))
+    token_type = db.Column(db.Unicode(audit_column_length.get("token_type")))
+    user = db.Column(db.Unicode(audit_column_length.get("user")), index=True)
+    realm = db.Column(db.Unicode(audit_column_length.get("realm")))
+    resolver = db.Column(db.Unicode(audit_column_length.get("resolver")))
     administrator = db.Column(
-        db.String(audit_column_length.get("administrator")))
+        db.Unicode(audit_column_length.get("administrator")))
     action_detail = db.Column(
-        db.String(audit_column_length.get("action_detail")))
-    info = db.Column(db.String(audit_column_length.get("info")))
+        db.Unicode(audit_column_length.get("action_detail")))
+    info = db.Column(db.Unicode(audit_column_length.get("info")))
     privacyidea_server = db.Column(
-        db.String(audit_column_length.get("privacyidea_server")))
-    client = db.Column(db.String(audit_column_length.get("client")))
-    loglevel = db.Column(db.String(audit_column_length.get("loglevel")))
-    clearance_level = db.Column(db.String(audit_column_length.get(
+        db.Unicode(audit_column_length.get("privacyidea_server")))
+    client = db.Column(db.Unicode(audit_column_length.get("client")))
+    loglevel = db.Column(db.Unicode(audit_column_length.get("loglevel")))
+    clearance_level = db.Column(db.Unicode(audit_column_length.get(
         "clearance_level")))
-    policies = db.Column(db.String(audit_column_length.get("policies")))
+    policies = db.Column(db.Unicode(audit_column_length.get("policies")))
 
     def __init__(self,
                  action="",


### PR DESCRIPTION
When using mysql with the audit log, there is an issue if one of the
columns of an entry contains non ascii symbols.
To avoid writing invalid data to mysql, the column types in the SQLAlchemy
model need to be set to `Unicode`.
Some possible regressions need to be caught when updating the code.

fixes #1560