### PR TITLE
Fix vertical spinner position

### DIFF
--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -358,7 +358,7 @@ myApp.directive('spinner', function() {
         },
         template: [
             '<div ng-show="showSpinner">',
-            '<span class="glyphicon glyphicon-refresh spin" style="margin: 50% 5px 0 0; font-size:120%; color: #787878;" aria-hidden="true"></span>',
+            '<span class="glyphicon glyphicon-refresh spin" aria-hidden="true"></span>',
             '</div>'
         ].join(''),
         controller: function($scope, $rootScope) {

--- a/privacyidea/static/css/menu.css
+++ b/privacyidea/static/css/menu.css
@@ -2,3 +2,6 @@
     padding-top: 7px;
     padding-bottom: 7px;
 }
+.spin {
+    padding: 15px;
+}


### PR DESCRIPTION
The spinner wasn't vertically aligned in the center.
The style of the element needed to be removed from the controller in order
to customize the style through css.

Fixes #1629