### PR TITLE
Add realmadmin, only tokens in certain realms visible

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -1,5 +1,23 @@
 # Update Notes
 
+## Update from 3.0 to 3.1
+
+* Policies
+
+  In the scope admin a new action "tokenlist" was added. This
+  action assures, that admins can only list tokens in certain realms.
+  Without this action, and administrator can not view any tokens.
+  To allow all administrators to still list tokens, during migration
+  from 3.0 to 3.1 a new policy **pi-update-policy-b9131d0686eb** is
+  automatically created.
+
+  After the update you might want to review this policy and the
+  token list rights of your administrators.
+
+  **Note**, that due to the naming of this auto-generated policy, it is
+  not possible to modify this policy. You can still disable and enable
+  or delete this policy.
+
 ## Update from 2.23 to 3.0
 
 * Database

--- a/doc/policies/admin.rst
+++ b/doc/policies/admin.rst
@@ -44,6 +44,20 @@ to enable tokens in the user-realm *sales*.
 The following actions are available in the scope
 *admin*:
 
+tokenlist
+~~~~~~~~~
+
+type: bool
+
+This allows the administrator to list existing tokens in the specified user realm.
+Note, that the resolver in this policy is ignored.
+
+If the policy with the action ``tokenlist`` is not bound to any user realm, this acts
+as a wild card and the admin is allowed to list all tokens.
+
+If the action ``tokenlist`` is not active, but admin policies exist, then the admin
+is not allowed to list any tokens.
+
 init
 ~~~~
 

--- a/doc/policies/admin.rst
+++ b/doc/policies/admin.rst
@@ -58,6 +58,12 @@ as a wild card and the admin is allowed to list all tokens.
 If the action ``tokenlist`` is not active, but admin policies exist, then the admin
 is not allowed to list any tokens.
 
+.. note:: As with all boolean policies, multiple *tokenlist* policies add up to
+   create the resulting rights of the administrator.
+   So if there are multiple matching policies for different realms,
+   the admin will have list rights on all mentioned realms
+   independent on the priority of the policies.
+
 init
 ~~~~
 

--- a/doc/policies/index.rst
+++ b/doc/policies/index.rst
@@ -45,6 +45,11 @@ Each policy can contain the following attributes:
   the policy. If you create a new policy with the same name,
   the policy is overwritten.
 
+  .. note:: In the web UI and the API policies can only be created
+     with the characters 0-9, a-z, A-Z, "_" and ".".
+     On a library level or during migration scripts policies with
+     other characters could be created.
+
 **scope**
 
   The scope of the policy as described above.

--- a/migrations/versions/b9131d0686eb_.py
+++ b/migrations/versions/b9131d0686eb_.py
@@ -1,0 +1,85 @@
+"""Add a generic admin policy for tokenlist
+
+Revision ID: b9131d0686eb
+Revises: 849170064430
+Create Date: 2019-06-28 07:37:59.224088
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b9131d0686eb'
+down_revision = '849170064430'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import orm
+from sqlalchemy.schema import Sequence
+from privacyidea.lib.policy import SCOPE, ACTION
+
+Base = declarative_base()
+
+# dashes are not allowed, when creating policies in the WebUI
+# or via the library. So we are sure, that in normal operation
+# this policy can never be created.
+POLICYNAME = u"pi-update-policy-b9131d0686eb"
+
+
+class Policy(Base):
+    """
+    The policy table contains policy definitions which control
+    the behaviour during
+     * enrollment
+     * authentication
+     * authorization
+     * administration
+     * user actions
+    """
+    __tablename__ = "policy"
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
+    id = sa.Column(sa.Integer, Sequence("policy_seq"), primary_key=True)
+    active = sa.Column(sa.Boolean, default=True)
+    check_all_resolvers = sa.Column(sa.Boolean, default=False)
+    name = sa.Column(sa.Unicode(64), unique=True, nullable=False)
+    scope = sa.Column(sa.Unicode(32), nullable=False)
+    action = sa.Column(sa.Unicode(2000), default=u"")
+    realm = sa.Column(sa.Unicode(256), default=u"")
+    adminrealm = sa.Column(sa.Unicode(256), default=u"")
+    resolver = sa.Column(sa.Unicode(256), default=u"")
+    user = sa.Column(sa.Unicode(256), default=u"")
+    client = sa.Column(sa.Unicode(256), default=u"")
+    time = sa.Column(sa.Unicode(64), default=u"")
+    condition = sa.Column(sa.Integer, default=0, nullable=False)
+    # If there are multiple matching policies, choose the one
+    # with the lowest priority number. We choose 1 to be the default priotity.
+    priority = sa.Column(sa.Integer, default=1, nullable=False)
+
+
+def upgrade():
+    """
+    During upgrade we check, if admin policies exist.
+    If so, we add a generic policy for all admins, that allows "tokenlist".
+    This mimicks the pervious behaviour.
+    :return:
+    """
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    if session.query(Policy).filter(Policy.scope == u"{0!s}".format(SCOPE.ADMIN),
+                                    Policy.active.is_(True)).all():
+        # add policy
+        tokenlist_pol = Policy(name=POLICYNAME, scope=u"{0!s}".format(SCOPE.ADMIN),
+                               action=u"{0!s}".format(ACTION.TOKENLIST))
+        session.add(tokenlist_pol)
+        print("Added '{0!s}' action for admin policies.".format(ACTION.TOKENLIST))
+    else:
+        print("No admin policy active. No need to create '{0!s}' action.".format(ACTION.TOKENLIST))
+
+    session.commit()
+
+
+def downgrade():
+    # Delete the policy, if it still exists
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    session.query(Policy).filter(Policy.name == u"{0!s}".format(POLICYNAME)).delete()
+    session.commit()

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -994,10 +994,10 @@ def check_anonymous_user(request=None, action=None):
 def check_admin_tokenlist(request=None, action=None):
     """
     Depending on the policy scope=admin, action=tokenlist, the
-    filterRealms parameter is set to define, the token of which
+    allowed_realms parameter is set to define, the token of which
     realms and administrator is allowed to see.
 
-    Sets the filterRealm
+    Sets the allowed_realms
     None: means the admin has no restrictions
     []: the admin can not see any realms
     ["realm1", "realm2"...]: the admin can see these realms
@@ -1005,7 +1005,7 @@ def check_admin_tokenlist(request=None, action=None):
     :param request:
     :return:
     """
-    filterRealm = None
+    allowed_realms = None
     wildcard = False
     role = g.logged_in_user.get("role")
     if role == ROLE.USER:
@@ -1028,18 +1028,18 @@ def check_admin_tokenlist(request=None, action=None):
                                              all_times=True)
 
     if pols_at_all:
-        filterRealm = []
+        allowed_realms = []
         for pol in pols:
             if not pol.get("realm"):
                 # if there is no realm set in a tokenlist policy, then this is a wildcard!
                 wildcard = True
             else:
-                filterRealm.extend(pol.get("realm"))
+                allowed_realms.extend(pol.get("realm"))
 
         if wildcard:
-            filterRealm = None
+            allowed_realms = None
 
-    request.filterRealm = filterRealm
+    request.allowed_realms = allowed_realms
     return True
 
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -991,6 +991,58 @@ def check_anonymous_user(request=None, action=None):
     return True
 
 
+def check_admin_tokenlist(request=None, action=None):
+    """
+    Depending on the policy scope=admin, action=tokenlist, the
+    filterRealms parameter is set to define, the token of which
+    realms and administrator is allowed to see.
+
+    Sets the filterRealm
+    None: means the admin has no restrictions
+    []: the admin can not see any realms
+    ["realm1", "realm2"...]: the admin can see these realms
+
+    :param request:
+    :return:
+    """
+    filterRealm = None
+    wildcard = False
+    role = g.logged_in_user.get("role")
+    if role == ROLE.USER:
+        return True
+
+    policy_object = g.policy_object
+    username = g.logged_in_user.get("username")
+    admin_realm = g.logged_in_user.get("realm")
+
+    pols = policy_object.get_policies(action=ACTION.TOKENLIST,
+                                      user=username,
+                                      scope=SCOPE.ADMIN,
+                                      client=g.client_ip,
+                                      adminrealm=admin_realm,
+                                      active=True,
+                                      audit_data=g.audit_object.audit_data)
+
+    pols_at_all = policy_object.get_policies(scope=SCOPE.ADMIN,
+                                             active=True,
+                                             all_times=True)
+
+    if pols_at_all:
+        filterRealm = []
+        for pol in pols:
+            if not pol.get("realm"):
+                # if there is no realm set in a tokenlist policy, then this is a wildcard!
+                wildcard = True
+            else:
+                filterRealm.extend(pol.get("realm"))
+
+        if wildcard:
+            filterRealm = None
+
+    request.filterRealm = filterRealm
+    return True
+
+
 def check_base_action(request=None, action=None, anonymous=False):
     """
     This decorator function takes the request and verifies the given action

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1039,7 +1039,7 @@ def check_admin_tokenlist(request=None, action=None):
         if wildcard:
             allowed_realms = None
 
-    request.allowed_realms = allowed_realms
+    request.pi_allowed_realms = allowed_realms
     return True
 
 

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -293,7 +293,7 @@ def init():
 
 @token_blueprint.route('/challenges/', methods=['GET'])
 @token_blueprint.route('/challenges/<serial>', methods=['GET'])
-@prepolicy(check_base_action, request, action=ACTION.TOKENLIST)
+@prepolicy(check_base_action, request, action=ACTION.GETCHALLENGES)
 @event("token_getchallenges", request, g)
 @log_with(log)
 @admin_required
@@ -381,14 +381,10 @@ def list_api():
     if ufields:
         user_fields = [u.strip() for u in ufields.split(",")]
 
-    if hasattr(request, "filterRealm"):
-        # filterRealm determines, which realms the admin would be allowed to see
-        filterRealm = request.filterRealm
-    else:
-        # In certain cases like for users, we do not have filterRealms  
-        filterRealm = None
-
-    g.audit_object.log({'info': "realm: {0!s}".format((filterRealm))})
+    # allowed_realms determines, which realms the admin would be allowed to see
+    # In certain cases like for users, we do not have allowed_realms
+    allowed_realms = getattr(request, "allowed_realms", None)
+    g.audit_object.log({'info': "realm: {0!s}".format((allowed_realms))})
 
     # get list of tokens as a dictionary
     tokens = get_tokens_paginate(serial=serial, realm=realm, page=page,
@@ -397,7 +393,7 @@ def list_api():
                                  tokentype=tokentype,
                                  resolver=resolver,
                                  description=description,
-                                 userid=userid, filterRealm=filterRealm)
+                                 userid=userid, allowed_realms=allowed_realms)
     g.audit_object.log({"success": True})
     if output_format == "csv":
         return send_csv_result(tokens)

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -88,7 +88,8 @@ from privacyidea.api.lib.prepolicy import (prepolicy, check_base_action,
                                            u2ftoken_allowed, u2ftoken_verify_cert,
                                            twostep_enrollment_activation,
                                            twostep_enrollment_parameters,
-                                           sms_identifiers, pushtoken_add_config)
+                                           sms_identifiers, pushtoken_add_config,
+                                           check_admin_tokenlist)
 from privacyidea.api.lib.postpolicy import (save_pin_change,
                                             postpolicy)
 from privacyidea.lib.event import event
@@ -292,7 +293,7 @@ def init():
 
 @token_blueprint.route('/challenges/', methods=['GET'])
 @token_blueprint.route('/challenges/<serial>', methods=['GET'])
-@prepolicy(check_base_action, request, action=ACTION.GETCHALLENGES)
+@prepolicy(check_base_action, request, action=ACTION.TOKENLIST)
 @event("token_getchallenges", request, g)
 @log_with(log)
 @admin_required
@@ -326,6 +327,7 @@ def get_challenges_api(serial=None):
 
 
 @token_blueprint.route('/', methods=['GET'])
+@prepolicy(check_admin_tokenlist, request)
 @event("token_list", request, g)
 @log_with(log)
 def list_api():
@@ -379,13 +381,13 @@ def list_api():
     if ufields:
         user_fields = [u.strip() for u in ufields.split(",")]
 
-    # filterRealm determines, which realms the admin would be allowed to see
-    filterRealm = ["*"]
-    # TODO: Userfields
+    if hasattr(request, "filterRealm"):
+        # filterRealm determines, which realms the admin would be allowed to see
+        filterRealm = request.filterRealm
+    else:
+        # In certain cases like for users, we do not have filterRealms  
+        filterRealm = None
 
-    # If the admin wants to see only one realm, then do it:
-    if realm and (realm in filterRealm or '*' in filterRealm):
-        filterRealm = [realm]
     g.audit_object.log({'info': "realm: {0!s}".format((filterRealm))})
 
     # get list of tokens as a dictionary
@@ -395,7 +397,7 @@ def list_api():
                                  tokentype=tokentype,
                                  resolver=resolver,
                                  description=description,
-                                 userid=userid)
+                                 userid=userid, filterRealm=filterRealm)
     g.audit_object.log({"success": True})
     if output_format == "csv":
         return send_csv_result(tokens)

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -383,7 +383,7 @@ def list_api():
 
     # allowed_realms determines, which realms the admin would be allowed to see
     # In certain cases like for users, we do not have allowed_realms
-    allowed_realms = getattr(request, "allowed_realms", None)
+    allowed_realms = getattr(request, "pi_allowed_realms", None)
     g.audit_object.log({'info': "realm: {0!s}".format((allowed_realms))})
 
     # get list of tokens as a dictionary

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -284,6 +284,7 @@ class ACTION(object):
     SETTOKENINFO = "settokeninfo"
     TOKENISSUER = "tokenissuer"
     TOKENLABEL = "tokenlabel"
+    TOKENLIST = "tokenlist"
     TOKENPAGESIZE = "token_page_size"
     TOKENREALMS = "tokenrealms"
     TOKENTYPE = "tokentype"
@@ -1222,6 +1223,10 @@ def get_static_policy_definitions(scope=None):
                                            'realms of a token.'),
                                  'mainmenu': [MAIN_MENU.TOKENS],
                                  'group': GROUP.TOKEN},
+            ACTION.TOKENLIST: {'type': 'bool',
+                               'desc': _('Admin is allowed to list tokens.'),
+                               'mainmenu': [MAIN_MENU.TOKENS],
+                               'group': GROUP.TOKEN},
             ACTION.GETSERIAL: {'type': 'bool',
                                'desc': _('Admin is allowed to retrieve a serial'
                                          ' for a given OTP value.'),

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -140,7 +140,7 @@ def create_tokenclass_object(db_token):
 def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
                         serial_exact=None, serial_wildcard=None, active=None, resolver=None,
                         rollout_state=None, description=None, revoked=None,
-                        locked=None, userid=None, tokeninfo=None, maxfail=None):
+                        locked=None, userid=None, tokeninfo=None, maxfail=None, filterRealm=None):
     """
     This function create the sql query for getting tokens. It is used by
     get_tokens and get_tokens_paginate.
@@ -189,6 +189,11 @@ def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
                                           TokenRealm.realm_id == Realm.id,
                                           TokenRealm.token_id ==
                                           Token.id)).distinct()
+
+    if filterRealm  is not None:
+        sql_query = sql_query.filter(and_(func.lower(Realm.name).in_([r.lower() for r in filterRealm]),
+                                          TokenRealm.realm_id == Realm.id,
+                                          TokenRealm.token_id == Token.id)).distinct()
 
     stripped_resolver = None if resolver is None else resolver.strip("*")
     stripped_userid = None if userid is None else userid.strip("*")
@@ -413,7 +418,7 @@ def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
 def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
                 serial=None, active=None, resolver=None, rollout_state=None,
                 sortby=Token.serial, sortdir="asc", psize=15,
-                page=1, description=None, userid=None):
+                page=1, description=None, userid=None, filterRealm=None):
     """
     This function is used to retrieve a token list, that can be displayed in
     the Web UI. It supports pagination.
@@ -451,7 +456,8 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
                                 serial_wildcard=serial, active=active,
                                 resolver=resolver,
                                 rollout_state=rollout_state,
-                                description=description, userid=userid)
+                                description=description, userid=userid,
+                                    filterRealm=filterRealm)
 
     if isinstance(sortby, string_types):
         # convert the string to a Token column

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -140,7 +140,7 @@ def create_tokenclass_object(db_token):
 def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
                         serial_exact=None, serial_wildcard=None, active=None, resolver=None,
                         rollout_state=None, description=None, revoked=None,
-                        locked=None, userid=None, tokeninfo=None, maxfail=None, filterRealm=None):
+                        locked=None, userid=None, tokeninfo=None, maxfail=None, allowed_realms=None):
     """
     This function create the sql query for getting tokens. It is used by
     get_tokens and get_tokens_paginate.
@@ -190,8 +190,8 @@ def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
                                           TokenRealm.token_id ==
                                           Token.id)).distinct()
 
-    if filterRealm  is not None:
-        sql_query = sql_query.filter(and_(func.lower(Realm.name).in_([r.lower() for r in filterRealm]),
+    if allowed_realms is not None:
+        sql_query = sql_query.filter(and_(func.lower(Realm.name).in_([r.lower() for r in allowed_realms]),
                                           TokenRealm.realm_id == Realm.id,
                                           TokenRealm.token_id == Token.id)).distinct()
 
@@ -418,7 +418,7 @@ def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
 def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
                 serial=None, active=None, resolver=None, rollout_state=None,
                 sortby=Token.serial, sortdir="asc", psize=15,
-                page=1, description=None, userid=None, filterRealm=None):
+                page=1, description=None, userid=None, allowed_realms=None):
     """
     This function is used to retrieve a token list, that can be displayed in
     the Web UI. It supports pagination.
@@ -457,7 +457,7 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
                                 resolver=resolver,
                                 rollout_state=rollout_state,
                                 description=description, userid=userid,
-                                    filterRealm=filterRealm)
+                                allowed_realms=allowed_realms)
 
     if isinstance(sortby, string_types):
         # convert the string to a Token column

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -448,6 +448,8 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
     :type psize: int
     :param page: The number of the page to view. Starts with 1 ;-)
     :type page: int
+    :param allowed_realms: A list of realms, that the admin is allowed to see
+    :type allowed_realms: list
     :return: dict with tokens, prev, next and count
     :rtype: dict
     """

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1561,7 +1561,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         r = check_admin_tokenlist(req)
         self.assertTrue(r)
         # The admin1 has the policy "pol-all-realms", so he is allowed to view all realms!
-        self.assertEqual(req.filterRealm, None)
+        self.assertEqual(req.pi_allowed_realms, None)
 
         enable_policy("pol-all-realms", False)
         # Now he is only allowed to view realm1
@@ -1570,7 +1570,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         r = check_admin_tokenlist(req)
         self.assertTrue(r)
         # The admin1 has the policy "pol-realm1", so he is allowed to view all realms!
-        self.assertEqual(req.filterRealm, [self.realm1])
+        self.assertEqual(req.pi_allowed_realms, [self.realm1])
 
         enable_policy("pol-realm1", False)
         # Now he only has the admin right to init tokens
@@ -1579,7 +1579,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         r = check_admin_tokenlist(req)
         self.assertTrue(r)
         # The admin1 has the policy "pol-only-init", so he is not allowed to list tokens
-        self.assertEqual(req.filterRealm, [])
+        self.assertEqual(req.pi_allowed_realms, [])
 
         for pol in ["pol-realm1", "pol-all-realms", "pol-only-init"]:
             delete_policy(pol)

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -8,7 +8,7 @@ import json
 
 from .base import (MyApiTestCase, PWFILE)
 
-from privacyidea.lib.policy import (set_policy, delete_policy,
+from privacyidea.lib.policy import (set_policy, delete_policy, enable_policy,
                                     PolicyClass, SCOPE, ACTION, REMOTE_USER,
                                     AUTOASSIGNVALUE)
 from privacyidea.api.lib.prepolicy import (check_token_upload,
@@ -26,7 +26,8 @@ from privacyidea.api.lib.prepolicy import (check_token_upload,
                                            papertoken_count, allowed_audit_realm,
                                            u2ftoken_verify_cert,
                                            tantoken_count, sms_identifiers,
-                                           pushtoken_add_config, pushtoken_wait)
+                                           pushtoken_add_config, pushtoken_wait,
+                                           check_admin_tokenlist)
 from privacyidea.lib.realm import set_realm as create_realm
 from privacyidea.lib.realm import delete_realm
 from privacyidea.api.lib.postpolicy import (check_serial, check_tokentype,
@@ -1521,6 +1522,67 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         self.assertEqual(req.all_data.get(PUSH_ACTION.WAIT), 10)
 
         delete_policy("push1")
+
+    def test_25_admin_token_list(self):
+        # The tokenlist policy can result in a None filter, an empty [] filter or
+        # a filter with realms ["realm1", "realm2"].
+        # The None is a wildcard, [] allows no listing at all.
+        admin1 = {"username": "admin1",
+                  "role": "admin",
+                  "realm": "realm1"}
+
+        # admin1 is allowed to see realm1
+        set_policy(name="pol-realm1",
+                   scope=SCOPE.ADMIN,
+                   action="tokenlist", user="admin1", realm=self.realm1)
+
+        # Admin1 is allowed to list all realms
+        set_policy(name="pol-all-realms",
+                   scope=SCOPE.ADMIN,
+                   action="tokenlist", user="admin1")
+
+        # Admin1 is allowed to only init, not list
+        set_policy(name="pol-only-init",
+                   scope=SCOPE.ADMIN)
+
+        g.policy_object = PolicyClass()
+        builder = EnvironBuilder(method='POST',
+                                 data={'serial': "OATH123456"},
+                                 headers={})
+        env = builder.get_environ()
+        # Set the remote address so that we can filter for it
+        env["REMOTE_ADDR"] = "10.0.0.1"
+        g.client_ip = env["REMOTE_ADDR"]
+        req = Request(env)
+        req.all_data = {}
+
+        # admin1 is allowed to do everything
+        g.logged_in_user = admin1
+        r = check_admin_tokenlist(req)
+        self.assertTrue(r)
+        # The admin1 has the policy "pol-all-realms", so he is allowed to view all realms!
+        self.assertEqual(req.filterRealm, None)
+
+        enable_policy("pol-all-realms", False)
+        # Now he is only allowed to view realm1
+        g.policy_object = PolicyClass()
+        req = Request(env)
+        r = check_admin_tokenlist(req)
+        self.assertTrue(r)
+        # The admin1 has the policy "pol-realm1", so he is allowed to view all realms!
+        self.assertEqual(req.filterRealm, [self.realm1])
+
+        enable_policy("pol-realm1", False)
+        # Now he only has the admin right to init tokens
+        g.policy_object = PolicyClass()
+        req = Request(env)
+        r = check_admin_tokenlist(req)
+        self.assertTrue(r)
+        # The admin1 has the policy "pol-only-init", so he is not allowed to list tokens
+        self.assertEqual(req.filterRealm, [])
+
+        for pol in ["pol-realm1", "pol-all-realms", "pol-only-init"]:
+            delete_policy(pol)
 
 
 class PostPolicyDecoratorTestCase(MyApiTestCase):


### PR DESCRIPTION
The admin who has a "tokenlist" policy can only
see tokens in certain realms.

Closes #1713

