### PR TITLE
Fix U2F enrollment for Chrome 72+

### DIFF
--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -348,7 +348,7 @@ class U2fTokenClass(TokenClass):
             if not app_id:
                 raise TokenAdminError(_("You need to define the appId in the "
                                         "token config!"))
-            nonce = urlsafe_b64encode_and_unicode(geturandom(32))
+            nonce = url_encode(geturandom(32))
             response_detail = TokenClass.get_init_detail(self, params, user)
             register_request = {"version": U2F_Version,
                                 "challenge": nonce,

--- a/tests/test_lib_tokens_u2f.py
+++ b/tests/test_lib_tokens_u2f.py
@@ -148,7 +148,7 @@ class U2FTokenTestCase(MyTestCase):
         version = registerRequest.get("version")
         self.assertEqual(version, "U2F_V2")
         challenge = registerRequest.get("challenge")
-        self.assertEqual(len(challenge), 44)
+        self.assertEqual(len(challenge), 43)
 
         # Init step 2
         token = init_token({"type": "u2f",


### PR DESCRIPTION
In Chrome 72, the base64url decoding behaviour changed.
This could be fixed, if we use the base64_encode function for u2f registration and not only for signing.

I did not test it in a good way yet. But I noticed that this works in my scenario with both, Google Chrome and Mozilla Firefox.

resolves #1636