### PR TITLE
Remove audit from remote user fetching

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1222,8 +1222,7 @@ def is_remote_user_allowed(req):
                                                          scope=SCOPE.WEBUI,
                                                          user=loginname,
                                                          realm=realm,
-                                                         client=g.client_ip,
-                                                         audit_data=g.audit_object.audit_data)
+                                                         client=g.client_ip)
 
         res = bool(ruser_active)
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1218,11 +1218,17 @@ def is_remote_user_allowed(req):
                                         get_from_config(SYSCONF.OVERRIDECLIENT))
         if "policy_object" not in g:
             g.policy_object = PolicyClass()
+        if "audit_object" in g:
+            audit_data = g.audit_object.audit_data
+        else:
+            audit_data = None
+
         ruser_active = g.policy_object.get_action_values(ACTION.REMOTE_USER,
                                                          scope=SCOPE.WEBUI,
                                                          user=loginname,
                                                          realm=realm,
-                                                         client=g.client_ip)
+                                                         client=g.client_ip,
+                                                         audit_data=audit_data)
 
         res = bool(ruser_active)
 

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -84,6 +84,16 @@ class APIAuthTestCase(MyApiTestCase):
             self.assertEqual(result.get("value").get("role"), "admin")
             self.assertTrue(result.get("status"), res.data)
 
+        # Check if the /auth request writes the policyname "remote" to the audit entry
+        with self.app.test_request_context('/audit/',
+                                           method='GET',
+                                           headers={'Authorization':
+                                                        self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            auditentry = res.json.get("result").get("value").get("auditdata")[0]
+            self.assertTrue("remote" in auditentry.get("policies"))
+
         self.setUp_user_realms()
         # User "cornelius" from the default realm as normale user
         with self.app.test_request_context('/auth', method='POST',


### PR DESCRIPTION
Fetching the remote user config also occurs by simply
calling the login dialog. At this point, we do not have
an audit object. The pure calling of the login dialog
also does not create any audit entry, so we do not
pass the audit_object.

fixes #1632