### PR TITLE
Fix empty client_ip condition for pre handler

### DIFF
--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -650,6 +650,8 @@ def check_ip_in_policy(client_ip, policy):
     """
     client_found = False
     client_excluded = False
+    # Remove empty strings from the list
+    policy = list(filter(None, policy))
     for ipdef in policy:
         if ipdef[0] in ['-', '!']:
             # exclude the client?

--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -749,24 +749,31 @@ def compare_condition(condition, value):
     :return: True or False
     """
     condition = condition.replace(" ", "")
+    if not condition:
+        # No condition to match!
+        return False
 
-    # compare equal
-    if condition[0] in "=" + string.digits:
-        if condition[0] == "=":
+    try:
+        # compare equal
+        if condition[0] in "=" + string.digits:
+            if condition[0] == "=":
+                compare_value = int(condition[1:])
+            else:
+                compare_value = int(condition)
+            return value == compare_value
+
+        # compare bigger
+        if condition[0] == ">":
             compare_value = int(condition[1:])
-        else:
-            compare_value = int(condition)
-        return value == compare_value
+            return value > compare_value
 
-    # compare bigger
-    if condition[0] == ">":
-        compare_value = int(condition[1:])
-        return value > compare_value
-
-    # compare less
-    if condition[0] == "<":
-        compare_value = int(condition[1:])
-        return value < compare_value
+        # compare less
+        if condition[0] == "<":
+            compare_value = int(condition[1:])
+            return value < compare_value
+    except ValueError:
+        log.warning(u"Invalid condition {0!s}. Needs to contain an integer.".format(condition))
+        return False
 
 
 def compare_value_value(value1, comparator, value2):

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -273,6 +273,12 @@ class UtilsTestCase(MyTestCase):
         self.assertFalse(compare_condition("<100", 1000))
         self.assertFalse(compare_condition("<100", 100))
 
+        # There are invalid conditions, which should not raise an exception
+        # An empty condition will result in False
+        self.assertFalse(compare_condition("", 100))
+        # An invalid condition, which misses a compare-value, will result in false
+        self.assertFalse(compare_condition(">", 100))
+
     def test_09_get_data_from_params(self):
         config_description = {
             "local":  {

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -643,6 +643,11 @@ class UtilsTestCase(MyTestCase):
         self.assertTrue(excluded)
         self.assertTrue(found)
 
+        # run a test for empty condition
+        found, excluded = check_ip_in_policy("10.0.1.2", ["10.0.1.0/24", "!10.0.1.2", u'', None])
+        self.assertTrue(excluded)
+        self.assertTrue(found)
+
     def test_30_split_pin_pass(self):
         pin, otp = split_pin_pass("test1234", 4, True)
         self.assertEqual(pin, "test")


### PR DESCRIPTION
If the client_ip in the condition would be empty
we would get a string index out of range error.

Fixes #1658