### PR TITLE
Change the enrolled text for PUSH token

### DIFF
--- a/privacyidea/static/components/token/views/token.enrolled.push.html
+++ b/privacyidea/static/components/token/views/token.enrolled.push.html
@@ -1,7 +1,7 @@
 <div class="row">
     <div class="col-sm-6" ng-show="enrolledToken.rollout_state === 'enrolled'">
         <p translate>
-            Congratulations. Your PUSH token {{ enrolledToken.serial }} was successfully enrolled.
+            Please note, that your smartphone needs internet access during the authentication process.
         </p>
     </div>
     <div class="col-sm-6" ng-show="enrolledToken.rollout_state === 'clientwait'">


### PR DESCRIPTION
We do not need the information about the serial number,
since it is contained in the generic text.
So we add an information, that internet access is required.

Closes #1598