### PR TITLE
Add a tokenmode "outofband"

### DIFF
--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2237,7 +2237,8 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
             # We did not find any successful response, so we need to increase the
             # failcounters
             for token_obj in challenge_response_token_list:
-                token_obj.inc_failcount()
+                if not token_obj.is_outofband():
+                    token_obj.inc_failcount()
             if not matching_challenge:
                 if len(challenge_response_token_list) == 1:
                     reply_dict["serial"] = challenge_response_token_list[0].token.serial

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -124,12 +124,19 @@ class TOKENKIND(object):
     VIRTUAL = "virtual"
 
 
+class TOKENMODE(object):
+    AUTHENTICATE = 'authenticate'
+    CHALLENGE = 'challenge'
+    # If the challenge is answered out of band
+    OUTOFBAND = 'outofband'
+
+
 class TokenClass(object):
 
     # Class properties
     using_pin = True
     hKeyRequired = False
-    mode = ['authenticate', 'challenge']
+    mode = [TOKENMODE.AUTHENTICATE, TOKENMODE.CHALLENGE]
 
     @log_with(log)
     def __init__(self, db_token):
@@ -162,6 +169,10 @@ class TokenClass(object):
         tokentype = u'' + tokentype
         self.type = tokentype
         self.token.tokentype = tokentype
+
+    @classmethod
+    def is_outofband(cls):
+        return TOKENMODE.OUTOFBAND in cls.mode
 
     @staticmethod
     def get_class_type():

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -40,7 +40,7 @@ from privacyidea.lib.policy import SCOPE, ACTION, get_action_values_from_options
 from privacyidea.lib.log import log_with
 from privacyidea.lib import _
 
-from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.tokenclass import TokenClass, TOKENMODE
 from privacyidea.models import Challenge, db
 from privacyidea.lib.decorators import check_token_locked
 import logging
@@ -173,6 +173,8 @@ class PushTokenClass(TokenClass):
     https://github.com/privacyidea/privacyidea/wiki/concept%3A-PushToken
 
     """
+    mode = [TOKENMODE.AUTHENTICATE, TOKENMODE.CHALLENGE, TOKENMODE.OUTOFBAND]
+
     def __init__(self, db_token):
         TokenClass.__init__(self, db_token)
         self.set_type(u"push")

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -80,7 +80,7 @@ from six.moves.urllib.parse import quote_plus
 
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.config import get_from_config
-from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.tokenclass import TokenClass, TOKENMODE
 from privacyidea.lib.log import log_with
 from privacyidea.lib.crypto import generate_otpkey
 from privacyidea.lib.utils import create_img
@@ -115,6 +115,7 @@ class TiqrTokenClass(OcraTokenClass):
     """
     The TiQR Token implementation.
     """
+    mode = [TOKENMODE.AUTHENTICATE, TOKENMODE.CHALLENGE, TOKENMODE.OUTOFBAND]
 
     @staticmethod
     def get_class_type():


### PR DESCRIPTION
challenge response tokens like "PUSH" and "TiQR" do the authentication
out of band. I.e. the 2nd /validate/check request or /auth request is
not used to send the response to the challenge but to verify, if the
challenge was answered correct. Therefore we must not increase the
failcounter in this case.

Closes #1697