### PR TITLE
Fix broken ``active`` parameter in GET /policy/ endpoint

### DIFF
--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -49,7 +49,7 @@ from ..lib.policy import (set_policy,
                           enable_policy, get_policy_condition_sections, get_policy_condition_comparators)
 from ..lib.token import get_dynamic_policy_definitions
 from ..lib.error import (ParameterError)
-from privacyidea.lib.utils import to_unicode
+from privacyidea.lib.utils import to_unicode, is_true
 from ..api.lib.prepolicy import prepolicy, check_base_action
 
 from flask import (g,

--- a/tests/test_api_policy.py
+++ b/tests/test_api_policy.py
@@ -44,6 +44,18 @@ class APIPolicyTestCase(MyApiTestCase):
             self.assertEqual(pol1.get("check_all_resolvers"), True)
             self.assertEqual(pol1.get("priority"), 3)
 
+        # get active policies
+        with self.app.test_request_context('/policy/?active=true',
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            self.assertTrue(res.json['result']['status'], res.json)
+            self.assertEqual(len(value), 1)
+            pol1 = value[0]
+            self.assertEqual(pol1.get("check_all_resolvers"), True)
+            self.assertEqual(pol1.get("priority"), 3)
+
         # Update policy to check_all_resolvers = false and priority = 5
         with self.app.test_request_context('/policy/pol1',
                                            method='POST',


### PR DESCRIPTION
This fixes the ``active`` parameter to the endpoint which I accidentally broke in 5bfb2d7dc becuase I forgot to actually import ``is_true`` :-)

https://github.com/privacyidea/privacyidea/blob/eb02e4129b877bd5db927602419bba8857e9211b/privacyidea/api/policy.py#L283

Working on #1436