### PR TITLE
Fix issues with migration scripts and privacyidea-schema-upgrade

### DIFF
--- a/migrations/versions/3d7f8b29cbb1_.py
+++ b/migrations/versions/3d7f8b29cbb1_.py
@@ -71,18 +71,25 @@ def upgrade():
 
     bind = op.get_bind()
     session = orm.Session(bind=bind)
-    if session.query(Policy).filter(Policy.scope == u"{0!s}".format(SCOPE.ADMIN),
-                                    Policy.active.is_(True)).all():
+    if session.query(Policy.id).filter(Policy.scope == u"{0!s}".format(SCOPE.ADMIN),
+                                       Policy.active.is_(True)).all():
 
-        # add policy
-        tokenlist_pol = Policy(name=POLICYNAME, scope=u"{0!s}".format(SCOPE.ADMIN),
-                               action=actions)
-        session.add(tokenlist_pol)
-        print("Added '{0!s}' action for admin policies.".format(actions))
+        if session.query(Policy.id).filter_by(name=POLICYNAME).first() is None:
+            # add policy
+            tokenlist_pol = Policy(name=POLICYNAME, scope=u"{0!s}".format(SCOPE.ADMIN),
+                                   action=actions)
+            session.add(tokenlist_pol)
+            print("Added '{0!s}' action for admin policies.".format(actions))
+        else:
+            print("Policy {} already exists.".format(POLICYNAME))
     else:
         print("No admin policy active. No need to create '{0!s}' action.".format(actions))
 
-    session.commit()
+    try:
+        session.commit()
+    except Exception as exx:
+        print("Could not create policy {}: {!r}".format(POLICYNAME, exx))
+        print(exx)
 
 
 def downgrade():

--- a/migrations/versions/b9131d0686eb_.py
+++ b/migrations/versions/b9131d0686eb_.py
@@ -64,17 +64,24 @@ def upgrade():
     """
     bind = op.get_bind()
     session = orm.Session(bind=bind)
-    if session.query(Policy).filter(Policy.scope == u"{0!s}".format(SCOPE.ADMIN),
-                                    Policy.active.is_(True)).all():
-        # add policy
-        tokenlist_pol = Policy(name=POLICYNAME, scope=u"{0!s}".format(SCOPE.ADMIN),
-                               action=u"{0!s}".format(ACTION.TOKENLIST))
-        session.add(tokenlist_pol)
-        print("Added '{0!s}' action for admin policies.".format(ACTION.TOKENLIST))
+    if session.query(Policy.id).filter(Policy.scope == u"{0!s}".format(SCOPE.ADMIN),
+                                       Policy.active.is_(True)).all():
+        # add policy if it does not exist yet
+        if session.query(Policy.id).filter_by(name=POLICYNAME).first() is None:
+            tokenlist_pol = Policy(name=POLICYNAME, scope=u"{0!s}".format(SCOPE.ADMIN),
+                                   action=u"{0!s}".format(ACTION.TOKENLIST))
+            session.add(tokenlist_pol)
+            print("Added '{0!s}' action for admin policies.".format(ACTION.TOKENLIST))
+        else:
+            print("Policy {} already exists.".format(POLICYNAME))
     else:
         print("No admin policy active. No need to create '{0!s}' action.".format(ACTION.TOKENLIST))
 
-    session.commit()
+    try:
+        session.commit()
+    except Exception as exx:
+        print("Could not create policy {}: {!r}".format(POLICYNAME, exx))
+        print(exx)
 
 
 def downgrade():

--- a/tools/privacyidea-schema-upgrade
+++ b/tools/privacyidea-schema-upgrade
@@ -19,4 +19,4 @@ if [ -z "$(pi-manage db current -v -d $MIGRATION_PATH | grep "^Rev:")" ]; then
 fi
 # Upgrade the database
 echo "++ Upgrading DB schema."
-pi-manage db upgrade -d $MIGRATION_PATH > /dev/null
+pi-manage db upgrade -d $MIGRATION_PATH

--- a/tools/privacyidea-schema-upgrade
+++ b/tools/privacyidea-schema-upgrade
@@ -4,7 +4,7 @@ MIGRATION_PATH=$1
 FIRST_VERSION="4f32a4e1bf33"
 SKIP_STAMP=$2
 
-if [ -z "$MIGRATION_PATH" ]; then
+if [ ! -d "$MIGRATION_PATH" ]; then
 	echo "Please specify the path with the migration files."
 	exit 1
 fi

--- a/tools/privacyidea-schema-upgrade
+++ b/tools/privacyidea-schema-upgrade
@@ -10,7 +10,7 @@ if [ ! -d "$MIGRATION_PATH" ]; then
 fi
 
 # check if we do not have DB versioning, yet.
-if [ -z "$(pi-manage db current -d $MIGRATION_PATH | grep "(head)$")" ]; then
+if [ -z "$(pi-manage db current -v -d $MIGRATION_PATH | grep "^Rev:")" ]; then
     if [ "$SKIP_STAMP" != "--skipstamp" ]; then
         # Set the version to the first PI 2.0 version
         echo "++ Stamping DB to $FIRST_VERSION"


### PR DESCRIPTION
This PR fixes several issues with migration scripts as mentioned in #1760.
* ``privacyidea-schema-upgrade`` now requires the first argument to point to a directory
* ``privacyidea-schema-upgrade`` now correctly recognizes an already-stamped database and doesn't re-run all migration scripts in this case
* ``privacyidea-schema-upgrade`` now prints the stdout of migration scripts.

Also, this PR improves the migration scripts that create migration policies:
* In case the policy already exists (for some reason), we don't try to create it again (which would cause an error)
* In case we cannot create the policy (for some reason), we do not crash but print the error to stdout
* When checking for existing policies we do not query the whole ``Policy`` row, but only the ``id``, which is a workaround for the case that we re-run  ``b9131d0686eb`` even though the database is up-to-date: In this case, migration script ``b9131d0686eb`` thinks that the ``Policy`` table still has a ``condition`` field even though it has been removed by ``dceb6cd3c41e``. If we query the whole ``Policy`` row, the migration script crashes (because SQLAlchemy references the non-existing ``condition`` field). If we only query for ``id``, the migration script doesn't crash.