### PR TITLE
Linearize migration scripts

### DIFF
--- a/migrations/versions/3d7f8b29cbb1_.py
+++ b/migrations/versions/3d7f8b29cbb1_.py
@@ -1,14 +1,14 @@
 """Add a generic admin policy for all admin read actions
 
 Revision ID: 3d7f8b29cbb1
-Revises: 849170064430
+Revises: dceb6cd3c41e
 Create Date: 2019-07-04 22:37:53.594962
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '3d7f8b29cbb1'
-down_revision = '849170064430'
+down_revision = 'dceb6cd3c41e'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
On current master, we have two migration revision heads:

```
$ ./pi-manage db branches

             _                    _______  _______
   ___  ____(_)  _____ _______ __/  _/ _ \/ __/ _ |
  / _ \/ __/ / |/ / _ `/ __/ // // // // / _// __ |
 / .__/_/ /_/|___/\_,_/\__/\_, /___/____/___/_/ |_|
/_/                       /___/
   
849170064430 (branchpoint)
             -> b9131d0686eb
             -> 3d7f8b29cbb1 (head)
```

In particular, current master has the following tree of revisions:

```
48ee74 -> 849170 -> b9131d -> dceb6cd
                \-> 3d7f8b
```
So this PR detaches 3d7f8b and uses it as the new head revision:

```
48ee74 -> 849170 -> b9131d -> dceb6cd -> 3d7f8b
```

This should(tm) be no problem, because 3d7f8b just adds a migration policy. 

Fixes #1733