### PR TITLE
Enable Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 sudo: false
 python:
   - "2.7"
-#  - "3.5"
+  - "3.5"
   - "3.6"
   - "3.7"
 # command to install dependencies
@@ -19,10 +19,6 @@ env:
     - PYTHONHASHSEED=random  # test for ordered dict use
   matrix:
     - TESTS=tests/
-
-#matrix:
-#    allow_failures:
-#       - python: 3.5
 
 # command to run tests
 script: "python -b -m pytest -v --cov=privacyidea $TESTS"

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -81,7 +81,7 @@ def before_request():
     This is executed before the request
     """
     ensure_no_config_object()
-    request.all_data = get_all_params(request.values, request.data)
+    request.all_data = get_all_params(request)
     privacyidea_server = current_app.config.get("PI_AUDIT_SERVERNAME") or \
                          request.host
     g.policy_object = PolicyClass()

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -132,7 +132,7 @@ def before_request():
     # remove session from param and gather all parameters, either
     # from the Form data or from JSON in the request body.
     ensure_no_config_object()
-    request.all_data = get_all_params(request.values, request.data)
+    request.all_data = get_all_params(request)
     if g.logged_in_user.get("role") == "user":
         # A user is calling this API. First thing we do is restricting the user parameter.
         # ...to restrict token view, audit view or token actions.

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -170,7 +170,7 @@ def sign_response(request, response):
     else:
         response_object = response
     if response_object.is_json:
-        content = response_object.json
+        content = response_object.get_json(cache=False)
         nonce = request.all_data.get("nonce")
         if nonce:
             content["nonce"] = nonce
@@ -201,7 +201,7 @@ def check_tokentype(request, response):
     :type response: Response object
     :return: A new (maybe modified) response
     """
-    tokentype = response.json.get("detail", {}).get("type")
+    tokentype = response.get_json(cache=False).get("detail", {}).get("type")
     policy_object = g.policy_object
     user_object = request.User
     allowed_tokentypes = policy_object.get_action_values(
@@ -233,7 +233,7 @@ def check_serial(request, response):
     :return: A new (maybe modified) response
     """
     policy_object = g.policy_object
-    serial = response.json.get("detail", {}).get("serial")
+    serial = response.get_json(cache=False).get("detail", {}).get("serial")
     # get the serials from a policy definition
     allowed_serials = policy_object.get_action_values(ACTION.SERIAL,
                                                       scope=SCOPE.AUTHZ,
@@ -265,7 +265,7 @@ def check_tokeninfo(request, response):
     :type response: Response object
     :return: A new modified response
     """
-    serial = response.json.get("detail", {}).get("serial")
+    serial = response.get_json(cache=False).get("detail", {}).get("serial")
 
     if serial:
         tokeninfos_pol = g.policy_object.get_action_values(
@@ -307,7 +307,7 @@ def no_detail_on_success(request, response):
     :param response:
     :return:
     """
-    content = response.json
+    content = response.get_json(cache=False)
     policy_object = g.policy_object
 
     # get the serials from a policy definition
@@ -336,7 +336,7 @@ def add_user_detail_to_response(request, response):
     :param response:
     :return:
     """
-    content = response.json
+    content = response.get_json(cache=False)
     policy_object = g.policy_object
 
     # Check for ADD USER IN RESPONSE
@@ -383,7 +383,7 @@ def no_detail_on_fail(request, response):
     :param response:
     :return:
     """
-    content = response.json
+    content = response.get_json(cache=False)
     policy_object = g.policy_object
 
     # get the serials from a policy definition
@@ -421,7 +421,7 @@ def save_pin_change(request, response, serial=None):
     :param action:
     :return:
     """
-    content = response.json
+    content = response.get_json(cache=False)
     policy_object = g.policy_object
     serial = serial or request.all_data.get("serial")
     if not serial:
@@ -476,7 +476,7 @@ def offline_info(request, response):
     OTP.
 
     """
-    content = response.json
+    content = response.get_json(cache=False)
     # check if the authentication was successful
     if content.get("result").get("value") is True and g.client_ip:
         # If there is no remote address, we can not determine
@@ -507,7 +507,7 @@ def get_webui_settings(request, response):
     :param response: flask response object
     :return: the response
     """
-    content = response.json
+    content = response.get_json(cache=False)
     # check, if the authentication was successful, then we need to do nothing
     if content.get("result").get("status") is True:
         role = content.get("result").get("value").get("role")
@@ -697,7 +697,7 @@ def autoassign(request, response):
     into account ACTION.MAXTOKENUSER and ACTION.MAXTOKENREALM.
     :return:
     """
-    content = response.json
+    content = response.get_json(cache=False)
     # check, if the authentication was successful, then we need to do nothing
     if content.get("result").get("value") is False:
         user_obj = request.User
@@ -776,7 +776,7 @@ def construct_radius_response(request, response):
     """
     if request.url_rule.rule == '/validate/radiuscheck':
         return_code = 400 # generic 400 error by default
-        content = response.json
+        content = response.get_json(cache=False)
         if content['result']['status']:
             if content['result']['value']:
                 # user was successfully authenticated
@@ -801,7 +801,7 @@ def mangle_challenge_response(request, response):
     if not response.is_json:
         # This can happen with the validate/radiuscheck endpoint
         return response
-    content = response.json
+    content = response.get_json(cache=False)
     policy_object = g.policy_object
     user_obj = request.User
 

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -159,7 +159,7 @@ def sign_response(request, response):
         log.debug(traceback.format_exc())
         return response
 
-    request.all_data = get_all_params(request.values, request.data)
+    request.all_data = get_all_params(request)
     # response can be either a Response object or a Tuple (Response, ErrorID)
     response_value = 200
     response_is_tuple = False
@@ -169,15 +169,15 @@ def sign_response(request, response):
         response_object = response[0]
     else:
         response_object = response
-    try:
-        content = json.loads(response_object.data)
+    if response_object.is_json:
+        content = response_object.json
         nonce = request.all_data.get("nonce")
         if nonce:
             content["nonce"] = nonce
 
         content["signature"] = sign_object.sign(json.dumps(content, sort_keys=True))
-        response_object.data = json.dumps(content)
-    except ValueError:
+        response_object.set_data(json.dumps(content))
+    else:
         # The response.data is no JSON (but CSV or policy export)
         # We do no signing in this case.
         log.info("We only sign JSON response data.")
@@ -201,8 +201,7 @@ def check_tokentype(request, response):
     :type response: Response object
     :return: A new (maybe modified) response
     """
-    content = json.loads(response.data)
-    tokentype = content.get("detail", {}).get("type")
+    tokentype = response.json.get("detail", {}).get("type")
     policy_object = g.policy_object
     user_object = request.User
     allowed_tokentypes = policy_object.get_action_values(
@@ -233,9 +232,8 @@ def check_serial(request, response):
     :type response: Response object
     :return: A new (maybe modified) response
     """
-    content = json.loads(response.data)
     policy_object = g.policy_object
-    serial = content.get("detail", {}).get("serial")
+    serial = response.json.get("detail", {}).get("serial")
     # get the serials from a policy definition
     allowed_serials = policy_object.get_action_values(ACTION.SERIAL,
                                                       scope=SCOPE.AUTHZ,
@@ -267,8 +265,7 @@ def check_tokeninfo(request, response):
     :type response: Response object
     :return: A new modified response
     """
-    content = json.loads(response.data)
-    serial = content.get("detail", {}).get("serial")
+    serial = response.json.get("detail", {}).get("serial")
 
     if serial:
         tokeninfos_pol = g.policy_object.get_action_values(
@@ -310,7 +307,7 @@ def no_detail_on_success(request, response):
     :param response:
     :return:
     """
-    content = json.loads(response.data)
+    content = response.json
     policy_object = g.policy_object
 
     # get the serials from a policy definition
@@ -323,7 +320,7 @@ def no_detail_on_success(request, response):
         # The policy was set, we need to strip the details, if the
         # authentication was successful. (value=true)
         del content["detail"]
-        response.data = json.dumps(content)
+        response.set_data(json.dumps(content))
         g.audit_object.add_policy([p.get("name") for p in detailPol])
 
     return response
@@ -339,7 +336,7 @@ def add_user_detail_to_response(request, response):
     :param response:
     :return:
     """
-    content = json.loads(response.data)
+    content = response.json
     policy_object = g.policy_object
 
     # Check for ADD USER IN RESPONSE
@@ -357,7 +354,6 @@ def add_user_detail_to_response(request, response):
             if type(value) == datetime.datetime:
                 ui[key] = str(value)
         content["detail"]["user"] = ui
-        response.data = json.dumps(content)
         g.audit_object.add_policy([p.get("name") for p in detail_pol])
 
     # Check for ADD RESOLVER IN RESPONSE
@@ -370,9 +366,9 @@ def add_user_detail_to_response(request, response):
         # The policy was set, we need to add the resolver and the realm
         content["detail"]["user-resolver"] = request.User.resolver
         content["detail"]["user-realm"] = request.User.realm
-        response.data = json.dumps(content)
         g.audit_object.add_policy([p.get("name") for p in detail_pol])
 
+    response.set_data(json.dumps(content))
     return response
 
 
@@ -387,7 +383,7 @@ def no_detail_on_fail(request, response):
     :param response:
     :return:
     """
-    content = json.loads(response.data)
+    content = response.json
     policy_object = g.policy_object
 
     # get the serials from a policy definition
@@ -400,7 +396,7 @@ def no_detail_on_fail(request, response):
         # The policy was set, we need to strip the details, if the
         # authentication was successful. (value=true)
         del content["detail"]
-        response.data = json.dumps(content)
+        response.set_data(json.dumps(content))
         g.audit_object.add_policy([p.get("name") for p in detailPol])
 
     return response
@@ -425,7 +421,7 @@ def save_pin_change(request, response, serial=None):
     :param action:
     :return:
     """
-    content = json.loads(response.data)
+    content = response.json
     policy_object = g.policy_object
     serial = serial or request.all_data.get("serial")
     if not serial:
@@ -480,15 +476,14 @@ def offline_info(request, response):
     OTP.
 
     """
-    content = json.loads(response.data)
+    content = response.json
     # check if the authentication was successful
     if content.get("result").get("value") is True and g.client_ip:
         # If there is no remote address, we can not determine
         # offline information
         client_ip = netaddr.IPAddress(g.client_ip)
         # check if there is a MachineToken definition
-        detail = content.get("detail", {})
-        serial = detail.get("serial")
+        serial = content.get("detail", {}).get("serial")
         try:
             # if the hostname can not be identified, there might be no
             # offline definition!
@@ -498,7 +493,7 @@ def offline_info(request, response):
                                         challenge=request.all_data.get("pass"))
             if auth_items:
                 content["auth_items"] = auth_items
-                response.data = json.dumps(content)
+                response.set_data(json.dumps(content))
         except Exception as exx:
             log.info(exx)
     return response
@@ -512,7 +507,7 @@ def get_webui_settings(request, response):
     :param response: flask response object
     :return: the response
     """
-    content = json.loads(response.data)
+    content = response.json
     # check, if the authentication was successful, then we need to do nothing
     if content.get("result").get("status") is True:
         role = content.get("result").get("value").get("role")
@@ -687,7 +682,7 @@ def get_webui_settings(request, response):
         content["result"]["value"]["hide_buttons"] = hide_buttons
         content["result"]["value"]["show_seed"] = show_seed
         content["result"]["value"]["subscription_status"] = subscription_status()
-        response.data = json.dumps(content)
+        response.set_data(json.dumps(content))
     return response
 
 
@@ -702,7 +697,7 @@ def autoassign(request, response):
     into account ACTION.MAXTOKENUSER and ACTION.MAXTOKENREALM.
     :return:
     """
-    content = json.loads(response.data)
+    content = response.json
     # check, if the authentication was successful, then we need to do nothing
     if content.get("result").get("value") is False:
         user_obj = request.User
@@ -723,7 +718,7 @@ def autoassign(request, response):
 
             # check if the user has no token
             if autoassign_values and get_tokens(user=user_obj, count=True) == 0:
-                # Check is the token would match
+                # Check if the token would match
                 # get all unassigned tokens in the realm and look for
                 # a matching OTP:
                 realm_tokens = get_tokens(realm=user_obj.realm,
@@ -751,18 +746,12 @@ def autoassign(request, response):
                                 # Set the response to true
                                 content.get("result")["value"] = True
                                 # Set the serial number
-                                if not content.get("detail"):
-                                    content["detail"] = {}
-                                content.get("detail")["serial"] = \
-                                    token_obj.token.serial
-                                content.get("detail")["otplen"] = \
-                                    token_obj.token.otplen
-                                content.get("detail")["type"] = token_obj.type
-                                content.get("detail")["message"] = "Token " \
-                                                                   "assigned to " \
-                                                                   "user via " \
-                                                                   "Autoassignment"
-                                response.data = json.dumps(content)
+                                detail = content.get("detail", {})
+                                detail["serial"] = token_obj.token.serial
+                                detail["otplen"] = token_obj.token.otplen
+                                detail["type"] = token_obj.type
+                                detail["message"] = "Token assigned to user via Autoassignment"
+                                response.set_data(json.dumps(content))
 
                                 g.audit_object.log(
                                     {"success": True,
@@ -787,7 +776,7 @@ def construct_radius_response(request, response):
     """
     if request.url_rule.rule == '/validate/radiuscheck':
         return_code = 400 # generic 400 error by default
-        content = json.loads(response.data)
+        content = response.json
         if content['result']['status']:
             if content['result']['value']:
                 # user was successfully authenticated
@@ -809,11 +798,10 @@ def mangle_challenge_response(request, response):
     :param response:
     :return:
     """
-    try:
-        content = json.loads(response.data)
-    except ValueError:
+    if not response.is_json:
         # This can happen with the validate/radiuscheck endpoint
         return response
+    content = response.json
     policy_object = g.policy_object
     user_obj = request.User
 
@@ -854,7 +842,6 @@ def mangle_challenge_response(request, response):
             message += footer
 
             content["detail"]["message"] = message
-            response.data = json.dumps(content)
+            response.set_data(json.dumps(content))
 
     return response
-

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -746,7 +746,7 @@ def autoassign(request, response):
                                 # Set the response to true
                                 content.get("result")["value"] = True
                                 # Set the serial number
-                                detail = content.get("detail", {})
+                                detail = content.setdefault("detail", {})
                                 detail["serial"] = token_obj.token.serial
                                 detail["otplen"] = token_obj.token.otplen
                                 detail["type"] = token_obj.type

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -202,21 +202,21 @@ def getLowerParams(param):
     return ret
 
 
-def get_all_params(param, body):
+def get_all_params(request):
     """
     Combine parameters from GET and POST requests
+    :param request:
+    :type request: Request
     """
     return_param = {}
-    for key in param.keys():
-        return_param[key] = param[key]
+    for key in request.values.keys():
+        return_param[key] = request.values[key]
 
     # In case of serialized JSON data in the body, add these to the values.
-    try:
-        json_data = json.loads(body)
+    json_data = request.get_json(force=True, silent=True)
+    if json_data:
         for k, v in json_data.items():
             return_param[k] = v
-    except Exception as exx:
-        log.debug("Can not get param: {0!s}".format(exx))
 
     return return_param
 

--- a/privacyidea/api/ttype.py
+++ b/privacyidea/api/ttype.py
@@ -57,7 +57,7 @@ def before_request():
     This is executed before the request
     """
     ensure_no_config_object()
-    request.all_data = get_all_params(request.values, request.data)
+    request.all_data = get_all_params(request)
     privacyidea_server = current_app.config.get("PI_AUDIT_SERVERNAME") or \
                          request.host
     # Create a policy_object, that reads the database audit settings

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -117,7 +117,7 @@ def before_request():
     This is executed before the request
     """
     ensure_no_config_object()
-    request.all_data = get_all_params(request.values, request.data)
+    request.all_data = get_all_params(request)
     request.User = get_user_from_param(request.all_data)
     privacyidea_server = current_app.config.get("PI_AUDIT_SERVERNAME") or \
                          request.host
@@ -176,10 +176,10 @@ def offlinerefill():
                     otps = MachineApplication.get_refill(tokenobj, password, mdef.get("options"))
                     refilltoken = MachineApplication.generate_new_refilltoken(tokenobj)
                     response = send_result(True)
-                    content = json.loads(response.data)
+                    content = response.json
                     content["auth_items"] = {"offline": [{"refilltoken": refilltoken,
                                                           "response": otps}]}
-                    response.data = json.dumps(content)
+                    response.set_data(json.dumps(content))
                     return response
         raise ParameterError("Token is not an offline token or refill token is incorrect")
 

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -176,7 +176,7 @@ def offlinerefill():
                     otps = MachineApplication.get_refill(tokenobj, password, mdef.get("options"))
                     refilltoken = MachineApplication.generate_new_refilltoken(tokenobj)
                     response = send_result(True)
-                    content = response.json
+                    content = response.get_json(cache=False)
                     content["auth_items"] = {"offline": [{"refilltoken": refilltoken,
                                                           "response": otps}]}
                     response.set_data(json.dumps(content))

--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -45,7 +45,6 @@ from privacyidea.lib.utils import (compare_condition, compare_value_value,
 import datetime
 from dateutil.tz import tzlocal
 import re
-import json
 import logging
 from privacyidea.lib.tokenclass import DATE_FORMAT
 
@@ -299,7 +298,7 @@ class BaseEventHandler(object):
     @staticmethod
     def _get_response_content(response):
         if response:
-            content = json.loads(response.data)
+            content = response.get_json(force=True)
         else:
             # In Pre-Handling we have no response and no content
             content = {}
@@ -323,8 +322,7 @@ class BaseEventHandler(object):
         content = self._get_response_content(response)
         user = self._get_tokenowner(request)
 
-        serial = request.all_data.get("serial") or \
-                 content.get("detail", {}).get("serial")
+        serial = request.all_data.get("serial") or content.get("detail", {}).get("serial")
         tokenrealms = []
         tokenresolvers = []
         tokentype = None

--- a/privacyidea/lib/privacyideaserver.py
+++ b/privacyidea/lib/privacyideaserver.py
@@ -20,10 +20,9 @@
 from privacyidea.models import PrivacyIDEAServer as PrivacyIDEAServerDB
 import logging
 from privacyidea.lib.log import log_with
-from privacyidea.lib.utils import fetch_one_resource
-from privacyidea.lib.error import ConfigAdminError, privacyIDEAError
+from privacyidea.lib.utils import fetch_one_resource, to_unicode
+from privacyidea.lib.error import ConfigAdminError
 import json
-from privacyidea.lib import _
 import requests
 
 __doc__ = """
@@ -80,7 +79,7 @@ class PrivacyIDEAServer(object):
                                                                response.status_code))
             return False
 
-        j_response = json.loads(response.content)
+        j_response = json.loads(to_unicode(response.content))
         result = j_response.get("result")
         return result.get("status") and result.get("value")
 

--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -43,8 +43,7 @@ from privacyidea.lib.tokens.u2f import (check_registration_data, url_decode,
 from privacyidea.lib.error import ValidateError, PolicyError, ParameterError
 from privacyidea.lib.policy import (SCOPE, GROUP, ACTION,
                                     get_action_values_from_options)
-from privacyidea.lib.utils import (is_true, hexlify_and_unicode,
-                                   urlsafe_b64encode_and_unicode)
+from privacyidea.lib.utils import (is_true, hexlify_and_unicode,to_unicode)
 import binascii
 import json
 import re
@@ -468,7 +467,7 @@ class U2fTokenClass(TokenClass):
             # This is a valid response for a U2F token
             challenge_url = url_encode(challenge)
             clientdata = url_decode(clientdata)
-            clientdata_dict = json.loads(clientdata)
+            clientdata_dict = json.loads(to_unicode(clientdata))
             client_challenge = clientdata_dict.get("challenge")
             if challenge_url != client_challenge:
                 return ret

--- a/privacyidea/webui/certificate.py
+++ b/privacyidea/webui/certificate.py
@@ -40,7 +40,7 @@ def before_request():
     """
     # remove session from param and gather all parameters, either
     # from the Form data or from JSON in the request body.
-    request.all_data = get_all_params(request.values, request.data)
+    request.all_data = get_all_params(request)
     # Verify the authtoken!
     authtoken = request.all_data.get("authtoken")
     r = verify_auth_token(authtoken, ["user", "admin"])

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     author_email='cornelius@privacyidea.org',
     url='http://www.privacyidea.org',
     keywords='OTP, two factor authentication, management, security',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     packages=find_packages(),
     scripts=["pi-manage"] + get_scripts("tools"),
     extras_require={
@@ -127,7 +127,7 @@ setup(
                  ['deploy/apache/privacyideaapp.wsgi',
                   'deploy/privacyidea/dictionary']),
                 ('share/man/man1', get_man_pages("tools")),
-               ('lib/privacyidea/authmodules/OTRS',
+                ('lib/privacyidea/authmodules/OTRS',
                  ["authmodules/OTRS/privacyIDEA.pm"]),
                 ('lib/privacyidea/migrations',
                  ["migrations/alembic.ini",
@@ -151,6 +151,7 @@ setup(
                  'Programming Language :: Python :: 2',
                  'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3',
+                 'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7'
                  ],

--- a/tests/base.py
+++ b/tests/base.py
@@ -155,7 +155,7 @@ class MyTestCase(unittest.TestCase):
                                            method='POST'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             self.at = result.get("value").get("token")
 
@@ -167,7 +167,7 @@ class MyTestCase(unittest.TestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_user = result.get("value").get("token")

--- a/tests/test_api_2stepinit.py
+++ b/tests/test_api_2stepinit.py
@@ -37,10 +37,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -67,7 +67,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertIn('2stepinit is only to be used in the first initialization step',
                           result.get("error").get("message"))
 
@@ -82,7 +82,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertIn('Malformed base32check data: Incorrect checksum',
                           result.get("error").get("message"))
 
@@ -94,7 +94,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": wrong_otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
@@ -110,10 +110,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
             self.assertNotIn('2step', detail)
@@ -127,7 +127,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -167,10 +167,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -186,7 +186,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": wrong_otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
@@ -205,7 +205,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
 
         client_component = b"correctsize" # 11 bytes
@@ -224,10 +224,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
 
@@ -240,7 +240,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -279,10 +279,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -300,7 +300,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
 
         client_component = b"correctsizeABCDE" # 16 bytes
@@ -319,10 +319,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
 
@@ -335,7 +335,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -372,10 +372,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey_bin = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -389,7 +389,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -409,10 +409,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -439,7 +439,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertIn('2stepinit is only to be used in the first initialization step',
                           result.get("error").get("message"))
 
@@ -454,7 +454,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertIn('Malformed base32check data: Incorrect checksum',
                           result.get("error").get("message"))
 
@@ -466,7 +466,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": wrong_otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
@@ -482,10 +482,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
             self.assertNotIn('2step', detail)
@@ -499,7 +499,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -542,10 +542,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             otpkey_url = detail.get("otpkey", {}).get("value")
             server_component = binascii.unhexlify(otpkey_url.split("/")[2])
@@ -563,7 +563,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": wrong_otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             self.assertTrue(result.get("result").get("status"))
             self.assertFalse(result.get("result").get("value"))
             self.assertEqual(result.get("detail").get("message"),
@@ -582,7 +582,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
 
         client_component = b"correctsize" # 11 bytes
@@ -601,10 +601,10 @@ class TwoStepInitTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             otpkey_url = detail.get("otpkey", {}).get("value")
             otpkey = otpkey_url.split("/")[2]
 
@@ -619,7 +619,7 @@ class TwoStepInitTestCase(MyApiTestCase):
                                                  "pass": otp_value}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 

--- a/tests/test_api_applications.py
+++ b/tests/test_api_applications.py
@@ -15,8 +15,8 @@ class APIApplicationsResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             value = result.get("value")
             self.assertTrue("ssh" in value)
             self.assertTrue("luks" in value)

--- a/tests/test_api_audit.py
+++ b/tests/test_api_audit.py
@@ -20,7 +20,7 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue(json_response.get("result").get("value").get(
                 "current") == 1, res)
@@ -42,7 +42,7 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 2)
@@ -52,7 +52,7 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 8)
@@ -67,7 +67,7 @@ class APIAuditTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 3)
@@ -82,7 +82,7 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             # We now have 3 entries, as we added one by the search in line #43
             audit_list = json_response.get("result").get("value").get("auditdata")
@@ -109,7 +109,7 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 5)
@@ -121,7 +121,7 @@ class APIAuditTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 7)
@@ -150,7 +150,7 @@ class APIAuditTestCase(MyApiTestCase):
                                                                 'password': 'test'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             value = json_response.get("result").get("value")
             # Helpdesk user is allowed to view the audit log.
             self.assertTrue("auditlog" in value.get("rights"))
@@ -162,7 +162,7 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': helpdesk_authorization}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             # We now have 3 entries, as we added one by the search in line #43
             count = json_response.get("result").get("value").get("count")
@@ -178,7 +178,7 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             # We now have 3 entries, as we added one by the search in line #43
             count = json_response.get("result").get("value").get("count")

--- a/tests/test_api_caconnector.py
+++ b/tests/test_api_caconnector.py
@@ -27,7 +27,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -44,7 +44,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -60,7 +60,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(len(value), 1)
@@ -75,7 +75,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(len(value), 2)
@@ -87,7 +87,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(len(value), 1)
@@ -102,7 +102,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             at_user = result.get("value").get("token")
@@ -117,7 +117,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(len(value), 2)
@@ -130,7 +130,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             value = result["value"]
             self.assertEqual(value, 1)
@@ -149,7 +149,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEquals(res.status_code, 401)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result['status'])
             self.assertEquals(result['error']['code'], ERROR.AUTHENTICATE_MISSING_RIGHT)
             self.assertIn("You do not have the necessary role (['admin']) to access this resource",
@@ -163,7 +163,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEquals(res.status_code, 401)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result['status'])
             self.assertEquals(result['error']['code'], ERROR.AUTHENTICATE_MISSING_RIGHT)
             self.assertIn("You do not have the necessary role (['admin']) to access this resource",

--- a/tests/test_api_clienttype.py
+++ b/tests/test_api_clienttype.py
@@ -13,7 +13,7 @@ class APIClienttypeTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue("PAM" in json_response.get("result").get("value"))
             self.assertTrue("RADIUS" in json_response.get("result").get(
@@ -34,7 +34,7 @@ class APIClienttypeTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue("PAM" in json_response.get("result").get("value"))
             self.assertTrue("RADIUS" in json_response.get("result").get(

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -90,8 +90,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the event
@@ -102,8 +102,8 @@ class APIEventsTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value")[0].get("action"), "sendmail")
             self.assertEqual(result.get("value")[0].get("conditions"),
                              {"blabla": "yes"})
@@ -124,8 +124,8 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the event
@@ -135,8 +135,8 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value")[0].get("action"),
                              "sendmail")
             self.assertEqual(result.get("value")[0].get("conditions"),
@@ -149,8 +149,8 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data.decode('utf8')).get("result")
-                detail = json.loads(res.data.decode('utf8')).get("detail")
+                result = res.json.get("result")
+                detail = res.json.get("detail")
                 self.assertEqual(result.get("value")[0].get("action"),
                                  "sendmail")
                 self.assertEqual(result.get("value")[0].get("conditions"),
@@ -164,8 +164,8 @@ class APIEventsTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty events
@@ -174,8 +174,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), [])
 
     def test_02_test_options(self):
@@ -196,8 +196,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list event with options
@@ -207,7 +207,7 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             event_list = result.get("value")
             self.assertEqual(len(event_list), 1)
             self.assertEqual(event_list[0].get("action"), "sendmail")
@@ -223,8 +223,8 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty events
@@ -233,8 +233,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), [])
 
     def test_03_available_events(self):
@@ -244,8 +244,8 @@ class APIEventsTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue("token_init" in result.get("value"))
             self.assertTrue("token_assign" in result.get("value"))
             self.assertTrue("token_unassign" in result.get("value"))
@@ -256,8 +256,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue("UserNotification" in result.get("value"))
 
     def test_05_get_handler_actions(self):
@@ -267,10 +267,10 @@ class APIEventsTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue("sendmail" in result.get("value"))
             self.assertTrue("sendsms" in result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
 
     def test_05_get_handler_conditions(self):
         with self.app.test_request_context('/event/conditions/UserNotification',
@@ -278,10 +278,10 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue("logged_in_user" in result.get("value"))
             self.assertTrue("result_value" in result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
 
     def test_06_test_enable_disable(self):
         # create an event configuration
@@ -300,8 +300,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list event with options
@@ -311,7 +311,7 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             event_list = result.get("value")
             self.assertEqual(len(event_list), 1)
             self.assertEqual(event_list[0].get("active"), True)
@@ -330,7 +330,7 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             event_list = result.get("value")
             self.assertEqual(len(event_list), 1)
             self.assertEqual(event_list[0].get("active"), False)
@@ -349,7 +349,7 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             event_list = result.get("value")
             self.assertEqual(len(event_list), 1)
             self.assertEqual(event_list[0].get("active"), True)
@@ -361,8 +361,8 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty events
@@ -371,8 +371,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), [])
 
     def test_07_positions(self):
@@ -383,7 +383,7 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue("post" in result.get("value"), result.get("value"))
             self.assertTrue("pre" in result.get("value"), result.get("value"))
 
@@ -402,8 +402,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the event
@@ -412,8 +412,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value")[0].get("position"), "post")
 
         # Update event with the position=pre
@@ -425,8 +425,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the event
@@ -435,8 +435,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value")[0].get("position"), "pre")
 
         # delete event
@@ -446,8 +446,8 @@ class APIEventsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty events
@@ -456,8 +456,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), [])
 
     @smtpmock.activate
@@ -489,8 +489,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         self.setUp_user_realm2()
@@ -503,8 +503,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value").get("tokens"), [])
 
         # user tries to authenticate. with the pin 1234.
@@ -517,8 +517,8 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
             self.assertTrue(detail.get("serial").startswith("PIEM"))
             # This is a challenge response!
@@ -534,7 +534,7 @@ class APIEventsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value").get("count"), 1)
             self.assertEqual(result.get("value").get("tokens")[0].get("tokentype"), u"email")

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1631,7 +1631,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # The token type SPASS is not allowed on this client, so an exception
         #  is raised.
         r = check_tokentype(req, resp)
-        jresult = json.loads(r.data)
+        jresult = r.json
         self.assertTrue(jresult.get("result").get("value"))
 
     def test_01_check_undetermined_tokentype(self):
@@ -1698,7 +1698,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
                    action="tokeninfo=testkey/test.*/", client="10.0.0.0/8")
         g.policy_object = PolicyClass()
         r = check_tokeninfo(req, resp)
-        jresult = json.loads(r.data)
+        jresult = r.json
         self.assertTrue(jresult.get("result").get("value"))
 
         # Set a policy that does NOT match
@@ -1723,7 +1723,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
                    action="tokeninfo=testkey/missingslash", client="10.0.0.0/8")
         g.policy_object = PolicyClass()
         r = check_tokeninfo(req, resp)
-        jresult = json.loads(r.data)
+        jresult = r.json
         self.assertTrue(jresult.get("result").get("value"))
 
         delete_policy("pol1")
@@ -1772,7 +1772,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # The token type SPASS is not allowed on this client, so an exception
         # is raised.
         r = check_serial(req, resp)
-        jresult = json.loads(r.data)
+        jresult = r.json
         self.assertTrue(jresult.get("result").get("value"))
 
     def test_03_no_detail_on_success(self):
@@ -1802,7 +1802,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         g.policy_object = PolicyClass()
 
         new_response = no_detail_on_success(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertTrue("detail" not in jresult, jresult)
         delete_policy("pol2")
 
@@ -1833,7 +1833,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         g.policy_object = PolicyClass()
 
         new_response = no_detail_on_fail(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertTrue("detail" not in jresult, jresult)
 
         # A successful call has a detail in the response!
@@ -1848,7 +1848,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         resp = jsonify(res)
 
         new_response = no_detail_on_fail(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertTrue("detail" in jresult, jresult)
 
         delete_policy("pol2")
@@ -1879,7 +1879,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         g.policy_object = PolicyClass()
 
         new_response = add_user_detail_to_response(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertTrue("user" not in jresult.get("detail"), jresult)
 
         # A successful get a user added
@@ -1890,7 +1890,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         g.policy_object = PolicyClass()
 
         new_response = add_user_detail_to_response(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertTrue("user" in jresult.get("detail"), jresult)
         self.assertFalse("user-resolver" in jresult.get("detail"), jresult)
         self.assertFalse("user-realm" in jresult.get("detail"), jresult)
@@ -1902,7 +1902,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         g.policy_object = PolicyClass()
 
         new_response = add_user_detail_to_response(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertTrue("user-resolver" in jresult.get("detail"), jresult)
         self.assertEqual(jresult.get("detail").get("user-resolver"), self.resolvername1)
         self.assertTrue("user-realm" in jresult.get("detail"), jresult)
@@ -1955,7 +1955,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         g.policy_object = PolicyClass()
 
         new_response = autoassign(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertTrue(jresult.get("result").get("value"), jresult)
         self.assertEqual(jresult.get("detail").get("serial"), "UASSIGN1")
         self.assertEqual(jresult.get("detail").get("otplen"), 6)
@@ -2016,7 +2016,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         g.policy_object = PolicyClass()
 
         new_response = autoassign(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertEqual(jresult.get("result").get("value"), True)
         self.assertEqual(jresult.get("detail").get("serial"), "UASSIGN2")
         self.assertEqual(jresult.get("detail").get("otplen"), 6)
@@ -2073,7 +2073,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         resp = jsonify(res)
 
         new_response = offline_info(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertTrue(jresult.get("result").get("value"), jresult)
         self.assertEqual(jresult.get("detail").get("serial"), serial)
 
@@ -2089,12 +2089,10 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         tokenobject = get_tokens(serial=serial)[0]
         self.assertEqual(tokenobject.token.count, 100)
         # check that we cannot authenticate with an offline value
-        self.assertTrue(passlib.hash.\
-                        pbkdf2_sha512.verify("offline287082",
-                                             response.get('1')))
-        self.assertTrue(passlib.hash.\
-                        pbkdf2_sha512.verify("offline516516",
-                                             response.get('99')))
+        self.assertTrue(passlib.hash.pbkdf2_sha512.verify("offline287082",
+                                                          response.get(1)))
+        self.assertTrue(passlib.hash.pbkdf2_sha512.verify("offline516516",
+                                                          response.get(99)))
         res = tokenobject.check_otp("516516") # count = 99
         self.assertEqual(res, -1)
         # check that we can authenticate online with the correct value
@@ -2139,7 +2137,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
 
         # signing of API responses is the default
         new_response = sign_response(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertEqual(jresult.get("nonce"), "12345678")
         # After switching to the PSS signature scheme, each signature will be
         # different. So we have to verify the signature through the sign object
@@ -2187,7 +2185,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         resp = jsonify(res)
 
         new_response = get_webui_settings(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertEqual(jresult.get("result").get("value").get(
             "token_wizard"), False)
 
@@ -2197,7 +2195,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
                    action=ACTION.TOKENWIZARD)
         g.policy_object = PolicyClass()
         new_response = get_webui_settings(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertEqual(jresult.get("result").get("value").get(
             "token_wizard"), True)
 
@@ -2206,7 +2204,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
                    active=False)
         g.policy_object = PolicyClass()
         new_response = get_webui_settings(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertEqual(jresult.get("result").get("value").get(
             "token_wizard"), False)
 
@@ -2220,7 +2218,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         set_policy(name="pol_dialog", scope=SCOPE.WEBUI, action=ACTION.DIALOG_NO_TOKEN)
         g.policy_object = PolicyClass()
         new_response = get_webui_settings(req, resp)
-        jresult = json.loads(new_response.data)
+        jresult = new_response.json
         self.assertEqual(jresult.get("result").get("value").get(
             ACTION.DIALOG_NO_TOKEN), True)
         delete_policy("pol_dialog")

--- a/tests/test_api_machineresolver.py
+++ b/tests/test_api_machineresolver.py
@@ -15,8 +15,8 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"), result)
             self.assertEqual("Not Implemented", detail.get("description"))
 
@@ -30,7 +30,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -39,7 +39,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("machineresolver1" in result["value"], result)
             self.assertTrue("filename" in result["value"]["machineresolver1"][
@@ -51,7 +51,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             # The value is empty
             self.assertTrue(result["value"] == {}, result)
@@ -62,7 +62,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue("machineresolver1" in value, value)
 
@@ -71,7 +71,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("machineresolver1" in result["value"], result)
@@ -85,7 +85,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("machineresolver1" in result["value"], result)
             self.assertTrue("filename" in result["value"]["machineresolver1"][
@@ -96,7 +96,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
@@ -106,7 +106,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(res.status_code, 404)
             self.assertFalse(result["status"])
 
@@ -121,7 +121,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -130,7 +130,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("machineresolver2" in result["value"], result)
             self.assertTrue("LDAPURI" in result["value"]["machineresolver2"][
@@ -141,7 +141,7 @@ class APIMachineResolverTestCase(MyApiTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -45,7 +45,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -55,7 +55,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 5)
             self.assertTrue("hostname" in result["value"][0])
@@ -69,7 +69,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 4)
             self.assertTrue("hostname" in result["value"][0])
@@ -91,7 +91,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
 
@@ -112,7 +112,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEquals(result["status"], True, result)
             self.assertGreaterEqual(result["value"]["added"], 1, result)
             self.assertEquals(result['value']['deleted'], 0, result)
@@ -133,7 +133,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEquals(result["status"], True, result)
             self.assertEquals(result["value"]["added"], 0, result)
             self.assertGreaterEqual(result['value']['deleted'], 1, result)
@@ -156,7 +156,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEquals(result["status"], True, result)
             self.assertGreaterEqual(result["value"]["added"], 1, result)
             self.assertEquals(result['value']['deleted'], 0, result)
@@ -176,7 +176,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 1)
             self.assertTrue(result["value"][0]["application"] == "luks")
@@ -186,7 +186,7 @@ class APIMachinesTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 1)
             self.assertTrue(result["value"][0]["application"] == "luks")
@@ -205,7 +205,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
 
@@ -232,7 +232,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             sshkey = result["value"].get("ssh")[0].get("sshkey")
             self.assertTrue(sshkey.startswith("ssh-rsa"), sshkey)
@@ -244,7 +244,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             sshkey = result["value"].get("ssh")[0].get("sshkey")
             self.assertTrue(sshkey.startswith("ssh-rsa"), sshkey)
@@ -260,7 +260,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             sshkey = result["value"].get("ssh")[0].get("sshkey")
             self.assertTrue(sshkey.startswith("ssh-rsa"), sshkey)
@@ -274,7 +274,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result["status"], True)
             sshkeys = result["value"].get("ssh")
             # No user DOMAIN\\testuser and no SSH keys
@@ -287,7 +287,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             sshkey = result["value"].get("ssh")[0].get("sshkey")
             self.assertTrue(sshkey.startswith("ssh-rsa"), sshkey)
 
@@ -311,7 +311,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             slot = result["value"].get("luks")[0].get("slot")
             self.assertEqual(slot, "1")
 
@@ -322,7 +322,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             slot = result["value"].get("luks")[0].get("slot")
             self.assertEqual(slot, "1")
             response = result["value"].get("luks")[0].get("response")
@@ -352,7 +352,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             offline_auth_item = result["value"].get("offline")[0]
             username = offline_auth_item.get("user")
             self.assertEqual(username, "cornelius")
@@ -371,7 +371,7 @@ class APIMachinesTestCase(MyApiTestCase):
                 method='GET'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             self.assertTrue(result['result']['status'])
             self.assertTrue(result['result']['value'])
             offline_auth_item = result["auth_items"]["offline"][0]
@@ -381,11 +381,9 @@ class APIMachinesTestCase(MyApiTestCase):
             response = offline_auth_item.get("response")
             self.assertEqual(len(response), 17)
             self.assertEqual(token_obj.token.count, 35) # 17 + 17 + 1, because we consumed 447589
-            self.assertTrue(passlib.hash.
-                            pbkdf2_sha512.verify("test903435", # count = 18
-                                                 response.get('18')))
-            self.assertTrue(passlib.hash.
-                            pbkdf2_sha512.verify("test749439", # count = 34
-                                                 response.get('34')))
+            self.assertTrue(passlib.hash.pbkdf2_sha512.verify("test903435",  # count = 18
+                                                              response.get(18)))
+            self.assertTrue(passlib.hash.pbkdf2_sha512.verify("test749439",  # count = 34
+                                                              response.get(34)))
         self.assertEqual(token_obj.check_otp('747439'), -1) # count = 34
         self.assertEqual(token_obj.check_otp('037211'), 35) # count = 35

--- a/tests/test_api_monitoring.py
+++ b/tests/test_api_monitoring.py
@@ -29,7 +29,7 @@ class APIMonitoringTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue("key1" in result.get("value"))
             self.assertTrue("key2" in result.get("value"))
 
@@ -40,7 +40,7 @@ class APIMonitoringTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(len(result.get("value")), 4)
             self.assertEqual(result.get("value")[0][1], 1)
             self.assertEqual(result.get("value")[1][1], 2)
@@ -55,7 +55,7 @@ class APIMonitoringTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(len(result.get("value")), 4)
 
         # End value in the past will return no data.
@@ -66,7 +66,7 @@ class APIMonitoringTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(len(result.get("value")), 0)
 
         # check with start timestamp after the 2nd value.
@@ -78,7 +78,7 @@ class APIMonitoringTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(len(result.get("value")), 2)
             self.assertEqual(result.get("value")[0][1], 3)
             self.assertEqual(result.get("value")[1][1], 4)
@@ -90,7 +90,7 @@ class APIMonitoringTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), 4)
 
     def test_02_delete_stats(self):
@@ -106,7 +106,7 @@ class APIMonitoringTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Number of deleted values
             self.assertEqual(result.get("value"), 3)
 
@@ -116,6 +116,6 @@ class APIMonitoringTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Number of remaining values
             self.assertEqual(len(result.get("value")), 1)

--- a/tests/test_api_policy.py
+++ b/tests/test_api_policy.py
@@ -26,7 +26,7 @@ class APIPolicyTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             result = data.get("result")
             self.assertTrue("setPolicy pol1" in result.get("value"),
                             result.get("value"))
@@ -57,7 +57,7 @@ class APIPolicyTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             result = data.get("result")
             self.assertTrue("setPolicy pol1" in result.get("value"),
                             result.get("value"))

--- a/tests/test_api_privacyideaserver.py
+++ b/tests/test_api_privacyideaserver.py
@@ -29,7 +29,7 @@ class PrivacyIDEAServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 
         # list servers
@@ -38,7 +38,7 @@ class PrivacyIDEAServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 1)
             server1 = server_list.get("server1")
@@ -58,7 +58,7 @@ class PrivacyIDEAServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 0)
 
@@ -89,5 +89,5 @@ class PrivacyIDEAServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)

--- a/tests/test_api_radiusserver.py
+++ b/tests/test_api_radiusserver.py
@@ -34,7 +34,7 @@ class RADIUSServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 
         # list servers
@@ -43,7 +43,7 @@ class RADIUSServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 1)
             server1 = server_list.get("server1")
@@ -64,7 +64,7 @@ class RADIUSServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 0)
 
@@ -85,7 +85,7 @@ class RADIUSServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 
     def test_03_radiusserver_user(self):
@@ -122,7 +122,7 @@ class RADIUSServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 
         # User is allowed to list the radius servers
@@ -131,7 +131,7 @@ class RADIUSServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 1)
             # The user does not get any information about the server!

--- a/tests/test_api_register.py
+++ b/tests/test_api_register.py
@@ -82,7 +82,7 @@ class RegisterTestCase(MyApiTestCase):
                                                      "cornelius@privacyidea.org"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("error").get("code"), ERROR.REGISTRATION)
             self.assertEqual(data.get("result").get("error").get("message"),
                          u'ERR402: No SMTP server configuration specified!')
@@ -119,7 +119,7 @@ class RegisterTestCase(MyApiTestCase):
                                            method='GET'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 
     @smtpmock.activate
@@ -134,7 +134,7 @@ class RegisterTestCase(MyApiTestCase):
                                                      "cornelius@privacyidea.org"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res.data)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 
     @smtpmock.activate
@@ -155,7 +155,7 @@ class RegisterTestCase(MyApiTestCase):
                                                  "password": new_password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res.data)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 
         # send an invalid recoverycode
@@ -167,7 +167,7 @@ class RegisterTestCase(MyApiTestCase):
                                                  "password": new_password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res.data)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), False)
 
         # test the new password

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -49,7 +49,7 @@ class APIAuthTestCase(MyApiTestCase):
                                                  "password": "testpw"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_admin = result.get("value").get("token")
@@ -65,7 +65,7 @@ class APIAuthTestCase(MyApiTestCase):
                                                         self.at_admin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue("4eyes" in result.get("value"))
             self.assertTrue("hotp" in result.get("value"))
             self.assertTrue(result.get("status"), res.data)
@@ -82,7 +82,7 @@ class APIAuthTestCase(MyApiTestCase):
                                                              "testadmin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue("token" in result.get("value"))
             self.assertTrue("username" in result.get("value"))
             self.assertEqual(result.get("value").get("role"), "admin")
@@ -106,7 +106,7 @@ class APIAuthTestCase(MyApiTestCase):
                                                              "cornelius"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue("token" in result.get("value"))
             self.assertTrue("username" in result.get("value"))
             self.assertEqual(result.get("value").get("role"), "user")
@@ -126,7 +126,7 @@ class APIAuthTestCase(MyApiTestCase):
                                                      "cornelius@adminrealm"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue("token" in result.get("value"))
             self.assertTrue("username" in result.get("value"))
             # ...and will have the role admin
@@ -151,7 +151,7 @@ class APIAuthTestCase(MyApiTestCase):
                                                         self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # In the result list should only be users from reso3.
             for user in result.get("value"):
                 self.assertEqual(user.get("resolver"), self.resolvername3)
@@ -179,7 +179,7 @@ class APIAuthChallengeResponse(MyApiTestCase):
                                                  "password": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 401, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertFalse(data.get("result").get("status"))
             detail = data.get("detail")
             self.assertTrue("enter otp" in detail.get("message"), detail.get("message"))
@@ -193,7 +193,7 @@ class APIAuthChallengeResponse(MyApiTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value").get("username"), "selfservice")
 
 
@@ -233,7 +233,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                  "password": "testpw"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_admin = result.get("value").get("token")
@@ -257,7 +257,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_admin = result.get("value").get("token")
@@ -343,7 +343,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             value = response.get("result").get("value")
             self.assertEqual(len(value), 1)
             self.assertEqual(value[0].get("username"), "selfservice")
@@ -355,7 +355,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             value = response.get("result").get("value")
             self.assertEqual(len(value), 1)
             self.assertEqual(value[0].get("username"), "selfservice")
@@ -375,7 +375,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
             serial = response.get("detail").get("serial")
@@ -393,7 +393,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
         # check if there is no token left
@@ -409,7 +409,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertFalse(response["result"]["status"])
         # check if the token still exists!
         tokenobject_list = get_tokens(serial=self.foreign_serial)
@@ -425,7 +425,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertFalse(response["result"]["status"])
         # check if the token still is enabled!
         tokenobject_list = get_tokens(serial=self.foreign_serial)
@@ -454,7 +454,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertFalse(response["result"]["status"])
 
         tokenobject = get_tokens(serial=self.foreign_serial)[0]
@@ -467,7 +467,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -481,7 +481,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -500,7 +500,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertFalse(response["result"]["status"])
 
         # token still inactive
@@ -517,7 +517,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -533,7 +533,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -569,7 +569,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertFalse(response["result"]["status"])
 
         # failcounter still on
@@ -583,7 +583,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
         # failcounter still on
@@ -601,7 +601,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertFalse(response["result"]["status"])
 
         # can set pin for own token
@@ -613,7 +613,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             self.assertTrue(response.get("result").get("value"),
                             response.get("result"))
 
@@ -683,12 +683,11 @@ class APISelfserviceTestCase(MyApiTestCase):
             ACTION.LOGOUTTIME, 200))
         with self.app.test_request_context('/auth',
                                            method='POST',
-                                           data={"username":
-                                                     "selfservice@realm1",
+                                           data={"username": "selfservice@realm1",
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # Test logout time
             self.assertEqual(result.get("value").get("logout_time"), 200)
@@ -696,6 +695,11 @@ class APISelfserviceTestCase(MyApiTestCase):
             self.assertEqual(result.get("value").get("user_page_size"), 20)
             self.assertEqual(result.get("value").get("policy_template_url"),
                              DEFAULT_POLICY_TEMPLATE_URL)
+            # check if we have the same values in the data attribute
+            result2 = json.loads(res.data.decode('utf8')).get('result')
+            self.assertTrue(result2.get("status"), res.data)
+            # Test logout time
+            self.assertEqual(result2.get("value").get("logout_time"), 200)
 
 
 class PolicyConditionsTestCase(MyApiTestCase):
@@ -795,7 +799,7 @@ class PolicyConditionsTestCase(MyApiTestCase):
                                                  "password": "ldaptest"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 403)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
             self.assertEqual(result["error"]["message"], "The login for this user is disabled.")
 
@@ -814,7 +818,7 @@ class PolicyConditionsTestCase(MyApiTestCase):
                                                  "password": "pin1"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 401)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
             self.assertIn("Wrong credentials", result["error"]["message"])
 
@@ -833,7 +837,7 @@ class PolicyConditionsTestCase(MyApiTestCase):
                                                  "password": "ldaptest"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 401)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
             self.assertIn("Wrong credentials", result["error"]["message"])
 
@@ -871,5 +875,5 @@ class PolicyConditionsTestCase(MyApiTestCase):
                                                  "password": "pin3"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 403)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertIn("conflicting actions", result["error"]["message"])

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -13,8 +13,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), [])
 
         # create an sms gateway definition
@@ -30,8 +30,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the gateway
@@ -42,8 +42,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             sms_gw = result.get("value")[0]
             self.assertEqual(sms_gw.get("description"), "myGateway")
             self.assertEqual(sms_gw.get("name"), "myGW")
@@ -68,8 +68,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # check the gateway
@@ -79,8 +79,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             sms_gw = result.get("value")[0]
             self.assertEqual(sms_gw.get("description"), "new description")
 
@@ -93,8 +93,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # list empty gateways
@@ -103,8 +103,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), [])
 
     def test_02_test_options(self):
@@ -122,8 +122,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), 1)
 
         # add option
@@ -136,7 +136,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
 
         # check options
         with self.app.test_request_context('/smsgateway',
@@ -145,7 +145,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                                    'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             sms_gw = result.get("value")[0]
             self.assertEqual(sms_gw.get("options").get("URL"),
                              "http://example.com")
@@ -158,8 +158,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
 
         # check options
         with self.app.test_request_context('/smsgateway',
@@ -168,7 +168,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             sms_gw = result.get("value")[0]
             self.assertEqual(sms_gw.get("options").get("URL"), None)
             self.assertEqual(sms_gw.get("options").get("HTTP_METHOD"),
@@ -180,7 +180,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            value = json.loads(res.data.decode('utf8')).get("result").get("value")
+            value = res.json.get("result").get("value")
             self.assertEqual(len(value), 5)
             self.assertTrue('privacyidea.lib.smsprovider.HttpSMSProvider'
                             '.HttpSMSProvider' in value)

--- a/tests/test_api_smtpserver.py
+++ b/tests/test_api_smtpserver.py
@@ -34,7 +34,7 @@ class SMTPServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 
         # list servers
@@ -43,7 +43,7 @@ class SMTPServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 1)
             server1 = server_list.get("server1")
@@ -65,7 +65,7 @@ class SMTPServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             server_list = data.get("result").get("value")
             self.assertEqual(len(server_list), 0)
 
@@ -87,6 +87,6 @@ class SMTPServerTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("value"), True)
 

--- a/tests/test_api_subscriptions.py
+++ b/tests/test_api_subscriptions.py
@@ -16,7 +16,7 @@ class APISubscriptionsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value >= 1, result)
 
@@ -27,7 +27,7 @@ class APISubscriptionsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(len(value), 1)
             self.assertEqual(value[0].get("application"), "demo_application")
@@ -39,7 +39,7 @@ class APISubscriptionsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(len(value), 1)
             self.assertEqual(value[0].get("application"),
@@ -52,7 +52,7 @@ class APISubscriptionsTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value, 1)
 
@@ -62,7 +62,7 @@ class APISubscriptionsTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(len(value), 0)
 

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -67,7 +67,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            method='POST',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"]["DefaultOtpLen"] == "insert",
@@ -78,7 +78,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1,result)
         
@@ -87,7 +87,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] is None, result)
 
@@ -115,7 +115,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertEquals(result['value']['setPolicy pol1'], 1, res.json)
 
@@ -170,7 +170,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("pol1" == result["value"][0].get("name"), res.data)
 
@@ -198,7 +198,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"]["setPolicy pol_update_del"] > 0,
                             res.data)
@@ -213,7 +213,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["value"]["setPolicy pol_update_del"] > 0,
                             res.data)
             
@@ -223,7 +223,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             policy = {}
             for pol in result["value"]:
@@ -239,7 +239,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
 
         # delete policy
@@ -248,7 +248,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result["status"])
 
         # check policy
@@ -257,7 +257,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == [], result)
 
@@ -287,8 +287,8 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"), result)
             self.assertTrue("no active server available in server pool" in
                             detail.get("description"),
@@ -314,7 +314,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             data = result["value"]["testL"]["data"]
             self.assertEqual(data.get("BINDPW"), CENSORED)
@@ -324,7 +324,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             data = result["value"]["testL"]["data"]
             self.assertEqual(data.get("BINDPW"), CENSORED)
@@ -340,7 +340,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
 
@@ -349,7 +349,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("resolver1" in result["value"], result)
             self.assertTrue("filename" in result["value"]["resolver1"]["data"])
@@ -360,7 +360,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             # The value is empty
             self.assertTrue(result["value"] == {}, result)
@@ -373,7 +373,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             # The value is empty
             self.assertTrue(result["value"] == {}, result)
@@ -384,7 +384,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue("resolver1" in value, value)
 
@@ -396,7 +396,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue("resolver1" in value, value)
 
@@ -405,7 +405,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("resolver1" in result["value"], result)
@@ -418,7 +418,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("resolver1" in result["value"], result)
             self.assertTrue("filename" in result["value"]["resolver1"]["data"])
@@ -428,7 +428,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 1, result)
@@ -438,7 +438,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(result["status"] is True, result)
             # Trying to delete a non existing resolver returns -1
@@ -455,7 +455,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             # The resolver was created. The ID of the resolver is returend.
             self.assertTrue(result["value"] > 0, result)
@@ -467,7 +467,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             # The resolver was created
             self.assertTrue(len(result["value"].get("added")) == 1, result)
@@ -479,7 +479,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             # The resolver was created = 1
             self.assertTrue(realmname in result["value"], result)
@@ -493,7 +493,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("adminrealm" in result["value"], result)
 
@@ -512,7 +512,7 @@ class APIConfigTestCase(MyApiTestCase):
             # The realm gets deleted
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             # The realm is successfully deleted: value == 1
             self.assertTrue(result["value"] == 1, result)
@@ -524,7 +524,7 @@ class APIConfigTestCase(MyApiTestCase):
             # The resolver must not be deleted, since it is contained in a realm
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             # The resolver was deleted = 1
             self.assertTrue(result["value"] == 1, result)
@@ -541,7 +541,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
 
         # create a realm
@@ -552,7 +552,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
 
         # get the default realm
@@ -561,7 +561,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("defrealm" in result["value"], result)
 
@@ -571,7 +571,7 @@ class APIConfigTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
 
         # get the default realm
@@ -580,7 +580,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == {}, result)
 
@@ -590,7 +590,7 @@ class APIConfigTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
 
 
@@ -600,7 +600,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             self.assertTrue(res.status_code == 200, res)
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue("defrealm" in result["value"], result)
 
@@ -612,7 +612,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertTrue(result["value"] == 2, result)
             # check if policies are there
@@ -658,7 +658,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
 
 
         with self.app.test_request_context('/policy/pol2',
@@ -671,7 +671,7 @@ class APIConfigTestCase(MyApiTestCase):
                                                  "client": "172.16.1.1"},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
 
         # CHECK: user=superuser, action=action1, client=172.16.1.1
@@ -689,7 +689,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("value").get("allowed"), result)
 
         # CHECK: user=superuser, action=action1, client=172.16.1.2
@@ -704,7 +704,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value").get("allowed"), result)
 
 
@@ -720,7 +720,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("value").get("allowed"), result)
 
 
@@ -736,7 +736,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value").get("allowed"), result)
 
 
@@ -747,7 +747,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             policies = result.get("value")
             admin_pol = policies.get("admin")
             self.assertTrue("enable" in admin_pol, admin_pol)
@@ -759,7 +759,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             admin_pol = result.get("value")
             self.assertTrue("enable" in admin_pol, admin_pol)
@@ -773,7 +773,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             conditions = result.get("value")
             self.assertIn("sections", conditions)
             self.assertIn("userinfo", conditions["sections"])
@@ -787,7 +787,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             pol = result.get("value")
             self.assertTrue(pol[0].get("active"), pol[0])
@@ -797,14 +797,14 @@ class APIConfigTestCase(MyApiTestCase):
                                            method='POST',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
 
         with self.app.test_request_context('/policy/pol2',
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             pol = result.get("value")
             self.assertFalse(pol[0].get("active"), pol[0])
@@ -814,14 +814,14 @@ class APIConfigTestCase(MyApiTestCase):
                                            method='POST',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
 
         with self.app.test_request_context('/policy/pol2',
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(res.status_code == 200, res)
             pol = result.get("value")
             self.assertTrue(pol[0].get("active"), pol[0])
@@ -841,7 +841,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value.get("is_ready"), value)
 
@@ -859,8 +859,8 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            details = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            details = res.json.get("detail")
             value = result.get("value")
             self.assertEqual(value, False)
             self.assertEqual(details.get("message"), "Not implemented")
@@ -871,7 +871,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             # hex encoded value
             self.assertEqual(len(value), 64)
@@ -884,7 +884,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             # hex encoded value
             self.assertEqual(len(value), 44)
@@ -898,7 +898,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             # We probably have no keys in here
             # But value returns a dictionary with the KeyID and "armor" and
@@ -928,7 +928,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             pass
 
         with self.app.test_request_context('/resolver/{0}'.format(resolvername),
@@ -936,7 +936,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             params = result.get("value").get(resolvername).get("data")
             # the returned password is censored
             self.assertEqual(params.get("BINDPW"), CENSORED)

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -106,7 +106,7 @@ class API000TokenAdminRealmList(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # we have two tokens
             self.assertEqual(2, result.get("value").get("count"))
 
@@ -129,7 +129,7 @@ class API000TokenAdminRealmList(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # we have two tokens
             self.assertEqual(2, result.get("value").get("count"))
 
@@ -141,7 +141,7 @@ class API000TokenAdminRealmList(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # we have one token
             self.assertEqual(1, result.get("value").get("count"))
             # The token is in realm1
@@ -156,7 +156,7 @@ class API000TokenAdminRealmList(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # we have two tokens
             self.assertEqual(0, result.get("value").get("count"))
 
@@ -199,8 +199,8 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue(result.get("status"), result)
             self.assertTrue(result.get("value"), result)
             self.assertTrue("value" in detail.get("googleurl"), detail)
@@ -213,7 +213,7 @@ class APITokenTestCase(MyApiTestCase):
                                                  "genkey": 0},
                                            headers={'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
-                data = json.loads(res.data.decode('utf8'))
+                data = res.json
                 self.assertTrue(res.status_code == 200, res)
                 result = data.get("result")
                 detail = data.get("detail")
@@ -233,7 +233,7 @@ class APITokenTestCase(MyApiTestCase):
                                                  "realm": self.realm1},
                                            headers={'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
-                data = json.loads(res.data.decode('utf8'))
+                data = res.json
                 self.assertTrue(res.status_code == 200, res)
                 result = data.get("result")
                 detail = data.get("detail")
@@ -250,8 +250,8 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             count = result.get("value").get("count")
             next = result.get("value").get("next")
@@ -278,8 +278,8 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             # NO token assigned, yet
             self.assertTrue(len(tokenlist) == 0, "{0!s}".format(tokenlist))
@@ -292,8 +292,8 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             self.assertTrue(len(tokenlist) == 1, len(tokenlist))
 
@@ -341,8 +341,8 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             count = result.get("value").get("count")
             next = result.get("value").get("next")
@@ -360,7 +360,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") is True, result)
 
         # Assign the same token to another user will fail
@@ -372,7 +372,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             error = result.get("error")
 #            self.assertEqual(error.get("message"),
 #                             "ERR1103: Token already assigned to user "
@@ -391,7 +391,7 @@ class APITokenTestCase(MyApiTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_user = result.get("value").get("token")
@@ -402,7 +402,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             error = result.get("error")
             self.assertEqual(error.get("message"), "ERR1103: Token already assigned to another user.")
 
@@ -414,7 +414,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # Assign the same token to another user will success
@@ -426,7 +426,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") is True, result)
 
         # Unassign without any arguments will raise a ParameterError
@@ -462,7 +462,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["value"], 2)
 
         # Check that it worked
@@ -477,7 +477,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # Try to remove token, that does not exist raises a 404
@@ -486,7 +486,7 @@ class APITokenTestCase(MyApiTestCase):
                                            data={},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(res.status_code, 404)
             self.assertFalse(result.get("status"))
 
@@ -508,7 +508,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # disable a disabled token will not count, so the value will be 0
@@ -518,7 +518,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 0, result)
 
         # enable the token again
@@ -528,7 +528,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # try to enable an already enabled token returns value=0
@@ -538,7 +538,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 0, result)
 
     def test_07_reset_failcounter(self):
@@ -557,7 +557,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # test the failcount
@@ -568,7 +568,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, value)
@@ -581,7 +581,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
     def test_07_resync(self):
@@ -592,7 +592,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
             """
@@ -618,7 +618,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") is False, result)
 
         # check that we have a failed request in the audit log
@@ -642,7 +642,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") is True, result)
 
         # Check for a successful request in the audit log
@@ -664,7 +664,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(token.get("count") == 4, result)
@@ -677,7 +677,7 @@ class APITokenTestCase(MyApiTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             self.at_user = result.get("value").get("token")
@@ -703,7 +703,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         # let the user resync the token
@@ -716,7 +716,7 @@ class APITokenTestCase(MyApiTestCase):
                                                          self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") is True, result)
 
 
@@ -730,7 +730,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # Set both PINs of the token
@@ -741,7 +741,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 2, result)
 
         # set a pin
@@ -751,7 +751,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # set an empty pin
@@ -761,7 +761,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
     def test_09_set_token_attributes(self):
@@ -774,7 +774,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
 
@@ -795,7 +795,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 9, result)
 
         # check the values
@@ -806,7 +806,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, result)
@@ -835,7 +835,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -845,7 +845,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(token.get("realms") == ["realm1"], token)
@@ -860,7 +860,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value == 3, result)
 
@@ -874,7 +874,7 @@ class APITokenTestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value == 3, result)
 
@@ -888,7 +888,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value == 3, result)
 
@@ -928,7 +928,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value == 1, result)
 
@@ -942,7 +942,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value == 1, result)
 
@@ -957,7 +957,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -968,7 +968,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value == 1, result)
 
@@ -980,7 +980,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -992,7 +992,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -1025,7 +1025,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value is True, result)
 
@@ -1034,7 +1034,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue("end_date" in value, value)
             self.assertTrue(value.get("serial") == "lostLOST001", value)
@@ -1058,7 +1058,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 28)
             self.assertEqual(value.get("serial"), None)
@@ -1078,7 +1078,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("serial"), "GETSERIAL2")
 
@@ -1088,7 +1088,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("serial"), None)
 
@@ -1100,7 +1100,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertNotEqual(value.get("serial"), "GETSERIAL2")
 
@@ -1111,7 +1111,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("serial"), "GETSERIAL2")
 
@@ -1126,9 +1126,9 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             registrationcode = detail.get("registrationcode")
 
         # check password
@@ -1138,7 +1138,7 @@ class APITokenTestCase(MyApiTestCase):
                                            method="POST"):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         # check password again. THe second time it will fail, since the token
@@ -1149,7 +1149,7 @@ class APITokenTestCase(MyApiTestCase):
                                            method="POST"):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("value"))
 
     def test_16_totp_timestep(self):
@@ -1165,9 +1165,9 @@ class APITokenTestCase(MyApiTestCase):
                                                headers={'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data.decode('utf8')).get("result")
+                result = res.json.get("result")
                 self.assertTrue(result.get("value"))
-                detail = json.loads(res.data.decode('utf8')).get("detail")
+                detail = res.json.get("detail")
 
             token = get_tokens(serial="totp{0!s}".format(timestep))[0]
             self.assertEqual(token.timestep, int(timestep))
@@ -1192,9 +1192,9 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             certificate = detail.get("certificate")
             self.assertTrue("-----BEGIN CERTIFICATE-----" in certificate)
 
@@ -1208,7 +1208,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
         # Try to enable the revoked token
@@ -1235,7 +1235,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 1)
             challenges = value.get("challenges")
@@ -1248,7 +1248,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 1)
             challenges = value.get("challenges")
@@ -1261,7 +1261,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 0)
 
@@ -1274,7 +1274,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 3)
             challenges = value.get("challenges")
@@ -1289,7 +1289,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("count"), 1)
             challenges = value.get("challenges")
@@ -1309,7 +1309,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), result)
             self.assertTrue(result.get("value"), result)
 
@@ -1386,7 +1386,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
 
             serial = detail.get("serial")
             token = get_tokens(serial=serial)[0]
@@ -1409,8 +1409,8 @@ class APITokenTestCase(MyApiTestCase):
 
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
 
             serial = "SP001"
             token = get_tokens(serial=serial)[0]
@@ -1429,7 +1429,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"), result)
         with self.app.test_request_context('/token/info/INF001/key2',
                                             method="POST",
@@ -1437,7 +1437,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"), result)
 
         with self.app.test_request_context('/token/',
@@ -1447,7 +1447,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, result)
@@ -1462,7 +1462,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"), result)
 
         with self.app.test_request_context('/token/',
@@ -1472,7 +1472,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, result)
@@ -1486,7 +1486,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
            res = self.app.full_dispatch_request()
            self.assertTrue(res.status_code == 200, res)
-           result = json.loads(res.data.decode('utf8')).get("result")
+           result = res.json.get("result")
            self.assertTrue(result.get("value"), result)
 
         # Delete a non-existing tokeninfo value
@@ -1495,7 +1495,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"), result)
 
         # Try to delete with an unknown serial
@@ -1504,7 +1504,7 @@ class APITokenTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
 
         # Check that the tokeninfo is correct
@@ -1515,7 +1515,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             token = value.get("tokens")[0]
             self.assertTrue(value.get("count") == 1, result)
@@ -1548,9 +1548,9 @@ class APITokenTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             googleurl = detail.get("googleurl")
             self.assertTrue("sha256" in googleurl.get("value"))
             serial = detail.get("serial")
@@ -1576,9 +1576,9 @@ class APITokenTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             token = get_tokens(serial=serial)[0]
             self.assertEqual(token.token.otplen, 8)
@@ -1600,9 +1600,9 @@ class APITokenTestCase(MyApiTestCase):
                                                         self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             token = get_tokens(serial=serial)[0]
             self.assertEqual(token.token.otplen, 6)
@@ -1621,7 +1621,7 @@ class APITokenTestCase(MyApiTestCase):
                                                  "realm": self.realm1},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(res.status_code == 200, res)
             result = data.get("result")
             detail = data.get("detail")
@@ -1646,7 +1646,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("code"), 905)
 
@@ -1663,8 +1663,8 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             self.assertTrue(u'image=https%3A//example.com/img.png' in detail.get("googleurl").get("value"),
@@ -1697,7 +1697,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertEqual(result.get("value"), 1)
 
@@ -1708,7 +1708,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertEqual(result.get("value").get("tokens")[0].get("description"),
                              "New Token")
@@ -1721,7 +1721,7 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 404, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
             self.assertEqual(result.get("error").get("message"),
                              u"The requested token could not be found.")
@@ -1757,7 +1757,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value").get("count"), self.token_count)
 
     def test_02_several_requests(self):
@@ -1768,7 +1768,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value").get("count"), 0)
 
         # Run POST assign with a wildcard. This shall not assign.
@@ -1781,7 +1781,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*"
             self.assertFalse(result["status"])
 
@@ -1795,7 +1795,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1810,7 +1810,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1821,7 +1821,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1831,7 +1831,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1841,7 +1841,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1851,7 +1851,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1862,7 +1862,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1872,7 +1872,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1882,7 +1882,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1892,7 +1892,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1904,7 +1904,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 1016)
             self.assertEqual(result.get("error").get("message"), "ERR1016: No unique token to copy from found")
@@ -1916,7 +1916,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 1017)
             self.assertEqual(result.get("error").get("message"), "ERR1017: No unique token to copy to found")
@@ -1929,7 +1929,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 1016)
             self.assertEqual(result.get("error").get("message"), "ERR1016: No unique token to copy from found")
@@ -1942,7 +1942,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertEqual(result.get("error").get("code"), 1017)
             self.assertEqual(result.get("error").get("message"), "ERR1017: No unique token to copy to found")
@@ -1960,7 +1960,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1975,7 +1975,7 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])
 
@@ -1989,6 +1989,6 @@ class API00TokenPerformance(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # Of course there is no exact token "perf*", it does not match perf001
             self.assertFalse(result["status"])

--- a/tests/test_api_ttype.py
+++ b/tests/test_api_ttype.py
@@ -31,7 +31,7 @@ class TtypeAPITestCase(MyApiTestCase):
                                                  "serial": "TIQR1",
                                                  "session": "12345"}):
             res = self.app.full_dispatch_request()
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             identity = data.get("identity")
             service = data.get("service")
             self.assertEqual(identity.get("displayName"), "Cornelius ")
@@ -44,7 +44,7 @@ class TtypeAPITestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             self.assertEqual(res.mimetype, u'application/fido.trusted-apps+json')
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue("trustedFacets" in data)
 
         # Check the audit log.
@@ -53,7 +53,7 @@ class TtypeAPITestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data.decode('utf8'))
+            json_response = res.json
             result = json_response.get("result")
             auditdata = result.get("value").get("auditdata")
             self.assertTrue(len(auditdata) > 0)

--- a/tests/test_api_u2f.py
+++ b/tests/test_api_u2f.py
@@ -69,7 +69,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             result = response.get("result")
             details = response.get("detail")
             self.assertEqual(result.get("value"), True)
@@ -95,7 +95,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            response = json.loads(res.data.decode('utf8'))
+            response = res.json
             result = response.get("result")
             self.assertEqual(result.get("value"), True)
 
@@ -113,8 +113,8 @@ class APIU2fTestCase(MyApiTestCase):
                                                  "pass": "u2f"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), False)
             transaction_id = detail.get("transaction_id")
             self.assertEqual(len(transaction_id), len('01350277175811850842'))
@@ -161,7 +161,7 @@ class APIU2fTestCase(MyApiTestCase):
                                                      signature_data_url}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), False)
 
@@ -170,7 +170,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            method='GET'):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue("trustedFacets" in data)
 
         set_policy(name="facet1", scope=SCOPE.AUTH,
@@ -180,7 +180,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            method='GET'):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue("trustedFacets" in data)
             facets = data["trustedFacets"][0]
             ids = facets["ids"]
@@ -213,7 +213,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -227,7 +227,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -254,7 +254,7 @@ class APIU2fTestCase(MyApiTestCase):
                                                      signature_data}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -286,7 +286,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -300,7 +300,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -327,7 +327,7 @@ class APIU2fTestCase(MyApiTestCase):
                                                      signature_data}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 403)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("code"), ERROR.POLICY)
             self.assertEqual(result.get("error").get("message"),
@@ -357,8 +357,8 @@ class APIU2fTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -375,7 +375,7 @@ class APIU2fTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 403)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("message"),
                              u'The U2F device is not allowed to be registered '

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -56,7 +56,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             value = result.get("result").get("value")
             self.assertTrue('r1' in value["added"], res.data)
             self.assertTrue('r2' in value["failed"], res.data)
@@ -69,7 +69,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             value = result.get("result").get("value")
             unames = [x.get('username') for x in value]
             self.assertIn("cornelius", unames, value)
@@ -83,7 +83,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             value = result.get("result").get("value")
             unames = [x.get('username') for x in value]
             self.assertIn("cornelius", unames, value)
@@ -97,7 +97,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             value = result.get("result").get("value")
             unames = [x.get('username') for x in value]
             self.assertNotIn("cornelius", unames, value)
@@ -131,7 +131,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") > 6, result.get("value"))
 
         # Get users
@@ -142,7 +142,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertEqual(result.get("value")[0].get("username"), "wordy")
 
@@ -156,7 +156,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         # Get user authentication and update by user.
@@ -166,7 +166,7 @@ class APIUsersTestCase(MyApiTestCase):
                                                  "password": "passwort"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             wordy_auth_token = result.get("value").get("token")
@@ -186,7 +186,7 @@ class APIUsersTestCase(MyApiTestCase):
                                                         wordy_auth_token}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         # Although the user "wordy" tried to update the password of user
@@ -197,7 +197,7 @@ class APIUsersTestCase(MyApiTestCase):
                                                  "password": "newPassword"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             wordy_auth_token = result.get("value").get("token")
@@ -211,7 +211,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
     def test_03_create_update_delete_unicode_user(self):
@@ -242,7 +242,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value") > 6, result.get("value"))
 
         # Get users
@@ -253,7 +253,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertEqual(result.get("value")[0].get("username"), u"wördy")
 
@@ -267,7 +267,7 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         # Get user authentication and update by user.
@@ -277,7 +277,7 @@ class APIUsersTestCase(MyApiTestCase):
                                                  "password": "passwort"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             wordy_auth_token = result.get("value").get("token")
@@ -297,7 +297,7 @@ class APIUsersTestCase(MyApiTestCase):
                                                         wordy_auth_token}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         # Although the user "wördy" tried to update the password of user
@@ -308,7 +308,7 @@ class APIUsersTestCase(MyApiTestCase):
                                                  "password": "newPassword"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             wordy_auth_token = result.get("value").get("token")
@@ -322,5 +322,5 @@ class APIUsersTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -198,7 +198,7 @@ class AuthorizationPolicyTestCase(MyApiTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -217,7 +217,7 @@ class AuthorizationPolicyTestCase(MyApiTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -242,7 +242,7 @@ class AuthorizationPolicyTestCase(MyApiTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -262,7 +262,7 @@ class DisplayTANTestCase(MyApiTestCase):
                                             headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertTrue(value == 1, result)
 
@@ -279,10 +279,10 @@ class DisplayTANTestCase(MyApiTestCase):
                                                  "challenge": challenge}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
             hex_challenge = detail.get("attributes").get("challenge")
             self.assertEqual(hex_challenge, "7196501689c356046867728f4feb74458dcfd079")
@@ -297,7 +297,7 @@ class DisplayTANTestCase(MyApiTestCase):
                                                      transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
 
@@ -311,7 +311,7 @@ class DisplayTANTestCase(MyApiTestCase):
                                                      transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
 
@@ -326,10 +326,10 @@ class DisplayTANTestCase(MyApiTestCase):
                                                  "challenge": challenge}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
             hex_challenge = detail.get("attributes").get("challenge")
             self.assertEqual(len(hex_challenge), 40)
@@ -405,13 +405,13 @@ class AValidateOfflineTestCase(MyApiTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             result = data.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("otplen"), 6)
-            auth_items = json.loads(res.data.decode('utf8')).get("auth_items")
+            auth_items = res.json.get("auth_items")
             offline = auth_items.get("offline")[0]
             # Check the number of OTP values
             self.assertEqual(len(offline.get("response")), 100)
@@ -431,17 +431,17 @@ class AValidateOfflineTestCase(MyApiTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
-            result = json.loads(res.data.decode('utf8')).get("result")
+            data = res.json
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            auth_items = json.loads(res.data.decode('utf8')).get("auth_items")
+            auth_items = res.json.get("auth_items")
             offline = auth_items.get("offline")[0]
             # Check the number of OTP values
             self.assertEqual(len(offline.get("response")), 3)
-            self.assertTrue("102" in offline.get("response"))
-            self.assertTrue("103" in offline.get("response"))
-            self.assertTrue("104" in offline.get("response"))
+            self.assertTrue(102 in offline.get("response"))
+            self.assertTrue(103 in offline.get("response"))
+            self.assertTrue(104 in offline.get("response"))
             refilltoken_2 = offline.get("refilltoken")
             self.assertEqual(len(refilltoken_2), 2 * REFILLTOKEN_LENGTH)
             # check the token counter
@@ -459,7 +459,7 @@ class AValidateOfflineTestCase(MyApiTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR905: Token is not an offline token or refill token is incorrect")
 
@@ -472,19 +472,19 @@ class AValidateOfflineTestCase(MyApiTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
-            result = json.loads(res.data.decode('utf8')).get("result")
+            data = res.json
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            auth_items = json.loads(res.data.decode('utf8')).get("auth_items")
+            auth_items = res.json.get("auth_items")
             offline = auth_items.get("offline")[0]
             # Check the number of OTP values
             self.assertEqual(len(offline.get("response")), 5)
-            self.assertTrue("105" in offline.get("response"))
-            self.assertTrue("106" in offline.get("response"))
-            self.assertTrue("107" in offline.get("response"))
-            self.assertTrue("108" in offline.get("response"))
-            self.assertTrue("109" in offline.get("response"))
+            self.assertTrue(105 in offline.get("response"))
+            self.assertTrue(106 in offline.get("response"))
+            self.assertTrue(107 in offline.get("response"))
+            self.assertTrue(108 in offline.get("response"))
+            self.assertTrue(109 in offline.get("response"))
             refilltoken_3 = offline.get("refilltoken")
             self.assertEqual(len(refilltoken_3), 2 * REFILLTOKEN_LENGTH)
             # check the token counter
@@ -504,7 +504,7 @@ class AValidateOfflineTestCase(MyApiTestCase):
                                                  "refilltoken": refilltoken_3},
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(res.status_code == 400, res)
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR401: You provided a wrong OTP value.")
@@ -519,7 +519,7 @@ class AValidateOfflineTestCase(MyApiTestCase):
                                                  "refilltoken": refilltoken_3},
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(res.status_code == 400, res)
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR905: The token does not exist")
@@ -534,7 +534,7 @@ class AValidateOfflineTestCase(MyApiTestCase):
                                            environ_base={'REMOTE_ADDR': '192.168.0.2'}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(res.status_code == 400, res)
             self.assertEqual(data.get("result").get("error").get("message"),
                              u"ERR905: Token is not an offline token or refill token is incorrect")
@@ -633,10 +633,10 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("otplen"), 6)
 
         # Check that the counter is increased!
@@ -655,7 +655,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
 
@@ -675,10 +675,10 @@ class ValidateAPITestCase(MyApiTestCase):
                                                      "pass": "pin287082"})):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
-            detail = json.loads(res.data).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("otplen"), 6)
 
         # Check that the counter is increased!
@@ -698,7 +698,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                      "pass": "pin287082"})):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
 
@@ -710,7 +710,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin969429"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is True, result)
 
@@ -721,8 +721,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin969429"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            details = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            details = res.json.get("detail")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
             self.assertEqual(details.get("message"), "wrong otp value. "
@@ -739,8 +739,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            details = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            details = res.json.get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -755,8 +755,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            details = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            details = res.json.get("detail")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -772,7 +772,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), True)
             self.assertEqual(result.get("value"), True)
 
@@ -800,8 +800,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "XXXX123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
 
         tok = get_tokens(serial="SE1")[0]
@@ -819,8 +819,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("serial"), "SE1")
             self.assertEqual(detail.get("message"), "wrong otp value")
 
@@ -845,8 +845,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "XXXX123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
 
         tok = get_tokens(serial="SE1")[0]
@@ -864,8 +864,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("serial"), "SE1")
             self.assertEqual(detail.get("message"), "wrong otp value")
 
@@ -889,7 +889,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                      "pass": "123456"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data.decode('utf8')).get("result")
+                result = res.json.get("result")
                 self.assertEqual(result.get("value"), True)
 
         # The 6th authentication will fail
@@ -899,8 +899,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), False)
             self.assertTrue("Authentication counter exceeded"
                             in detail.get("message"))
@@ -917,8 +917,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "123456"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertEqual(result.get("value"), False)
             self.assertEqual(detail.get("message"), "matching 1 tokens, "
                                                     "Failcounter exceeded")
@@ -932,8 +932,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin338314"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             value = result.get("value")
             attributes = value.get("attributes")
             self.assertEqual(value.get("auth"), True)
@@ -948,8 +948,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin254676"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             value = result.get("value")
             attributes = value.get("attributes")
             self.assertEqual(value.get("auth"), True)
@@ -968,8 +968,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin254676"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             value = result.get("value")
             attributes = value.get("attributes")
             self.assertEqual(value.get("auth"), False)
@@ -987,8 +987,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pin254676"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             value = result.get("value")
             attributes = value.get("attributes")
             self.assertEqual(value.get("auth"), False)
@@ -1012,7 +1012,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
 
@@ -1034,8 +1034,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
             self.assertEqual(detail.get("message"), _("please enter otp: "))
             transaction_id = detail.get("transaction_id")
@@ -1050,8 +1050,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue(result.get("value"))
 
         self.assertEqual(token.get_failcount(), 0)
@@ -1071,7 +1071,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
 
@@ -1099,8 +1099,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": chalresp_pins[0]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
             self.assertEqual(detail.get("message"), _("please enter otp: "))
             transaction_id = detail.get("transaction_id")
@@ -1118,8 +1118,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "111111"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
 
         # Failcounter for the first token is increased
@@ -1136,8 +1136,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue(result.get("value"))
 
         # Failcounter for the first token is reset
@@ -1155,8 +1155,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
 
         # send an incorrect OTP value
@@ -1168,8 +1168,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "111111"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
 
         # Failcounter for both tokens are increased
@@ -1192,7 +1192,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
 
@@ -1211,8 +1211,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
             self.assertTrue("The PIN was correct, "
                             "but the SMS could not be sent" in
@@ -1228,8 +1228,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
             self.assertEqual(detail.get("message"),
                              "No active challenge response token found")
@@ -1251,7 +1251,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
             self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
 
@@ -1270,8 +1270,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertFalse(result.get("value"))
             self.assertEqual(detail.get("message"), _("Enter the OTP from the Email:"))
             transaction_id = detail.get("transaction_id")
@@ -1286,8 +1286,8 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "359152"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue(result.get("value"))
 
         # delete the token
@@ -1306,7 +1306,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         # Set validity period
@@ -1318,9 +1318,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("value"))
-            details = json.loads(res.data.decode('utf8')).get("detail")
+            details = res.json.get("detail")
             self.assertTrue("Outside validity period" in details.get("message"))
 
         token_obj.set_validity_period_end("1999-01-01T10:00+0200")
@@ -1332,9 +1332,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("value"))
-            details = json.loads(res.data.decode('utf8')).get("detail")
+            details = res.json.get("detail")
             self.assertTrue("Outside validity period" in details.get("message"))
 
         # delete the token
@@ -1357,7 +1357,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": serial1}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         set_privacyidea_config("splitAtSign", "0")
@@ -1377,7 +1377,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": serial2}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         # The default behaviour - if the config entry does not exist,
@@ -1390,7 +1390,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": serial2}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
     def test_16_autoresync_hotp(self):
@@ -1409,7 +1409,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "async399871"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), False)
 
         # counter = 9, will be autosynced.
@@ -1421,7 +1421,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "async520489"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         delete_privacyidea_config("AutoResync")
@@ -1446,7 +1446,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                      "pass": pin}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data.decode('utf8')).get("result")
+                result = res.json.get("result")
                 self.assertEqual(result.get("value"), True)
 
         with self.app.test_request_context('/validate/check',
@@ -1456,7 +1456,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), False)
 
         delete_policy("pol_time1")
@@ -1481,7 +1481,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                      "pass": "wrongpin"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                result = json.loads(res.data.decode('utf8')).get("result")
+                result = res.json.get("result")
                 self.assertEqual(result.get("value"), False)
 
         # Now we do the correct authentication, but
@@ -1493,9 +1493,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), False)
-            details = json.loads(res.data.decode('utf8')).get("detail")
+            details = res.json.get("detail")
             self.assertEqual(details.get("message"),
                              "Only 2 failed authentications per 0:00:20")
 
@@ -1515,7 +1515,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                         "pass": "pthru"})):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         # Passthru with POST Request
@@ -1526,7 +1526,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pthru"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         # Test if the policies "reset_all_tokens" and "passthru" work out fine at the same time
@@ -1539,7 +1539,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pthru"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         delete_policy("reset_all_tokens")
@@ -1573,7 +1573,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value, True)
 
@@ -1584,9 +1584,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
             question = detail.get("message")
             self.assertTrue(question in questions)
@@ -1601,7 +1601,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": answer}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
     def test_21_validate_disabled(self):
@@ -1628,7 +1628,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "superSecret"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         # disable 2nd token
@@ -1643,7 +1643,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "superSecret"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         delete_policy("disabled")
@@ -1675,7 +1675,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "locked"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         remove_token("spass1l")
@@ -1707,9 +1707,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("serial"), serial)
 
         # User that does not exist, can authenticate
@@ -1720,9 +1720,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("message"),
                              u"user does not exist, accepted "
                              u"due to 'pass_no'")
@@ -1739,9 +1739,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("message"),
                              u"user does not exist, accepted "
                              u"due to 'pass_no'")
@@ -1758,9 +1758,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("message"),
                              u"user has no token, "
                              u"accepted due to 'pass_no'")
@@ -1776,9 +1776,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "wrongPiN"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), False)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("message"),
                              "wrong otp pin")
 
@@ -1794,7 +1794,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail, None)
 
     def test_23a_pass_no_user_resolver(self):
@@ -1816,7 +1816,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "secret"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("message"),
                              u'user does not exist, accepted due to \'pol1\'')
         delete_policy("pol1")
@@ -1845,9 +1845,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), 1)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("messages")[0],
                              _("Enter the OTP from the SMS:"))
             transaction_id = detail.get("transaction_ids")[0]
@@ -1862,7 +1862,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         # Trigger challenge for user
@@ -1874,9 +1874,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), 1)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("messages")[0],
                              _("Enter the OTP from the SMS:"))
             transaction_id = detail.get("transaction_ids")[0]
@@ -1891,7 +1891,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "969429"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         remove_token(serial)
@@ -1924,9 +1924,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), 1)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("messages")[0],
                              _("Enter the OTP from the Email:"))
             transaction_id = detail.get("transaction_ids")[0]
@@ -1964,9 +1964,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), False)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
             multi_challenge = detail.get("multi_challenge")
             self.assertEqual(multi_challenge[0].get("serial"), "CR2A")
@@ -1993,9 +1993,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             self.assertEqual(serial, "CR2B")
 
@@ -2036,9 +2036,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pinB}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), False)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
             multi_challenge = detail.get("multi_challenge")
             self.assertEqual(multi_challenge[0].get("serial"), "CR2B")
@@ -2063,9 +2063,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "287082"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             self.assertEqual(serial, "CR2B")
 
@@ -2110,7 +2110,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "123456"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertFalse(result.get("status"))
 
     def test_29_several_CR_one_locked(self):
@@ -2140,10 +2140,10 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             # This is a challene, the value is False
             self.assertEqual(result.get("value"), False)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             self.assertEqual(serial, "CR2A")
             # Only one challenge, the 2nd token was revoked.
@@ -2180,9 +2180,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("type"), "undetermined")
 
         # two same token types.
@@ -2197,9 +2197,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("type"), "spass")
 
         # A user has one HOTP token and two spass tokens.
@@ -2214,9 +2214,9 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("type"), "spass")
 
         # policy only allows HOTP.
@@ -2230,10 +2230,10 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "hallo123"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 403)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("status"), False)
             self.assertEqual(result.get("error").get("code"), ERROR.POLICY)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail, None)
 
         # Define a passthru policy
@@ -2247,7 +2247,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "pthru"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), True)
 
         delete_policy("onlyHOTP")
@@ -2292,7 +2292,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "email"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            resp = json.loads(res.data.decode('utf8'))
+            resp = res.json
             self.assertEqual(resp.get("detail").get("message"), "check your email")
 
         # Challenge Response with SMS
@@ -2302,7 +2302,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "sms"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            resp = json.loads(res.data.decode('utf8'))
+            resp = res.json
             self.assertEqual(resp.get("detail").get("message"), "check your sms")
 
         # Two different token types that are triggered by the same PIN:
@@ -2322,7 +2322,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "PIN"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
-            resp = json.loads(res.data.decode('utf8'))
+            resp = res.json
             self.assertEqual(resp.get("detail").get("message"), "check your sms, check your email")
 
         delete_policy("chalsms")
@@ -2340,7 +2340,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": ""}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             error_msg = result.get("error").get("message")
             self.assertEqual("ERR905: You need to specify a serial or a user.", error_msg)
 
@@ -2351,7 +2351,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": ""}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             error_msg = result.get("error").get("message")
             self.assertEqual("ERR905: Invalid user.", error_msg)
 
@@ -2362,7 +2362,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": ""}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             error_msg = result.get("error").get("message")
             self.assertEqual("ERR905: Invalid serial number.", error_msg)
 
@@ -2378,7 +2378,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         self.assertEqual(int(tok.get_tokeninfo("count_auth")), 1)
@@ -2391,7 +2391,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("value"))
 
         self.assertEqual(int(tok.get_tokeninfo("count_auth")), 1)
@@ -2436,7 +2436,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": "spass"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -2447,7 +2447,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get("count"), 1)
             self.assertTrue("logged in as Cooper." in json_response.get("result").get("value").get("auditdata")[0].get("info"),
@@ -2467,7 +2467,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": OTPs[1]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -2483,10 +2483,10 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": OTPs[1]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("message"), u"Authenticated by AuthCache.")
 
         delete_policy("authcache")
@@ -2499,10 +2499,10 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": OTPs[1]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertFalse(result.get("value"))
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             self.assertEqual(detail.get("message"), u"wrong otp value. previous otp used again")
 
         # If there is no authcache, the same value must not be used again!
@@ -2513,7 +2513,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": OTPs[2]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
 
@@ -2529,7 +2529,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": OTPs[2]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertFalse(result.get("value"))
 
@@ -2556,7 +2556,7 @@ class RegistrationValidity(MyApiTestCase):
                                                  "pass": password}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2609,7 +2609,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2624,7 +2624,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(data.get("result").get("value"))
 
         # Now we send the challenge and then we disable the token
@@ -2634,7 +2634,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2652,7 +2652,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
             self.assertEqual(detail.get("message"), "Challenge matches, but token is not fit for challenge. Token is disabled")
@@ -2665,7 +2665,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2695,7 +2695,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2709,7 +2709,7 @@ class AChallengeResponse(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             # Triggerchallenge returns the numbers of tokens in the "value
             self.assertEqual(data.get("result").get("value"), 1)
@@ -2742,7 +2742,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2757,7 +2757,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2772,7 +2772,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": OTPs[2]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertTrue(data.get("result").get("value"))
 
@@ -2783,7 +2783,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": OTPs[1]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertTrue(data.get("result").get("value"))
 
@@ -2814,7 +2814,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2829,7 +2829,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2844,7 +2844,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": OTPs[1]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             # The first challenge will not authenticate anymore, since the OTP is not stored in the challenge data
             # and the token counter was increased
@@ -2857,7 +2857,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": OTPs[2]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertTrue(data.get("result").get("value"))
 
@@ -2891,7 +2891,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2905,7 +2905,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2919,7 +2919,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": OTPs[2]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertTrue(data.get("result").get("value"))
 
@@ -2930,7 +2930,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": OTPs[1]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertTrue(data.get("result").get("value"))
 
@@ -2968,7 +2968,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2982,7 +2982,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -2996,7 +2996,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": OTPs[1]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             # First OTP fails, since the counter increased
             self.assertFalse(data.get("result").get("value"))
@@ -3008,7 +3008,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": OTPs[2]}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             # Last value succeeds
             self.assertTrue(data.get("result").get("value"))
@@ -3042,7 +3042,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -3079,7 +3079,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -3108,7 +3108,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -3121,7 +3121,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -3140,7 +3140,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "pass": "pin"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -3153,7 +3153,7 @@ class AChallengeResponse(MyApiTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
             detail = data.get("detail")
@@ -3188,7 +3188,7 @@ class AChallengeResponse(MyApiTestCase):
                                            headers={"authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertEqual(data.get("result").get("value"), 2)
             # The two challenges should be the same
@@ -3220,7 +3220,7 @@ class TriggeredPoliciesTestCase(MyApiTestCase):
                                            data={"serial": "triggtoken", "pass": ""}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertTrue(data.get("result").get("value"))
 
@@ -3231,7 +3231,7 @@ class TriggeredPoliciesTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get(
                 "count"), 1)
@@ -3246,7 +3246,7 @@ class TriggeredPoliciesTestCase(MyApiTestCase):
                                            data={"serial": "triggtoken", "pass": ""}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data)
+            data = res.json
             self.assertTrue(data.get("result").get("status"))
             self.assertFalse(data.get("result").get("value"))
 
@@ -3257,7 +3257,7 @@ class TriggeredPoliciesTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            json_response = json.loads(res.data)
+            json_response = res.json
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get("count"), 1)
             # Both policies have triggered

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -672,7 +672,7 @@ class FederationEventTestCase(MyTestCase):
         add_privacyideaserver("remotePI", url="https://remote", tls=False)
         res = f_handler.do(ACTION_TYPE.FORWARD, options=options)
         self.assertTrue(res)
-        response = json.loads(options.get("response").data)
+        response = options.get("response").json
         self.assertEqual(response.get("detail").get("origin"),
                          "https://remote/validate/check")
 
@@ -712,7 +712,7 @@ class FederationEventTestCase(MyTestCase):
         add_privacyideaserver("remotePI", url="https://remote", tls=False)
         res = f_handler.do(ACTION_TYPE.FORWARD, options=options)
         self.assertTrue(res)
-        response = json.loads(options.get("response").data)
+        response = options.get("response").json
         self.assertEqual(response.get("detail").get("origin"),
                          "https://remote/validate/check")
 
@@ -751,7 +751,7 @@ class FederationEventTestCase(MyTestCase):
         add_privacyideaserver("remotePI", url="https://remote", tls=False)
         res = f_handler.do(ACTION_TYPE.FORWARD, options=options)
         self.assertTrue(res)
-        response = json.loads(options.get("response").data)
+        response = options.get("response").json
         self.assertEqual(response.get("detail").get("origin"),
                          "https://remote/token/serial")
 
@@ -844,7 +844,7 @@ class FederationEventTestCase(MyTestCase):
         add_privacyideaserver("remotePI", url="https://remote", tls=False)
         res = f_handler.do(ACTION_TYPE.FORWARD, options=options)
         self.assertTrue(res)
-        response = json.loads(options.get("response").data)
+        response = options.get("response").json
         self.assertEqual(response.get("detail").get("origin"),
                          "https://remote/token/init")
 
@@ -2484,7 +2484,7 @@ class UserNotificationTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertEqual(result.get("value"), 1)
 
         # Cleanup

--- a/tests/test_lib_lifecycle.py
+++ b/tests/test_lib_lifecycle.py
@@ -40,7 +40,7 @@ class LifecycleTestCase(MyTestCase):
             register_finalizer(finalizer1)
             register_finalizer(finalizer2)
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
         finalizer1.assert_called_once()
         finalizer2.assert_called_once()
@@ -49,7 +49,7 @@ class LifecycleTestCase(MyTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
         finalizer1.assert_called_once()
         finalizer2.assert_called_once()
@@ -65,7 +65,7 @@ class LifecycleTestCase(MyTestCase):
             register_finalizer(finalizer1)
             register_finalizer(finalizer2)
             res = self.app.full_dispatch_request()
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"))
         finalizer1.assert_called_once()
         finalizer2.assert_called_once()

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -206,7 +206,7 @@ class PushTokenTestCase(MyTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code,  200)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             serial = detail.get("serial")
             self.assertEqual(detail.get("rollout_state"), "clientwait")
             self.assertTrue("pushurl" in detail)
@@ -226,9 +226,9 @@ class PushTokenTestCase(MyTestCase):
                                                  "fbtoken": "firebaseT"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 404, res)
-            status = json.loads(res.data.decode('utf8')).get("result").get("status")
+            status = res.json.get("result").get("status")
             self.assertFalse(status)
-            error = json.loads(res.data.decode('utf8')).get("result").get("error")
+            error = res.json.get("result").get("error")
             self.assertEqual(error.get("message"),
                              "No token with this serial number in the rollout state 'clientwait'.")
 
@@ -241,9 +241,9 @@ class PushTokenTestCase(MyTestCase):
                                                  "enrollment_credential": "WRonG"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
-            status = json.loads(res.data.decode('utf8')).get("result").get("status")
+            status = res.json.get("result").get("status")
             self.assertFalse(status)
-            error = json.loads(res.data.decode('utf8')).get("result").get("error")
+            error = res.json.get("result").get("error")
             self.assertEqual(error.get("message"),
                              "ERR905: Invalid enrollment credential. You are not authorized to finalize this token.")
 
@@ -256,7 +256,7 @@ class PushTokenTestCase(MyTestCase):
                                                  "fbtoken": "firebaseT"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            detail = res.json.get("detail")
             # still the same serial number
             self.assertEqual(serial, detail.get("serial"))
             self.assertEqual(detail.get("rollout_state"), "enrolled")
@@ -315,7 +315,7 @@ class PushTokenTestCase(MyTestCase):
                                                      "pass": "pushpin"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 400, res)
-                jsonresp = json.loads(res.data.decode('utf8'))
+                jsonresp = res.json
                 self.assertFalse(jsonresp.get("result").get("status"))
                 self.assertEqual(jsonresp.get("result").get("error").get("code"), 401)
                 self.assertEqual(jsonresp.get("result").get("error").get("message"), "ERR401: Failed to submit "
@@ -353,7 +353,7 @@ class PushTokenTestCase(MyTestCase):
                                                      "pass": "pushpin"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                jsonresp = json.loads(res.data.decode('utf8'))
+                jsonresp = res.json
                 self.assertFalse(jsonresp.get("result").get("value"))
                 self.assertTrue(jsonresp.get("result").get("status"))
                 self.assertEqual(jsonresp.get("detail").get("serial"), tokenobj.token.serial)
@@ -371,7 +371,7 @@ class PushTokenTestCase(MyTestCase):
                                                  "transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            jsonresp = json.loads(res.data.decode('utf8'))
+            jsonresp = res.json
             # Result-Value is false, the user has not answered the challenge, yet
             self.assertFalse(jsonresp.get("result").get("value"))
 
@@ -389,7 +389,7 @@ class PushTokenTestCase(MyTestCase):
                                                  "state": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            jsonresp = json.loads(res.data.decode('utf8'))
+            jsonresp = res.json
             # Result-Value is True, since the challenge is marked resolved in the DB
         self.assertTrue(jsonresp.get("result").get("value"))
 
@@ -416,7 +416,7 @@ class PushTokenTestCase(MyTestCase):
                                                      "pass": "pushpin"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                jsonresp = json.loads(res.data.decode('utf8'))
+                jsonresp = res.json
                 # We successfully authenticated! YEAH!
                 self.assertTrue(jsonresp.get("result").get("value"))
                 self.assertTrue(jsonresp.get("result").get("status"))
@@ -442,7 +442,7 @@ class PushTokenTestCase(MyTestCase):
                                                      "pass": "pushpin"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                jsonresp = json.loads(res.data.decode('utf8'))
+                jsonresp = res.json
                 # We fail to authenticate! Oh No!
                 self.assertFalse(jsonresp.get("result").get("value"))
                 self.assertTrue(jsonresp.get("result").get("status"))
@@ -506,7 +506,7 @@ class PushTokenTestCase(MyTestCase):
                                                      "pass": "pushpin"}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
-                jsonresp = json.loads(res.data.decode('utf8'))
+                jsonresp = res.json
                 self.assertFalse(jsonresp.get("result").get("value"))
                 self.assertTrue(jsonresp.get("result").get("status"))
                 self.assertEqual(jsonresp.get("detail").get("serial"), tokenobj.token.serial)
@@ -631,7 +631,7 @@ class PushTokenTestCase(MyTestCase):
                                                  "state": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            jsonresp = json.loads(res.data.decode('utf8'))
+            jsonresp = res.json
             # Result-Value is True
             self.assertTrue(jsonresp.get("result").get("value"))
 

--- a/tests/test_lib_tokens_tiqr.py
+++ b/tests/test_lib_tokens_tiqr.py
@@ -497,8 +497,8 @@ class TiQRTokenTestCase(MyApiTestCase):
                                                "pass": pin})):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
             transaction_id = detail.get("transaction_id")
@@ -647,8 +647,8 @@ class TiQRTokenTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
-            detail = json.loads(res.data.decode('utf8')).get("detail")
+            result = res.json.get("result")
+            detail = res.json.get("detail")
             self.assertTrue(result.get("status") is True, result)
             transaction_id = detail.get("transaction_id")
             # we've got two challenges with the same transaction ID

--- a/tests/test_resolver_realm.py
+++ b/tests/test_resolver_realm.py
@@ -44,7 +44,7 @@ class APIResolverTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(res.json['result']['status'], res.json)
             self.assertEquals(res.json['result']['value'], 1, res.json)
-                    
+
         # check if the resolver was created
         with self.app.test_request_context('/resolver/',
                                            method='GET',
@@ -53,7 +53,7 @@ class APIResolverTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(b'"fileName": "/etc/passwd"' in res.data, res.data)
             self.assertTrue(b'"resolvername": "r1"' in res.data, res.data)
-            
+
     def test_01_create_realm(self):
         realm = u"realm1"
         resolvers = u"r1, r2"
@@ -63,11 +63,11 @@ class APIResolverTestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8'))
+            result = res.json
             value = result.get("result").get("value")
             self.assertTrue('r1' in value["added"], res.data)
             self.assertTrue('r2' in value["failed"], res.data)
-            
+
 '''
         with self.app.test_request_context(
                 '/api/1.0/comments/' + str(c.id),

--- a/tests/test_ui_certificate.py
+++ b/tests/test_ui_certificate.py
@@ -35,7 +35,7 @@ class WebUICertificateTestCase(MyTestCase):
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = json.loads(res.data.decode('utf8')).get("result")
+            result = res.json.get("result")
             self.assertTrue(result.get("status"), res.data)
             # In self.at_user we store the user token
             authtoken = result.get("value")


### PR DESCRIPTION
privacyIDEA did not work correctly with python 3.5 due to some json
encoding issues.
Since we are using Flask 1.0, the Response class provides a `json` property
which we can use to read the corresponding data.

Fixes #1616