### PR TITLE
Fix typo which made the SMTP server config link disappear

### DIFF
--- a/privacyidea/static/components/config/views/config.system.html
+++ b/privacyidea/static/components/config/views/config.system.html
@@ -17,7 +17,7 @@
                         <span translate>Get System Documentation</span></a></li>
                     <li role="presentation"
                         ng-class="{ active: $state.includes('config.smtp')}"
-                        ng-show="checkRight('smtpserver_read ')">
+                        ng-show="checkRight('smtpserver_read')">
                         <a ui-sref="config.smtp">
                             <span class="glyphicon glyphicon-envelope"></span>
                             <span translate>SMTP servers</span>


### PR DESCRIPTION
Related to #1495, #1721