### PR TITLE
Allow users to change the description

### DIFF
--- a/doc/policies/user.rst
+++ b/doc/policies/user.rst
@@ -104,7 +104,15 @@ setpin
 
 type: bool 
 
-The user ist allowed to set the OTP PIN for his tokens.
+The user is allowed to set the OTP PIN for his tokens.
+
+
+setdescription
+~~~~~~~~~~~~~~
+
+type: bool
+
+The user is allowed to set the description of his tokens.
 
 enrollpin
 ~~~~~~~~~

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -673,6 +673,31 @@ def setpin_api(serial=None):
     return send_result(res)
 
 
+@token_blueprint.route('/description', methods=['POST'])
+@token_blueprint.route('/description/<serial>', methods=['POST'])
+@prepolicy(check_base_action, request, action=ACTION.SETDESCRIPTION)
+@event("token_set", request, g)
+@log_with(log)
+def set_description_api(serial=None):
+    """
+    This endpoint can be used by the user or by the admin to set
+    the description of a token.
+
+    :jsonparam basestring description: The description for the token
+    :param serial:
+    :return:
+    """
+    user = request.User
+    if not serial:
+        serial = getParam(request.all_data, "serial", required)
+    g.audit_object.log({"serial": serial})
+    description = getParam(request.all_data, "description", optional=required)
+    g.audit_object.add_to_log({'action_detail': u"description={0!r}".format(description)})
+    res = set_description(serial, description, user=user)
+    g.audit_object.log({"success": True})
+    return send_result(res)
+
+
 @token_blueprint.route('/set', methods=['POST'])
 @token_blueprint.route('/set/<serial>', methods=['POST'])
 @prepolicy(check_base_action, request, action=ACTION.SET)

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -274,6 +274,7 @@ class ACTION(object):
     RESYNC = "resync"
     REVOKE = "revoke"
     SET = "set"
+    SETDESCRIPTION = "setdescription"
     SETPIN = "setpin"
     SETREALM = "setrealm"
     SERIAL = "serial"
@@ -1463,6 +1464,10 @@ def get_static_policy_definitions(scope=None):
                                       "PIN of his tokens."),
                             'mainmenu': [MAIN_MENU.TOKENS],
                             'group': GROUP.PIN},
+            ACTION.SETDESCRIPTION: {'type': 'bool',
+                                    'desc': _('The user is allowed to set the token description.'),
+                                    'mainmenu': [MAIN_MENU.TOKENS],
+                                    'group': GROUP.TOKEN},
             ACTION.ENROLLPIN: {'type': 'bool',
                                "desc": _("The user is allowed to set the OTP "
                                          "PIN during enrollment."),

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -30,6 +30,7 @@ myApp.directive('tokenDataEdit', function(AuthFactory, instanceUrl) {
             setRight: '@',
             inputPattern: '@',
             inputType: '@',
+            editableAsUser: '@',
             callback: '&',
             callbackCancel: '&'
         },

--- a/privacyidea/static/components/directives/views/directive.tokendata.html
+++ b/privacyidea/static/components/directives/views/directive.tokendata.html
@@ -10,24 +10,27 @@
     </form>
 </td>
 
-<td><div ng-hide="loggedInUser.role == 'user' || tokenLocked == 'true' ">
-    <button ng-show="editFlag"
-            class="btn btn-primary"
-            ng-click="callback({key: tokenKey, value: tokenData}); editFlag =
-            false;"
-            ng-disabled="tokenDataForm.$invalid"
-            >{{ buttonText }}
-    </button>
-    <button class="btn btn-danger"
-            ng-show="editFlag"
-            ng-click="callbackCancel(); editFlag = false;"
-            translate>Cancel
-    </button>
-    <button ng-hide="editFlag || (setRight == 'false' && hideButtons == 'true')"
-            class="btn btn-primary"
-            ng-click="editFlag = true;"
-            ng-disabled="setRight == 'false'"
-            translate>Edit
-    </button>
+<td>
+    <div ng-hide="loggedInUser.role == 'user' && editableAsUser != 'true' ">
+        <div ng-hide="tokenLocked == 'true'">
+            <button ng-show="editFlag"
+                    class="btn btn-primary"
+                    ng-click="callback({key: tokenKey, value: tokenData}); editFlag =
+                    false;"
+                    ng-disabled="tokenDataForm.$invalid"
+                    >{{ buttonText }}
+            </button>
+            <button class="btn btn-danger"
+                    ng-show="editFlag"
+                    ng-click="callbackCancel(); editFlag = false;"
+                    translate>Cancel
+            </button>
+            <button ng-hide="editFlag || (setRight == 'false' && hideButtons == 'true')"
+                    class="btn btn-primary"
+                    ng-click="editFlag = true;"
+                    ng-disabled="setRight == 'false'"
+                    translate>Edit
+            </button>
+        </div>
     </div>
 </td>

--- a/privacyidea/static/components/token/controllers/tokenDetailController.js
+++ b/privacyidea/static/components/token/controllers/tokenDetailController.js
@@ -138,6 +138,9 @@ myApp.controller("tokenDetailController", function ($scope,
     $scope.set = function (key, value) {
         TokenFactory.set($scope.tokenSerial, key, value, $scope.get);
     };
+    $scope.setdescription = function (description) {
+        TokenFactory.set_description($scope.tokenSerial, description, $scope.get);
+    };
     $scope.reset = function () {
         TokenFactory.reset($scope.tokenSerial, $scope.get);
     };

--- a/privacyidea/static/components/token/factories/token.js
+++ b/privacyidea/static/components/token/factories/token.js
@@ -175,6 +175,14 @@ angular.module("TokenModule", ["privacyideaAuth"])
                     }).success(callback
                 ).error(AuthFactory.authError);
             },
+            set_description: function (serial, description, callback) {
+                $http.post(tokenUrl + "/description/" + serial,
+                    {"description": description},
+                    {
+                        headers: {'PI-Authorization': AuthFactory.getAuthToken()}
+                    }).success(callback
+                ).error(AuthFactory.authError);
+            },
             set_dict: function (serial, params, callback) {
                 $http.post(tokenUrl + "/set/" + serial, params,
                     {

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -132,7 +132,8 @@
             logged-in-user="loggedInUser"></tr>
         <!-- If setData is called within the directive tokenDataEdit,
         the function set in the parent scope is called -->
-        <tr token-data-edit text="{{ 'Description'|translate }}"
+        <tr ng-show="loggedInUser.role==='admin'"
+            token-data-edit text="{{ 'Description'|translate }}"
             button-text="{{ 'Set description'|translate }}"
             token-data="{{ token.description }}"
             token-locked="{{ token.locked }}"
@@ -141,6 +142,18 @@
             token-key="description"
             callback-cancel="get()"
             callback="set(key, value)"
+            logged-in-user="loggedInUser"></tr>
+        <tr ng-show="loggedInUser.role==='user'"
+            token-data-edit text="{{ 'Description'|translate }}"
+            button-text="{{ 'Set description'|translate }}"
+            token-data="{{ token.description }}"
+            token-locked="{{ token.locked }}"
+            hide-buttons="{{ hide_buttons }}"
+            set-right="{{ checkRight('setdescription') }}"
+            editable-as-user = true
+            token-key="description"
+            callback-cancel="get()"
+            callback="setdescription(value)"
             logged-in-user="loggedInUser"></tr>
         <tr>
             <td translate>Info</td>


### PR DESCRIPTION
User can now use the "setdescription" policy
to set the description of their tokens

Closes #1717