### PR TITLE
Default usercache time to 0 seconds

### DIFF
--- a/privacyidea/lib/usercache.py
+++ b/privacyidea/lib/usercache.py
@@ -70,7 +70,12 @@ def get_cache_time():
     :return: UserCacheExpiration config value as a timedelta
     :rtype: timedelta
     """
-    seconds = int(get_from_config(EXPIRATION_SECONDS, '0'))
+    seconds = 0
+    try:
+        seconds = int(get_from_config(EXPIRATION_SECONDS, '0'))
+    except:
+        log.info(u"Non-Integer value stored in system config {0!s}".format(EXPIRATION_SECONDS))
+
     return datetime.timedelta(seconds=seconds)
 
 

--- a/privacyidea/lib/usercache.py
+++ b/privacyidea/lib/usercache.py
@@ -73,7 +73,7 @@ def get_cache_time():
     seconds = 0
     try:
         seconds = int(get_from_config(EXPIRATION_SECONDS, '0'))
-    except:
+    except ValueError:
         log.info(u"Non-Integer value stored in system config {0!s}".format(EXPIRATION_SECONDS))
 
     return datetime.timedelta(seconds=seconds)

--- a/tests/test_lib_usercache.py
+++ b/tests/test_lib_usercache.py
@@ -71,8 +71,20 @@ class UserCacheTestCase(MyTestCase):
         delete_resolver(self.resolvername1)
 
     def test_00_set_config(self):
-        set_privacyidea_config(EXPIRATION_SECONDS, 600)
+        # Save wrong data in EXPIRATION_SECONDS
+        set_privacyidea_config(EXPIRATION_SECONDS, "wrong")
+        exp_delta = get_cache_time()
+        self.assertEqual(exp_delta, timedelta(seconds=0))
+        self.assertFalse(is_cache_enabled())
 
+        # Save empty data in EXPIRATION_SECONDS
+        set_privacyidea_config(EXPIRATION_SECONDS, "")
+        exp_delta = get_cache_time()
+        self.assertEqual(exp_delta, timedelta(seconds=0))
+        self.assertFalse(is_cache_enabled())
+
+        # Save real data in EXPIRATION_SECONDS
+        set_privacyidea_config(EXPIRATION_SECONDS, 600)
         exp_delta = get_cache_time()
         self.assertEqual(exp_delta, timedelta(seconds=600))
         self.assertTrue(is_cache_enabled())


### PR DESCRIPTION
If invalid data is saved in the usercase timeout,
we default to 0.

Fix #1596