### PR TITLE
Check if a given token belongs to a given user

### DIFF
--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -325,8 +325,7 @@ def check():
     if serial:
         if user:
             # check if the given token belongs to the user
-            token_list = get_tokens(user=user, serial=serial)
-            if not token_list:
+            if not get_tokens(user=user, serial=serial, count=True):
                 raise ParameterError('Given serial does not belong to given user!')
         if not otp_only:
             result, details = check_serial_pass(serial, password, options=options)

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -323,6 +323,11 @@ def check():
                         "realm": user.realm})
 
     if serial:
+        if user:
+            # check if the given token belongs to the user
+            token_list = get_tokens(user=user, serial=serial)
+            if not token_list:
+                raise ParameterError('Given serial does not belong to given user!')
         if not otp_only:
             result, details = check_serial_pass(serial, password, options=options)
         else:

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -2555,7 +2555,7 @@ class ValidateAPITestCase(MyApiTestCase):
                              result)
 
         # try to authenticate with a token assigned to a different user
-        token.add_user(User("nönäscii", self.realm1))
+        token.add_user(User(u"nönäscii", self.realm2))
         token.set_pin("pin")
         self.assertEqual(token.token.owners.first().user_id, "1116")
         with self.app.test_request_context('/validate/check',

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -2533,6 +2533,36 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(result.get("status"))
             self.assertFalse(result.get("value"))
 
+    def test_34_validate_user_and_serial(self):
+        # create a new token
+        db_token = Token(self.serials[1], tokentype="hotp")
+        db_token.update_otpkey(self.otpkey)
+        db_token.save()
+        token = HotpTokenClass(db_token)
+        self.assertEqual(token.token.serial, self.serials[1], token)
+        # try to authenticate a given user with a given unassigned token serial
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "cornelius",
+                                                 "realm": self.realm1,
+                                                 "serial": self.serials[1],
+                                                 "pass": OTPs[3]}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400, res)
+
+        # try to authenticate with a token assigned to a different user
+        token.add_user(User("nönäscii", self.realm1))
+        token.set_pin("pin")
+        self.assertEqual(token.token.owners.first().user_id, "1116")
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "cornelius",
+                                                 "realm": self.realm1,
+                                                 "serial": self.serials[1],
+                                                 "pass": OTPs[3]}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400, res)
+
 
 class RegistrationValidity(MyApiTestCase):
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -2549,6 +2549,10 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "pass": OTPs[3]}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 400, res)
+            result = res.json['result']
+            self.assertEqual(result['error']['message'],
+                             u"ERR905: Given serial does not belong to given user!",
+                             result)
 
         # try to authenticate with a token assigned to a different user
         token.add_user(User("nönäscii", self.realm1))
@@ -2561,6 +2565,10 @@ class ValidateAPITestCase(MyApiTestCase):
                                                  "serial": self.serials[1],
                                                  "pass": OTPs[3]}):
             res = self.app.full_dispatch_request()
+            result = res.json['result']
+            self.assertEqual(result['error']['message'],
+                             u"ERR905: Given serial does not belong to given user!",
+                             result)
             self.assertEqual(res.status_code, 400, res)
 
 


### PR DESCRIPTION
The validate/check endpoint could be used with a given user or a given
(token) serial. In case both were given, only the token was used for
authentication.

Fixes #1768