### PR TITLE
Fix IE11 rendering issue with 3.0

### DIFF
--- a/privacyidea/static/components/login/factories/u2f.js
+++ b/privacyidea/static/components/login/factories/u2f.js
@@ -65,7 +65,8 @@ angular.module("privacyideaAuth")
                     var appId = signRequests[0].appId;
                     var challenge = signRequests[0].challenge;
                     var registeredKeys = [];
-                    for (let signRequest of signRequests) {
+                    for (var i = 0; i < signRequests.length; i++) {
+                        var signRequest = signRequests[i];
                         registeredKeys.push({
                             version: signRequest.version,
                             keyHandle: signRequest.keyHandle


### PR DESCRIPTION
IE11 is still used in many corporate environments and does not render the WebUI due to an unsupported for..of loop.  Replaced for..of loop with simple iterative loop.