### PR TITLE
Do not increase failcounter for quering status TIQR token

### DIFF
--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -440,6 +440,8 @@ class TiqrTokenClass(OcraTokenClass):
             for challengeobject in challengeobject_list:
                 # check if we are still in time.
                 if challengeobject.is_valid():
+                    # This is a valid transaction ID not need to increase fail counter
+                    self.set_failcount(abs(self.get_failcount()) - 1)
                     _, status = challengeobject.get_otp_status()
                     if status is True:
                         # create a positive response


### PR DESCRIPTION
The failcounter is increased if we check if the qrcode is
accepted, see:
 * https://community.privacyidea.org/t/tiqr-authentication-fail-counter-increase-if-we-query-the-status/1061