### PR TITLE
Fix logic of auth counters and registration token

### DIFF
--- a/doc/configuration/system_config.rst
+++ b/doc/configuration/system_config.rst
@@ -72,7 +72,8 @@ clear the failcounter again:
 
 * A successful authentication with correct PIN and correct OTP value
 * A successfully triggered challenge (Usually this means a correct PIN)
-* An authentication with a correct PIN, but a wrong OTP value
+* An authentication with a correct PIN, but a wrong OTP value (Only if
+  :ref:`reset_failcounter_on_correct_pin` is set).
 
 A "0" means automatically clearing the fail counter is not used.
 
@@ -80,6 +81,9 @@ A "0" means automatically clearing the fail counter is not used.
    update the mentioned timestamp.
 
 Also see :ref:`brute_force`.
+
+
+.. _reset_failcounter_on_correct_pin:
 
 Resetting Failcounter on correct PIN
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration/system_config.rst
+++ b/doc/configuration/system_config.rst
@@ -81,6 +81,19 @@ A "0" means automatically clearing the fail counter is not used.
 
 Also see :ref:`brute_force`.
 
+Resetting Failcounter on correct PIN
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the above mentioned timeout the failcounter is reset by a successful
+authentication (correct PIN and OTP value) or by the correct PIN of a challenge
+response token.
+
+It can be also reset by the correct PIN of any token, when setting
+``ResetFailcounterOnPIN`` to True.
+The default behaviour is, that the correct PIN of a normal token will *not*
+reset the failcounter after the clearing timeout.
+
+
 Prepend PIN
 ~~~~~~~~~~~
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1280,6 +1280,7 @@ def pushtoken_add_config(request, action):
             resolver=token_resolver,
             client=g.client_ip,
             audit_data=g.audit_object.audit_data,
+            allow_white_space_in_action=True,
             unique=True)
         if len(firebase_config) == 1:
             request.all_data[PUSH_ACTION.FIREBASE_CONFIG] = list(firebase_config)[0]

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -212,6 +212,7 @@ class SYSCONF(object):
     SPLITATSIGN = "splitAtSign"
     INCFAILCOUNTER = "IncFailCountOnFalsePin"
     RETURNSAML = "ReturnSamlAttributes"
+    RESET_FAILCOUNTER_ON_PIN_ONLY = "ResetFailcounterOnPIN"
 
 
 #@cache.cached(key_prefix="allConfig")

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -47,6 +47,7 @@ SMS_PROVIDERS = [
     "privacyidea.lib.smsprovider.SmppSMSProvider.SmppSMSProvider",
     "privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider"]
 
+
 class SMSError(Exception):
     def __init__(self, error_id, description):
         Exception.__init__(self)
@@ -89,6 +90,14 @@ class ISMSProvider(object):
         :rtype: bool
         """
         return True
+
+    def check_configuration(self):
+        """
+        This method checks the sanity of the configuration of this provider.
+        If there is a configuration error, than an exception is raised.
+        :return:
+        """
+        return
 
     @classmethod
     def parameters(cls):
@@ -170,6 +179,7 @@ def set_smsgateway(identifier, providermodule, description=None,
     smsgateway = SMSGateway(identifier, providermodule,
                             description=description,
                             options=options)
+    create_sms_instance(identifier).check_configuration()
     return smsgateway.id
 
 

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2264,8 +2264,7 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         # So we increase the failcounter. Return failure.
         for tokenobject in pin_matching_token_list:
             tokenobject.inc_failcount()
-            if get_from_config(SYSCONF.RESET_FAILCOUNTER_ON_PIN_ONLY, False, return_bool=True):  # pragma: no cover
-                tokenobject.check_reset_failcount()
+            tokenobject.check_reset_failcount()
             reply_dict["message"] = "wrong otp value"
             if len(pin_matching_token_list) == 1:
                 # If there is only one pin matching token, we look if it was

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2160,12 +2160,14 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         message_list = ["matching {0:d} tokens".format(len(valid_token_list))]
         # write serial numbers or something to audit log
         for token_obj in valid_token_list:
-            if increase_auth_counters:
-                token_obj.inc_count_auth_success()
-            # Reset the failcounter, if there is a timeout set
-            token_obj.check_reset_failcount()
-            # Check if the max auth is succeeded
-            if token_obj.check_all(message_list):
+            # Check if the max auth is succeeded.
+            # We need to set the offsets, since we are in the n+1st authentication.
+            if token_obj.check_all(message_list, offset=1, offset_success=1):
+                if increase_auth_counters:
+                    token_obj.inc_count_auth_success()
+                # Reset the failcounter, if there is a timeout set
+                token_obj.check_reset_failcount()
+
                 # The token is active and the auth counters are ok.
                 res = True
                 if not reply_dict.get("type"):

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -82,7 +82,7 @@ from privacyidea.models import (Token, Realm, TokenRealm, Challenge,
                                 MachineToken, TokenInfo, TokenOwner)
 from privacyidea.lib.config import (get_token_class, get_token_prefix,
                                     get_token_types, get_from_config,
-                                    get_inc_fail_count_on_false_pin)
+                                    get_inc_fail_count_on_false_pin, SYSCONF)
 from privacyidea.lib.user import User
 from privacyidea.lib import _
 from privacyidea.lib.realm import realm_is_defined
@@ -2160,13 +2160,13 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         message_list = ["matching {0:d} tokens".format(len(valid_token_list))]
         # write serial numbers or something to audit log
         for token_obj in valid_token_list:
+            # Reset the failcounter, if there is a timeout set
+            token_obj.check_reset_failcount()
             # Check if the max auth is succeeded.
             # We need to set the offsets, since we are in the n+1st authentication.
             if token_obj.check_all(message_list):
                 if increase_auth_counters:
                     token_obj.inc_count_auth_success()
-                # Reset the failcounter, if there is a timeout set
-                token_obj.check_reset_failcount()
 
                 # The token is active and the auth counters are ok.
                 res = True
@@ -2264,7 +2264,8 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         # So we increase the failcounter. Return failure.
         for tokenobject in pin_matching_token_list:
             tokenobject.inc_failcount()
-            tokenobject.check_reset_failcount()
+            if get_from_config(SYSCONF.RESET_FAILCOUNTER_ON_PIN_ONLY, False, return_bool=True):  # pragma: no cover
+                tokenobject.check_reset_failcount()
             reply_dict["message"] = "wrong otp value"
             if len(pin_matching_token_list) == 1:
                 # If there is only one pin matching token, we look if it was

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2162,7 +2162,7 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         for token_obj in valid_token_list:
             # Check if the max auth is succeeded.
             # We need to set the offsets, since we are in the n+1st authentication.
-            if token_obj.check_all(message_list, offset=1, offset_success=1):
+            if token_obj.check_all(message_list):
                 if increase_auth_counters:
                     token_obj.inc_count_auth_success()
                 # Reset the failcounter, if there is a timeout set

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1055,7 +1055,7 @@ class TokenClass(object):
         """
         return self.token.failcount < self.token.maxfail
 
-    def check_auth_counter(self, offset=0, offset_success=0):
+    def check_auth_counter(self):
         """
         This function checks the count_auth and the count_auth_success.
         If the counters are less or equal than the maximum allowed counters
@@ -1068,10 +1068,10 @@ class TokenClass(object):
         count_auth_max = self.get_count_auth_max()
         count_auth_success = self.get_count_auth_success()
         count_auth_success_max = self.get_count_auth_success_max()
-        if count_auth_max != 0 and count_auth + offset > count_auth_max:
+        if count_auth_max != 0 and count_auth >= count_auth_max:
             return False
 
-        if count_auth_success_max != 0 and count_auth_success + offset_success > count_auth_success_max:
+        if count_auth_success_max != 0 and count_auth_success >= count_auth_success_max:
             return False
 
         return True
@@ -1101,7 +1101,7 @@ class TokenClass(object):
 
         return True
 
-    def check_all(self, message_list, offset=0, offset_success=0):
+    def check_all(self, message_list):
         """
         Perform all checks on the token. Returns False if the token is either:
         * auth counter exceeded
@@ -1116,7 +1116,7 @@ class TokenClass(object):
         """
         r = False
         # Check if the max auth is succeeded
-        if not self.check_auth_counter(offset=offset, offset_success=offset_success):
+        if not self.check_auth_counter():
             message_list.append("Authentication counter exceeded")
         # Check if the token is disabled
         elif not self.is_active():

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1055,23 +1055,23 @@ class TokenClass(object):
         """
         return self.token.failcount < self.token.maxfail
 
-    def check_auth_counter(self):
+    def check_auth_counter(self, offset=0, offset_success=0):
         """
         This function checks the count_auth and the count_auth_success.
-        If the count_auth is less than count_auth_max
-        and count_auth_success is less than count_auth_success_max
+        If the counters are less or equal than the maximum allowed counters
         it returns True. Otherwise False.
         
         :return: success if the counter is less than max
         :rtype: bool
         """
-        if self.get_count_auth_max() != 0 and self.get_count_auth() >= \
-                self.get_count_auth_max():
+        count_auth = self.get_count_auth()
+        count_auth_max = self.get_count_auth_max()
+        count_auth_success = self.get_count_auth_success()
+        count_auth_success_max = self.get_count_auth_success_max()
+        if count_auth_max != 0 and count_auth + offset > count_auth_max:
             return False
 
-        if self.get_count_auth_success_max() != 0 and  \
-                        self.get_count_auth_success() >=  \
-                        self.get_count_auth_success_max():
+        if count_auth_success_max != 0 and count_auth_success + offset_success > count_auth_success_max:
             return False
 
         return True
@@ -1101,7 +1101,7 @@ class TokenClass(object):
 
         return True
 
-    def check_all(self, message_list):
+    def check_all(self, message_list, offset=0, offset_success=0):
         """
         Perform all checks on the token. Returns False if the token is either:
         * auth counter exceeded
@@ -1116,7 +1116,7 @@ class TokenClass(object):
         """
         r = False
         # Check if the max auth is succeeded
-        if not self.check_auth_counter():
+        if not self.check_auth_counter(offset=offset, offset_success=offset_success):
             message_list.append("Authentication counter exceeded")
         # Check if the token is disabled
         elif not self.is_active():

--- a/privacyidea/static/components/config/controllers/smsgatewayController.js
+++ b/privacyidea/static/components/config/controllers/smsgatewayController.js
@@ -81,6 +81,7 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
             }
         }
 
+        delete $scope.form.options;
         ConfigFactory.setSMSGateway($scope.form, function() {
             $state.go("config.smsgateway.list");
             $('html,body').scrollTop(0);

--- a/privacyidea/static/components/login/factories/u2f.js
+++ b/privacyidea/static/components/login/factories/u2f.js
@@ -65,7 +65,8 @@ angular.module("privacyideaAuth")
                     var appId = signRequests[0].appId;
                     var challenge = signRequests[0].challenge;
                     var registeredKeys = [];
-                    for (let signRequest of signRequests) {
+                    for (var i = 0; i < signRequests.length; i++) {
+                        var signRequest = signRequests[i];
                         registeredKeys.push({
                             version: signRequest.version,
                             keyHandle: signRequest.keyHandle

--- a/privacyidea/static/components/token/views/token.enrolled.push.html
+++ b/privacyidea/static/components/token/views/token.enrolled.push.html
@@ -1,7 +1,7 @@
 <div class="row">
     <div class="col-sm-6" ng-show="enrolledToken.rollout_state === 'enrolled'">
         <p translate>
-            Congratulations. Your PUSH token {{ enrolledToken.serial }} was successfully enrolled.
+            Please note, that your smartphone needs internet access during the authentication process.
         </p>
     </div>
     <div class="col-sm-6" ng-show="enrolledToken.rollout_state === 'clientwait'">

--- a/privacyidea/static/css/menu.css
+++ b/privacyidea/static/css/menu.css
@@ -1,0 +1,4 @@
+.navbar-nav .btn-group {
+    padding-top: 7px;
+    padding-bottom: 7px;
+}

--- a/privacyidea/static/templates/header.html
+++ b/privacyidea/static/templates/header.html
@@ -9,9 +9,10 @@
     <link rel="icon" type="image/png" href="{{ instance }}/static/favicon.png">
     <!-- Custom styles for this template -->
     <link href="{{ instance }}/static/css/signin.css" rel="stylesheet">
+    <link href="{{ instance }}/static/css/menu.css" rel="stylesheet">
     <link href="{{ instance }}/static/css/table-ui.css" rel="stylesheet">
-    <link href="{{ instance }}/static/contrib/css/animate.css" rel="stylesheet">
     <link href="{{ instance }}/static/css/navbar-fixed-top.css" rel="stylesheet">
+    <link href="{{ instance }}/static/contrib/css/animate.css" rel="stylesheet">
     <link href="{{ instance }}/static/contrib/css/angular-multi-select.css"
           rel="stylesheet"/>
     <link href="{{ instance }}/static/contrib/css/angular-inform.css"

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -20,7 +20,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
         # create an sms gateway definition
         param = {
             "name": "myGW",
-            "module": "privacyidea.lib.SMS",
+            "module": "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider",
             "description": "myGateway",
             "option.URL": "http://example.com"
         }
@@ -49,14 +49,14 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertEqual(sms_gw.get("name"), "myGW")
             self.assertEqual(sms_gw.get("id"), 1)
             self.assertEqual(sms_gw.get("providermodule"),
-                             "privacyidea.lib.SMS")
+                             "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider")
             self.assertEqual(sms_gw.get("options").get("URL"),
                              "http://example.com")
 
         # update
         param = {
             "name": "myGW",
-            "module": "privacyidea.lib.SMS",
+            "module": "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider",
             "description": "new description",
             "id": 1
         }
@@ -112,7 +112,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
         # create an sms gateway configuration
         param = {
             "name": "myGW",
-            "module": "privacyidea.lib.SMS",
+            "module": "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider",
             "description": "myGateway",
             "option.URL": "http://example.com"
         }

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -69,7 +69,7 @@ class SMSTestCase(MyTestCase):
 
     def test_02_create_modify_delete_smsgateway_configuration(self):
         identifier = "myGW"
-        provider_module = "privacyidea.lib.smsprovider.HTTPSmsPrpvoder"
+        provider_module = "privacyidea.lib.smsprovider.HttpSMSProvider.HttpSMSProvider"
         id = set_smsgateway(identifier, provider_module, description="test",
                             options={"HTTP_METHOD": "POST",
                                      "URL": "example.com"})

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -18,7 +18,7 @@ from privacyidea.lib.user import (User)
 from privacyidea.lib.tokenclass import TokenClass, TOKENKIND, FAILCOUNTER_EXCEEDED, FAILCOUNTER_CLEAR_TIMEOUT
 from privacyidea.lib.tokens.totptoken import TotpTokenClass
 from privacyidea.models import (Token, Challenge, TokenRealm)
-from privacyidea.lib.config import (set_privacyidea_config, get_token_types)
+from privacyidea.lib.config import (set_privacyidea_config, get_token_types, delete_privacyidea_config)
 from privacyidea.lib.policy import set_policy, SCOPE, ACTION, delete_policy
 from privacyidea.lib.utils import b32encode_and_unicode
 import datetime
@@ -1458,26 +1458,6 @@ class TokenTestCase(MyTestCase):
         # Check that we did not miss any tokens
         self.assertEquals(set(t.token.serial for t in list1 + list2), all_serials)
 
-    def test_57_reset_failcounter(self):
-        # Set failcounter clear timeout to 1 minute
-        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 1)
-
-        tokenobject_list = get_tokens()
-
-        # Simulate a HOTP token whose failcounter was exceeded 2 minutes ago
-        hotp_tokenobject = get_tokens(serial="hotptoken")[0]
-        hotp_tokenobject.token.count = 10
-        hotp_tokenobject.set_pin("hotppin")
-        hotp_tokenobject.set_failcount(10)
-        exceeded_timestamp = datetime.datetime.now(tzlocal()) - datetime.timedelta(minutes=1)
-        hotp_tokenobject.add_tokeninfo(FAILCOUNTER_EXCEEDED, exceeded_timestamp.strftime(DATE_FORMAT))
-
-        # OTP value #11
-        res, reply = check_token_list(tokenobject_list, "hotppin481090")
-        self.assertTrue(res)
-
-        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 0)
-
 
 class TokenFailCounterTestCase(MyTestCase):
     """
@@ -1637,3 +1617,59 @@ class TokenFailCounterTestCase(MyTestCase):
         # Clean up
         remove_token(pin1)
         remove_token(pin2)
+
+    def test_05_reset_failcounter(self):
+        tok = init_token({"type": "hotp",
+                          "serial": "test05",
+                          "otpkey": self.otpkey})
+        # Set failcounter clear timeout to 1 minute
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 1)
+        tok.token.count = 10
+        tok.set_pin("hotppin")
+        tok.set_failcount(10)
+        exceeded_timestamp = datetime.datetime.now(tzlocal()) - datetime.timedelta(minutes=1)
+        tok.add_tokeninfo(FAILCOUNTER_EXCEEDED, exceeded_timestamp.strftime(DATE_FORMAT))
+
+        # OTP value #11
+        res, reply = check_token_list([tok], "hotppin481090")
+        self.assertTrue(res)
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 0)
+        remove_token("test05")
+
+    def test_06_reset_failcounter_out_of_sync(self):
+        # Reset fail counter of a token that is out of sync
+        # The fail counter will reset, even if the token is out of sync, since the
+        # autoresync is handled in the tokenclass.authenticate.
+        tok = init_token({"type": "hotp",
+                          "serial": "test06",
+                          "otpkey": self.otpkey})
+
+        set_privacyidea_config("AutoResyncTimeout", "300")
+        set_privacyidea_config("AutoResync", 1)
+
+        tok.set_pin("hotppin")
+        tok.set_count_window(2)
+
+        res, reply = check_token_list([tok], "hotppin{0!s}".format(self.valid_otp_values[0]))
+        self.assertTrue(res)
+
+        # Now we set the failoucnter and the exceeded time.
+        tok.set_failcount(10)
+        exceeded_timestamp = datetime.datetime.now(tzlocal()) - datetime.timedelta(minutes=1)
+        tok.add_tokeninfo(FAILCOUNTER_EXCEEDED, exceeded_timestamp.strftime(DATE_FORMAT))
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 1)
+
+        # authentication with otp value #3 will fail
+        res, reply = check_token_list([tok], "hotppin{0!s}".format(self.valid_otp_values[3]))
+        self.assertFalse(res)
+
+        # authentication with otp value #4 will resync and succeed
+        res, reply = check_token_list([tok], "hotppin{0!s}".format(self.valid_otp_values[4]))
+        self.assertTrue(res)
+        self.assertEqual(tok.get_failcount(), 0)
+
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 0)
+        delete_privacyidea_config("AutoResyncTimeout")
+        delete_privacyidea_config("AutoResync")
+        remove_token("test06")
+

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 PWFILE = "tests/testdata/passwords"
 FIREBASE_FILE = "tests/testdata/firebase-test.json"
+CLIENT_FILE = "tests/testdata/google-services.json"
 
 from .base import MyTestCase
 from privacyidea.lib.error import ParameterError
@@ -14,7 +15,8 @@ from privacyidea.lib.crypto import geturandom
 from privacyidea.models import Token
 from privacyidea.lib.policy import (SCOPE, set_policy)
 from privacyidea.lib.utils import to_bytes, b32encode_and_unicode, to_unicode
-from privacyidea.lib.smsprovider.SMSProvider import set_smsgateway
+from privacyidea.lib.smsprovider.SMSProvider import set_smsgateway, SMSError
+from privacyidea.lib.error import ConfigAdminError
 from base64 import b32decode
 import json
 import responses
@@ -84,14 +86,29 @@ class PushTokenTestCase(MyTestCase):
         # Unknown config
         self.assertRaises(ParameterError, token.get_init_detail, params={"firebase_config": "bla"})
 
-        r = set_smsgateway(self.firebase_config_name, u'privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider',
-                           "myFB",
-                           {FIREBASE_CONFIG.REGISTRATION_URL: "http://test/ttype/push",
-                            FIREBASE_CONFIG.TTL: 10,
-                            FIREBASE_CONFIG.API_KEY: "1",
-                            FIREBASE_CONFIG.APP_ID: "2",
-                            FIREBASE_CONFIG.PROJECT_NUMBER: "3",
-                            FIREBASE_CONFIG.PROJECT_ID: "4"})
+        fb_config = {FIREBASE_CONFIG.REGISTRATION_URL: "http://test/ttype/push",
+                     FIREBASE_CONFIG.JSON_CONFIG: CLIENT_FILE,
+                     FIREBASE_CONFIG.TTL: 10,
+                     FIREBASE_CONFIG.API_KEY: "1",
+                     FIREBASE_CONFIG.APP_ID: "2",
+                     FIREBASE_CONFIG.PROJECT_NUMBER: "3",
+                     FIREBASE_CONFIG.PROJECT_ID: "4"}
+
+        # Wrong JSON file
+        self.assertRaises(ConfigAdminError, set_smsgateway,
+                          "fb1", u'privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider', "myFB",
+                          fb_config)
+
+        # Wrong Project number
+        fb_config[FIREBASE_CONFIG.JSON_CONFIG] = FIREBASE_FILE
+        self.assertRaises(ConfigAdminError, set_smsgateway,
+                          "fb1", u'privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider', "myFB",
+                          fb_config)
+
+        # Everything is fine
+        fb_config[FIREBASE_CONFIG.PROJECT_ID] = "test-123456"
+        r = set_smsgateway("fb1", u'privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider', "myFB",
+                           fb_config)
         self.assertTrue(r > 0)
 
         detail = token.get_init_detail(params={"firebase_config": self.firebase_config_name})
@@ -153,8 +170,8 @@ class PushTokenTestCase(MyTestCase):
                             FIREBASE_CONFIG.API_KEY: "1",
                             FIREBASE_CONFIG.APP_ID: "2",
                             FIREBASE_CONFIG.PROJECT_NUMBER: "3",
-                            FIREBASE_CONFIG.PROJECT_ID: "4",
-                            FIREBASE_CONFIG.JSON_CONFG: FIREBASE_FILE})
+                            FIREBASE_CONFIG.PROJECT_ID: "test-123456",
+                            FIREBASE_CONFIG.JSON_CONFIG: FIREBASE_FILE})
         self.assertTrue(r > 0)
         set_policy("push1", scope=SCOPE.ENROLL,
                    action="{0!s}={1!s}".format(PUSH_ACTION.FIREBASE_CONFIG,
@@ -261,7 +278,7 @@ class PushTokenTestCase(MyTestCase):
             mySA.from_json_keyfile_name.return_value = myCredentials(myAccessTokenInfo("my_bearer_token"))
 
             # add responses, to simulate the failing communication (status 500)
-            responses.add(responses.POST, 'https://fcm.googleapis.com/v1/projects/4/messages:send',
+            responses.add(responses.POST, 'https://fcm.googleapis.com/v1/projects/test-123456/messages:send',
                           body="""{}""",
                           status=500,
                           content_type="application/json")
@@ -300,7 +317,7 @@ class PushTokenTestCase(MyTestCase):
             mySA.from_json_keyfile_name.return_value = myCredentials(myAccessTokenInfo("my_bearer_token"))
 
             # add responses, to simulate the communication to firebase
-            responses.add(responses.POST, 'https://fcm.googleapis.com/v1/projects/4/messages:send',
+            responses.add(responses.POST, 'https://fcm.googleapis.com/v1/projects/test-123456/messages:send',
                           body="""{}""",
                           content_type="application/json")
 
@@ -389,7 +406,7 @@ class PushTokenTestCase(MyTestCase):
             mySA.from_json_keyfile_name.return_value = myCredentials(myAccessTokenInfo("my_bearer_token"))
 
             # add responses, to simulate the communication to firebase
-            responses.add_callback(responses.POST, 'https://fcm.googleapis.com/v1/projects/4/messages:send',
+            responses.add_callback(responses.POST, 'https://fcm.googleapis.com/v1/projects/test-123456/messages:send',
                           callback=check_firebase_params,
                           content_type="application/json")
 

--- a/tests/testdata/firebase-test.json
+++ b/tests/testdata/firebase-test.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "test-123456",
+  "private_key_id": "123456",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAxXFUS/ESmYet/ODJkuA3kDTCgJYBc1VdOk6/cE5Ij1qZV9G2\nA9QvbLgv3A7BlxoNJFDxZipWUnD2FLzjjuWG3dumH3f5IrO+Y2aKlhSo6S/hHWEe\nSvhIqNSQ6TWhpIwvkmBBFmWKEY48HjIldrWEOmtwRXCfSn6YFZDbmKRB0sgYTzLS\nCjCSJHrUzcAnYElW7dZfdrG75NZDpPpDq3QzUpAwdlH0lLeqxYTRhGGaMkNGnibb\nMhdr4gVItQA7FD9WTHLo35s0NbXGOzUkYX1ot9J2NBfgMV1xeAzYpkxOiZl9z6SA\n//7zdy1xXVEAF0JEY0oiXBJZxBsF7++Rie8JVwIDAQABAoIBAE8mP0SyP2KMoZLe\nCfB3Mc79V3t0puA1OEpHhzbeKvhMuWwbBXxDcz+CFq2AvNp19w635A2wqyohXoSx\ntAd0u7v0cYPr9FOU+p2eXbAMWCoip3u/kwU6wuXrUKwsc8Ai8m8bZvwzeEXRXwg7\n0gjkez1wFHHB1Blo5k6+40ktj7WPDH0NCKeIYK0g2zVqqOyJtMrHmS3TmGqySCm1\n1psxP3Ft/UbqFeJ0XWDiwwgDarF3PAtAyOKWx6V8HD8/MhJLS/f4qZd1c5249/Uq\nF/Lyb4C7vf1wBYXxpYJm8oePQOvK8sOLTtNxrO1HsOohPH9IyIwIzsD4L9+8DiOC\nlDVqkAECgYEA8SxCPeyEOu79737oR9MUWrzOsaWtZ6mDyIOIhZDpqUw60S9KaoCg\nb9KXDC08ZQCdVI05jBd+8nQjRIphmItJd+oXTt+pptT8KoiwWvyTBc4Q0f5w8PXT\nBBc2PqI7hzfX6QT+/Qe+10U81SRVFLk5KIK95Y0FglkAybM7HynC7xcCgYEA0ZTQ\nt8Yy9vXc2n0/GaKKaNC24V501Vb4LsZp8bLxLbOSWDa+S0gQXzllyAqwGE2xWeBQ\nlOrkJUaOvq1Qgy7fH4WMOr05eTwevJyr8pUlS6brIBEIgPKpf0SnUElFZIW2rofv\n3Dm6BrClytI4WM8sRIWj/HrK4mkdh7NX6yBDH8ECgYEAhS1pjwRyqJCdDYnI/xCi\nptCoWxUgQqQrL6ji1M8HGQQNXsJ8l39cGSPzYTgBp8zFFJG/+4pmAcD8ULcR2cjg\n0yUjpdyAtK3caih9KmFbVtNKGowlFgrJcfLXc5LmyG6f/f9SR6vlSL7lLtYXXZBC\n7gn0jzRmnGpFsxwUQ8st6BUCgYEAsbReGUUcF5y27CfApirU8zTtrEBcDjzU6Uxh\nrogMybR2RQf96HUtNKDFdY3ibGkMFOoHSY21bwnZpUHtf53xoJerJG8n2W0pnsG1\nZlYiLnhU63al4DhhkcEToRbPmQFruacXsYLdAiksGsKO9naL0XoDZuRzPPDmEhb2\nWC6d28ECgYEAoxzxRdr+zzETC1fOgNKY4/CzRq2aWsZkhYNAMbyeoMvUfT4r8H9t\ne/J/q6V0wZOn3o3luAYbRiwPd020iaPlfN9BalKpD91zshp5aYShmGKPhKD1Z62m\nZ8ZNuJOMO0sKtZpyZ+i5PDjCBQD3WHIocOnzQQ8KoWBVHDgbRHHpgyg=\n-----END RSA PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk@test-123456.iam.gserviceaccount.com",
+  "client_id": "clientid123456",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk40test-123456.iam.gserviceaccount.com"
+}

--- a/tests/testdata/google-services.json
+++ b/tests/testdata/google-services.json
@@ -1,0 +1,40 @@
+{
+  "project_info": {
+    "project_number": "815841760360",
+    "firebase_url": "https://push-8845d.firebaseio.com",
+    "project_id": "push-8845d",
+    "storage_bucket": "push-8845d.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:815841760360:android:4c03425a4746e192",
+        "android_client_info": {
+          "package_name": "com.example.push"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "815841760360-gr3su7qlhsidsec1clg5epvdgouuql4c.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA-whNOL5aO35YeWFoATBttkiBsHtXs6_k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "815841760360-gr3su7qlhsidsec1clg5epvdgouuql4c.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
The check for the auth counters and max_auth_counters is fixed.
The order or checking the counters and increasing the counters (which
implies deleting the registration token) is changed and fixed.

We now first check if the token is allowed to be used for authentication
("check_all") and then increase the counters (which deletes the
registration token).
This way we need to add an offset to the counter checking.

Fixes #1587