### PR TITLE
Change the cursor symbol to pointer

### DIFF
--- a/privacyidea/static/css/content.css
+++ b/privacyidea/static/css/content.css
@@ -45,3 +45,8 @@ select.ng-invalid:focus:not(#username):not(#password){
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483;
           box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px #ce8483;
 }
+
+/* Style all anchors without hrefs (usually some js callback) with the pointer cursor */
+a:not([href]) {
+  cursor: pointer;
+}


### PR DESCRIPTION
In case an anchor element does not contain a href attribute, the cursor
symbol did not change when hovering. This is now fixed.

Fixes #1725 