### PR TITLE
Quote parameters of subprocess invocations with shell=True

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -62,6 +62,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 import flask
+from six.moves import shlex_quote
 
 from privacyidea.lib.sqlutils import delete_matching_rows
 from privacyidea.lib.security.default import DefaultSecurityModule
@@ -289,9 +290,10 @@ def create(directory="/var/lib/privacyidea/backup/",
         defaults_file = "{0!s}/mysql.cnf".format(conf_dir)
         _write_mysql_defaults(defaults_file, username, password)
         call("mysqldump --defaults-file=%s -h %s %s > %s" % (
-            defaults_file,
-            datahost,
-            database, sqlfile), shell=True)
+            shlex_quote(defaults_file),
+            shlex_quote(datahost),
+            shlex_quote(database),
+            shlex_quote(sqlfile)), shell=True)
     else:
         print("unsupported SQL syntax: %s" % sqltype)
         sys.exit(2)
@@ -396,10 +398,10 @@ def restore(backup_file):
         _write_mysql_defaults(defaults_file, username, password)
         # Rewriting database
         print("Restoring database.")
-        call("mysql --defaults-file=%s -h %s %s < %s" % (defaults_file,
-                                                         datahost,
-                                                         database,
-                                                         sqlfile), shell=True)
+        call("mysql --defaults-file=%s -h %s %s < %s" % (shlex_quote(defaults_file),
+                                                         shlex_quote(datahost),
+                                                         shlex_quote(database),
+                                                         shlex_quote(sqlfile)), shell=True)
         os.unlink(sqlfile)
     else:
         print("unsupported SQL syntax: %s" % sqltype)

--- a/tools/privacyidea-create-certificate
+++ b/tools/privacyidea-create-certificate
@@ -5,6 +5,8 @@ import os
 import sys
 from getopt import getopt, GetoptError
 from subprocess import call
+from six.moves import shlex_quote
+
 
 __version__ = '0.1'
 CONFIG_FILE = "/etc/apache2/sites-available/privacyidea"
@@ -37,7 +39,7 @@ def create_keys(file):
 
     if key and cert:
         command = "openssl req -x509 -newkey rsa:2048 -keyout %s -out %s " \
-                  "-days 1000 -subj /CN=privacyideaserver -nodes" % (key, cert)
+                  "-days 1000 -subj /CN=privacyideaserver -nodes" % (shlex_quote(key), shlex_quote(cert))
         r = call(command, shell=True)
         if r == 0:
             print("created key and cert...")

--- a/tools/privacyidea-fix-access-rights
+++ b/tools/privacyidea-fix-access-rights
@@ -5,7 +5,7 @@ __version__ = '0.1'
 import sys
 from getopt import getopt, GetoptError
 from subprocess import call
-
+from six.moves import shlex_quote
 
 def usage():
     print('''
@@ -24,31 +24,31 @@ def fix_rights(file, user):
 
     # Create the user
     try:
-        call("/usr/sbin/adduser  --system %s" % user, shell=True)
+        call("/usr/sbin/adduser  --system %s" % shlex_quote(user), shell=True)
         print("Created user %s" % user)
     except Exception as e:
         print("Failed to create user %s: %s" % (user, str(e)))
 
     # fix the file itself!
     try:
-        call("chmod 640 %s" % file, shell=True)
-        call("chown %s:%s %s" % (user, "root", file), shell=True)
+        call("chmod 640 %s" % shlex_quote(file), shell=True)
+        call("chown %s:%s %s" % (shlex_quote(user), "root", shlex_quote(file)), shell=True)
         print("Fixed access rights for %s" % file)
     except Exception as _e:
         print("Failed to fix access rights for %s" % file)
 
     # Fix the encryption file
     try:
-        call("chmod 400 %s" % conf.get("PI_ENCFILE"), shell=True)
-        call("chown %s %s" % (user, conf.get("PI_ENCFILE")), shell=True)
+        call("chmod 400 %s" % shlex_quote(conf.get("PI_ENCFILE")), shell=True)
+        call("chown %s %s" % (shlex_quote(user), shlex_quote(conf.get("PI_ENCFILE"))), shell=True)
         print("Fixed access rights for %s" % conf.get("PI_ENCFILE"))
     except Exception as _e:
         print("Failed to fix access rights for %s" % conf.get("PI_ENCFILE"))
 
     # fix the audit key
     try:
-        call("chmod 400 %s" % conf.get("PI_AUDIT_KEY_PRIVATE"), shell=True)
-        call("chown %s %s" % (user, conf.get("PI_AUDIT_KEY_PRIVATE")), shell=True)
+        call("chmod 400 %s" % shlex_quote(conf.get("PI_AUDIT_KEY_PRIVATE")), shell=True)
+        call("chown %s %s" % (shlex_quote(user), shlex_quote(conf.get("PI_AUDIT_KEY_PRIVATE"))), shell=True)
         print("Fixed access rights for %s" % conf.get("PI_AUDIT_KEY_PRIVATE"))
     except Exception as _e:
         print("Failed to fix access rights for %s" % conf.get("PI_AUDIT_KEY_PRIVATE"))


### PR DESCRIPTION
According to the [subprocess documentation](https://docs.python.org/2/library/subprocess.html#frequently-used-arguments), one should always quote arguments when constructing a command string with ``shell=True``.

There are some occurrences of ``shell=True`` in our scripts, and this PR ensures that the arguments are properly quoted in these cases.

The usage of ``six.moves.shlex_quote`` ensures compatibility with both Python 2 and 3.