### PR TITLE
Fix sending mails in combination with CRAM-MD5 authentication

### DIFF
--- a/privacyidea/lib/smtpserver.py
+++ b/privacyidea/lib/smtpserver.py
@@ -17,11 +17,13 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
+import six
+
 from privacyidea.lib.queue import job, wrap_job, has_job_queue
 from privacyidea.models import SMTPServer as SMTPServerDB
 from privacyidea.lib.crypto import (decryptPassword, encryptPassword,
                                     FAILED_TO_DECRYPT_PASSWORD)
-from privacyidea.lib.utils import fetch_one_resource
+from privacyidea.lib.utils import fetch_one_resource, to_utf8
 import logging
 from privacyidea.lib.log import log_with
 from time import gmtime, strftime
@@ -113,6 +115,10 @@ class SMTPServer(object):
             password = decryptPassword(config['password'])
             if password == FAILED_TO_DECRYPT_PASSWORD:
                 password = config['password']
+            # Under Python 2, we pass passwords as bytestrings to get CRAM-MD5 to work.
+            # Under Python 3, we pass passwords as unicode.
+            if six.PY2:
+                password = to_utf8(password)
             mail.login(config['username'], password)
         r = mail.sendmail(mail_from, recipient, msg.as_string())
         log.info("Mail sent: {0!s}".format(r))

--- a/privacyidea/lib/smtpserver.py
+++ b/privacyidea/lib/smtpserver.py
@@ -19,11 +19,12 @@
 #
 import six
 
+from privacyidea.lib.framework import get_app_config_value
 from privacyidea.lib.queue import job, wrap_job, has_job_queue
 from privacyidea.models import SMTPServer as SMTPServerDB
 from privacyidea.lib.crypto import (decryptPassword, encryptPassword,
                                     FAILED_TO_DECRYPT_PASSWORD)
-from privacyidea.lib.utils import fetch_one_resource, to_utf8
+from privacyidea.lib.utils import fetch_one_resource, to_bytes
 import logging
 from privacyidea.lib.log import log_with
 from time import gmtime, strftime
@@ -116,9 +117,10 @@ class SMTPServer(object):
             if password == FAILED_TO_DECRYPT_PASSWORD:
                 password = config['password']
             # Under Python 2, we pass passwords as bytestrings to get CRAM-MD5 to work.
+            # We add a safeguard config option to disable the conversion.
             # Under Python 3, we pass passwords as unicode.
-            if six.PY2:
-                password = to_utf8(password)
+            if six.PY2 and get_app_config_value("PI_SMTP_PASSWORD_AS_BYTES", True):
+                password = to_bytes(password)
             mail.login(config['username'], password)
         r = mail.sendmail(mail_from, recipient, msg.as_string())
         log.info("Mail sent: {0!s}".format(r))


### PR DESCRIPTION
Under Python 2, we need to pass passwords as bytestrings, while Python 3 expects passwords as (unicode) strings.

In order to test this, I used a modified version of a [fake SMTP server](https://github.com/ReachFive/fake-smtp-server):
```
git clone https://github.com/fredreichbier/fake-smtp-server
cd fake-smtp-server
npm install .
node ./index.js
```
starts a SMTP server on port 1025. This server advertises CRAM-MD5:
```
$ (sleep 1; echo 'EHLO test') | nc localhost 1025
220 teapot ESMTP
250-teapot Nice to meet you, localhost
250-PIPELINING
250-8BITMIME
250-SMTPUTF8
250 AUTH PLAIN LOGIN CRAM-MD5
```
In privacyIDEA, I now configure a SMTP server on localhost:1025 with username ``test`` and password ``huhu5``, and test the configuration.

Without this PR, I get a privacyIDEA error "TypeError: character mapping must return integer, None or unicode". With this PR, privacyIDEA says "Test Email sent successfully", and the fake SMTP server prints:
```
INFO: CRAM-MD5 SMTP login for user: test password: undefined
INFO: CRAM-MD5 authentication -- is password huhu5 correct?  true
```

Fixes #1637