### PR TITLE
Make LDAP resolver server pool persistent per-process

### DIFF
--- a/doc/configuration/useridresolvers.rst
+++ b/doc/configuration/useridresolvers.rst
@@ -111,7 +111,7 @@ The ``LoginName attribute`` is the attribute that holds the loginname. It
 can be changed to your needs.
 
 Starting with version 2.20 you can provide a list of attributes in
-``LoginName Attribute`` like:
+``LoginName Attribute`` like::
 
     sAMAccountName, userPrincipalName
 
@@ -136,7 +136,7 @@ The above attributes are used for privacyIDEA's normal functionality and are
 listed in the userview. However, with a SAML authentication request user
 attributes can be returned. (see :ref:`return_saml_attributes`). To return
 arbitrary attributes from the LDAP you can add additional keys to the
-attribute mapping with a key, you make up and the LDAP attribute like:
+attribute mapping with a key, you make up and the LDAP attribute like::
 
    "homedir": "homeDirectory",
    "studentID": "objectGUID"
@@ -176,6 +176,20 @@ are unnecessary.
 The ``CACHE_TIMEOUT`` configures a short living per process cache for LDAP users.
 The cache is not shared between different Python processes, if you are running more processes
 in Apache or Nginx. You can set this to ``0`` to deactivate this cache.
+
+The *Server pool retry rounds* and *Server pool skip timeout* settings configure the behavior of
+the LDAP server pool. When establishing a LDAP connection, the resolver uses a round-robin
+strategy to select a LDAP server from the pool. If the current server is not reachable, it is removed
+from the pool and will be re-inserted after the number of seconds specified in the *skip timeout*.
+If no server from the pool is reachable, the servers are queried again from the beginning. If
+a reachable server has not been found after the number of rounds specified in the *retry rounds*,
+the request fails.
+
+By default, knowledge about unavailable pool servers is not persisted between requests.
+Consequently, a new request may retry to reach unavailable servers, even though the *skip timeout*
+has not passed yet. If the *Per-process server pool* is enabled, knowledge about unavailable
+servers is persisted within each process. This setting may improve performance in situations in
+which a LDAP server from the pool is down for extended periods of time.
 
 TLS certificates
 ~~~~~~~~~~~~~~~~

--- a/privacyidea/lib/machines/ldap.py
+++ b/privacyidea/lib/machines/ldap.py
@@ -65,8 +65,8 @@ class LdapMachineResolver(BaseMachineResolver):
 
     def _bind(self):
         if not self.i_am_bound:
-            server_pool = IdResolver.get_serverpool(self.uri, self.timeout,
-                                                    tls_context=self.tls_context)
+            server_pool = IdResolver.create_serverpool(self.uri, self.timeout,
+                                                       tls_context=self.tls_context)
             self.l = IdResolver.create_connection(authtype=self.authtype,
                                                   server=server_pool,
                                                   user=self.binddn,
@@ -312,10 +312,10 @@ class LdapMachineResolver(BaseMachineResolver):
         else:
             tls_context = None
         try:
-            server_pool = IdResolver.get_serverpool(ldap_uri,
-                                                    float(params.get(
+            server_pool = IdResolver.create_serverpool(ldap_uri,
+                                                       float(params.get(
                                                         "TIMEOUT", 5)),
-                                                    tls_context=tls_context)
+                                                       tls_context=tls_context)
             l = IdResolver.create_connection(authtype=\
                                                  params.get("AUTHTYPE",
                                                             AUTHTYPE.SIMPLE),

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -903,7 +903,7 @@ class IdResolver (UserIdResolver):
                             self.serverpool_rounds,
                             self.serverpool_skip)
         if pool_description not in pools:
-            log.debug("Creating a persistent server pool instance for {!r} ...")
+            log.debug("Creating a persistent server pool instance for {!r} ...".format(pool_description))
             # Create a suitable instance of ``LockingServerPool``
             server_pool = self.create_serverpool(self.uri, self.timeout, get_info,
                                                  self.tls_context, self.serverpool_rounds, self.serverpool_skip,

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -58,6 +58,7 @@ The file is tested in tests/test_lib_resolver.py
 
 import logging
 import yaml
+import threading
 import functools
 
 from .UserIdResolver import UserIdResolver
@@ -77,6 +78,7 @@ import hashlib
 import binascii
 from privacyidea.lib.crypto import urandom, geturandom
 from privacyidea.lib.utils import is_true
+from privacyidea.lib.framework import get_app_local_store
 import datetime
 
 from privacyidea.lib import _
@@ -108,6 +110,33 @@ elif os.path.isfile("/etc/ssl/certs/ca-bundle.crt"):
     DEFAULT_CA_FILE = "/etc/ssl/certs/ca-bundle.crt"
 else:
     DEFAULT_CA_FILE = "/etc/privacyidea/ldap-ca.crt"
+
+
+class LockingServerPool(ldap3.ServerPool):
+    """
+    A ``ServerPool`` subclass that uses a RLock to synchronize invocations of
+    ``initialize``, ``get_server`` and ``get_current_server``.
+
+    We synchronize invocations to rule out race conditions when multiple threads
+    try to manipulate the server pool state concurrently.
+
+    We use a ``RLock`` instead of a simple ``Lock`` to avoid locking ourselves.
+    """
+    def __init__(self, *args, **kwargs):
+        ldap3.ServerPool.__init__(self, *args, **kwargs)
+        self._lock = threading.RLock()
+
+    def initialize(self, connection):
+        with self._lock:
+            return ldap3.ServerPool.initialize(self, connection)
+
+    def get_server(self, connection):
+        with self._lock:
+            return ldap3.ServerPool.get_server(self, connection)
+
+    def get_current_server(self, connection):
+        with self._lock:
+            return ldap3.ServerPool.get_current_server(self, connection)
 
 
 def get_ad_timestamp_now():
@@ -298,11 +327,7 @@ class IdResolver (UserIdResolver):
             bind_user = self._getDN(uid)
 
         if not self.serverpool:
-            self.serverpool = self.get_serverpool(self.uri, self.timeout,
-                                                  get_info=ldap3.NONE,
-                                                  tls_context=self.tls_context,
-                                                  rounds=self.serverpool_rounds,
-                                                  exhaust=self.serverpool_skip)
+            self.serverpool = self.get_persistent_serverpool(get_info=ldap3.NONE)
 
         try:
             log.debug("Authtype: {0!r}".format(self.authtype))
@@ -445,11 +470,7 @@ class IdResolver (UserIdResolver):
     def _bind(self):
         if not self.i_am_bound:
             if not self.serverpool:
-                self.serverpool = self.get_serverpool(self.uri, self.timeout,
-                                              get_info=self.get_info,
-                                              tls_context=self.tls_context,
-                                              rounds=self.serverpool_rounds,
-                                              exhaust=self.serverpool_skip)
+                self.serverpool = self.get_persistent_serverpool(self.get_info)
             self.l = self.create_connection(authtype=self.authtype,
                                             server=self.serverpool,
                                             user=self.binddn,
@@ -804,7 +825,7 @@ class IdResolver (UserIdResolver):
 
     @classmethod
     def get_serverpool(cls, urilist, timeout, get_info=None, tls_context=None, rounds=SERVERPOOL_ROUNDS,
-                       exhaust=SERVERPOOL_SKIP):
+                       exhaust=SERVERPOOL_SKIP, pool_cls=ldap3.ServerPool):
         """
         This create the serverpool for the ldap3 connection.
         The URI from the LDAP resolver can contain a comma separated list of
@@ -826,13 +847,14 @@ class IdResolver (UserIdResolver):
             before giving up
         :param exhaust: The seconds, for how long a non-reachable server should be
             removed from the serverpool
+        :param pool_cls: ``ldap3.ServerPool`` subclass that should be instantiated
         :return: Server Pool
-        :rtype: LDAP3 Server Pool Instance
+        :rtype: serverpool_cls
         """
         get_info = get_info or ldap3.SCHEMA
-        server_pool = ldap3.ServerPool(None, ldap3.ROUND_ROBIN,
-                                       active=rounds,
-                                       exhaust=exhaust)
+        server_pool = pool_cls(None, ldap3.ROUND_ROBIN,
+                               active=rounds,
+                               exhaust=exhaust)
         for uri in urilist.split(","):
             uri = uri.strip()
             host, port, ssl = cls.split_uri(uri)
@@ -844,6 +866,40 @@ class IdResolver (UserIdResolver):
             server_pool.add(server)
             log.debug("Added {0!s}, {1!s}, {2!s} to server pool.".format(host, port, ssl))
         return server_pool
+
+    def get_persistent_serverpool(self, get_info=None):
+        """
+        Return a process-level instance of ``LockingServerPool`` for the current LDAP resolver
+        configuration. Retrieve it from the app-local store. If such an instance does not exist
+        yet, create one.
+        :param get_info: one of ldap3.SCHEMA, ldap3.NONE, ldap3.ALL
+        :return: a ``LockingServerPool`` instance
+        """
+        if not get_info:
+            get_info = ldap3.SCHEMA
+        pools = get_app_local_store().setdefault('ldap_server_pools', {})
+        # Create a hashable tuple that describes the current server pool configuration
+        pool_description = (self.uri,
+                            self.timeout,
+                            get_info,
+                            repr(self.tls_context),  # this is the string representation of the TLS context
+                            self.serverpool_rounds,
+                            self.serverpool_skip)
+        if pool_description not in pools:
+            # Create a suitable instance of ``LockingServerPool``
+            server_pool = self.get_serverpool(self.uri, self.timeout, get_info,
+                                              self.tls_context, self.serverpool_rounds, self.serverpool_skip,
+                                              pool_cls=LockingServerPool)
+            # It may happen that another thread tries to add an instance to the dictionary concurrently.
+            # However, only one of them will win, and the other ``LockingServerPool`` instance will be
+            # garbage-collected eventually.
+            return pools.setdefault(pool_description, server_pool)
+        else:
+            # If there is already a ``LockingServerPool`` instance, return it.
+            # We never remove instances from the dictionary, so a ``KeyError`` cannot occur.
+            # As a side effect, when we change the LDAP Id resolver configuration,
+            # outdated ``LockingServerPool`` instances will survive until the next server restart.
+            return pools[pool_description]
 
     @classmethod
     def getResolverClassDescriptor(cls):

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -824,8 +824,8 @@ class IdResolver (UserIdResolver):
         return server, port, ssl
 
     @classmethod
-    def get_serverpool(cls, urilist, timeout, get_info=None, tls_context=None, rounds=SERVERPOOL_ROUNDS,
-                       exhaust=SERVERPOOL_SKIP, pool_cls=ldap3.ServerPool):
+    def create_serverpool(cls, urilist, timeout, get_info=None, tls_context=None, rounds=SERVERPOOL_ROUNDS,
+                          exhaust=SERVERPOOL_SKIP, pool_cls=ldap3.ServerPool):
         """
         This create the serverpool for the ldap3 connection.
         The URI from the LDAP resolver can contain a comma separated list of
@@ -887,9 +887,9 @@ class IdResolver (UserIdResolver):
                             self.serverpool_skip)
         if pool_description not in pools:
             # Create a suitable instance of ``LockingServerPool``
-            server_pool = self.get_serverpool(self.uri, self.timeout, get_info,
-                                              self.tls_context, self.serverpool_rounds, self.serverpool_skip,
-                                              pool_cls=LockingServerPool)
+            server_pool = self.create_serverpool(self.uri, self.timeout, get_info,
+                                                 self.tls_context, self.serverpool_rounds, self.serverpool_skip,
+                                                 pool_cls=LockingServerPool)
             # It may happen that another thread tries to add an instance to the dictionary concurrently.
             # However, only one of them will win, and the other ``LockingServerPool`` instance will be
             # garbage-collected eventually.
@@ -976,11 +976,11 @@ class IdResolver (UserIdResolver):
             tls_context = None
         get_info = get_info_configuration(is_true(param.get("NOSCHEMAS")))
         try:
-            server_pool = cls.get_serverpool(ldap_uri, timeout,
-                                             tls_context=tls_context,
-                                             get_info=get_info,
-                                             rounds=serverpool_rounds,
-                                             exhaust=serverpool_skip)
+            server_pool = cls.create_serverpool(ldap_uri, timeout,
+                                                tls_context=tls_context,
+                                                get_info=get_info,
+                                                rounds=serverpool_rounds,
+                                                exhaust=serverpool_skip)
             l = cls.create_connection(authtype=param.get("AUTHTYPE",
                                                           AUTHTYPE.SIMPLE),
                                       server=server_pool,

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -955,6 +955,7 @@ class IdResolver (UserIdResolver):
                                 'CACHE_TIMEOUT': 'int',
                                 'SERVERPOOL_ROUNDS': 'int',
                                 'SERVERPOOL_SKIP': 'int',
+                                'SERVERPOOL_PERSISTENT': 'bool',
                                 'OBJECT_CLASSES': 'string',
                                 'DN_TEMPLATE': 'string'}
         return {typ: descriptor}

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -903,6 +903,7 @@ class IdResolver (UserIdResolver):
                             self.serverpool_rounds,
                             self.serverpool_skip)
         if pool_description not in pools:
+            log.debug("Creating a persistent server pool instance for {!r} ...")
             # Create a suitable instance of ``LockingServerPool``
             server_pool = self.create_serverpool(self.uri, self.timeout, get_info,
                                                  self.tls_context, self.serverpool_rounds, self.serverpool_skip,

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -894,6 +894,7 @@ myApp.controller("LdapResolverController", function ($scope, ConfigFactory, $sta
             $scope.params.TLS_VERIFY = isTrue($scope.params.TLS_VERIFY);
             $scope.params.START_TLS = isTrue($scope.params.START_TLS);
             $scope.params.NOSCHEMAS = isTrue($scope.params.NOSCHEMAS);
+            $scope.params.SERVERPOOL_PERSISTENT = isTrue($scope.params.SERVERPOOL_PERSISTENT);
             $scope.params.type = 'ldapresolver';
         });
     }

--- a/privacyidea/static/components/config/views/config.resolvers.ldap.html
+++ b/privacyidea/static/components/config/views/config.resolvers.ldap.html
@@ -163,13 +163,13 @@
         </div>
     </div>
     <div class="form-group">
-        <label for="serverpool-persistent" class="col-sm-3 control-label" translate>
-            Per-process server pool
-        </label>
-        <div class="col-sm-9">
-            <input name="serverpool-persistent"
-                   ng-model="params.SERVERPOOL_PERSISTENT"
-                   type="checkbox" />
+        <label for="sizelimit" class="col-sm-3 control-label"
+                translate>Size Limit</label>
+
+        <div class="col-sm-3">
+            <input name="sizelimit" class="form-control"
+                   ng-model="params.SIZELIMIT" required
+                   placeholder="500"/>
         </div>
     </div>
     <div class="form-group">
@@ -191,13 +191,16 @@
         </div>
     </div>
     <div class="form-group">
-        <label for="sizelimit" class="col-sm-3 control-label"
-                translate>Size Limit</label>
-
-        <div class="col-sm-3">
-            <input name="sizelimit" class="form-control"
-                   ng-model="params.SIZELIMIT" required
-                   placeholder="500"/>
+        <label for="serverpool-persistent" class="col-sm-3 control-label" translate>
+            Per-process server pool
+        </label>
+        <div class="col-sm-9">
+            <input name="serverpool-persistent"
+                   ng-model="params.SERVERPOOL_PERSISTENT"
+                   type="checkbox" />
+            <p class="help-block" translate>
+                This setting activates a LDAP server pool that is persisted between requests.
+            </p>
         </div>
     </div>
     <div class="form-group">

--- a/privacyidea/static/components/config/views/config.resolvers.ldap.html
+++ b/privacyidea/static/components/config/views/config.resolvers.ldap.html
@@ -163,6 +163,16 @@
         </div>
     </div>
     <div class="form-group">
+        <label for="serverpool-persistent" class="col-sm-3 control-label" translate>
+            Per-process server pool
+        </label>
+        <div class="col-sm-9">
+            <input name="serverpool-persistent"
+                   ng-model="params.SERVERPOOL_PERSISTENT"
+                   type="checkbox" />
+        </div>
+    </div>
+    <div class="form-group">
         <label for="serverpool-rounds" class="col-sm-3 control-label"
                 translate>Server pool retry rounds</label>
 

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -2089,6 +2089,21 @@ class LDAPResolverTestCase(MyTestCase):
         self.assertIs(type(y4.serverpool), LockingServerPool)
         self.assertIs(y3.serverpool, y4.serverpool)
 
+    def test_36_locking_serverpool(self):
+        # check that the LockingServerPool correctly forwards all relevant method calls
+        pool = LockingServerPool()
+        pool.add(ldap3.Server('server1'))
+        pool.add(ldap3.Server('server2'))
+        with mock.patch('ldap3.ServerPool.initialize') as mock_method:
+            pool.initialize(None)
+            mock_method.assert_called_once()
+        with mock.patch('ldap3.ServerPool.get_server') as mock_method:
+            pool.get_server(None)
+            mock_method.assert_called_once()
+        with mock.patch('ldap3.ServerPool.get_current_server') as mock_method:
+            pool.get_current_server(None)
+            mock_method.assert_called_once()
+
 class BaseResolverTestCase(MyTestCase):
 
     def test_00_basefunctions(self):

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -1128,28 +1128,28 @@ class LDAPResolverTestCase(MyTestCase):
     def test_07_get_serverpool(self):
         timeout = 5
         urilist = "ldap://themis"
-        server_pool = LDAPResolver.get_serverpool(urilist, timeout)
+        server_pool = LDAPResolver.create_serverpool(urilist, timeout)
         self.assertEqual(len(server_pool), 1)
         self.assertEqual(server_pool.active, SERVERPOOL_ROUNDS)
         self.assertEqual(server_pool.exhaust, SERVERPOOL_SKIP)
         self.assertEqual(server_pool.strategy, "ROUND_ROBIN")
 
         urilist = "ldap://themis, ldap://server2"
-        server_pool = LDAPResolver.get_serverpool(urilist, timeout)
+        server_pool = LDAPResolver.create_serverpool(urilist, timeout)
         self.assertEqual(len(server_pool), 2)
         self.assertEqual(server_pool.servers[0].name, "ldap://themis:389")
         self.assertEqual(server_pool.servers[1].name, "ldap://server2:389")
 
         urilist = "ldap://themis, ldaps://server2"
-        server_pool = LDAPResolver.get_serverpool(urilist, timeout)
+        server_pool = LDAPResolver.create_serverpool(urilist, timeout)
         self.assertEqual(len(server_pool), 2)
         self.assertEqual(server_pool.servers[0].name, "ldap://themis:389")
         self.assertEqual(server_pool.servers[1].name, "ldaps://server2:636")
 
         urilist = "ldap://themis, ldaps://server2"
-        server_pool = LDAPResolver.get_serverpool(urilist, timeout,
-                                                  rounds=5,
-                                                  exhaust=60)
+        server_pool = LDAPResolver.create_serverpool(urilist, timeout,
+                                                     rounds=5,
+                                                     exhaust=60)
         self.assertEqual(len(server_pool), 2)
         self.assertEqual(server_pool.active, 5)
         self.assertEqual(server_pool.exhaust, 60)


### PR DESCRIPTION
This implements a per-process LDAP server pool.

Until now, every resolver object uses its own ``ldap3.ServerPool``.  But resolver objects are only alive for the duration of the current request. So if a LDAP server goes offline at some point, this information gets lost when the request ends, and subsequent requests will re-try to contact the LDAP server.

With this PR, the admin can check the "Per-process server pool" checkbox in the LDAP resolver configuration. If it is checked, all LDAP resolvers with the same server pool configuration will use the same shared server pool instance. This PR defines a ``LockingServerPool`` class which uses locks to synchronize access to the server pool state, in order to rule out race conditions if two threads concurrently manipulate the server pool state.

I decided to implement this as an opt-in feature to avoid unforeseen issues with existing installations.

I'm happy about any comments :)

Closes #1396.