### PR TITLE
Add optional token-specific plausibility checks during enrollment

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1504,6 +1504,29 @@ def u2ftoken_allowed(request, action):
     return True
 
 
+def check_plausibility(request=None, action=None):
+    """
+    This is a wrapper for the /token/init endpoint.
+    If a policy with scope ENROLL and action CHECK_PLAUSIBILITY is defined,
+    this wrapper passes the parameter ``check_plausibility=1`` to the /token/init
+    endpoint. If no such policy is defined, the user-provided value is not modified.
+    :param request:
+    :param action:
+    :return:
+    """
+    user_object = request.User
+    check_plausibility_policies = g.policy_object.match_policies(
+        action=ACTION.CHECK_PLAUSIBILITY,
+        scope=SCOPE.ENROLL,
+        user_object=user_object if user_object else None,
+        active=True,
+        client=g.client_ip,
+        audit_data=g.audit_object.audit_data)
+    if check_plausibility_policies:
+        request.all_data["check_plausibility"] = True
+    return True
+
+
 def allowed_audit_realm(request=None, action=None):
     """
     This decorator function takes the request and adds additional parameters 

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -89,7 +89,7 @@ from privacyidea.api.lib.prepolicy import (prepolicy, check_base_action,
                                            twostep_enrollment_activation,
                                            twostep_enrollment_parameters,
                                            sms_identifiers, pushtoken_add_config,
-                                           check_admin_tokenlist)
+                                           check_admin_tokenlist, check_plausibility)
 from privacyidea.api.lib.postpolicy import (save_pin_change,
                                             postpolicy)
 from privacyidea.lib.event import event
@@ -130,6 +130,7 @@ To see how to authenticate read :ref:`rest_auth`.
 @prepolicy(tantoken_count, request)
 @prepolicy(u2ftoken_allowed, request)
 @prepolicy(u2ftoken_verify_cert, request)
+@prepolicy(check_plausibility, request)
 @prepolicy(pushtoken_add_config, request)
 @postpolicy(save_pin_change, request)
 @CheckSubscription(request)

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -226,6 +226,7 @@ class ACTION(object):
     CHALLENGETEXT_HEADER = "challenge_text_header"
     CHALLENGETEXT_FOOTER = "challenge_text_footer"
     GETCHALLENGES = "getchallenges"
+    CHECK_PLAUSIBILITY = "check_plausibility"
     COPYTOKENPIN = "copytokenpin"
     COPYTOKENUSER = "copytokenuser"
     DEFAULT_TOKENTYPE = "default_tokentype"
@@ -1789,6 +1790,11 @@ def get_static_policy_definitions(scope=None):
                 'value': list(range(1, 61)),
                 'desc': _('The length of the validity for the temporary '
                           'token (in days).')},
+            ACTION.CHECK_PLAUSIBILITY: {
+                'type': 'bool',
+                'desc': _('Prevent enrollment of tokens with invalid configuration.'),
+                'group': GROUP.TOKEN,
+            }
         },
         SCOPE.AUTH: {
             ACTION.OTPPIN: {

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -950,9 +950,10 @@ def import_token(serial, token_dict, default_hashlib=None, tokenrealms=None):
 
 @log_with(log)
 def init_token(param, user=None, tokenrealms=None,
-               tokenkind=None):
+               tokenkind=None, check_plausibility=False):
     """
-    create a new token or update an existing token
+    create a new token or update an existing token.
+    If a ParameterError occurs during the enrollment of a new token, remove the token from the database.
 
     :param param: initialization parameters like:
                   serial (optional)
@@ -965,6 +966,8 @@ def init_token(param, user=None, tokenrealms=None,
     :type tokenrealms: list
     :param tokenkind: The kind of the token, can be "software",
         "hardware" or "virtual"
+    :param check_plausibility: if True, invoke the token-specific ``ensure_plausibility`` method
+                               after token creation/update to check for invalid token configurations.
     :return: token object or None
     :rtype: TokenClass object
     """
@@ -1028,6 +1031,8 @@ def init_token(param, user=None, tokenrealms=None,
 
     try:
         tokenobject.update(param)
+        if check_plausibility:
+            tokenobject.ensure_plausibility()
     except ParameterError:
         # If we just created a new token in the database, but enrollment
         # failed because of invalid parameters, we delete it from the database

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -476,6 +476,12 @@ class TokenClass(object):
         else:
             raise ParameterError("Unknown OTP key format: {!r}".format(otpkeyformat))
 
+    def ensure_plausibility(self):
+        """
+        Check for invalid token configurations and throw a ParameterError if the token is misconfigured.
+        This function may be called by ``init_token`` after token creation/update.
+        """
+        pass
 
     def update(self, param, reset_failcount=True):
         """


### PR DESCRIPTION
This PR implements a possible solution of #1631. See the issue for details.