### PR TITLE
Add a policy to enforce setting an app PIN

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -548,16 +548,15 @@ def init_tokenlabel(request=None, action=None):
         request.all_data[ACTION.APPIMAGEURL] = list(imageurl_pols)[0]
 
     # check the force_app_pin policy
-    app_pin_pols = policy_object.match_policies(action='{0!s}_force_app_pin'.format(token_type),
+    app_pin_pols = policy_object.match_policies(action='{0!s}_{1!s}'.format(token_type,
+                                                                            ACTION.FORCE_APP_PIN),
                                                 scope=SCOPE.ENROLL,
                                                 user_object=user_object,
                                                 client=g.client_ip,
                                                 active=True,
                                                 audit_data=g.audit_object.audit_data)
     if app_pin_pols:
-        request.all_data["force_app_pin"] = True
-    else:
-        request.all_data["force_app_pin"] = False
+        request.all_data[ACTION.FORCE_APP_PIN] = True
 
     return True
 

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -234,6 +234,7 @@ class ACTION(object):
     EMAILCONFIG = "smtpconfig"
     ENABLE = "enable"
     ENCRYPTPIN = "encrypt_pin"
+    FORCE_APP_PIN = "force_app_pin"
     GETSERIAL = "getserial"
     GETRANDOM = "getrandom"
     IMPORT = "importtokens"

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -63,7 +63,7 @@ from privacyidea.lib.utils import (create_img, is_true, b32encode_and_unicode,
 from privacyidea.lib.policydecorators import challenge_response_allowed
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.auth import ROLE
-from privacyidea.lib.policy import SCOPE
+from privacyidea.lib.policy import SCOPE, ACTION
 from privacyidea.lib import _
 import traceback
 import logging
@@ -149,7 +149,7 @@ class HotpTokenClass(TokenClass):
                            'desc': _("The difficulty factor used for the OTP seed generation "
                                      "(should be at least 10000)")
                        },
-                       'hotp_force_app_pin': {
+                       'hotp_' + ACTION.FORCE_APP_PIN: {
                            'type': 'bool',
                            'desc': _('Enforce setting an app pin for the privacyIDEA '
                                      'Authenticator App')

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -148,6 +148,11 @@ class HotpTokenClass(TokenClass):
                            'type': 'int',
                            'desc': _("The difficulty factor used for the OTP seed generation "
                                      "(should be at least 10000)")
+                       },
+                       'hotp_force_app_pin': {
+                           'type': 'bool',
+                           'desc': _('Enforce setting an app pin for the privacyIDEA '
+                                     'Authenticator App')
                        }
                    },
                    SCOPE.USER: {
@@ -220,6 +225,9 @@ class HotpTokenClass(TokenClass):
         imageurl = params.get("appimageurl")
         if imageurl:
             extra_data.update({"image": imageurl})
+        force_app_pin = params.get('force_app_pin')
+        if force_app_pin:
+            extra_data.update({'pin': True})
         if otpkey:
             tok_type = self.type.lower()
             if user is not None:                               

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -156,7 +156,13 @@ class TotpTokenClass(HotpTokenClass):
                                                       "contributed by the server (in bytes)")},
                        '2step_difficulty': {'type': 'int',
                                             'desc': _("The difficulty factor used for the "
-                                                      "OTP seed generation ""(should be at least 10000)")}
+                                                      "OTP seed generation ""(should be at least "
+                                                      "10000)")},
+                       'totp_force_app_pin': {
+                           'type': 'bool',
+                           'desc': _('Enforce setting an app pin for the privacyIDEA '
+                                     'Authenticator App')
+                       }
                    }
                },
                }

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -158,7 +158,7 @@ class TotpTokenClass(HotpTokenClass):
                                             'desc': _("The difficulty factor used for the "
                                                       "OTP seed generation ""(should be at least "
                                                       "10000)")},
-                       'totp_force_app_pin': {
+                       'totp_' + ACTION.FORCE_APP_PIN: {
                            'type': 'bool',
                            'desc': _('Enforce setting an app pin for the privacyIDEA '
                                      'Authenticator App')

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -504,8 +504,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         g.policy_object = PolicyClass()
 
         # request, that matches the policy
-        req.all_data = {
-                        "user": "cornelius",
+        req.all_data = {"user": "cornelius",
                         "realm": "home"}
         init_tokenlabel(req)
 
@@ -513,9 +512,31 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         self.assertEqual(req.all_data.get("tokenlabel"), "<u>@<r>")
         # Check, if the tokenissuer was added
         self.assertEqual(req.all_data.get("tokenissuer"), "myPI")
+        # Check, if force_app_pin was added and set to False (since there is no policy)
+        self.assertFalse(req.all_data.get('force_app_pin'))
+
+        # reset the request data and start again with force_app_pin policy
+        set_policy(name="pol3",
+                   scope=SCOPE.ENROLL,
+                   action="hotp_force_app_pin=True")
+        req.all_data = {"user": "cornelius",
+                        "realm": "home"}
+        init_tokenlabel(req)
+        # Check, if force_app_pin was added and is True
+        self.assertTrue(req.all_data.get('force_app_pin'))
+
+        # Check that the force_app_pin policy isn't set for totp token
+        req.all_data = {"user": "cornelius",
+                        "realm": "home",
+                        "type": "TOTP"}
+        init_tokenlabel(req)
+        # Check, if force_app_pin was added and is False
+        self.assertFalse(req.all_data.get('force_app_pin'))
+
         # finally delete policy
         delete_policy("pol1")
         delete_policy("pol2")
+        delete_policy("pol3")
 
     def test_07_set_random_pin(self):
         g.logged_in_user = {"username": "admin1",

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -509,16 +509,16 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         init_tokenlabel(req)
 
         # Check, if the tokenlabel was added
-        self.assertEqual(req.all_data.get("tokenlabel"), "<u>@<r>")
+        self.assertEqual(req.all_data.get(ACTION.TOKENLABEL), "<u>@<r>")
         # Check, if the tokenissuer was added
-        self.assertEqual(req.all_data.get("tokenissuer"), "myPI")
-        # Check, if force_app_pin was added and set to False (since there is no policy)
-        self.assertFalse(req.all_data.get('force_app_pin'))
+        self.assertEqual(req.all_data.get(ACTION.TOKENISSUER), "myPI")
+        # Check, if force_app_pin wasn't added (since there is no policy)
+        self.assertNotIn(ACTION.FORCE_APP_PIN, req.all_data, req.all_data)
 
         # reset the request data and start again with force_app_pin policy
         set_policy(name="pol3",
                    scope=SCOPE.ENROLL,
-                   action="hotp_force_app_pin=True")
+                   action="hotp_{0!s}=True".format(ACTION.FORCE_APP_PIN))
         req.all_data = {"user": "cornelius",
                         "realm": "home"}
         init_tokenlabel(req)
@@ -530,8 +530,8 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
                         "realm": "home",
                         "type": "TOTP"}
         init_tokenlabel(req)
-        # Check, if force_app_pin was added and is False
-        self.assertFalse(req.all_data.get('force_app_pin'))
+        # Check, that force_app_pin wasn't added
+        self.assertNotIn(ACTION.FORCE_APP_PIN, req.all_data, req.all_data)
 
         # finally delete policy
         delete_policy("pol1")

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1733,8 +1733,8 @@ class APITokenTestCase(MyApiTestCase):
 
     def test_30_force_app_pin(self):
         set_policy("app_pin", scope=SCOPE.ENROLL,
-                   action={"hotp_force_app_pin": True,
-                           "totp_force_app_pin": True})
+                   action={"hotp_" + ACTION.FORCE_APP_PIN: True,
+                           "totp_" + ACTION.FORCE_APP_PIN: True})
         with self.app.test_request_context('/token/init',
                                            method='POST',
                                            data={"user": "cornelius",

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1731,6 +1731,31 @@ class APITokenTestCase(MyApiTestCase):
         remove_token("SETDESC01")
         remove_token("SETDESC02")
 
+    def test_30_force_app_pin(self):
+        set_policy("app_pin", scope=SCOPE.ENROLL,
+                   action={"hotp_force_app_pin": True,
+                           "totp_force_app_pin": True})
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"user": "cornelius",
+                                                 "genkey": "1",
+                                                 "realm": self.realm1,
+                                                 "serial": "goog2",
+                                                 "type": 'TOTP',
+                                                 "pin": "test"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json["result"]
+            detail = res.json["detail"]
+            self.assertTrue(result.get("status"))
+            self.assertTrue(result.get("value"))
+            self.assertTrue(u'pin=True' in detail.get("googleurl").get("value"),
+                            detail.get("googleurl"))
+
+        remove_token("goog2")
+        delete_policy('app_pin')
+
 
 class API00TokenPerformance(MyApiTestCase):
 


### PR DESCRIPTION
The privacyIDEA Authenticator App has the ability to enforce setting a PIN
for a token. With this policy the appropriate parameter can be set during
rollout of a TOTP/HOTP Token

Fixes #1295