### PR TITLE
Add simple way to log SQL dialect in diagnostics file

### DIFF
--- a/tools/privacyidea-diag
+++ b/tools/privacyidea-diag
@@ -59,6 +59,9 @@ get_pi_cfg() {
 	log "SECTION: pi.cfg file"
 	log "===================="
 	grep -v -e 'SECRET_KEY\|PI_PEPPER\|SQLALCHEMY_DATABASE_URI' $PICFG >> $tempfile
+	# only write the driver part of the URI to the logfile.
+	# So we need if eg. pymysql, mysql or any other dialect is used.
+	grep ^SQLALCHEMY_DATABASE_URI $PICFG | cut -d':' -f 1 >> $tempfile
 }
 
 

--- a/tools/privacyidea-diag
+++ b/tools/privacyidea-diag
@@ -60,7 +60,7 @@ get_pi_cfg() {
 	log "===================="
 	grep -v -e 'SECRET_KEY\|PI_PEPPER\|SQLALCHEMY_DATABASE_URI' $PICFG >> $tempfile
 	# only write the driver part of the URI to the logfile.
-	# So we need if eg. pymysql, mysql or any other dialect is used.
+	# So we see if eg. pymysql, mysql or any other dialect is used.
 	grep ^SQLALCHEMY_DATABASE_URI $PICFG | cut -d':' -f 1 >> $tempfile
 }
 


### PR DESCRIPTION
Closes #1667

This is a simple but effective way to log the SQL driver and dialect in the diagnostics file.
If anyone knows a nicer way, like the "censor_connect_string" does, go for it.

I am no awk guru and I would avoid to do this do complex to not break things.
