### PR TITLE
Remove whitespace from key during Yubikey token initialization

### DIFF
--- a/doc/configuration/tokens/yubikey.rst
+++ b/doc/configuration/tokens/yubikey.rst
@@ -49,8 +49,7 @@ initialized the yubikey with the external *ykpersonalize* tool.
 
 When using the yubikey personalization GUI you need to copy the value of
 "Secret Key (16 bytes Hex)". This is the secret OTP key, which you need to
-copy and paste in the field "OTP Key" in the privacyIDEA Web UI. (Remove
-possible white spaces!)
+copy and paste in the field "OTP Key" in the privacyIDEA Web UI.
 
 .. figure:: images/enroll_yubikey.png
    :width: 500

--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -456,5 +456,10 @@ h={h}
 
     @log_with(log)
     def update(self, param, reset_failcount=True):
-        TokenClass.update(self, param, reset_failcount)
+        update_params = param.copy()
+        # As the secret is usually copy-pasted from the Yubikey personalization GUI,
+        # which separates hexlified bytes by spaces, we remove all spaces from the OTP key.
+        if "otpkey" in update_params:
+            update_params["otpkey"] = update_params["otpkey"].replace(" ", "")
+        TokenClass.update(self, update_params, reset_failcount)
         self.add_tokeninfo("tokenkind", TOKENKIND.HARDWARE)

--- a/privacyidea/static/components/token/views/token.enroll.yubikey.html
+++ b/privacyidea/static/components/token/views/token.enroll.yubikey.html
@@ -38,7 +38,7 @@
 
 <div class="form-group">
     <label for="otpkey" translate>OTP Key</label>
-    <input type="text" ng-pattern="/^[0-9a-fA-F]*$/"
+    <input type="text" ng-pattern="/^[0-9a-fA-F ]*$/"
            ng-init="form.genkey=false"
            autofocus
            class="form-control"


### PR DESCRIPTION
When enrolling Yubikey (AES mode) tokens, we now strip whitespaces from the OTP key.

I decided to implement the whitespace stripping on the server side because I couldn't think of a nice way to do it in the frontend :-) As it is implemented in the ``update`` method of the Yubikey token class, it doesn't interfere with other token classes.

Closes #1735