### PR TITLE
Add possibility to use user object for policy matching

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -208,9 +208,7 @@ def check_tokentype(request, response):
     allowed_tokentypes = policy_object.get_action_values(
         ACTION.TOKENTYPE,
         scope=SCOPE.AUTHZ,
-        user=user_object.login,
-        resolver=user_object.resolver,
-        realm=user_object.realm,
+        user_object=user_object,
         client=g.client_ip,
         audit_data=g.audit_object.audit_data)
     if tokentype and allowed_tokentypes and tokentype not in allowed_tokentypes:
@@ -719,9 +717,7 @@ def autoassign(request, response):
             autoassign_values = policy_object.\
                 get_action_values(action=ACTION.AUTOASSIGN,
                                   scope=SCOPE.ENROLL,
-                                  user=user_obj.login,
-                                  resolver=user_obj.resolver,
-                                  realm=user_obj.realm,
+                                  user_object=user_obj,
                                   client=g.client_ip,
                                   unique=True)
 
@@ -825,9 +821,7 @@ def mangle_challenge_response(request, response):
                                                  scope=SCOPE.AUTH,
                                                  allow_white_space_in_action=True,
                                                  client=g.client_ip,
-                                                 user=user_obj.login,
-                                                 realm=user_obj.realm,
-                                                 resolver=user_obj.resolver,
+                                                 user_object=user_obj,
                                                  audit_data=g.audit_object.audit_data,
                                                  unique=True)
 
@@ -835,9 +829,7 @@ def mangle_challenge_response(request, response):
                                                  scope=SCOPE.AUTH,
                                                  allow_white_space_in_action=True,
                                                  client=g.client_ip,
-                                                 user=user_obj.login,
-                                                 realm=user_obj.realm,
-                                                 resolver=user_obj.resolver,
+                                                 user_object=user_obj,
                                                  audit_data=g.audit_object.audit_data,
                                                  unique=True)
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -146,8 +146,7 @@ def init_random_pin(request=None, action=None):
     # get the length of the random PIN from the policies
     pin_pols = policy_object.get_action_values(action=ACTION.OTPPINRANDOM,
                                                scope=SCOPE.ENROLL,
-                                               user=user_object.login,
-                                               realm=user_object.realm,
+                                               user_object=user_object,
                                                client=g.client_ip,
                                                unique=True,
                                                audit_data=g.audit_object.audit_data)
@@ -159,7 +158,7 @@ def init_random_pin(request=None, action=None):
         # handle the PIN
         handle_pols = policy_object.get_action_values(
             action=ACTION.PINHANDLING, scope=SCOPE.ENROLL,
-            user=user_object.login, realm=user_object.realm,
+            user_object=user_object,
             client=g.client_ip,
             audit_data=g.audit_object.audit_data)
         # We can have more than one pin handler policy. So we can process the
@@ -364,14 +363,11 @@ def papertoken_count(request=None, action=None):
     :return:
     """
     from privacyidea.lib.tokens.papertoken import PAPERACTION
-    user_object = request.User
     policy_object = g.policy_object
     pols = policy_object.get_action_values(
         action=PAPERACTION.PAPERTOKEN_COUNT,
         scope=SCOPE.ENROLL,
-        user=user_object.login,
-        resolver=user_object.resolver,
-        realm=user_object.realm,
+        user_object=request.User,
         client=g.client_ip,
         unique=True,
         audit_data=g.audit_object.audit_data)
@@ -396,14 +392,11 @@ def tantoken_count(request=None, action=None):
     :return:
     """
     from privacyidea.lib.tokens.tantoken import TANACTION
-    user_object = request.User
     policy_object = g.policy_object
     pols = policy_object.get_action_values(
         action=TANACTION.TANTOKEN_COUNT,
         scope=SCOPE.ENROLL,
-        user=user_object.login,
-        resolver=user_object.resolver,
-        realm=user_object.realm,
+        user=request.User,
         client=g.client_ip,
         unique=True,
         audit_data=g.audit_object.audit_data)
@@ -522,8 +515,7 @@ def init_tokenlabel(request=None, action=None):
     # get the serials from a policy definition
     label_pols = policy_object.get_action_values(action=ACTION.TOKENLABEL,
                                                  scope=SCOPE.ENROLL,
-                                                 user=user_object.login,
-                                                 realm=user_object.realm,
+                                                 user_object=user_object,
                                                  client=g.client_ip,
                                                  unique=True,
                                                  allow_white_space_in_action=True,
@@ -535,8 +527,7 @@ def init_tokenlabel(request=None, action=None):
 
     issuer_pols = policy_object.get_action_values(action=ACTION.TOKENISSUER,
                                                   scope=SCOPE.ENROLL,
-                                                  user=user_object.login,
-                                                  realm=user_object.realm,
+                                                  user_object=user_object,
                                                   client=g.client_ip,
                                                   unique=True,
                                                   allow_white_space_in_action=True,
@@ -546,8 +537,7 @@ def init_tokenlabel(request=None, action=None):
 
     imageurl_pols = policy_object.get_action_values(action=ACTION.APPIMAGEURL,
                                                     scope=SCOPE.ENROLL,
-                                                    user=user_object.login,
-                                                    realm=user_object.realm,
+                                                    user_object=user_object,
                                                     client=g.client_ip,
                                                     unique=True,
                                                     allow_white_space_in_action=True,
@@ -699,9 +689,7 @@ def check_max_token_user(request=None, action=None):
         # check maximum tokens of user
         limit_list = policy_object.get_action_values(ACTION.MAXTOKENUSER,
                                                      scope=SCOPE.ENROLL,
-                                                     realm=user_object.realm,
-                                                     resolver=user_object.resolver,
-                                                     user=user_object.login,
+                                                     user_object=user_object,
                                                      client=g.client_ip)
         if limit_list:
             # we need to check how many tokens the user already has assigned!
@@ -720,9 +708,7 @@ def check_max_token_user(request=None, action=None):
         # check maximum active tokens of user
         limit_list = policy_object.get_action_values(ACTION.MAXACTIVETOKENUSER,
                                                      scope=SCOPE.ENROLL,
-                                                     realm=user_object.realm,
-                                                     resolver=user_object.resolver,
-                                                     user=user_object.login,
+                                                     user_object=user_object,
                                                      client=g.client_ip)
         if limit_list:
             # we need to check how many active tokens the user already has assigned!
@@ -948,8 +934,7 @@ def mangle(request=None, action=None):
     policy_object = g.policy_object
     mangle_pols = policy_object.get_action_values(ACTION.MANGLE,
                                                   scope=SCOPE.AUTH,
-                                                  realm=user_object.realm,
-                                                  user=user_object.login,
+                                                  user_object=user_object,
                                                   client=g.client_ip)
     # We can have several mangle policies! One for user, one for realm and
     # one for pass. So we do no checking here.
@@ -1343,20 +1328,11 @@ def pushtoken_add_config(request, action):
     if ttype and ttype.lower() == "push":
         ttl = None
         registration_url = None
-        user_object = request.User
-        if user_object:
-            token_user = user_object.login
-            token_realm = user_object.realm
-            token_resolver = user_object.resolver
-        else:
-            token_realm = token_resolver = token_user = None
         # Get the firebase configuration from the policies
         firebase_config = g.policy_object.get_action_values(
             action=PUSH_ACTION.FIREBASE_CONFIG,
             scope=SCOPE.ENROLL,
-            realm=token_realm,
-            user=token_user,
-            resolver=token_resolver,
+            user_object=request.User if request.User else None,
             client=g.client_ip,
             audit_data=g.audit_object.audit_data,
             allow_white_space_in_action=True,
@@ -1370,9 +1346,7 @@ def pushtoken_add_config(request, action):
         ssl_verify = g.policy_object.get_action_values(
             action=PUSH_ACTION.SSL_VERIFY,
             scope=SCOPE.ENROLL,
-            realm=token_realm,
-            user=token_user,
-            resolver=token_resolver,
+            user_object=request.User if request.User else None,
             client=g.client_ip,
             audit_data=g.audit_object.audit_data,
             unique=True
@@ -1448,7 +1422,6 @@ def u2ftoken_allowed(request, action):
     if reg_data:
         # We have a registered u2f device!
         serial = request.all_data.get("serial")
-        user_object = request.User
 
         # We just check, if the issuer is allowed, not if the certificate
         # is still valid! (verify_cert=False)
@@ -1464,19 +1437,10 @@ def u2ftoken_allowed(request, action):
             "attestation_subject": x509name_to_string(
                 attestation_cert.get_subject())}
 
-        if user_object:
-            token_user = user_object.login
-            token_realm = user_object.realm
-            token_resolver = user_object.resolver
-        else:
-            token_realm = token_resolver = token_user = None
-
         allowed_certs_pols = policy_object.get_action_values(
             U2FACTION.REQ,
             scope=SCOPE.ENROLL,
-            realm=token_realm,
-            user=token_user,
-            resolver=token_resolver,
+            user_object=request.User if request.User else None,
             client=g.client_ip,
             audit_data=g.audit_object.audit_data)
         for allowed_cert in allowed_certs_pols:

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -475,10 +475,22 @@ class PolicyClass(with_metaclass(Singleton, object)):
         *or* pass a user object from which login name, resolver and realm will be read.
         In case of conflicting parameters, a ParameterError will be raised.
 
+        The following rule holds for all filter arguments:
+
+        If ``None`` is passed as a value, policies are not filtered according to the
+        argument at all. As an example, if ``realm=None`` is passed,
+        policies are matched regardless of their ``realm`` attribute.
+        If any value is passed (even the empty string), policies are filtered
+        according to the given value. As an example, if ``realm=''`` is passed,
+        only policies that have a matching (or empty) realm attribute are returned.
+
+        The only exception is the ``client`` parameter, which does not accept the empty string,
+        and throws a ParameterError if the empty string is passed.
+
         :param name: The name of the policy
         :param scope: The scope of the policy
         :param realm: The realm in the policy
-        :param active: Only active policies
+        :param active: One of None, True, False: All policies, only active or only inactive policies
         :param resolver: Only policies with this resolver
         :param user: Only policies with this user
         :type user: basestring
@@ -600,6 +612,9 @@ class PolicyClass(with_metaclass(Singleton, object)):
         # the client 10.0.0.1 does not match the policy "10.0.0.0/8, -10.0.0.1".
         # An empty client definition in the policy matches all clients.
         if client is not None:
+            if not client:
+                raise ParameterError("client argument must be a non-empty string")
+
             new_policies = []
             for policy in reduced_policies:
                 log.debug(u"checking client ip in policy {0!s}.".format(policy))

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -121,9 +121,7 @@ def challenge_response_allowed(func):
             allowed_tokentypes_dict = policy_object.get_action_values(
                 action=ACTION.CHALLENGERESPONSE,
                 scope=SCOPE.AUTH,
-                realm=user_object.realm,
-                resolver=user_object.resolver,
-                user=user_object.login,
+                user_object=user_object,
                 client=clientip)
             log.debug("Found these allowed tokentypes: {0!s}".format(list(allowed_tokentypes_dict)))
 
@@ -167,9 +165,7 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
         auth_cache_dict = policy_object.get_action_values(
             action=ACTION.AUTH_CACHE,
             scope=SCOPE.AUTH,
-            realm=user_object.realm,
-            resolver=user_object.resolver,
-            user=user_object.login,
+            user_object=user_object,
             client=clientip,
             unique=True)
         if auth_cache_dict:
@@ -333,9 +329,7 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
                     # TODO: here we can check, if the token should be assigned.
                     passthru_assign = policy_object.get_action_values(action=ACTION.PASSTHRU_ASSIGN,
                                                                       scope=SCOPE.AUTH,
-                                                                      realm=user_object.realm,
-                                                                      resolver=user_object.resolver,
-                                                                      user=user_object.login,
+                                                                      user_object=user_object,
                                                                       client=clientip,
                                                                       unique=True,
                                                                       audit_data=g.audit_object.audit_data)
@@ -403,17 +397,13 @@ def auth_user_timelimit(wrapped_function, user_object, passw, options=None):
         max_success_dict = policy_object.get_action_values(
             action=ACTION.AUTHMAXSUCCESS,
             scope=SCOPE.AUTHZ,
-            realm=user_object.realm,
-            resolver=user_object.resolver,
-            user=user_object.login,
+            user_object=user_object,
             client=clientip,
             unique=True)
         max_fail_dict = policy_object.get_action_values(
             action=ACTION.AUTHMAXFAIL,
             scope=SCOPE.AUTHZ,
-            realm=user_object.realm,
-            resolver=user_object.resolver,
-            user=user_object.login,
+            user_object=user_object,
             client=clientip,
             unique=True)
         # Check for maximum failed authentications
@@ -562,9 +552,7 @@ def login_mode(wrapped_function, *args, **kwds):
         login_mode_dict = policy_object.get_action_values(
             ACTION.LOGINMODE,
             scope=SCOPE.WEBUI,
-            realm=user_object.realm,
-            resolver=user_object.resolver,
-            user=user_object.login,
+            user_object=user_object,
             client=clientip,
             unique=True,
             audit_data=g.audit_object.audit_data)
@@ -621,9 +609,7 @@ def auth_otppin(wrapped_function, *args, **kwds):
         policy_object = g.policy_object
         otppin_dict = policy_object.get_action_values(ACTION.OTPPIN,
                                                       scope=SCOPE.AUTH,
-                                                      realm=user_object.realm,
-                                                      resolver=user_object.resolver,
-                                                      user=user_object.login,
+                                                      user_object=user_object,
                                                       client=clientip,
                                                       unique=True,
                                                       audit_data=g.audit_object.audit_data)
@@ -668,41 +654,28 @@ def config_lost_token(wrapped_function, *args, **kwds):
         serial = args[0]
         toks = get_tokens(serial=serial)
         if len(toks) == 1:
-            username = None
-            realm = None
-            resolver = None
             user_object = toks[0].user
-            if user_object:
-                username = user_object.login
-                realm = user_object.realm
-                resolver = user_object.resolver
             clientip = options.get("clientip")
             # get the policy
             policy_object = g.policy_object
             contents_dict = policy_object.get_action_values(
                 ACTION.LOSTTOKENPWCONTENTS,
                 scope=SCOPE.ENROLL,
-                realm=realm,
-                resolver=resolver,
-                user=username,
+                user_object=user_object if user_object else None,
                 client=clientip,
                 unique=True,
                 audit_data=g.audit_object.audit_data)
             validity_dict = policy_object.get_action_values(
                 ACTION.LOSTTOKENVALID,
                 scope=SCOPE.ENROLL,
-                realm=realm,
-                resolver=resolver,
-                user=username,
+                user_object=user_object if user_object else None,
                 client=clientip,
                 unique=True,
                 audit_data=g.audit_object.audit_data)
             pw_len_dict = policy_object.get_action_values(
                 ACTION.LOSTTOKENPWLEN,
                 scope=SCOPE.ENROLL,
-                realm=realm,
-                resolver=resolver,
-                user=username,
+                user_object=user_object if user_object else None,
                 client=clientip,
                 unique=True,
                 audit_data=g.audit_object.audit_data)
@@ -743,9 +716,7 @@ def reset_all_user_tokens(wrapped_function, *args, **kwds):
         reset_all = policy_object.get_policies(
             action=ACTION.RESETALLTOKENS,
             scope=SCOPE.AUTH,
-            realm=token_owner.login if token_owner else None,
-            resolver=token_owner.resolver if token_owner else None,
-            user=token_owner.realm if token_owner else None,
+            user_object=token_owner if token_owner else None,
             client=clientip, active=True,
             audit_data=g.audit_object.audit_data)
         if reset_all:

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -353,20 +353,14 @@ class EmailTokenClass(HotpTokenClass):
         message = default
         mimetype = "plain"
         g = options.get("g")
-        username = None
-        realm = None
         user_object = options.get("user")
-        if user_object:  # pragma: no cover
-            username = user_object.login
-            realm = user_object.realm
         if g:
             clientip = options.get("clientip")
             policy_object = g.policy_object
             messages = policy_object.\
                 get_action_values(action=action,
                                   scope=SCOPE.AUTH,
-                                  realm=realm,
-                                  user=username,
+                                  user_object=user_object if user_object else None,
                                   client=clientip,
                                   unique=True,
                                   allow_white_space_in_action=True,

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -498,20 +498,14 @@ class SmsTokenClass(HotpTokenClass):
         """
         message = "<otp>"
         g = options.get("g")
-        username = None
-        realm = None
         user_object = options.get("user")
-        if user_object:
-            username = user_object.login
-            realm = user_object.realm
         if g:
             clientip = options.get("clientip")
             policy_object = g.policy_object
             messages = policy_object.\
                 get_action_values(action=SMSACTION.SMSTEXT,
                                   scope=SCOPE.AUTH,
-                                  realm=realm,
-                                  user=username,
+                                  user_object=user_object if user_object else None,
                                   client=clientip,
                                   unique=True,
                                   allow_white_space_in_action=True,

--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -494,18 +494,11 @@ class U2fTokenClass(TokenClass):
                     # certificate is authorized.
                     # If not, we can raise a policy exception
                     g = options.get("g")
-                    if self.user:
-                        token_user = self.user.login
-                        token_realm = self.user.realm
-                        token_resolver = self.user.resolver
-                    else:
-                        token_realm = token_resolver = token_user = None
+                    user_object = self.user
                     allowed_certs_pols = g.policy_object.get_action_values(
                         U2FACTION.REQ,
                         scope=SCOPE.AUTHZ,
-                        realm=token_realm,
-                        user=token_user,
-                        resolver=token_resolver,
+                        user_object=user_object if user_object else None,
                         client=g.client_ip,
                         audit_data=g.audit_object.audit_data)
                     for allowed_cert in allowed_certs_pols:

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -225,6 +225,10 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(_check_policy_name("pol4", p), p)
         self.assertTrue(len(p) == 1, p)
 
+        # client="" throws a ParameterError
+        with self.assertRaises(ParameterError):
+            P.get_policies(client="")
+
     def test_08_user_policies(self):
         set_policy(name="pol1", scope="s", user="*")
         set_policy(name="pol2", scope="s", user="admin, root, user1")
@@ -253,6 +257,12 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(_check_policy_name("pol2", p), p)
         self.assertTrue(_check_policy_name("pol3", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
+        # get policies for empty user
+        p = P.get_policies(user="")
+        self.assertEqual(len(p), 3)
+        self.assertTrue(_check_policy_name("pol1", p), p)
+        self.assertTrue(_check_policy_name("pol3", p), p)
+        self.assertTrue(_check_policy_name("pol4", p), p)
 
     def test_09_realm_resolver_policy(self):
         set_policy(name="pol1", scope="s", realm="r1")
@@ -275,6 +285,14 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(_check_policy_name("pol3", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
 
+        # Check cases in which we pass an empty realm or realm=None
+        p = P.get_policies(realm="")
+        self.assertEqual(len(p), 1)
+        self.assertTrue(_check_policy_name("pol3", p), p)
+
+        p = P.get_policies(realm=None)
+        self.assertEqual(len(p), 4)
+
         p = P.get_policies(resolver="reso1")
         self.assertEqual(len(p), 3)
         self.assertTrue(_check_policy_name("pol1", p), p)
@@ -287,6 +305,12 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertFalse(_check_policy_name("pol2", p), p)
         self.assertTrue(_check_policy_name("pol3", p), p)
+        self.assertTrue(_check_policy_name("pol4", p), p)
+
+        # Check case in which we pass an empty resolver
+        p = P.get_policies(resolver="")
+        self.assertEqual(len(p), 2)
+        self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
 
     def test_10_action_policies(self):
@@ -307,6 +331,16 @@ class PolicyTestCase(MyTestCase):
 
         p = P.get_policies(action="otppin")
         self.assertTrue(len(p) == 2, (len(p), p))
+
+        # Check cases in which we pass an empty action or action=None
+        p = P.get_policies(action="")
+        # Here, we get pol3 and pol4
+        self.assertEqual(len(p), 2)
+        self.assertTrue(_check_policy_name("pol3", p), p)
+        self.assertTrue(_check_policy_name("pol4", p), p)
+
+        p = P.get_policies(action=None)
+        self.assertEqual(len(p), 4)
 
     def test_11_get_policy_definitions(self):
         p = get_static_policy_definitions()

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -16,7 +16,7 @@ from privacyidea.lib.policy import (set_policy, delete_policy,
 from privacyidea.lib.realm import (set_realm, delete_realm, get_realms)
 from privacyidea.lib.resolver import (save_resolver, get_resolver_list,
                                       delete_resolver)
-from privacyidea.lib.error import ParameterError, ServerError
+from privacyidea.lib.error import ParameterError
 from privacyidea.lib.user import User
 import datetime
 from .base import PWFILE as FILE_PASSWORDS


### PR DESCRIPTION
This adds a ``user_object`` parameter to ``get_policies`` and ``get_action_values``.

One can either pass ``user``/``realm``/``resolver`` or ``user_object``. In the latter case, user/realm/resolver are read from the user object.

Working on #1436/#1645, as this will allow us to implement conditions on arbitrary user attributes in a simple way.

This also fixes some cases in which the user resolver is not taken into account when matching policies (see #1646)