### PR TITLE
Add focus for filter input

### DIFF
--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -59,6 +59,21 @@ myApp.directive("piFilter", function (instanceUrl) {
     };
 });
 
+myApp.directive('focusMe', function($timeout) {
+  return {
+    link: function(scope, element, attrs) {
+      scope.$watch(attrs.focusMe, function(value) {
+        if(value === true) {
+          $timeout(function() {
+            element[0].focus();
+            scope[attrs.focusMe] = false;
+          });
+        }
+      });
+    }
+  };
+});
+
 myApp.directive("piSortBy", function(){
     return {
         restrict: 'A',

--- a/privacyidea/static/components/directives/views/directive.filter.table.html
+++ b/privacyidea/static/components/directives/views/directive.filter.table.html
@@ -1,5 +1,5 @@
 <span class="glyphicon glyphicon-filter"
-      ng-click="filterVisible=!filterVisible"
+      ng-click="filterVisible=!filterVisible; focusInput=true"
       ng-class="{filtered:filterValue}"></span>
  <input ng-show="filterVisible" ng-change="updateFilter()"
-        ng-model="filterValue" placeholder="filter" class="form-control">
+        ng-model="filterValue" focus-me="focusInput" placeholder="filter" class="form-control">


### PR DESCRIPTION
If you enable a filter, the input field should be focused automatically.

(Tested with Google Chrome)