### PR TITLE
Improve the Firebase configuration

### DIFF
--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -55,8 +55,6 @@ class ERROR:
     SERVER = 903
     USER = 904
     PARAMETER = 905
-    FIREBASE_JSON = 1001
-    FIREBASE_PROJECT = 1002
 
 
 @six.python_2_unicode_compatible

--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -55,6 +55,8 @@ class ERROR:
     SERVER = 903
     USER = 904
     PARAMETER = 905
+    FIREBASE_JSON = 1001
+    FIREBASE_PROJECT = 1002
 
 
 @six.python_2_unicode_compatible

--- a/privacyidea/lib/smsprovider/FirebaseProvider.py
+++ b/privacyidea/lib/smsprovider/FirebaseProvider.py
@@ -23,8 +23,8 @@ Firebase Cloud Messaging Service.
 This provider is used for the push token and can be used for SMS tokens.
 """
 
-from privacyidea.lib.smsprovider.SMSProvider import (ISMSProvider, SMSError)
-from privacyidea.lib.error import ERROR
+from privacyidea.lib.smsprovider.SMSProvider import (ISMSProvider)
+from privacyidea.lib.error import ConfigAdminError
 from privacyidea.lib import _
 import logging
 from oauth2client.service_account import ServiceAccountCredentials
@@ -111,15 +111,13 @@ class FirebaseProvider(ISMSProvider):
             server_config = json.load(f)
         if server_config:
             if server_config.get("type") != "service_account":
-                raise SMSError(error_id=ERROR.FIREBASE_JSON,
-                               description="The JSON file is not a valid firebase credentials file.")
+                raise ConfigAdminError(description="The JSON file is not a valid firebase credentials file.")
             project_id = self.smsgateway.option_dict.get(FIREBASE_CONFIG.PROJECT_ID)
             if server_config.get("project_id") != project_id:
-                raise SMSError(error_id=ERROR.FIREBASE_PROJECT,
-                               description="The project_id you entered does not match the project_id from the JSON file.")
+                raise ConfigAdminError(description="The project_id you entered does not match the project_id from the JSON file.")
 
         else:
-            raise SMSError(error_id=123, description="Please check your configuration. Can not load JSON file.")
+            raise ConfigAdminError(description="Please check your configuration. Can not load JSON file.")
 
     @classmethod
     def parameters(cls):

--- a/privacyidea/lib/smsprovider/FirebaseProvider.py
+++ b/privacyidea/lib/smsprovider/FirebaseProvider.py
@@ -24,6 +24,7 @@ This provider is used for the push token and can be used for SMS tokens.
 """
 
 from privacyidea.lib.smsprovider.SMSProvider import (ISMSProvider, SMSError)
+from privacyidea.lib.error import ERROR
 from privacyidea.lib import _
 import logging
 from oauth2client.service_account import ServiceAccountCredentials
@@ -44,7 +45,7 @@ log = logging.getLogger(__name__)
 class FIREBASE_CONFIG:
     REGISTRATION_URL = "registration URL"
     TTL = "time to live"
-    JSON_CONFG = "JSON config file"
+    JSON_CONFIG = "JSON config file"
     PROJECT_ID = "projectid"
     PROJECT_NUMBER = "projectnumber"
     APP_ID = "appid"
@@ -67,7 +68,7 @@ class FirebaseProvider(ISMSProvider):
         res = False
 
         credentials = ServiceAccountCredentials.\
-                from_json_keyfile_name(self.smsgateway.option_dict.get(FIREBASE_CONFIG.JSON_CONFG),
+                from_json_keyfile_name(self.smsgateway.option_dict.get(FIREBASE_CONFIG.JSON_CONFIG),
                                        SCOPES)
 
         access_token_info = credentials.get_access_token()
@@ -97,6 +98,28 @@ class FirebaseProvider(ISMSProvider):
             log.warning(u"Failed to send message to firebase service: {0!s}".format(resp.text))
 
         return res
+
+    def check_configuration(self):
+        """
+        This method checks the sanity of the configuration of this provider.
+        If there is a configuration error, than an exception is raised.
+        :return:
+        """
+        json_file = self.smsgateway.option_dict.get(FIREBASE_CONFIG.JSON_CONFIG)
+        server_config = None
+        with open(json_file) as f:
+            server_config = json.load(f)
+        if server_config:
+            if server_config.get("type") != "service_account":
+                raise SMSError(error_id=ERROR.FIREBASE_JSON,
+                               description="The JSON file is not a valid firebase credentials file.")
+            project_id = self.smsgateway.option_dict.get(FIREBASE_CONFIG.PROJECT_ID)
+            if server_config.get("project_id") != project_id:
+                raise SMSError(error_id=ERROR.FIREBASE_PROJECT,
+                               description="The project_id you entered does not match the project_id from the JSON file.")
+
+        else:
+            raise SMSError(error_id=123, description="Please check your configuration. Can not load JSON file.")
 
     @classmethod
     def parameters(cls):
@@ -136,7 +159,7 @@ class FirebaseProvider(ISMSProvider):
                           "description": _(
                               "The API Key, that the client should use. Get it from your Firebase console.")
                       },
-                      FIREBASE_CONFIG.JSON_CONFG: {
+                      FIREBASE_CONFIG.JSON_CONFIG: {
                           "required": True,
                           "description": _("The filename of the JSON config file, that allows privacyIDEA to talk"
                                            " to the Firebase REST API.")

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -47,6 +47,7 @@ SMS_PROVIDERS = [
     "privacyidea.lib.smsprovider.SmppSMSProvider.SmppSMSProvider",
     "privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider"]
 
+
 class SMSError(Exception):
     def __init__(self, error_id, description):
         Exception.__init__(self)
@@ -89,6 +90,14 @@ class ISMSProvider(object):
         :rtype: bool
         """
         return True
+
+    def check_configuration(self):
+        """
+        This method checks the sanity of the configuration of this provider.
+        If there is a configuration error, than an exception is raised.
+        :return:
+        """
+        return
 
     @classmethod
     def parameters(cls):
@@ -170,6 +179,7 @@ def set_smsgateway(identifier, providermodule, description=None,
     smsgateway = SMSGateway(identifier, providermodule,
                             description=description,
                             options=options)
+    create_sms_instance(identifier).check_configuration()
     return smsgateway.id
 
 

--- a/privacyidea/static/components/config/controllers/smsgatewayController.js
+++ b/privacyidea/static/components/config/controllers/smsgatewayController.js
@@ -81,6 +81,7 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
             }
         }
 
+        delete $scope.form.options;
         ConfigFactory.setSMSGateway($scope.form, function() {
             $state.go("config.smsgateway.list");
             $('html,body').scrollTop(0);

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -112,7 +112,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
         # create an sms gateway configuration
         param = {
             "name": "myGW",
-            "module": "privacyidea.lib.SMS",
+            "module": "privacyidea.lib.smsprovider.SMSProvider",
             "description": "myGateway",
             "option.URL": "http://example.com"
         }

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -20,7 +20,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
         # create an sms gateway definition
         param = {
             "name": "myGW",
-            "module": "privacyidea.lib.SMS",
+            "module": "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider",
             "description": "myGateway",
             "option.URL": "http://example.com"
         }
@@ -49,14 +49,14 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertEqual(sms_gw.get("name"), "myGW")
             self.assertEqual(sms_gw.get("id"), 1)
             self.assertEqual(sms_gw.get("providermodule"),
-                             "privacyidea.lib.SMS")
+                             "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider")
             self.assertEqual(sms_gw.get("options").get("URL"),
                              "http://example.com")
 
         # update
         param = {
             "name": "myGW",
-            "module": "privacyidea.lib.SMS",
+            "module": "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider",
             "description": "new description",
             "id": 1
         }
@@ -112,7 +112,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
         # create an sms gateway configuration
         param = {
             "name": "myGW",
-            "module": "privacyidea.lib.smsprovider.SMSProvider",
+            "module": "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider",
             "description": "myGateway",
             "option.URL": "http://example.com"
         }

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -69,7 +69,7 @@ class SMSTestCase(MyTestCase):
 
     def test_02_create_modify_delete_smsgateway_configuration(self):
         identifier = "myGW"
-        provider_module = "privacyidea.lib.smsprovider.HTTPSmsPrpvoder"
+        provider_module = "privacyidea.lib.smsprovider.HttpSMSProvider.HttpSMSProvider"
         id = set_smsgateway(identifier, provider_module, description="test",
                             options={"HTTP_METHOD": "POST",
                                      "URL": "example.com"})

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -108,7 +108,7 @@ class PushTokenTestCase(MyTestCase):
         # Everything is fine
         fb_config[FIREBASE_CONFIG.PROJECT_ID] = "test-123456"
         r = set_smsgateway("fb1", u'privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider', "myFB",
-                           fb_config
+                           fb_config)
         self.assertTrue(r > 0)
 
         detail = token.get_init_detail(params={"firebase_config": self.firebase_config_name})

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -16,6 +16,7 @@ from privacyidea.models import Token
 from privacyidea.lib.policy import (SCOPE, set_policy)
 from privacyidea.lib.utils import to_bytes, b32encode_and_unicode, to_unicode
 from privacyidea.lib.smsprovider.SMSProvider import set_smsgateway, SMSError
+from privacyidea.lib.error import ConfigAdminError
 from base64 import b32decode
 import json
 import responses
@@ -91,13 +92,13 @@ class PushTokenTestCase(MyTestCase):
                      FIREBASE_CONFIG.PROJECT_ID: "4"}
 
         # Wrong JSON file
-        self.assertRaises(SMSError, set_smsgateway,
+        self.assertRaises(ConfigAdminError, set_smsgateway,
                           "fb1", u'privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider', "myFB",
                           fb_config)
 
         # Wrong Project number
         fb_config[FIREBASE_CONFIG.JSON_CONFIG] = FIREBASE_FILE
-        self.assertRaises(SMSError, set_smsgateway,
+        self.assertRaises(ConfigAdminError, set_smsgateway,
                           "fb1", u'privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider', "myFB",
                           fb_config)
 

--- a/tests/testdata/firebase-test.json
+++ b/tests/testdata/firebase-test.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "test-123456",
+  "private_key_id": "123456",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAxXFUS/ESmYet/ODJkuA3kDTCgJYBc1VdOk6/cE5Ij1qZV9G2\nA9QvbLgv3A7BlxoNJFDxZipWUnD2FLzjjuWG3dumH3f5IrO+Y2aKlhSo6S/hHWEe\nSvhIqNSQ6TWhpIwvkmBBFmWKEY48HjIldrWEOmtwRXCfSn6YFZDbmKRB0sgYTzLS\nCjCSJHrUzcAnYElW7dZfdrG75NZDpPpDq3QzUpAwdlH0lLeqxYTRhGGaMkNGnibb\nMhdr4gVItQA7FD9WTHLo35s0NbXGOzUkYX1ot9J2NBfgMV1xeAzYpkxOiZl9z6SA\n//7zdy1xXVEAF0JEY0oiXBJZxBsF7++Rie8JVwIDAQABAoIBAE8mP0SyP2KMoZLe\nCfB3Mc79V3t0puA1OEpHhzbeKvhMuWwbBXxDcz+CFq2AvNp19w635A2wqyohXoSx\ntAd0u7v0cYPr9FOU+p2eXbAMWCoip3u/kwU6wuXrUKwsc8Ai8m8bZvwzeEXRXwg7\n0gjkez1wFHHB1Blo5k6+40ktj7WPDH0NCKeIYK0g2zVqqOyJtMrHmS3TmGqySCm1\n1psxP3Ft/UbqFeJ0XWDiwwgDarF3PAtAyOKWx6V8HD8/MhJLS/f4qZd1c5249/Uq\nF/Lyb4C7vf1wBYXxpYJm8oePQOvK8sOLTtNxrO1HsOohPH9IyIwIzsD4L9+8DiOC\nlDVqkAECgYEA8SxCPeyEOu79737oR9MUWrzOsaWtZ6mDyIOIhZDpqUw60S9KaoCg\nb9KXDC08ZQCdVI05jBd+8nQjRIphmItJd+oXTt+pptT8KoiwWvyTBc4Q0f5w8PXT\nBBc2PqI7hzfX6QT+/Qe+10U81SRVFLk5KIK95Y0FglkAybM7HynC7xcCgYEA0ZTQ\nt8Yy9vXc2n0/GaKKaNC24V501Vb4LsZp8bLxLbOSWDa+S0gQXzllyAqwGE2xWeBQ\nlOrkJUaOvq1Qgy7fH4WMOr05eTwevJyr8pUlS6brIBEIgPKpf0SnUElFZIW2rofv\n3Dm6BrClytI4WM8sRIWj/HrK4mkdh7NX6yBDH8ECgYEAhS1pjwRyqJCdDYnI/xCi\nptCoWxUgQqQrL6ji1M8HGQQNXsJ8l39cGSPzYTgBp8zFFJG/+4pmAcD8ULcR2cjg\n0yUjpdyAtK3caih9KmFbVtNKGowlFgrJcfLXc5LmyG6f/f9SR6vlSL7lLtYXXZBC\n7gn0jzRmnGpFsxwUQ8st6BUCgYEAsbReGUUcF5y27CfApirU8zTtrEBcDjzU6Uxh\nrogMybR2RQf96HUtNKDFdY3ibGkMFOoHSY21bwnZpUHtf53xoJerJG8n2W0pnsG1\nZlYiLnhU63al4DhhkcEToRbPmQFruacXsYLdAiksGsKO9naL0XoDZuRzPPDmEhb2\nWC6d28ECgYEAoxzxRdr+zzETC1fOgNKY4/CzRq2aWsZkhYNAMbyeoMvUfT4r8H9t\ne/J/q6V0wZOn3o3luAYbRiwPd020iaPlfN9BalKpD91zshp5aYShmGKPhKD1Z62m\nZ8ZNuJOMO0sKtZpyZ+i5PDjCBQD3WHIocOnzQQ8KoWBVHDgbRHHpgyg=\n-----END RSA PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk@test-123456.iam.gserviceaccount.com",
+  "client_id": "clientid123456",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk40test-123456.iam.gserviceaccount.com"
+}

--- a/tests/testdata/google-services.json
+++ b/tests/testdata/google-services.json
@@ -1,0 +1,40 @@
+{
+  "project_info": {
+    "project_number": "815841760360",
+    "firebase_url": "https://push-8845d.firebaseio.com",
+    "project_id": "push-8845d",
+    "storage_bucket": "push-8845d.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:815841760360:android:4c03425a4746e192",
+        "android_client_info": {
+          "package_name": "com.example.push"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "815841760360-gr3su7qlhsidsec1clg5epvdgouuql4c.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA-whNOL5aO35YeWFoATBttkiBsHtXs6_k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "815841760360-gr3su7qlhsidsec1clg5epvdgouuql4c.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
The firebase configuration is a bit tricky.
To avoid uploading the wrong json file or entering wrong data
SMSprovider now can have a config-check-method, which is run
after the SMS provider is created.

This way privacyIDEA checks the sanity of the firebase configuration.
It checks if the correct json file is specified and if
the correct project number is configured.

Closes #1592