### PR TITLE
Add distinction between match_policies/list_policies

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -1090,7 +1090,7 @@ def p_export(filename=None):
     import pprint
     pp = pprint.PrettyPrinter(indent=4)
     pol_cls = PolicyClass()
-    policies = pol_cls.match_policies()
+    policies = pol_cls.list_policies()
     pol_str = pp.pformat(policies)
     if filename:
         with open(filename, 'w') as f:
@@ -1109,7 +1109,7 @@ def p_import(filename, cleanup=False):
     if cleanup:
         print("Cleanup old policies.")
         pol_cls = PolicyClass()
-        policies = pol_cls.match_policies()
+        policies = pol_cls.list_policies()
         for policy in policies:
             name = policy.get("name")
             r = delete_policy(name)

--- a/pi-manage
+++ b/pi-manage
@@ -1043,7 +1043,7 @@ def list_policies():
     list the policies
     """
     pol_cls = PolicyClass()
-    policies = pol_cls.get_policies()
+    policies = pol_cls.match_policies()
     print("Active \t Name \t Scope")
     print(40*"=")
     for policy in policies:
@@ -1090,7 +1090,7 @@ def p_export(filename=None):
     import pprint
     pp = pprint.PrettyPrinter(indent=4)
     pol_cls = PolicyClass()
-    policies = pol_cls.get_policies()
+    policies = pol_cls.match_policies()
     pol_str = pp.pformat(policies)
     if filename:
         with open(filename, 'w') as f:
@@ -1109,7 +1109,7 @@ def p_import(filename, cleanup=False):
     if cleanup:
         print("Cleanup old policies.")
         pol_cls = PolicyClass()
-        policies = pol_cls.get_policies()
+        policies = pol_cls.match_policies()
         for policy in policies:
             name = policy.get("name")
             r = delete_policy(name)

--- a/pi-manage
+++ b/pi-manage
@@ -1043,7 +1043,7 @@ def list_policies():
     list the policies
     """
     pol_cls = PolicyClass()
-    policies = pol_cls.match_policies()
+    policies = pol_cls.list_policies()
     print("Active \t Name \t Scope")
     print(40*"=")
     for policy in policies:

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -314,10 +314,10 @@ def no_detail_on_success(request, response):
     policy_object = g.policy_object
 
     # get the serials from a policy definition
-    detailPol = policy_object.get_policies(action=ACTION.NODETAILSUCCESS,
-                                           scope=SCOPE.AUTHZ,
-                                           client=g.client_ip,
-                                           active=True)
+    detailPol = policy_object.match_policies(action=ACTION.NODETAILSUCCESS,
+                                             scope=SCOPE.AUTHZ,
+                                             client=g.client_ip,
+                                             active=True)
 
     if detailPol and content.get("result", {}).get("value"):
         # The policy was set, we need to strip the details, if the
@@ -343,10 +343,10 @@ def add_user_detail_to_response(request, response):
     policy_object = g.policy_object
 
     # Check for ADD USER IN RESPONSE
-    detail_pol = policy_object.get_policies(action=ACTION.ADDUSERINRESPONSE,
-                                            scope=SCOPE.AUTHZ,
-                                            client=g.client_ip,
-                                            active=True)
+    detail_pol = policy_object.match_policies(action=ACTION.ADDUSERINRESPONSE,
+                                              scope=SCOPE.AUTHZ,
+                                              client=g.client_ip,
+                                              active=True)
 
     if detail_pol and content.get("result", {}).get("value") and request.User:
         # The policy was set, we need to add the user
@@ -361,10 +361,10 @@ def add_user_detail_to_response(request, response):
         g.audit_object.add_policy([p.get("name") for p in detail_pol])
 
     # Check for ADD RESOLVER IN RESPONSE
-    detail_pol = policy_object.get_policies(action=ACTION.ADDRESOLVERINRESPONSE,
-                                            scope=SCOPE.AUTHZ,
-                                            client=g.client_ip,
-                                            active=True)
+    detail_pol = policy_object.match_policies(action=ACTION.ADDRESOLVERINRESPONSE,
+                                              scope=SCOPE.AUTHZ,
+                                              client=g.client_ip,
+                                              active=True)
 
     if detail_pol and content.get("result", {}).get("value") and request.User:
         # The policy was set, we need to add the resolver and the realm
@@ -391,10 +391,10 @@ def no_detail_on_fail(request, response):
     policy_object = g.policy_object
 
     # get the serials from a policy definition
-    detailPol = policy_object.get_policies(action=ACTION.NODETAILFAIL,
-                                           scope=SCOPE.AUTHZ,
-                                           client=g.client_ip,
-                                           active=True)
+    detailPol = policy_object.match_policies(action=ACTION.NODETAILFAIL,
+                                             scope=SCOPE.AUTHZ,
+                                             client=g.client_ip,
+                                             active=True)
 
     if detailPol and content.get("result", {}).get("value") is False:
         # The policy was set, we need to strip the details, if the
@@ -440,10 +440,10 @@ def save_pin_change(request, response, serial=None):
         realm = realm or get_default_realm()
 
         if g.logged_in_user.get("role") == ROLE.ADMIN:
-            pinpol = policy_object.get_policies(action=ACTION.CHANGE_PIN_FIRST_USE,
-                                                scope=SCOPE.ENROLL, realm=realm,
-                                                client=g.client_ip, active=True,
-                                                audit_data=g.audit_object.audit_data)
+            pinpol = policy_object.match_policies(action=ACTION.CHANGE_PIN_FIRST_USE,
+                                                  scope=SCOPE.ENROLL, realm=realm,
+                                                  client=g.client_ip, active=True,
+                                                  audit_data=g.audit_object.audit_data)
             if pinpol:
                 token = get_one_token(serial=serial)
                 token.set_next_pin_change(diff="0d")
@@ -554,18 +554,18 @@ def get_webui_settings(request, response):
             unique=True,
             audit_data=g.audit_object.audit_data)
         token_wizard_2nd = bool(role == ROLE.USER and
-            policy_object.get_policies(action=ACTION.TOKENWIZARD2ND,
-                                       scope=SCOPE.WEBUI,
-                                       realm=realm,
-                                       client=client,
-                                       active=True,
-                                       audit_data=g.audit_object.audit_data))
+            policy_object.match_policies(action=ACTION.TOKENWIZARD2ND,
+                                         scope=SCOPE.WEBUI,
+                                         realm=realm,
+                                         client=client,
+                                         active=True,
+                                         audit_data=g.audit_object.audit_data))
         token_wizard = False
         dialog_no_token = False
         if role == ROLE.USER:
             user_obj = User(loginname, realm)
             user_token_num = get_tokens(user=user_obj, count=True)
-            token_wizard_pol = policy_object.get_policies(
+            token_wizard_pol = policy_object.match_policies(
                 action=ACTION.TOKENWIZARD,
                 scope=SCOPE.WEBUI,
                 realm=user_obj.realm,
@@ -581,7 +581,7 @@ def get_webui_settings(request, response):
             # already has tokens, we do not run the wizard.
             token_wizard = bool(token_wizard_pol) and (user_token_num == 0)
 
-            dialog_no_token_pol = policy_object.get_policies(
+            dialog_no_token_pol = policy_object.match_policies(
                 scope=SCOPE.WEBUI,
                 action=ACTION.DIALOG_NO_TOKEN,
                 client=client,
@@ -592,7 +592,7 @@ def get_webui_settings(request, response):
                 audit_data=g.audit_object.audit_data
             )
             dialog_no_token = bool(dialog_no_token_pol) and (user_token_num == 0)
-        user_details_pol = policy_object.get_policies(
+        user_details_pol = policy_object.match_policies(
             action=ACTION.USERDETAILS,
             scope=SCOPE.WEBUI,
             realm=realm,
@@ -600,7 +600,7 @@ def get_webui_settings(request, response):
             active=True,
             audit_data=g.audit_object.audit_data
         )
-        search_on_enter = policy_object.get_policies(
+        search_on_enter = policy_object.match_policies(
             action=ACTION.SEARCH_ON_ENTER,
             scope=SCOPE.WEBUI,
             realm=realm,
@@ -608,7 +608,7 @@ def get_webui_settings(request, response):
             active=True,
             audit_data=g.audit_object.audit_data
         )
-        hide_welcome = policy_object.get_policies(
+        hide_welcome = policy_object.match_policies(
             action=ACTION.HIDE_WELCOME,
             scope=SCOPE.WEBUI,
             realm=realm,
@@ -617,7 +617,7 @@ def get_webui_settings(request, response):
             audit_data=g.audit_object.audit_data
         )
         hide_welcome = bool(hide_welcome)
-        hide_buttons = policy_object.get_policies(
+        hide_buttons = policy_object.match_policies(
             action=ACTION.HIDE_BUTTONS,
             scope=SCOPE.WEBUI,
             realm=realm,
@@ -633,7 +633,7 @@ def get_webui_settings(request, response):
             unique=True,
             audit_data=g.audit_object.audit_data
         )
-        show_seed = policy_object.get_policies(
+        show_seed = policy_object.match_policies(
             action=ACTION.SHOW_SEED,
             scope=SCOPE.WEBUI,
             realm=realm,

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -465,9 +465,7 @@ def enroll_pin(request=None, action=None):
                                             client=g.client_ip,
                                             active=True,
                                             audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.match_policies(scope=scope,
-                                                 active=True,
-                                                 all_times=True)
+    action_at_all = policy_object.list_policies(scope=scope, active=True)
 
     if action_at_all and not pin_pols:
         # Not allowed to set a PIN during enrollment!
@@ -983,9 +981,7 @@ def check_anonymous_user(request=None, action=None):
                                           adminrealm=None,
                                           active=True,
                                           audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.match_policies(scope=scope,
-                                                 active=True,
-                                                 all_times=True)
+    action_at_all = policy_object.list_policies(scope=scope, active=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR)
     return True
@@ -1023,9 +1019,7 @@ def check_admin_tokenlist(request=None, action=None):
                                         active=True,
                                         audit_data=g.audit_object.audit_data)
 
-    pols_at_all = policy_object.match_policies(scope=SCOPE.ADMIN,
-                                               active=True,
-                                               all_times=True)
+    pols_at_all = policy_object.list_policies(scope=SCOPE.ADMIN, active=True)
 
     if pols_at_all:
         allowed_realms = []
@@ -1098,9 +1092,7 @@ def check_base_action(request=None, action=None, anonymous=False):
                                           adminrealm=admin_realm,
                                           active=True,
                                           audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.match_policies(scope=scope,
-                                                 active=True,
-                                                 all_times=True)
+    action_at_all = policy_object.list_policies(scope=scope, active=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR.get(role))
     return True
@@ -1126,8 +1118,7 @@ def check_token_upload(request=None, action=None):
                                           adminrealm=admin_realm,
                                           active=True,
                                           audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.match_policies(scope=SCOPE.ADMIN,
-                                                 active=True, all_times=True)
+    action_at_all = policy_object.list_policies(scope=SCOPE.ADMIN, active=True)
     if action_at_all and len(action) == 0:
         raise PolicyError("Admin actions are defined, but you are not allowed"
                           " to upload token files.")
@@ -1176,8 +1167,7 @@ def check_token_init(request=None, action=None):
                                           adminrealm=admin_realm,
                                           active=True,
                                           audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.match_policies(scope=scope, active=True,
-                                                 all_times=True)
+    action_at_all = policy_object.list_policies(scope=scope, active=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR.get(role))
     return True

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -198,7 +198,7 @@ def realmadmin(request=None, action=None):
         if not "realm" in params:
             # add the realm to params
             policy_object = g.policy_object
-            po = policy_object.get_policies(
+            po = policy_object.match_policies(
                 action=action, scope=SCOPE.ADMIN,
                 user=g.logged_in_user.get("username"),
                 adminrealm=g.logged_in_user.get("realm"), client=g.client_ip,
@@ -422,13 +422,13 @@ def encrypt_pin(request=None, action=None):
     policy_object = g.policy_object
     user_object = get_user_from_param(params)
     # get the length of the random PIN from the policies
-    pin_pols = policy_object.get_policies(action=ACTION.ENCRYPTPIN,
-                                          scope=SCOPE.ENROLL,
-                                          user=user_object.login,
-                                          realm=user_object.realm,
-                                          client=g.client_ip,
-                                          active=True,
-                                          audit_data=g.audit_object.audit_data)
+    pin_pols = policy_object.match_policies(action=ACTION.ENCRYPTPIN,
+                                            scope=SCOPE.ENROLL,
+                                            user=user_object.login,
+                                            realm=user_object.realm,
+                                            client=g.client_ip,
+                                            active=True,
+                                            audit_data=g.audit_object.audit_data)
 
     if pin_pols:
         request.all_data["encryptpin"] = "True"
@@ -457,17 +457,17 @@ def enroll_pin(request=None, action=None):
         username = g.logged_in_user.get("username")
         realm = getParam(request.all_data, "realm")
         adminrealm = g.logged_in_user.get("realm")
-    pin_pols = policy_object.get_policies(action=ACTION.ENROLLPIN,
-                                          scope=scope,
-                                          user=username,
-                                          realm=realm,
-                                          adminrealm=adminrealm,
-                                          client=g.client_ip,
-                                          active=True,
-                                          audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=scope,
-                                               active=True,
-                                               all_times=True)
+    pin_pols = policy_object.match_policies(action=ACTION.ENROLLPIN,
+                                            scope=scope,
+                                            user=username,
+                                            realm=realm,
+                                            adminrealm=adminrealm,
+                                            client=g.client_ip,
+                                            active=True,
+                                            audit_data=g.audit_object.audit_data)
+    action_at_all = policy_object.match_policies(scope=scope,
+                                                 active=True,
+                                                 all_times=True)
 
     if action_at_all and not pin_pols:
         # Not allowed to set a PIN during enrollment!
@@ -975,17 +975,17 @@ def check_anonymous_user(request=None, action=None):
     username = user_obj.login
     realm = user_obj.realm
 
-    action = policy_object.get_policies(action=action,
-                                        user=username,
-                                        realm=realm,
-                                        scope=scope,
-                                        client=g.client_ip,
-                                        adminrealm=None,
-                                        active=True,
-                                        audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=scope,
-                                               active=True,
-                                               all_times=True)
+    action = policy_object.match_policies(action=action,
+                                          user=username,
+                                          realm=realm,
+                                          scope=scope,
+                                          client=g.client_ip,
+                                          adminrealm=None,
+                                          active=True,
+                                          audit_data=g.audit_object.audit_data)
+    action_at_all = policy_object.match_policies(scope=scope,
+                                                 active=True,
+                                                 all_times=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR)
     return True
@@ -1015,17 +1015,17 @@ def check_admin_tokenlist(request=None, action=None):
     username = g.logged_in_user.get("username")
     admin_realm = g.logged_in_user.get("realm")
 
-    pols = policy_object.get_policies(action=ACTION.TOKENLIST,
-                                      user=username,
-                                      scope=SCOPE.ADMIN,
-                                      client=g.client_ip,
-                                      adminrealm=admin_realm,
-                                      active=True,
-                                      audit_data=g.audit_object.audit_data)
+    pols = policy_object.match_policies(action=ACTION.TOKENLIST,
+                                        user=username,
+                                        scope=SCOPE.ADMIN,
+                                        client=g.client_ip,
+                                        adminrealm=admin_realm,
+                                        active=True,
+                                        audit_data=g.audit_object.audit_data)
 
-    pols_at_all = policy_object.get_policies(scope=SCOPE.ADMIN,
-                                             active=True,
-                                             all_times=True)
+    pols_at_all = policy_object.match_policies(scope=SCOPE.ADMIN,
+                                               active=True,
+                                               all_times=True)
 
     if pols_at_all:
         allowed_realms = []
@@ -1089,18 +1089,18 @@ def check_base_action(request=None, action=None, anonymous=False):
             realm = get_realms_of_token(request.view_args.get("serial"),
                                         only_first_realm=True)
 
-    action = policy_object.get_policies(action=action,
-                                        user=username,
-                                        realm=realm,
-                                        scope=scope,
-                                        resolver=resolver,
-                                        client=g.client_ip,
-                                        adminrealm=admin_realm,
-                                        active=True,
-                                        audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=scope,
-                                               active=True,
-                                               all_times=True)
+    action = policy_object.match_policies(action=action,
+                                          user=username,
+                                          realm=realm,
+                                          scope=scope,
+                                          resolver=resolver,
+                                          client=g.client_ip,
+                                          adminrealm=admin_realm,
+                                          active=True,
+                                          audit_data=g.audit_object.audit_data)
+    action_at_all = policy_object.match_policies(scope=scope,
+                                                 active=True,
+                                                 all_times=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR.get(role))
     return True
@@ -1118,16 +1118,16 @@ def check_token_upload(request=None, action=None):
     policy_object = g.policy_object
     username = g.logged_in_user.get("username")
     admin_realm = g.logged_in_user.get("realm")
-    action = policy_object.get_policies(action=ACTION.IMPORT,
-                                        user=username,
-                                        realm=params.get("realm"),
-                                        scope=SCOPE.ADMIN,
-                                        client=g.client_ip,
-                                        adminrealm=admin_realm,
-                                        active=True,
-                                        audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=SCOPE.ADMIN,
-                                               active=True, all_times=True)
+    action = policy_object.match_policies(action=ACTION.IMPORT,
+                                          user=username,
+                                          realm=params.get("realm"),
+                                          scope=SCOPE.ADMIN,
+                                          client=g.client_ip,
+                                          adminrealm=admin_realm,
+                                          active=True,
+                                          audit_data=g.audit_object.audit_data)
+    action_at_all = policy_object.match_policies(scope=SCOPE.ADMIN,
+                                                 active=True, all_times=True)
     if action_at_all and len(action) == 0:
         raise PolicyError("Admin actions are defined, but you are not allowed"
                           " to upload token files.")
@@ -1167,17 +1167,17 @@ def check_token_init(request=None, action=None):
 
     tokentype = params.get("type", "HOTP")
     action = "enroll{0!s}".format(tokentype.upper())
-    action = policy_object.get_policies(action=action,
-                                        user=username,
-                                        realm=realm,
-                                        resolver=resolver,
-                                        scope=scope,
-                                        client=g.client_ip,
-                                        adminrealm=admin_realm,
-                                        active=True,
-                                        audit_data=g.audit_object.audit_data)
-    action_at_all = policy_object.get_policies(scope=scope, active=True,
-                                               all_times=True)
+    action = policy_object.match_policies(action=action,
+                                          user=username,
+                                          realm=realm,
+                                          resolver=resolver,
+                                          scope=scope,
+                                          client=g.client_ip,
+                                          adminrealm=admin_realm,
+                                          active=True,
+                                          audit_data=g.audit_object.audit_data)
+    action_at_all = policy_object.match_policies(scope=scope, active=True,
+                                                 all_times=True)
     if action_at_all and len(action) == 0:
         raise PolicyError(ERROR.get(role))
     return True
@@ -1227,13 +1227,13 @@ def api_key_required(request=None, action=None):
     user_object = request.User
 
     # Get the policies
-    action = policy_object.get_policies(action=ACTION.APIKEY,
-                                        user=user_object.login,
-                                        realm=user_object.realm,
-                                        scope=SCOPE.AUTHZ,
-                                        client=g.client_ip,
-                                        active=True,
-                                        audit_data=g.audit_object.audit_data)
+    action = policy_object.match_policies(action=ACTION.APIKEY,
+                                          user=user_object.login,
+                                          realm=user_object.realm,
+                                          scope=SCOPE.AUTHZ,
+                                          client=g.client_ip,
+                                          active=True,
+                                          audit_data=g.audit_object.audit_data)
     # Do we have a policy?
     if action:
         # check if we were passed a correct JWT
@@ -1436,7 +1436,7 @@ def u2ftoken_verify_cert(request, action):
         else:
             token_realm = token_resolver = token_user = None
 
-        do_not_verify_the_cert = policy_object.get_policies(
+        do_not_verify_the_cert = policy_object.match_policies(
             action=U2FACTION.NO_VERIFY_CERT,
             scope=SCOPE.ENROLL,
             realm=token_realm,
@@ -1525,7 +1525,7 @@ def allowed_audit_realm(request=None, action=None):
     """
     admin_user = g.logged_in_user
     policy_object = g.policy_object
-    pols = policy_object.get_policies(
+    pols = policy_object.match_policies(
         action=ACTION.AUDIT,
         scope=SCOPE.ADMIN,
         user=admin_user.get("username"),

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -275,12 +275,12 @@ def get_policy(name=None, export=None):
     if not export:
         log.debug("retrieving policy name: {0!s}, realm: {1!s}, scope: {2!s}".format(name, realm, scope))
 
-        pol = P.get_policies(name=name, realm=realm, scope=scope,
-                             active=active, all_times=True)
+        pol = P.match_policies(name=name, realm=realm, scope=scope,
+                               active=active, all_times=True)
         ret = send_result(pol)
     else:
         # We want to export all policies
-        pol = P.get_policies()
+        pol = P.match_policies()
         response = make_response(export_policies(pol))
         response.headers["Content-Disposition"] = ("attachment; "
                                                    "filename=%s" % export)
@@ -484,9 +484,9 @@ def check_policy_api():
     resolver = getParam(param, "resolver", optional)
 
     P = g.policy_object
-    policies = P.get_policies(user=user, realm=realm, resolver=resolver,
-                              scope=scope, action=action, client=client,
-                              active=True)
+    policies = P.match_policies(user=user, realm=realm, resolver=resolver,
+                                scope=scope, action=action, client=client,
+                                active=True)
     if policies:
         res["allowed"] = True
         res["policy"] = policies

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -270,17 +270,18 @@ def get_policy(name=None, export=None):
     realm = getParam(param, "realm")
     scope = getParam(param, "scope")
     active = getParam(param, "active")
+    if active is not None:
+        active = is_true(active)
 
     P = g.policy_object
     if not export:
         log.debug("retrieving policy name: {0!s}, realm: {1!s}, scope: {2!s}".format(name, realm, scope))
 
-        pol = P.match_policies(name=name, realm=realm, scope=scope,
-                               active=active, all_times=True)
+        pol = P.list_policies(name=name, realm=realm, scope=scope, active=active)
         ret = send_result(pol)
     else:
         # We want to export all policies
-        pol = P.match_policies()
+        pol = P.list_policies()
         response = make_response(export_policies(pol))
         response.headers["Content-Disposition"] = ("attachment; "
                                                    "filename=%s" % export)

--- a/privacyidea/api/realm.py
+++ b/privacyidea/api/realm.py
@@ -196,11 +196,11 @@ def get_realms_api():
     g.audit_object.log({"success": True})
     # This endpoint is called by admins anyways
     luser = g.logged_in_user
-    policies = g.policy_object.get_policies(scope=luser.get("role", ROLE.ADMIN),
-                                            client=g.client_ip,
-                                            adminrealm=luser.get("realm"),
-                                            user=luser.get("username"),
-                                            active=True)
+    policies = g.policy_object.match_policies(scope=luser.get("role", ROLE.ADMIN),
+                                              client=g.client_ip,
+                                              adminrealm=luser.get("realm"),
+                                              user=luser.get("username"),
+                                              active=True)
     realms = reduce_realms(all_realms, policies)
 
     return send_result(realms)

--- a/privacyidea/api/system.py
+++ b/privacyidea/api/system.py
@@ -94,7 +94,7 @@ def get_config_documentation():
     config = get_from_config()
     resolvers = get_resolver_list()
     realms = get_realms()
-    policies = P.get_policies()
+    policies = P.match_policies()
     admins = get_db_admins()
     context = {"system": socket.getfqdn(socket.gethostname()),
                "date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M"),

--- a/privacyidea/lib/passwordreset.py
+++ b/privacyidea/lib/passwordreset.py
@@ -142,11 +142,11 @@ def is_password_reset():
     rlist = get_resolver_list(editable=True)
     log.debug("Number of editable resolvers: {0!s}".format(len(rlist)))
     Policy = PolicyClass()
-    policy_at_all = Policy.get_policies(scope=SCOPE.USER, active=True)
+    policy_at_all = Policy.match_policies(scope=SCOPE.USER, active=True)
     log.debug("Policy at all: {0!s}".format(policy_at_all))
-    policy_reset_pw = Policy.get_policies(scope=SCOPE.USER,
-                                          action=ACTION.PASSWORDRESET,
-                                          active=True)
+    policy_reset_pw = Policy.match_policies(scope=SCOPE.USER,
+                                            action=ACTION.PASSWORDRESET,
+                                            active=True)
     log.debug("Password reset policy: {0!s}".format(policy_reset_pw))
     pwreset = (policy_at_all and policy_reset_pw) or not policy_at_all
     log.debug("Password reset allowed via policy: {0!s}".format(pwreset))

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -445,11 +445,11 @@ class PolicyClass(object):
         return value_found, value_excluded
 
     @log_with(log)
-    def get_policies(self, name=None, scope=None, realm=None, active=None,
-                     resolver=None, user=None, user_object=None,
-                     client=None, action=None,
-                     adminrealm=None, time=None, all_times=False,
-                     sort_by_priority=True, audit_data=None):
+    def match_policies(self, name=None, scope=None, realm=None, active=None,
+                       resolver=None, user=None, user_object=None,
+                       client=None, action=None,
+                       adminrealm=None, time=None, all_times=False,
+                       sort_by_priority=True, audit_data=None):
         """
         Return the policies of the given filter values.
 
@@ -679,10 +679,10 @@ class PolicyClass(object):
         :rtype: dict
         """
         policy_values = {}
-        policies = self.get_policies(scope=scope, adminrealm=adminrealm,
-                                     action=action, active=True,
-                                     realm=realm, resolver=resolver, user=user, user_object=user_object,
-                                     client=client, sort_by_priority=True)
+        policies = self.match_policies(scope=scope, adminrealm=adminrealm,
+                                       action=action, active=True,
+                                       realm=realm, resolver=resolver, user=user, user_object=user_object,
+                                       client=client, sort_by_priority=True)
         # If unique = True, only consider the policies with the highest priority
         if policies and unique:
             highest_priority = policies[0]['priority']
@@ -782,12 +782,12 @@ class PolicyClass(object):
             userrealm = realm
             logged_in_user["role"] = ROLE.USER
             resolver = User(username, userrealm).resolver
-        pols = self.get_policies(scope=scope,
-                                 adminrealm=adminrealm,
-                                 realm=userrealm,
-                                 resolver=resolver,
-                                 user=username, active=True,
-                                 client=client)
+        pols = self.match_policies(scope=scope,
+                                   adminrealm=adminrealm,
+                                   realm=userrealm,
+                                   resolver=resolver,
+                                   user=username, active=True,
+                                   client=client)
         for pol in pols:
             for action, action_value in pol.get("action").items():
                 if action_value:
@@ -796,7 +796,7 @@ class PolicyClass(object):
                     if isinstance(action_value, string_types):
                         rights.add(u"{}={}".format(action, action_value))
         # check if we have policies at all:
-        pols = self.get_policies(scope=scope, active=True)
+        pols = self.match_policies(scope=scope, active=True)
         if not pols:
             # We do not have any policies in this scope, so we return all
             # possible actions in this scope.
@@ -844,7 +844,7 @@ class PolicyClass(object):
             admin_realm = None
             user_realm = logged_in_user.get("realm")
         # check, if we have a policy definition at all.
-        pols = self.get_policies(scope=role, active=True)
+        pols = self.match_policies(scope=role, active=True)
         tokenclasses = get_token_classes()
         for tokenclass in tokenclasses:
             # Check if the tokenclass is ui enrollable for "user" or "admin"
@@ -858,12 +858,12 @@ class PolicyClass(object):
             filtered_enroll_types = {}
             for tokentype in enroll_types.keys():
                 # determine, if there is a enrollment policy for this very type
-                typepols = self.get_policies(scope=role, client=client,
-                                             user=logged_in_user.get("username"),
-                                             realm=user_realm,
-                                             active=True,
-                                             action="enroll"+tokentype.upper(),
-                                             adminrealm=admin_realm)
+                typepols = self.match_policies(scope=role, client=client,
+                                               user=logged_in_user.get("username"),
+                                               realm=user_realm,
+                                               active=True,
+                                               action="enroll"+tokentype.upper(),
+                                               adminrealm=admin_realm)
                 if typepols:
                     # If there is no policy allowing the enrollment of this
                     # tokentype, it is deleted.

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -220,12 +220,12 @@ def auth_user_has_no_token(wrapped_function, user_object, passw,
     if g:
         clientip = options.get("clientip")
         policy_object = g.policy_object
-        pass_no_token = policy_object.get_policies(action=ACTION.PASSNOTOKEN,
-                                                   scope=SCOPE.AUTH,
-                                                   realm=user_object.realm,
-                                                   resolver=user_object.resolver,
-                                                   user=user_object.login,
-                                                   client=clientip, active=True)
+        pass_no_token = policy_object.match_policies(action=ACTION.PASSNOTOKEN,
+                                                     scope=SCOPE.AUTH,
+                                                     realm=user_object.realm,
+                                                     resolver=user_object.resolver,
+                                                     user=user_object.login,
+                                                     client=clientip, active=True)
         if pass_no_token:
             # Now we need to check, if the user really has no token.
             tokencount = get_tokens(user=user_object, count=True)
@@ -258,13 +258,13 @@ def auth_user_does_not_exist(wrapped_function, user_object, passw,
     if g:
         clientip = options.get("clientip")
         policy_object = g.policy_object
-        pass_no_user = policy_object.get_policies(action=ACTION.PASSNOUSER,
-                                                  scope=SCOPE.AUTH,
-                                                  realm=user_object.realm,
-                                                  resolver=user_object.resolver,
-                                                  user=user_object.login,
-                                                  client=clientip,
-                                                  active=True)
+        pass_no_user = policy_object.match_policies(action=ACTION.PASSNOUSER,
+                                                    scope=SCOPE.AUTH,
+                                                    realm=user_object.realm,
+                                                    resolver=user_object.resolver,
+                                                    user=user_object.login,
+                                                    client=clientip,
+                                                    active=True)
         if pass_no_user:
             # Check if user object exists
             if not user_object.exist():
@@ -298,14 +298,14 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
     if g:
         policy_object = g.policy_object
         clientip = options.get("clientip")
-        pass_thru = policy_object.get_policies(action=ACTION.PASSTHRU,
-                                               scope=SCOPE.AUTH,
-                                               realm=user_object.realm,
-                                               resolver=user_object.resolver,
-                                               user=user_object.login,
-                                               client=clientip,
-                                               active=True,
-                                               sort_by_priority=True)
+        pass_thru = policy_object.match_policies(action=ACTION.PASSTHRU,
+                                                 scope=SCOPE.AUTH,
+                                                 realm=user_object.realm,
+                                                 resolver=user_object.resolver,
+                                                 user=user_object.login,
+                                                 client=clientip,
+                                                 active=True,
+                                                 sort_by_priority=True)
         # We only go to passthru, if the user has no tokens!
         if pass_thru and get_tokens(user=user_object, count=True) == 0:
             # Ensure that there are no conflicting action values within the same priority
@@ -713,7 +713,7 @@ def reset_all_user_tokens(wrapped_function, *args, **kwds):
         clientip = options.get("clientip")
         policy_object = g.policy_object
         token_owner = tokenobject_list[0].user
-        reset_all = policy_object.get_policies(
+        reset_all = policy_object.match_policies(
             action=ACTION.RESETALLTOKENS,
             scope=SCOPE.AUTH,
             user_object=token_owner if token_owner else None,

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -405,12 +405,12 @@ class EmailTokenClass(HotpTokenClass):
             clientip = options.get("clientip")
             policy_object = g.policy_object
             autoemailpol = policy_object.\
-                get_policies(action=EMAILACTION.EMAILAUTO,
-                             scope=SCOPE.AUTH,
-                             realm=realm,
-                             user=username,
-                             client=clientip, active=True,
-                             audit_data=g.audit_object.audit_data)
+                match_policies(action=EMAILACTION.EMAILAUTO,
+                               scope=SCOPE.AUTH,
+                               realm=realm,
+                               user=username,
+                               client=clientip, active=True,
+                               audit_data=g.audit_object.audit_data)
             autosms = len(autoemailpol) >= 1
 
         return autosms

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -540,12 +540,12 @@ class SmsTokenClass(HotpTokenClass):
             clientip = options.get("clientip")
             policy_object = g.policy_object
             autosmspol = policy_object.\
-                get_policies(action=SMSACTION.SMSAUTO,
-                             scope=SCOPE.AUTH,
-                             realm=realm,
-                             user=username,
-                             client=clientip, active=True,
-                             audit_data=g.audit_object.audit_data)
+                match_policies(action=SMSACTION.SMSAUTO,
+                               scope=SCOPE.AUTH,
+                               realm=realm,
+                               user=username,
+                               client=clientip, active=True,
+                               audit_data=g.audit_object.audit_data)
             autosms = len(autosmspol) >= 1
 
         return autosms

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -89,10 +89,10 @@ def single_page_application():
     realms = ""
     client_ip = get_client_ip(request,
                               get_from_config(SYSCONF.OVERRIDECLIENT))
-    realm_dropdown = policy_object.get_policies(action=ACTION.REALMDROPDOWN,
-                                                scope=SCOPE.WEBUI,
-                                                client=client_ip,
-                                                active=True)
+    realm_dropdown = policy_object.match_policies(action=ACTION.REALMDROPDOWN,
+                                                  scope=SCOPE.WEBUI,
+                                                  client=client_ip,
+                                                  active=True)
     if realm_dropdown:
         try:
             realm_dropdown_values = policy_object.get_action_values(

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -617,9 +617,9 @@ class APIConfigTestCase(MyApiTestCase):
             self.assertTrue(result["value"] == 2, result)
             # check if policies are there
             P = PolicyClass()
-            p1 = P.get_policies(name="importpol1")
+            p1 = P.match_policies(name="importpol1")
             self.assertTrue(len(p1) == 1, p1)
-            p2 = P.get_policies(name="importpol2")
+            p2 = P.match_policies(name="importpol2")
             self.assertTrue(len(p2) == 1, p2)
 
         # import empty file

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1325,7 +1325,7 @@ class APITokenTestCase(MyApiTestCase):
         tn = datetime.datetime.now()
         dow = tn.isoweekday()
         P = PolicyClass()
-        all_admin_policies = P.get_policies(all_times=True)
+        all_admin_policies = P.match_policies(all_times=True)
         self.assertEqual(len(all_admin_policies), 1)
         self.assertEqual(len(P.policies), 1)
 

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1325,7 +1325,7 @@ class APITokenTestCase(MyApiTestCase):
         tn = datetime.datetime.now()
         dow = tn.isoweekday()
         P = PolicyClass()
-        all_admin_policies = P.match_policies(all_times=True)
+        all_admin_policies = P.list_policies()
         self.assertEqual(len(all_admin_policies), 1)
         self.assertEqual(len(P.policies), 1)
 

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -63,19 +63,19 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(p > 0)
 
         P = PolicyClass()
-        policies = P.get_policies(name="pol3")
+        policies = P.match_policies(name="pol3")
         # only one policy found
         self.assertTrue(len(policies) == 1, len(policies))
 
-        policies = P.get_policies(scope=SCOPE.AUTHZ)
+        policies = P.match_policies(scope=SCOPE.AUTHZ)
         self.assertTrue(len(policies) == 2, len(policies))
 
-        policies = P.get_policies(scope=SCOPE.AUTHZ,
-                                  action="tokentype")
+        policies = P.match_policies(scope=SCOPE.AUTHZ,
+                                    action="tokentype")
         self.assertTrue(len(policies) == 1, len(policies))
 
-        policies = P.get_policies(scope="admin",
-                                  action="disable")
+        policies = P.match_policies(scope="admin",
+                                    action="disable")
         self.assertTrue(len(policies) == 1, len(policies))
         self.assertTrue(policies[0].get("name") == "pol4")
 
@@ -117,62 +117,62 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(p > 0)
 
         # enable and disable policies
-        policies = PolicyClass().get_policies(active=False)
+        policies = PolicyClass().match_policies(active=False)
         num_old = len(policies)
         p = enable_policy("pol4", False)
-        policies = PolicyClass().get_policies(active=False)
+        policies = PolicyClass().match_policies(active=False)
         self.assertTrue(num_old + 1 == len(policies), (num_old, len(policies)))
         p = enable_policy("pol4", True)
-        policies = PolicyClass().get_policies(active=False)
+        policies = PolicyClass().match_policies(active=False)
         self.assertTrue(num_old == len(policies), len(policies))
 
         # find inactive policies
         P = PolicyClass()
-        policies = P.get_policies(active=False)
+        policies = P.match_policies(active=False)
         self.assertTrue(len(policies) == 1, len(policies))
         self.assertTrue(policies[0].get("name") == "pol1")
 
         # find policies action tokentype
-        policies = P.get_policies(action="tokentype")
+        policies = P.match_policies(action="tokentype")
         self.assertTrue(len(policies) == 2, policies)
         # find policies action serial
-        policies = P.get_policies(action="serial")
+        policies = P.match_policies(action="serial")
         self.assertTrue(len(policies) == 1, policies)
         # find policies with scope authorization
-        policies = P.get_policies(scope=SCOPE.AUTHZ)
+        policies = P.match_policies(scope=SCOPE.AUTHZ)
         self.assertTrue(len(policies) == 3, policies)
         # find policies authorization and realm2
-        policies = P.get_policies(action="tokentype", scope=SCOPE.AUTHZ)
+        policies = P.match_policies(action="tokentype", scope=SCOPE.AUTHZ)
         self.assertTrue(len(policies) == 2, policies)
         # find policies with user admin
-        policies = P.get_policies(scope="admin", user="admin")
+        policies = P.match_policies(scope="admin", user="admin")
         self.assertTrue(len(policies) == 1, "{0!s}".format(len(policies)))
         # find policies with resolver2 and authorization. THe result should
         # be pol2 and pol2a
-        policies = P.get_policies(resolver="resolver2", scope=SCOPE.AUTHZ)
+        policies = P.match_policies(resolver="resolver2", scope=SCOPE.AUTHZ)
         self.assertTrue(len(policies) == 2, policies)
 
         # find policies with realm1 and authorization. We also include the
         # "*" into the result list. We find pol2 and pol3
-        policies = P.get_policies(realm="realm1", scope=SCOPE.AUTHZ)
+        policies = P.match_policies(realm="realm1", scope=SCOPE.AUTHZ)
         self.assertTrue(len(policies) == 2, policies)
 
         # find policies with resolver1 and authorization.
         # All other authorization policies will also match, since they either
         # user * or
         # have no destinct information about resolvers
-        policies = P.get_policies(resolver="resolver1", scope=SCOPE.AUTHZ)
+        policies = P.match_policies(resolver="resolver1", scope=SCOPE.AUTHZ)
         self.assertTrue(len(policies) == 3, policies)
 
     def test_04_delete_policy(self):
         delete_policy(name="pol4")
         P = PolicyClass()
-        pol4 = P.get_policies(name="pol4")
+        pol4 = P.match_policies(name="pol4")
         self.assertTrue(pol4 == [], pol4)
 
     def test_05_export_policies(self):
         P = PolicyClass()
-        policies = P.get_policies()
+        policies = P.match_policies()
         file = export_policies(policies)
         self.assertTrue("[pol1]" in file, file)
         self.assertTrue("[pol2]" in file, file)
@@ -180,12 +180,12 @@ class PolicyTestCase(MyTestCase):
 
     def test_06_import_policies(self):
         P = PolicyClass()
-        file = export_policies(P.get_policies())
+        file = export_policies(P.match_policies())
         delete_policy("pol1")
         delete_policy("pol2")
         delete_policy("pol3")
         P = PolicyClass()
-        policies = P.get_policies()
+        policies = P.match_policies()
         self.assertFalse(_check_policy_name("pol1", policies), policies)
         self.assertFalse(_check_policy_name("pol2", policies), policies)
         self.assertFalse(_check_policy_name("pol3", policies), policies)
@@ -193,7 +193,7 @@ class PolicyTestCase(MyTestCase):
         num = import_policies(file)
         self.assertTrue(num == 4, num)
         P = PolicyClass()
-        policies = P.get_policies()
+        policies = P.match_policies()
         self.assertTrue(_check_policy_name("pol1", policies), policies)
         self.assertTrue(_check_policy_name("pol2", policies), policies)
         self.assertTrue(_check_policy_name("pol3", policies), policies)
@@ -209,25 +209,25 @@ class PolicyTestCase(MyTestCase):
 
         # One policy with matching client, one without any clients
         P = PolicyClass()
-        p = P.get_policies(client="10.0.0.1")
+        p = P.match_policies(client="10.0.0.1")
         self.assertTrue(_check_policy_name("pol3", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
         self.assertTrue(len(p) == 2, p)
 
         # client matches pol4 and pol2
-        p = P.get_policies(client="192.168.2.3")
+        p = P.match_policies(client="192.168.2.3")
         self.assertTrue(_check_policy_name("pol2", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
         self.assertTrue(len(p) == 2, p)
 
         # client only matches pol4, since it is excluded in pol2
-        p = P.get_policies(client="192.168.1.1")
+        p = P.match_policies(client="192.168.1.1")
         self.assertTrue(_check_policy_name("pol4", p), p)
         self.assertTrue(len(p) == 1, p)
 
         # client="" throws a ParameterError
         with self.assertRaises(ParameterError):
-            P.get_policies(client="")
+            P.match_policies(client="")
 
     def test_08_user_policies(self):
         set_policy(name="pol1", scope="s", user="*")
@@ -237,28 +237,28 @@ class PolicyTestCase(MyTestCase):
 
         # get policies for user1
         P = PolicyClass()
-        p = P.get_policies(user="user1")
+        p = P.match_policies(user="user1")
         self.assertTrue(len(p) == 3, (len(p), p))
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertTrue(_check_policy_name("pol2", p), p)
         self.assertFalse(_check_policy_name("pol3", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
         # get policies for root
-        p = P.get_policies(user="root")
+        p = P.match_policies(user="root")
         self.assertTrue(len(p) == 3, p)
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertTrue(_check_policy_name("pol2", p), p)
         self.assertTrue(_check_policy_name("pol3", p), p)
         self.assertFalse(_check_policy_name("pol4", p), p)
         # get policies for admin
-        p = P.get_policies(user="admin")
+        p = P.match_policies(user="admin")
         self.assertTrue(len(p) == 4, p)
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertTrue(_check_policy_name("pol2", p), p)
         self.assertTrue(_check_policy_name("pol3", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
         # get policies for empty user
-        p = P.get_policies(user="")
+        p = P.match_policies(user="")
         self.assertEqual(len(p), 3)
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertTrue(_check_policy_name("pol3", p), p)
@@ -271,14 +271,14 @@ class PolicyTestCase(MyTestCase):
         set_policy(name="pol4", scope="s", realm="r2", active=True)
 
         P = PolicyClass()
-        p = P.get_policies(realm="r1")
+        p = P.match_policies(realm="r1")
         self.assertTrue(len(p) == 3, p)
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertTrue(_check_policy_name("pol2", p), p)
         self.assertTrue(_check_policy_name("pol3", p), p)
         self.assertFalse(_check_policy_name("pol4", p), p)
 
-        p = P.get_policies(realm="r2")
+        p = P.match_policies(realm="r2")
         self.assertTrue(len(p) == 2, p)
         self.assertFalse(_check_policy_name("pol1", p), p)
         self.assertFalse(_check_policy_name("pol2", p), p)
@@ -286,21 +286,21 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(_check_policy_name("pol4", p), p)
 
         # Check cases in which we pass an empty realm or realm=None
-        p = P.get_policies(realm="")
+        p = P.match_policies(realm="")
         self.assertEqual(len(p), 1)
         self.assertTrue(_check_policy_name("pol3", p), p)
 
-        p = P.get_policies(realm=None)
+        p = P.match_policies(realm=None)
         self.assertEqual(len(p), 4)
 
-        p = P.get_policies(resolver="reso1")
+        p = P.match_policies(resolver="reso1")
         self.assertEqual(len(p), 3)
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertTrue(_check_policy_name("pol2", p), p)
         self.assertFalse(_check_policy_name("pol3", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
 
-        p = P.get_policies(resolver="reso2")
+        p = P.match_policies(resolver="reso2")
         self.assertTrue(len(p) == 3, p)
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertFalse(_check_policy_name("pol2", p), p)
@@ -308,7 +308,7 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(_check_policy_name("pol4", p), p)
 
         # Check case in which we pass an empty resolver
-        p = P.get_policies(resolver="")
+        p = P.match_policies(resolver="")
         self.assertEqual(len(p), 2)
         self.assertTrue(_check_policy_name("pol1", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
@@ -320,26 +320,26 @@ class PolicyTestCase(MyTestCase):
         set_policy(name="pol4", action="*, -otppin=2")
 
         P = PolicyClass()
-        p = P.get_policies(action="enroll")
+        p = P.match_policies(action="enroll")
         self.assertTrue(len(p) == 4, (len(p), p))
 
-        p = P.get_policies(action="init")
+        p = P.match_policies(action="init")
         self.assertTrue(len(p) == 3, (len(p), p))
 
-        p = P.get_policies(action="disable")
+        p = P.match_policies(action="disable")
         self.assertTrue(len(p) == 2, (len(p), p))
 
-        p = P.get_policies(action="otppin")
+        p = P.match_policies(action="otppin")
         self.assertTrue(len(p) == 2, (len(p), p))
 
         # Check cases in which we pass an empty action or action=None
-        p = P.get_policies(action="")
+        p = P.match_policies(action="")
         # Here, we get pol3 and pol4
         self.assertEqual(len(p), 2)
         self.assertTrue(_check_policy_name("pol3", p), p)
         self.assertTrue(_check_policy_name("pol4", p), p)
 
-        p = P.get_policies(action=None)
+        p = P.match_policies(action=None)
         self.assertEqual(len(p), 4)
 
     def test_11_get_policy_definitions(self):
@@ -620,13 +620,13 @@ class PolicyTestCase(MyTestCase):
         tn = datetime.datetime.now()
         dow = tn.isoweekday()
         P = PolicyClass()
-        policies = P.get_policies(name="time1",
-                                  scope=SCOPE.AUTHZ,
-                                  all_times=True)
+        policies = P.match_policies(name="time1",
+                                    scope=SCOPE.AUTHZ,
+                                    all_times=True)
         self.assertEqual(len(policies), 1)
 
-        policies = P.get_policies(name="time1",
-                                  scope=SCOPE.AUTHZ)
+        policies = P.match_policies(name="time1",
+                                    scope=SCOPE.AUTHZ)
         if dow in [1, 2, 3]:
             self.assertEqual(len(policies), 1)
         else:
@@ -769,8 +769,8 @@ class PolicyTestCase(MyTestCase):
                        action="{0}=totp".format(ACTION.TOKENTYPE))
         self.assertTrue(p > 0)
         P = PolicyClass()
-        pols = P.get_policies(scope=SCOPE.AUTHZ, realm=user.realm,
-                              resolver=user.resolver, user=user.login)
+        pols = P.match_policies(scope=SCOPE.AUTHZ, realm=user.realm,
+                                resolver=user.resolver, user=user.login)
         self.assertEqual(len(pols), 1)
 
         # Now we change the policy, so that it uses check_all_resolver, i.e.
@@ -779,8 +779,8 @@ class PolicyTestCase(MyTestCase):
                        action="{0}=totp".format(ACTION.TOKENTYPE))
         self.assertTrue(p > 0)
         P = PolicyClass()
-        pols = P.get_policies(scope=SCOPE.AUTHZ, realm=user.realm,
-                              resolver=user.resolver, user=user.login)
+        pols = P.match_policies(scope=SCOPE.AUTHZ, realm=user.realm,
+                                resolver=user.resolver, user=user.login)
         self.assertEqual(len(pols), 2)
 
         # delete policy
@@ -799,10 +799,10 @@ class PolicyTestCase(MyTestCase):
                    scope='s')
 
         P = PolicyClass()
-        p = P.get_policies(action="enroll", user='somebodyelse')
+        p = P.match_policies(action="enroll", user='somebodyelse')
         self.assertEqual(len(p), 0)
 
-        p = P.get_policies(action="enroll", user=u'nönäscii')
+        p = P.match_policies(action="enroll", user=u'nönäscii')
         self.assertEqual(len(p), 1)
 
         delete_policy(name="polnonascii")
@@ -843,7 +843,7 @@ class PolicyTestCase(MyTestCase):
                 unique=True, allow_white_space_in_action=True)
         self.assertIn("policies with conflicting actions", str(cm.exception))
 
-        pols = P.get_policies(action="emailtext", scope=SCOPE.AUTH)
+        pols = P.match_policies(action="emailtext", scope=SCOPE.AUTH)
         self.assertEqual(len(pols), 3)
         with self.assertRaises(PolicyError) as cm:
             P.check_for_conflicts(pols, "emailtext")
@@ -864,13 +864,13 @@ class PolicyTestCase(MyTestCase):
         # email4, priority=3
 
         # export, delete all, re-import
-        exported = export_policies(P.get_policies())
+        exported = export_policies(P.match_policies())
         self.assertIn("priority = 4", exported)
         self.assertIn("priority = 77", exported)
         delete_all_policies()
         import_policies(exported)
 
-        pols = P.get_policies(action="emailtext", scope=SCOPE.AUTH)
+        pols = P.match_policies(action="emailtext", scope=SCOPE.AUTH)
         self.assertEqual(len(pols), 3)
         # this sorts by priority
         self.assertEqual([p['name'] for p in pols],
@@ -976,44 +976,44 @@ class PolicyTestCase(MyTestCase):
                    user=u"nönäscii", realm="realm1")
 
         P = PolicyClass()
-        self.assertEqual(set(p['name'] for p in P.get_policies(user_object=cornelius)),
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=cornelius)),
                          {"act1", "act2", "act3"})
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH,
                                              user_object=cornelius),
                          {"userstore": ["act1", "act2"], "none": ["act3"]})
 
-        self.assertEqual(set(p['name'] for p in P.get_policies(user_object=nonascii)),
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=nonascii)),
                          {"act1", "act2", "act3", "act4"})
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH,
                                              user_object=nonascii),
                          {"userstore": ["act1", "act2"], "none": ["act3", "act4"]})
 
-        self.assertEqual(set(p['name'] for p in P.get_policies(user_object=selfservice)),
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=selfservice)),
                          {"act2", "act3"})
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH,
                                              user_object=selfservice),
                          {"userstore": ["act2"], "none": ["act3"]})
 
-        self.assertEqual(set(p['name'] for p in P.get_policies(user_object=whoopsie)),
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=whoopsie)),
                          set())
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH,
                                              user_object=whoopsie),
                          {})
 
-        self.assertEqual(set(p['name'] for p in P.get_policies(user_object=None)),
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=None)),
                          {"act1", "act2", "act3", "act4"})
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH,
                                              user_object=None),
                          {"userstore": ["act1", "act2"], "none": ["act3", "act4"]})
 
-        self.assertEqual(set(p['name'] for p in P.get_policies(user_object=User())),
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=User())),
                          set())
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH,
                                              user_object=User()),
                          {})
 
         with self.assertRaises(ParameterError):
-            P.get_policies(user_object=cornelius, realm="realm3")
+            P.match_policies(user_object=cornelius, realm="realm3")
 
         with self.assertRaises(ParameterError):
             P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH,
@@ -1023,12 +1023,12 @@ class PolicyTestCase(MyTestCase):
 
         P = PolicyClass()
         # If we pass an empty user object, only policies without user match
-        self.assertEqual(set(p['name'] for p in P.get_policies(user_object=User())),
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=User())),
                          {"act5"})
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH, user_object=User()),
                          {"none": ["act5"]})
         # If we pass None as the user object, all policies match
-        self.assertEqual(set(p['name'] for p in P.get_policies(user_object=None)),
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=None)),
                          {"act1", "act2", "act3", "act4", "act5"})
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH, user_object=None),
                          {"userstore": ["act1", "act2"], "none": ["act3", "act4", "act5"]})
@@ -1043,17 +1043,17 @@ class PolicyTestCase(MyTestCase):
         # First, remove all policies
         policy_object = PolicyClass()
         delete_all_policies()
-        self.assertEqual(policy_object.get_policies(), [])
+        self.assertEqual(policy_object.match_policies(), [])
         # Now, add a policy and check if the policies have been reloaded
         set_policy("act1", scope=SCOPE.AUTH, action="{0!s}=userstore".format(ACTION.OTPPIN), priority=1)
-        self.assertEqual([p["name"] for p in policy_object.get_policies()], ["act1"])
-        self.assertEqual(policy_object.get_policies()[0]["priority"], 1)
+        self.assertEqual([p["name"] for p in policy_object.match_policies()], ["act1"])
+        self.assertEqual(policy_object.match_policies()[0]["priority"], 1)
         # Update the policy and check if the policies have been reloaded
         set_policy("act1", scope=SCOPE.AUTH, action="{0!s}=userstore".format(ACTION.OTPPIN), priority=2)
-        self.assertEqual(policy_object.get_policies()[0]["priority"], 2)
+        self.assertEqual(policy_object.match_policies()[0]["priority"], 2)
         # Add a second policy, check
         set_policy("act2", scope=SCOPE.AUTH, action="{0!s}=none".format(ACTION.OTPPIN), priority=3)
-        self.assertEqual([p["name"] for p in policy_object.get_policies()], ["act1", "act2"])
+        self.assertEqual([p["name"] for p in policy_object.match_policies()], ["act1", "act2"])
         # Delete a policy, check
         delete_policy("act1")
-        self.assertEqual([p["name"] for p in policy_object.get_policies()], ["act2"])
+        self.assertEqual([p["name"] for p in policy_object.match_policies()], ["act2"])


### PR DESCRIPTION
Before, we only had one method ``get_policies`` to get matching policies.

This PR implements two methods for policy matching: ``list_policies`` and ``match_policies``.
* ``list_policies`` should be used to retrieve a list of policies matching some criteria (e.g. name, realm, scope, ...), e.g. for displaying them in the WebUI
* ``match_policies`` should be used to retrieve a list of policies that should apply to the current request. This, for example, also takes the current time into account!

Working on #1436