### PR TITLE
Add serial and resolver to audit during auth

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -267,10 +267,14 @@ def get_auth_token():
             g.audit_object.log({"user": "",
                                 "administrator": user_obj.login,
                                 "realm": user_obj.realm,
+                                "resolver": user_obj.resolver,
+                                "serial": details.get('serial', None) if details else None,
                                 "info": log_used_user(user_obj)})
         else:
             g.audit_object.log({"user": user_obj.login,
                                 "realm": user_obj.realm,
+                                "resolver": user_obj.resolver,
+                                "serial": details.get('serial', None) if details else None,
                                 "info": log_used_user(user_obj)})
 
     if not admin_auth and not user_auth:


### PR DESCRIPTION
The authentication endpoint did not log the resolver nor the serial of the
token (when login_mode == privacyIDEA) to the audit log.
This patch fixes that for users and admins, except for the internal admin,
which does not have a resolver, nor a token to authenticate.

Fixes #1593