### PR TITLE
Add distinction between list_policies/get_policies

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -465,9 +465,7 @@ def enroll_pin(request=None, action=None):
                                           client=g.client_ip,
                                           active=True,
                                           audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=scope,
-                                               active=True,
-                                               all_times=True)
+    action_at_all = policy_object.list_policies(scope=scope, active=True)
 
     if action_at_all and not pin_pols:
         # Not allowed to set a PIN during enrollment!
@@ -983,9 +981,7 @@ def check_anonymous_user(request=None, action=None):
                                         adminrealm=None,
                                         active=True,
                                         audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=scope,
-                                               active=True,
-                                               all_times=True)
+    action_at_all = policy_object.list_policies(scope=scope, active=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR)
     return True
@@ -1046,9 +1042,7 @@ def check_base_action(request=None, action=None, anonymous=False):
                                         adminrealm=admin_realm,
                                         active=True,
                                         audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=scope,
-                                               active=True,
-                                               all_times=True)
+    action_at_all = policy_object.list_policies(scope=scope, active=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR.get(role))
     return True
@@ -1074,8 +1068,7 @@ def check_token_upload(request=None, action=None):
                                         adminrealm=admin_realm,
                                         active=True,
                                         audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=SCOPE.ADMIN,
-                                               active=True, all_times=True)
+    action_at_all = policy_object.list_policies(scope=SCOPE.ADMIN, active=True)
     if action_at_all and len(action) == 0:
         raise PolicyError("Admin actions are defined, but you are not allowed"
                           " to upload token files.")
@@ -1124,8 +1117,7 @@ def check_token_init(request=None, action=None):
                                         adminrealm=admin_realm,
                                         active=True,
                                         audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=scope, active=True,
-                                               all_times=True)
+    action_at_all = policy_object.list_policies(scope=scope, active=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR.get(role))
     return True

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -49,7 +49,7 @@ from ..lib.policy import (set_policy,
                           enable_policy)
 from ..lib.token import get_dynamic_policy_definitions
 from ..lib.error import (ParameterError)
-from privacyidea.lib.utils import to_unicode
+from privacyidea.lib.utils import to_unicode, is_true
 from ..api.lib.prepolicy import prepolicy, check_base_action
 
 from flask import (g,
@@ -270,17 +270,18 @@ def get_policy(name=None, export=None):
     realm = getParam(param, "realm")
     scope = getParam(param, "scope")
     active = getParam(param, "active")
+    if active is not None:
+        active = is_true(active)
 
     P = g.policy_object
     if not export:
         log.debug("retrieving policy name: {0!s}, realm: {1!s}, scope: {2!s}".format(name, realm, scope))
 
-        pol = P.get_policies(name=name, realm=realm, scope=scope,
-                             active=active, all_times=True)
+        pol = P.list_policies(name=name, realm=realm, scope=scope, active=active)
         ret = send_result(pol)
     else:
         # We want to export all policies
-        pol = P.get_policies()
+        pol = P.list_policies()
         response = make_response(export_policies(pol))
         response.headers["Content-Disposition"] = ("attachment; "
                                                    "filename=%s" % export)

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -461,12 +461,26 @@ class PolicyClass(with_metaclass(Singleton, object)):
 
         return value_found, value_excluded
 
+    def list_policies(self, *args, **kwargs):
+        """
+        Return all policies matching the given arguments, but do not take the
+        current context into account. In particular, return all policies
+        regardless of their defined validity time.
+
+        This function is useful if the caller is interested in a list of currently
+        defined policies (e.g. for displaying them in the WebUI),
+        instead of a list of policies matching a set of arguments.
+        This is equivalent to calling ``get_policies`` with ``match_context=False``.
+        """
+        return self.get_policies(*args, match_context=False, **kwargs)
+
     @log_with(log)
     def get_policies(self, name=None, scope=None, realm=None, active=None,
                      resolver=None, user=None, user_object=None,
                      client=None, action=None,
-                     adminrealm=None, time=None, all_times=False,
-                     sort_by_priority=True, audit_data=None):
+                     adminrealm=None, time=None,
+                     sort_by_priority=True, audit_data=None,
+                     match_context=True):
         """
         Return the policies of the given filter values.
 
@@ -503,9 +517,9 @@ class PolicyClass(with_metaclass(Singleton, object)):
         :param time: The optional time, for which the policies should be
             fetched. The default time is now()
         :type time: datetime
-        :param all_times: If True the time restriction of the policies is
+        :param match_context: If True the time restriction of the policies is
             ignored. Policies of all time ranges will be returned.
-        :type all_times: bool
+        :type match_context: bool
         :param sort_by_priority: If true, sort the resulting list by priority, ascending
         by their policy numbers.
         :type sort_by_priority: bool
@@ -525,7 +539,7 @@ class PolicyClass(with_metaclass(Singleton, object)):
 
         # filter policy for time. If no time is set or is a time is set and
         # it matches the time_range, then we add this policy
-        if not all_times:
+        if match_context:
             reduced_policies = [policy for policy in reduced_policies if
                                 (policy.get("time") and
                                  check_time_in_range(policy.get("time"), time))

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1248,7 +1248,7 @@ class APITokenTestCase(MyApiTestCase):
         tn = datetime.datetime.now()
         dow = tn.isoweekday()
         P = PolicyClass()
-        all_admin_policies = P.get_policies(all_times=True)
+        all_admin_policies = P.get_policies(match_context=False)
         self.assertEqual(len(all_admin_policies), 1)
         self.assertEqual(len(P.policies), 1)
 

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -622,7 +622,10 @@ class PolicyTestCase(MyTestCase):
         P = PolicyClass()
         policies = P.get_policies(name="time1",
                                   scope=SCOPE.AUTHZ,
-                                  all_times=True)
+                                  match_context=False)
+        self.assertEqual(len(policies), 1)
+
+        policies = P.list_policies(name="time1", scope=SCOPE.AUTHZ)
         self.assertEqual(len(policies), 1)
 
         policies = P.get_policies(name="time1",


### PR DESCRIPTION
The former should be used to retrieve a list of policy definitions, e.g. to display them in the WebUI. The latter should be used to get a list of policies that should take effect when handling the current request.

We already (kind of) have this distinction with the parameter ``all_times``: If it is set to ``True``, we ignore the ``time`` of policies. This PR just makes this distinction more explicit by introducing a parameter ``match_context`` and a new method ``list_policies`` as a shorthand.

This will be useful when implementing policy matching based on arbitrary user info attributes (#1436).