### PR TITLE
Implement userinfo matching for enrollX policy actions and fix user login

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1151,7 +1151,7 @@ def check_token_init(request=None, action=None):
                            g.logged_in_user.get("realm"))
     elif role == ROLE.ADMIN:
         # If the logged-in admin enrolls the token, the "user"/"adminrealm" parameters match
-        # administrator.  If the token is enrolled *for* a user, the "resolver" and "realm"
+        # the administrator.  If the token is enrolled *for* a user, the "resolver" and "realm"
         # fields match the token owner's resolver and realm.
         scope = SCOPE.ADMIN
         username = g.logged_in_user.get("username")

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1140,21 +1140,33 @@ def check_token_init(request=None, action=None):
                       "enroll this token type!"}
     params = request.all_data
     policy_object = g.policy_object
-    username = g.logged_in_user.get("username")
     role = g.logged_in_user.get("role")
-    admin_realm = g.logged_in_user.get("realm")
-    scope = SCOPE.ADMIN
-    # We need this user, if an admin enrolls a token for a user
-    user_obj = get_user_from_param(params)
-    resolver = realm = None
     if role == ROLE.USER:
+        # If the logged-in user enrolls the token, we pass a user object to match_policies
+        # to allow matching for userinfo attributes
         scope = SCOPE.USER
-        realm = admin_realm
+        username = resolver = realm = None
         admin_realm = None
-        resolver = User(username, realm).resolver
-    elif role == ROLE.ADMIN and user_obj:
-        resolver = user_obj.resolver
-        realm = user_obj.realm
+        user_object = User(g.logged_in_user.get("username"),
+                           g.logged_in_user.get("realm"))
+    elif role == ROLE.ADMIN:
+        # If the logged-in admin enrolls the token, the "user"/"adminrealm" parameters match
+        # administrator.  If the token is enrolled *for* a user, the "resolver" and "realm"
+        # fields match the token owner's resolver and realm.
+        scope = SCOPE.ADMIN
+        username = g.logged_in_user.get("username")
+        new_token_owner = get_user_from_param(params)
+        if new_token_owner:
+            resolver = new_token_owner.resolver
+            realm = new_token_owner.realm
+        else:
+            resolver = realm = None
+        admin_realm = g.logged_in_user.get("realm")
+        # ... but we cannot pass a user object to match_policies, because "username" is
+        # taken from the admin and "resolver"/"realm" are taken from the user.
+        user_object = None
+    else:
+        raise PolicyError(u"Unknown role: {}".format(role))
 
     tokentype = params.get("type", "HOTP")
     action = "enroll{0!s}".format(tokentype.upper())
@@ -1165,6 +1177,7 @@ def check_token_init(request=None, action=None):
                                           scope=scope,
                                           client=g.client_ip,
                                           adminrealm=admin_realm,
+                                          user_object=user_object,
                                           active=True,
                                           audit_data=g.audit_object.audit_data)
     action_at_all = policy_object.list_policies(scope=scope, active=True)

--- a/privacyidea/lib/passwordreset.py
+++ b/privacyidea/lib/passwordreset.py
@@ -142,7 +142,7 @@ def is_password_reset():
     rlist = get_resolver_list(editable=True)
     log.debug("Number of editable resolvers: {0!s}".format(len(rlist)))
     Policy = PolicyClass()
-    policy_at_all = Policy.match_policies(scope=SCOPE.USER, active=True)
+    policy_at_all = Policy.list_policies(scope=SCOPE.USER, active=True)
     log.debug("Policy at all: {0!s}".format(policy_at_all))
     policy_reset_pw = Policy.match_policies(scope=SCOPE.USER,
                                             action=ACTION.PASSWORDRESET,

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -960,15 +960,14 @@ class PolicyClass(object):
         if role == ROLE.ADMIN:
             # If the logged-in user is an admin, we match for username/adminrealm
             user_name = logged_in_user.get("username")
-            user_realm = None
             user_object = None
             admin_realm = logged_in_user.get("realm")
         else:
             # If the logged-in user is a user, we pass an user object to allow matching for userinfo attributes
-            user_name = user_realm = None
-            admin_realm = None
+            user_name = None
             user_object = User(logged_in_user.get("username"),
                                logged_in_user.get("realm"))
+            admin_realm = None
         # check, if we have a policy definition at all.
         pols = self.list_policies(scope=role, active=True)
         tokenclasses = get_token_classes()
@@ -986,7 +985,6 @@ class PolicyClass(object):
                 # determine, if there is a enrollment policy for this very type
                 typepols = self.match_policies(scope=role, client=client,
                                                user=user_name,
-                                               realm=user_realm,
                                                user_object=user_object,
                                                active=True,
                                                action="enroll"+tokentype.upper(),

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -221,6 +221,13 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
                             "role": "user"}
         r = check_token_init(req)
         self.assertTrue(r)
+
+        # An exception is raised for an invalid role
+        g.logged_in_user = {"username": "user1",
+                            "role": "invalid"}
+        with self.assertRaises(PolicyError):
+            check_token_init(req)
+
         # finally delete policy
         delete_policy("pol1")
 

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -536,6 +536,10 @@ class PolicyTestCase(MyTestCase):
 
     def test_17_ui_get_rights(self):
         P = PolicyClass()
+        # Check invalid scope
+        with self.assertRaises(PolicyError):
+            P.ui_get_rights(SCOPE.ENROLL, "realm1", "admin")
+
         # Without policies, the admin gets all
         rights = P.ui_get_rights(SCOPE.ADMIN, "realm1", "admin")
         self.assertTrue(len(rights) >= 60)


### PR DESCRIPTION
On current master, users can't login whenever a policy with ``scope=USER`` contains active userinfo policy conditions. This is because ``ui_get_rights`` and ``ui_get_tokentypes`` do not pass user objects to ``match_policies``, so userinfo isn't available, so a ``PolicyError`` is raised. Whoops :-)

This PR fixes this by making ``ui_get_*`` pass a user object to ``match_policies`` if a user is logging in.

In addition, this PR modifies ``check_token_init`` to also pass a user object to ``match_policies`` if a user is enrolling a token, which makes it possible to define userinfo conditions for ``enrollX`` actions in ``scope=USER`` policies.

ref #1436 