### PR TITLE
Rebased: Fix logic of auth counters and registration token

### DIFF
--- a/doc/configuration/system_config.rst
+++ b/doc/configuration/system_config.rst
@@ -72,7 +72,8 @@ clear the failcounter again:
 
 * A successful authentication with correct PIN and correct OTP value
 * A successfully triggered challenge (Usually this means a correct PIN)
-* An authentication with a correct PIN, but a wrong OTP value
+* An authentication with a correct PIN, but a wrong OTP value (Only if
+  :ref:`reset_failcounter_on_correct_pin` is set).
 
 A "0" means automatically clearing the fail counter is not used.
 
@@ -80,6 +81,9 @@ A "0" means automatically clearing the fail counter is not used.
    update the mentioned timestamp.
 
 Also see :ref:`brute_force`.
+
+
+.. _reset_failcounter_on_correct_pin:
 
 Resetting Failcounter on correct PIN
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration/system_config.rst
+++ b/doc/configuration/system_config.rst
@@ -81,6 +81,19 @@ A "0" means automatically clearing the fail counter is not used.
 
 Also see :ref:`brute_force`.
 
+Resetting Failcounter on correct PIN
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the above mentioned timeout the failcounter is reset by a successful
+authentication (correct PIN and OTP value) or by the correct PIN of a challenge
+response token.
+
+It can be also reset by the correct PIN of any token, when setting
+``ResetFailcounterOnPIN`` to True.
+The default behaviour is, that the correct PIN of a normal token will *not*
+reset the failcounter after the clearing timeout.
+
+
 Prepend PIN
 ~~~~~~~~~~~
 

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -212,6 +212,7 @@ class SYSCONF(object):
     SPLITATSIGN = "splitAtSign"
     INCFAILCOUNTER = "IncFailCountOnFalsePin"
     RETURNSAML = "ReturnSamlAttributes"
+    RESET_FAILCOUNTER_ON_PIN_ONLY = "ResetFailcounterOnPIN"
 
 
 #@cache.cached(key_prefix="allConfig")

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2264,7 +2264,7 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         # So we increase the failcounter. Return failure.
         for tokenobject in pin_matching_token_list:
             tokenobject.inc_failcount()
-            if get_from_config(SYSCONF.RESET_FAILCOUNTER_ON_PIN_ONLY, False, return_bool=True):  # pragma: no cover
+            if get_from_config(SYSCONF.RESET_FAILCOUNTER_ON_PIN_ONLY, False, return_bool=True):
                 tokenobject.check_reset_failcount()
             reply_dict["message"] = "wrong otp value"
             if len(pin_matching_token_list) == 1:

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2160,12 +2160,14 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         message_list = ["matching {0:d} tokens".format(len(valid_token_list))]
         # write serial numbers or something to audit log
         for token_obj in valid_token_list:
-            if increase_auth_counters:
-                token_obj.inc_count_auth_success()
-            # Reset the failcounter, if there is a timeout set
-            token_obj.check_reset_failcount()
-            # Check if the max auth is succeeded
-            if token_obj.check_all(message_list):
+            # Check if the max auth is succeeded.
+            # We need to set the offsets, since we are in the n+1st authentication.
+            if token_obj.check_all(message_list, offset=1, offset_success=1):
+                if increase_auth_counters:
+                    token_obj.inc_count_auth_success()
+                # Reset the failcounter, if there is a timeout set
+                token_obj.check_reset_failcount()
+
                 # The token is active and the auth counters are ok.
                 res = True
                 if not reply_dict.get("type"):

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -82,7 +82,7 @@ from privacyidea.models import (Token, Realm, TokenRealm, Challenge,
                                 MachineToken, TokenInfo, TokenOwner)
 from privacyidea.lib.config import (get_token_class, get_token_prefix,
                                     get_token_types, get_from_config,
-                                    get_inc_fail_count_on_false_pin)
+                                    get_inc_fail_count_on_false_pin, SYSCONF)
 from privacyidea.lib.user import User
 from privacyidea.lib import _
 from privacyidea.lib.realm import realm_is_defined
@@ -2160,13 +2160,13 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         message_list = ["matching {0:d} tokens".format(len(valid_token_list))]
         # write serial numbers or something to audit log
         for token_obj in valid_token_list:
+            # Reset the failcounter, if there is a timeout set
+            token_obj.check_reset_failcount()
             # Check if the max auth is succeeded.
             # We need to set the offsets, since we are in the n+1st authentication.
             if token_obj.check_all(message_list):
                 if increase_auth_counters:
                     token_obj.inc_count_auth_success()
-                # Reset the failcounter, if there is a timeout set
-                token_obj.check_reset_failcount()
 
                 # The token is active and the auth counters are ok.
                 res = True
@@ -2264,7 +2264,8 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         # So we increase the failcounter. Return failure.
         for tokenobject in pin_matching_token_list:
             tokenobject.inc_failcount()
-            tokenobject.check_reset_failcount()
+            if get_from_config(SYSCONF.RESET_FAILCOUNTER_ON_PIN_ONLY, False, return_bool=True):  # pragma: no cover
+                tokenobject.check_reset_failcount()
             reply_dict["message"] = "wrong otp value"
             if len(pin_matching_token_list) == 1:
                 # If there is only one pin matching token, we look if it was

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2162,7 +2162,7 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
         for token_obj in valid_token_list:
             # Check if the max auth is succeeded.
             # We need to set the offsets, since we are in the n+1st authentication.
-            if token_obj.check_all(message_list, offset=1, offset_success=1):
+            if token_obj.check_all(message_list):
                 if increase_auth_counters:
                     token_obj.inc_count_auth_success()
                 # Reset the failcounter, if there is a timeout set

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1055,7 +1055,7 @@ class TokenClass(object):
         """
         return self.token.failcount < self.token.maxfail
 
-    def check_auth_counter(self, offset=0, offset_success=0):
+    def check_auth_counter(self):
         """
         This function checks the count_auth and the count_auth_success.
         If the counters are less or equal than the maximum allowed counters
@@ -1068,10 +1068,10 @@ class TokenClass(object):
         count_auth_max = self.get_count_auth_max()
         count_auth_success = self.get_count_auth_success()
         count_auth_success_max = self.get_count_auth_success_max()
-        if count_auth_max != 0 and count_auth + offset > count_auth_max:
+        if count_auth_max != 0 and count_auth >= count_auth_max:
             return False
 
-        if count_auth_success_max != 0 and count_auth_success + offset_success > count_auth_success_max:
+        if count_auth_success_max != 0 and count_auth_success >= count_auth_success_max:
             return False
 
         return True
@@ -1101,7 +1101,7 @@ class TokenClass(object):
 
         return True
 
-    def check_all(self, message_list, offset=0, offset_success=0):
+    def check_all(self, message_list):
         """
         Perform all checks on the token. Returns False if the token is either:
         * auth counter exceeded
@@ -1116,7 +1116,7 @@ class TokenClass(object):
         """
         r = False
         # Check if the max auth is succeeded
-        if not self.check_auth_counter(offset=offset, offset_success=offset_success):
+        if not self.check_auth_counter():
             message_list.append("Authentication counter exceeded")
         # Check if the token is disabled
         elif not self.is_active():

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1055,23 +1055,23 @@ class TokenClass(object):
         """
         return self.token.failcount < self.token.maxfail
 
-    def check_auth_counter(self):
+    def check_auth_counter(self, offset=0, offset_success=0):
         """
         This function checks the count_auth and the count_auth_success.
-        If the count_auth is less than count_auth_max
-        and count_auth_success is less than count_auth_success_max
+        If the counters are less or equal than the maximum allowed counters
         it returns True. Otherwise False.
         
         :return: success if the counter is less than max
         :rtype: bool
         """
-        if self.get_count_auth_max() != 0 and self.get_count_auth() >= \
-                self.get_count_auth_max():
+        count_auth = self.get_count_auth()
+        count_auth_max = self.get_count_auth_max()
+        count_auth_success = self.get_count_auth_success()
+        count_auth_success_max = self.get_count_auth_success_max()
+        if count_auth_max != 0 and count_auth + offset > count_auth_max:
             return False
 
-        if self.get_count_auth_success_max() != 0 and  \
-                        self.get_count_auth_success() >=  \
-                        self.get_count_auth_success_max():
+        if count_auth_success_max != 0 and count_auth_success + offset_success > count_auth_success_max:
             return False
 
         return True
@@ -1101,7 +1101,7 @@ class TokenClass(object):
 
         return True
 
-    def check_all(self, message_list):
+    def check_all(self, message_list, offset=0, offset_success=0):
         """
         Perform all checks on the token. Returns False if the token is either:
         * auth counter exceeded
@@ -1116,7 +1116,7 @@ class TokenClass(object):
         """
         r = False
         # Check if the max auth is succeeded
-        if not self.check_auth_counter():
+        if not self.check_auth_counter(offset=offset, offset_success=offset_success):
             message_list.append("Authentication counter exceeded")
         # Check if the token is disabled
         elif not self.is_active():

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -18,7 +18,7 @@ from privacyidea.lib.user import (User)
 from privacyidea.lib.tokenclass import TokenClass, TOKENKIND, FAILCOUNTER_EXCEEDED, FAILCOUNTER_CLEAR_TIMEOUT
 from privacyidea.lib.tokens.totptoken import TotpTokenClass
 from privacyidea.models import (Token, Challenge, TokenRealm)
-from privacyidea.lib.config import (set_privacyidea_config, get_token_types)
+from privacyidea.lib.config import (set_privacyidea_config, get_token_types, delete_privacyidea_config)
 from privacyidea.lib.policy import set_policy, SCOPE, ACTION, delete_policy
 from privacyidea.lib.utils import b32encode_and_unicode
 import datetime
@@ -1458,26 +1458,6 @@ class TokenTestCase(MyTestCase):
         # Check that we did not miss any tokens
         self.assertEquals(set(t.token.serial for t in list1 + list2), all_serials)
 
-    def test_57_reset_failcounter(self):
-        # Set failcounter clear timeout to 1 minute
-        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 1)
-
-        tokenobject_list = get_tokens()
-
-        # Simulate a HOTP token whose failcounter was exceeded 2 minutes ago
-        hotp_tokenobject = get_tokens(serial="hotptoken")[0]
-        hotp_tokenobject.token.count = 10
-        hotp_tokenobject.set_pin("hotppin")
-        hotp_tokenobject.set_failcount(10)
-        exceeded_timestamp = datetime.datetime.now(tzlocal()) - datetime.timedelta(minutes=1)
-        hotp_tokenobject.add_tokeninfo(FAILCOUNTER_EXCEEDED, exceeded_timestamp.strftime(DATE_FORMAT))
-
-        # OTP value #11
-        res, reply = check_token_list(tokenobject_list, "hotppin481090")
-        self.assertTrue(res)
-
-        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 0)
-
 
 class TokenFailCounterTestCase(MyTestCase):
     """
@@ -1637,3 +1617,59 @@ class TokenFailCounterTestCase(MyTestCase):
         # Clean up
         remove_token(pin1)
         remove_token(pin2)
+
+    def test_05_reset_failcounter(self):
+        tok = init_token({"type": "hotp",
+                          "serial": "test05",
+                          "otpkey": self.otpkey})
+        # Set failcounter clear timeout to 1 minute
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 1)
+        tok.token.count = 10
+        tok.set_pin("hotppin")
+        tok.set_failcount(10)
+        exceeded_timestamp = datetime.datetime.now(tzlocal()) - datetime.timedelta(minutes=1)
+        tok.add_tokeninfo(FAILCOUNTER_EXCEEDED, exceeded_timestamp.strftime(DATE_FORMAT))
+
+        # OTP value #11
+        res, reply = check_token_list([tok], "hotppin481090")
+        self.assertTrue(res)
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 0)
+        remove_token("test05")
+
+    def test_06_reset_failcounter_out_of_sync(self):
+        # Reset fail counter of a token that is out of sync
+        # The fail counter will reset, even if the token is out of sync, since the
+        # autoresync is handled in the tokenclass.authenticate.
+        tok = init_token({"type": "hotp",
+                          "serial": "test06",
+                          "otpkey": self.otpkey})
+
+        set_privacyidea_config("AutoResyncTimeout", "300")
+        set_privacyidea_config("AutoResync", 1)
+
+        tok.set_pin("hotppin")
+        tok.set_count_window(2)
+
+        res, reply = check_token_list([tok], "hotppin{0!s}".format(self.valid_otp_values[0]))
+        self.assertTrue(res)
+
+        # Now we set the failoucnter and the exceeded time.
+        tok.set_failcount(10)
+        exceeded_timestamp = datetime.datetime.now(tzlocal()) - datetime.timedelta(minutes=1)
+        tok.add_tokeninfo(FAILCOUNTER_EXCEEDED, exceeded_timestamp.strftime(DATE_FORMAT))
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 1)
+
+        # authentication with otp value #3 will fail
+        res, reply = check_token_list([tok], "hotppin{0!s}".format(self.valid_otp_values[3]))
+        self.assertFalse(res)
+
+        # authentication with otp value #4 will resync and succeed
+        res, reply = check_token_list([tok], "hotppin{0!s}".format(self.valid_otp_values[4]))
+        self.assertTrue(res)
+        self.assertEqual(tok.get_failcount(), 0)
+
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 0)
+        delete_privacyidea_config("AutoResyncTimeout")
+        delete_privacyidea_config("AutoResync")
+        remove_token("test06")
+


### PR DESCRIPTION
This is just #1606, rebased to ``branch-3.0``, with an additional unit test for the RESET_FAILCOUNTER_ON_PIN_ONLY option.

Closes #1587 