### PR TITLE
Add a parameter "serial" to the PUSH enrollment URL

### DIFF
--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -343,6 +343,7 @@ class PushTokenClass(TokenClass):
                 extra_data[k] = fb_options.get(k)
             # this allows to upgrade our crypto
             extra_data["v"] = 1
+            extra_data["serial"] = self.get_serial()
             extra_data["sslverify"] = sslverify
             # We display this during the first enrollment step!
             qr_url = create_push_token_url(url=fb_options.get(FIREBASE_CONFIG.REGISTRATION_URL),

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -167,6 +167,8 @@ class PushTokenTestCase(MyTestCase):
             serial = detail.get("serial")
             self.assertEqual(detail.get("rollout_state"), "clientwait")
             self.assertTrue("pushurl" in detail)
+            # check that the new URL contains the serial number
+            self.assertTrue("&serial=PIPU" in detail.get("pushurl").get("value"))
             self.assertFalse("otpkey" in detail)
             enrollment_credential = detail.get("enrollment_credential")
 


### PR DESCRIPTION
The PUSH enrollment URL needs the *real* serial number,
if a policy changes the label.
In contrast to HOTP or TOTP tokens, the PUSH token needs the
realm serial number to communicate with privacyIDEA.

Closes #1589