### PR TITLE
Fix {caconnector,privacyideaserver,radiusserver}_read policies

### DIFF
--- a/privacyidea/api/caconnector.py
+++ b/privacyidea/api/caconnector.py
@@ -45,7 +45,7 @@ caconnector_blueprint = Blueprint('caconnector_blueprint', __name__)
 @caconnector_blueprint.route('/<name>', methods=['GET'])
 @caconnector_blueprint.route('/', methods=['GET'])
 @log_with(log)
-#@prepolicy(check_base_action, request, ACTION.CACONNECTORREAD)
+@prepolicy(check_base_action, request, ACTION.CACONNECTORREAD)
 def get_caconnector_api(name=None):
     """
     returns a json list of the available CA connectors

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1709,8 +1709,24 @@ def get_static_policy_definitions(scope=None):
                                    'desc': _("The user is allowed to do a "
                                              "password reset in an editable "
                                              "UserIdResolver."),
-                                   'mainmenu': []}
-
+                                   'mainmenu': []},
+            ACTION.CACONNECTORREAD: {"type": "bool",
+                                     "desc": _("User is allowed to read the "
+                                               "CA Connector definitions."),
+                                     "group": GROUP.SYSTEM,
+                                     "mainmenu": [MAIN_MENU.CONFIG]},
+            ACTION.PRIVACYIDEASERVERREAD: {"type": "bool",
+                                           "desc": _("User is allowed to "
+                                                     "read remote "
+                                                     "privacyIDEA server "
+                                                     "definitions."),
+                                           "group": GROUP.SYSTEM,
+                                           "mainmenu": [MAIN_MENU.CONFIG]},
+            ACTION.RADIUSSERVERREAD: {'type': 'bool',
+                                      'desc': _("User is allowed to read "
+                                                "RADIUS server definitions."),
+                                      'mainmenu': [MAIN_MENU.CONFIG],
+                                      'group': GROUP.SYSTEM},
         },
         SCOPE.ENROLL: {
             ACTION.MAXTOKENREALM: {

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1428,7 +1428,12 @@ def get_static_policy_definitions(scope=None):
             ACTION.RESOLVERREAD: {'type': 'bool',
                                    'desc': _("Admin is allowed to read resolvers."),
                                    'group': GROUP.SYSTEM,
-                                '   mainmenu': [MAIN_MENU.CONFIG]},
+                                   'mainmenu': [MAIN_MENU.CONFIG]},
+            ACTION.CACONNECTORREAD: {"type": "bool",
+                                     "desc": _("Admin is allowed to read the "
+                                               "CA Connector definitions."),
+                                     "group": GROUP.SYSTEM,
+                                     "mainmenu": [MAIN_MENU.CONFIG]},
             ACTION.CACONNECTORWRITE: {'type': 'bool',
                                       "desc": _("Admin is allowed to create new"
                                                 " CA Connector definitions "

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -287,6 +287,10 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
             // because the user might not be allowed to list RADIUS servers
             $scope.getRADIUSIdentifiers();
         }
+        if($scope.form.type == "certificate") {
+            // only load CA connectors when the user actually tries to enroll a certificate token
+            $scope.getCAConnectors();
+        }
         // preset twostep enrollment
         $scope.setTwostepEnrollmentDefault();
     };
@@ -513,7 +517,6 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
             //debug: console.log($scope.CAConnectors);
         });
     };
-    $scope.getCAConnectors();
 
     // If the user is admin, he can read the config.
     ConfigFactory.loadSystemConfig(function (data) {

--- a/tests/test_api_radiusserver.py
+++ b/tests/test_api_radiusserver.py
@@ -4,6 +4,8 @@ import json
 from . import radiusmock
 from privacyidea.lib.config import set_privacyidea_config
 from privacyidea.lib.radiusserver import delete_radius
+from privacyidea.lib.policy import set_policy, SCOPE, ACTION, delete_policy
+
 DICT_FILE = "tests/testdata/dictionary"
 
 
@@ -141,4 +143,33 @@ class RADIUSServerTestCase(MyApiTestCase):
             self.assertEqual(server1.get("dictionary"), "")
             self.assertEqual(server1.get("description"), "")
 
+        # define a USER policy: not allowed to read RADIUS Servers anymore
+        set_policy("pol_user", scope=SCOPE.USER, action=ACTION.AUDIT)
+        with self.app.test_request_context('/radiusserver/',
+                                           method='GET',
+                                           headers={'Authorization': self.at_user}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 403)
+            result = json.loads(res.data.decode('utf8')).get("result")
+            self.assertIn("radiusserver_read is not allowed", result['error']['message'])
+
+        # ... but we are allowed with a matching policy
+        set_policy("pol_radius", scope=SCOPE.USER, action=ACTION.RADIUSSERVERREAD)
+        with self.app.test_request_context('/radiusserver/',
+                                           method='GET',
+                                           headers={'Authorization': self.at_user}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            data = json.loads(res.data.decode('utf8'))
+            server_list = data.get("result").get("value")
+            self.assertEqual(len(server_list), 1)
+            # The user does not get any information about the server!
+            server1 = server_list.get("server1")
+            self.assertEqual(server1.get("port"), "")
+            self.assertEqual(server1.get("server"), "")
+            self.assertEqual(server1.get("dictionary"), "")
+            self.assertEqual(server1.get("description"), "")
+
+        delete_policy("pol_radius")
+        delete_policy("pol_user")
         delete_radius("server1")


### PR DESCRIPTION
This PR fixes #1749:
* reintroduces enforcing the ``caconnector_read`` policy action for admins and users
* adds the possibility to define ``caconnector_read``, ``privacyideaserver_read`` and ``radiusserver_read`` policies for users
* fixes the WebUI, such that CA connectors are only retrieved when the user tries to enroll a certificate token.

Open question:

Should we add the respective user policy to the policy migration script here? https://github.com/privacyidea/privacyidea/blob/master/migrations/versions/3d7f8b29cbb1_.py

I think it's not as urgent as with the admin policies in this case, as admins can simply add the respective ``_read`` policies by hand.