### PR TITLE
Add /system/names/{caconnector,radius} endpoints

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -94,7 +94,6 @@ def teardown_request(exc):
 @audit_blueprint.before_request
 @user_blueprint.before_request
 @system_blueprint.before_request
-@privacyideaserver_blueprint.before_request
 @user_required
 def before_user_request():
     before_request()
@@ -113,6 +112,7 @@ def before_user_request():
 @smsgateway_blueprint.before_request
 @radiusserver_blueprint.before_request
 @caconnector_blueprint.before_request
+@privacyideaserver_blueprint.before_request
 @client_blueprint.before_request
 @subscriptions_blueprint.before_request
 @monitoring_blueprint.before_request

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -93,9 +93,7 @@ def teardown_request(exc):
 @token_blueprint.before_request
 @audit_blueprint.before_request
 @user_blueprint.before_request
-@caconnector_blueprint.before_request
 @system_blueprint.before_request
-@radiusserver_blueprint.before_request
 @privacyideaserver_blueprint.before_request
 @user_required
 def before_user_request():
@@ -113,6 +111,8 @@ def before_user_request():
 @eventhandling_blueprint.before_request
 @periodictask_blueprint.before_request
 @smsgateway_blueprint.before_request
+@radiusserver_blueprint.before_request
+@caconnector_blueprint.before_request
 @client_blueprint.before_request
 @subscriptions_blueprint.before_request
 @monitoring_blueprint.before_request

--- a/privacyidea/api/caconnector.py
+++ b/privacyidea/api/caconnector.py
@@ -34,7 +34,6 @@ from privacyidea.lib.caconnector import (save_caconnector,
                                          get_caconnector_list)
 from ..api.lib.prepolicy import prepolicy, check_base_action
 from privacyidea.lib.policy import ACTION
-from .auth import admin_required
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +43,6 @@ caconnector_blueprint = Blueprint('caconnector_blueprint', __name__)
 
 @caconnector_blueprint.route('/<name>', methods=['GET'])
 @caconnector_blueprint.route('/', methods=['GET'])
-@admin_required
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.CACONNECTORREAD)
 def get_caconnector_api(name=None):
@@ -59,7 +57,6 @@ def get_caconnector_api(name=None):
 
 
 @caconnector_blueprint.route('/<name>', methods=['POST'])
-@admin_required
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.CACONNECTORWRITE)
 def save_caconnector_api(name=None):
@@ -75,7 +72,6 @@ def save_caconnector_api(name=None):
 
 
 @caconnector_blueprint.route('/<name>', methods=['DELETE'])
-@admin_required
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.CACONNECTORDELETE)
 def delete_caconnector_api(name=None):

--- a/privacyidea/api/caconnector.py
+++ b/privacyidea/api/caconnector.py
@@ -44,16 +44,16 @@ caconnector_blueprint = Blueprint('caconnector_blueprint', __name__)
 
 @caconnector_blueprint.route('/<name>', methods=['GET'])
 @caconnector_blueprint.route('/', methods=['GET'])
+@admin_required
 @log_with(log)
-#@prepolicy(check_base_action, request, ACTION.CACONNECTORREAD)
+@prepolicy(check_base_action, request, ACTION.CACONNECTORREAD)
 def get_caconnector_api(name=None):
     """
     returns a json list of the available CA connectors
     """
     g.audit_object.log({"detail": u"{0!s}".format(name)})
-    role = g.logged_in_user.get("role")
     res = get_caconnector_list(filter_caconnector_name=name,
-                               return_config=(role == "admin"))
+                               return_config=True)  # the endpoint is only accessed by admins
     g.audit_object.log({"success": True})
     return send_result(res)
 

--- a/privacyidea/api/privacyideaserver.py
+++ b/privacyidea/api/privacyideaserver.py
@@ -40,7 +40,6 @@ from privacyidea.lib.privacyideaserver import (add_privacyideaserver,
                                                delete_privacyideaserver,
                                                get_privacyideaservers)
 from privacyidea.models import PrivacyIDEAServer as PrivacyIDEAServerDB
-from privacyidea.api.auth import admin_required
 
 
 log = logging.getLogger(__name__)
@@ -49,7 +48,6 @@ privacyideaserver_blueprint = Blueprint('privacyideaserver_blueprint', __name__)
 
 
 @privacyideaserver_blueprint.route('/<identifier>', methods=['POST'])
-@admin_required
 @prepolicy(check_base_action, request, ACTION.PRIVACYIDEASERVERWRITE)
 @log_with(log)
 def create(identifier=None):
@@ -101,7 +99,6 @@ def list_privacyidea():
 
 
 @privacyideaserver_blueprint.route('/<identifier>', methods=['DELETE'])
-@admin_required
 @prepolicy(check_base_action, request, ACTION.PRIVACYIDEASERVERWRITE)
 @log_with(log)
 def delete_server(identifier=None):
@@ -118,7 +115,6 @@ def delete_server(identifier=None):
 
 
 @privacyideaserver_blueprint.route('/test_request', methods=['POST'])
-@admin_required
 @prepolicy(check_base_action, request, ACTION.PRIVACYIDEASERVERWRITE)
 @log_with(log)
 def test():

--- a/privacyidea/api/radiusserver.py
+++ b/privacyidea/api/radiusserver.py
@@ -38,7 +38,6 @@ import logging
 from privacyidea.lib.radiusserver import (add_radius, RADIUSServer,
                                           delete_radius, get_radiusservers, test_radius)
 from privacyidea.models import RADIUSServer as RADIUSServerDB
-from privacyidea.api.auth import admin_required
 
 
 log = logging.getLogger(__name__)
@@ -47,7 +46,6 @@ radiusserver_blueprint = Blueprint('radiusserver_blueprint', __name__)
 
 
 @radiusserver_blueprint.route('/<identifier>', methods=['POST'])
-@admin_required
 @prepolicy(check_base_action, request, ACTION.RADIUSSERVERWRITE)
 @log_with(log)
 def create(identifier=None):
@@ -82,7 +80,6 @@ def create(identifier=None):
 
 @radiusserver_blueprint.route('/', methods=['GET'])
 @log_with(log)
-@admin_required
 @prepolicy(check_base_action, request, ACTION.RADIUSSERVERREAD)
 def list_radius():
     """
@@ -104,7 +101,6 @@ def list_radius():
 
 
 @radiusserver_blueprint.route('/<identifier>', methods=['DELETE'])
-@admin_required
 @prepolicy(check_base_action, request, ACTION.RADIUSSERVERWRITE)
 @log_with(log)
 def delete_server(identifier=None):
@@ -121,7 +117,6 @@ def delete_server(identifier=None):
 
 
 @radiusserver_blueprint.route('/test_request', methods=['POST'])
-@admin_required
 @prepolicy(check_base_action, request, ACTION.RADIUSSERVERWRITE)
 @log_with(log)
 def test():

--- a/privacyidea/api/radiusserver.py
+++ b/privacyidea/api/radiusserver.py
@@ -82,6 +82,7 @@ def create(identifier=None):
 
 @radiusserver_blueprint.route('/', methods=['GET'])
 @log_with(log)
+@admin_required
 @prepolicy(check_base_action, request, ACTION.RADIUSSERVERREAD)
 def list_radius():
     """
@@ -91,23 +92,13 @@ def list_radius():
     server_list = get_radiusservers()
     for server in server_list:
         # We do not add the secret!
-        if g.logged_in_user.get("role") == "admin":
-            res[server.config.identifier] = {"server": server.config.server,
-                                             "port": server.config.port,
-                                             "dictionary": server.config.dictionary,
-                                             "description":
-                                                 server.config.description,
-                                             "timeout": server.config.timeout,
-                                             "retries": server.config.retries}
-        else:
-            # We do not pass any information to a normal user!
-            res[server.config.identifier] = {"server": "",
-                                             "port": "",
-                                             "dictionary": "",
-                                             "description": "",
-                                             "timeout": 0,
-                                             "retries": 0}
-
+        res[server.config.identifier] = {"server": server.config.server,
+                                         "port": server.config.port,
+                                         "dictionary": server.config.dictionary,
+                                         "description":
+                                             server.config.description,
+                                         "timeout": server.config.timeout,
+                                         "retries": server.config.retries}
     g.audit_object.log({'success': True})
     return send_result(res)
 

--- a/privacyidea/api/system.py
+++ b/privacyidea/api/system.py
@@ -52,6 +52,8 @@ from .lib.utils import (getParam,
                         required,
                         send_result)
 from ..lib.log import log_with
+from ..lib.radiusserver import get_radiusservers
+from ..lib.caconnector import get_caconnector_list
 from ..lib.config import (get_token_class,
                           set_privacyidea_config,
                           delete_privacyidea_config,
@@ -353,3 +355,30 @@ def test(tokentype=None):
     g.audit_object.log({"success": 1,
                         "tokentype": tokentype})
     return send_result(res, details={"message": description})
+
+
+@system_blueprint.route('/names/radius', methods=['GET'])
+@prepolicy(check_base_action, request, action="enrollRADIUS")
+def list_radius_servers():
+    """
+    Return the list of identifiers of all defined RADIUS servers.
+    This endpoint requires the enrollRADIUS right.
+    """
+    server_list = get_radiusservers()
+    res = [server.config.identifier for server in server_list]
+    g.audit_object.log({'success': True})
+    return send_result(res)
+
+
+@system_blueprint.route('/names/caconnector', methods=['GET'])
+@prepolicy(check_base_action, request, action="enrollCERTIFICATE")
+def list_ca_connectors():
+    """
+    Return a list of defined CA connectors. Each item of the list is
+    a dictionary with the CA connector information, including the
+    name and defined templates, but excluding the CA connector data.
+    This endpoint requires the enrollCERTIFICATE right.
+    """
+    ca_list = get_caconnector_list(return_config=False)
+    g.audit_object.log({"success": True})
+    return send_result(ca_list)

--- a/privacyidea/lib/caconnector.py
+++ b/privacyidea/lib/caconnector.py
@@ -149,13 +149,15 @@ def get_caconnector_list(filter_caconnector_type=None,
              "type": conn.catype}
         # Add the connector configuration
         data = {}
+        for conf in conn.caconfig:
+            value = conf.Value
+            if conf.Type == "password":
+                value = decryptPassword(value)
+            data[conf.Key] = value
         if return_config:
-            for conf in conn.caconfig:
-                value = conf.Value
-                if conf.Type == "password":
-                    value = decryptPassword(value)
-                data[conf.Key] = value
-        c["data"] = data
+            c["data"] = data
+        else:
+            c["data"] = {}
 
         # Also add templates
         c_obj_class = get_caconnector_class(conn.catype)
@@ -164,7 +166,7 @@ def get_caconnector_list(filter_caconnector_type=None,
                 "unknown CA connector class {0!s} ".format(conn.name))
         else:
             # create the resolver instance and load the config
-            c_obj = c_obj_class(conn.name, c.get("data"))
+            c_obj = c_obj_class(conn.name, data)
             if c_obj:
                 c["templates"] = templates = c_obj.get_templates()
 

--- a/privacyidea/static/components/config/factories/config.js
+++ b/privacyidea/static/components/config/factories/config.js
@@ -290,6 +290,11 @@ myApp.factory("ConfigFactory", function (AuthFactory, $http, $state, $rootScope,
             }).success(callback
             ).error(AuthFactory.authError);
         },
+        getCAConnectorNames: function (callback) {
+            $http.get(systemUrl + "/names/caconnector", {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken()}
+            }).success(callback).error(AuthFactory.authError);
+        },
         getCAConnector: function (connectorname, callback) {
             $http.get(CAConnectorUrl + "/" + connectorname, {
                 headers: {'PI-Authorization': AuthFactory.getAuthToken()}
@@ -451,6 +456,12 @@ myApp.factory("ConfigFactory", function (AuthFactory, $http, $state, $rootScope,
         getRadius: function(callback, identifier) {
             if (!identifier) {identifier = "";}
             $http.get(radiusServerUrl + "/" + identifier, {
+                headers: {'PI-Authorization': AuthFactory.getAuthToken(),
+                          'Content-Type': 'application/json'}
+            }).success(callback).error(AuthFactory.authError);
+        },
+        getRadiusNames: function(callback) {
+            $http.get(systemUrl + "/names/radius", {
                 headers: {'PI-Authorization': AuthFactory.getAuthToken(),
                           'Content-Type': 'application/json'}
             }).success(callback).error(AuthFactory.authError);

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -287,6 +287,9 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
             // because the user might not be allowed to list RADIUS servers
             $scope.getRADIUSIdentifiers();
         }
+        if ($scope.form.type === "certificate") {
+            $scope.getCAConnectors();
+        }
         // preset twostep enrollment
         $scope.setTwostepEnrollmentDefault();
     };
@@ -496,14 +499,14 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
 
     // get the list of configured RADIUS server identifiers
     $scope.getRADIUSIdentifiers = function() {
-        ConfigFactory.getRadius(function(data){
+        ConfigFactory.getRadiusNames(function(data){
             $scope.radiusIdentifiers = data.result.value;
         });
     };
 
     // get the list of configured CA connectors
     $scope.getCAConnectors = function () {
-        ConfigFactory.getCAConnectors(function (data){
+        ConfigFactory.getCAConnectorNames(function (data){
             var CAConnectors = data.result.value;
             angular.forEach(CAConnectors, function(value, key){
                 $scope.CAConnectors.push(value.connectorname);
@@ -513,7 +516,6 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
             //debug: console.log($scope.CAConnectors);
         });
     };
-    $scope.getCAConnectors();
 
     // If the user is admin, he can read the config.
     ConfigFactory.loadSystemConfig(function (data) {

--- a/privacyidea/static/components/token/views/token.enroll.radius.html
+++ b/privacyidea/static/components/token/views/token.enroll.radius.html
@@ -37,8 +37,7 @@
     <select class="form-control"
             ng-model="form['radius.identifier']"
             name="identifier"
-            ng-options="identifier as identifier for (identifier, config) in
-            radiusIdentifiers">
+            ng-options="identifier for identifier in radiusIdentifiers">
     </select>
 
 <div class="form-group">

--- a/tests/test_api_caconnector.py
+++ b/tests/test_api_caconnector.py
@@ -111,17 +111,15 @@ class CAConnectorTestCase(MyApiTestCase):
             self.assertTrue(role == "user", result)
             self.assertEqual(result.get("value").get("realm"), "realm1")
 
+        # Only admins are allowed to access the /caconnector/ endpoints
         with self.app.test_request_context('/caconnector/',
                                            data={},
                                            method='GET',
                                            headers={'Authorization': at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEquals(res.status_code, 401)
             result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertTrue(result["status"] is True, result)
-            value = result["value"]
-            self.assertEqual(len(value), 2)
-            self.assertEqual(value[0].get("data"), {})
+            self.assertIn("do not have the necessary role", result["error"]["message"])
 
     def test_06_delete_caconnector(self):
         with self.app.test_request_context('/caconnector/con1',

--- a/tests/test_api_privacyideaserver.py
+++ b/tests/test_api_privacyideaserver.py
@@ -45,6 +45,15 @@ class PrivacyIDEAServerTestCase(MyApiTestCase):
             self.assertEqual(server1.get("url"), "https://pi")
             self.assertEqual(server1.get("description"), "myServer")
 
+        # Listing privacyIDEA servers as a user is not allowed
+        self.setUp_user_realms()
+        self.authenticate_selfservice_user()
+        with self.app.test_request_context('/privacyideaserver/',
+                                           method='GET',
+                                           headers={'Authorization': self.at_user}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 401)
+
         # delete server
         with self.app.test_request_context('/privacyideaserver/server1',
                                            method='DELETE',

--- a/tests/test_api_radiusserver.py
+++ b/tests/test_api_radiusserver.py
@@ -125,20 +125,13 @@ class RADIUSServerTestCase(MyApiTestCase):
             data = json.loads(res.data.decode('utf8'))
             self.assertEqual(data.get("result").get("value"), True)
 
-        # User is allowed to list the radius servers
+        # Users are not allowed to list the radius servers
         with self.app.test_request_context('/radiusserver/',
                                            method='GET',
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
-            data = json.loads(res.data.decode('utf8'))
-            server_list = data.get("result").get("value")
-            self.assertEqual(len(server_list), 1)
-            # The user does not get any information about the server!
-            server1 = server_list.get("server1")
-            self.assertEqual(server1.get("port"), "")
-            self.assertEqual(server1.get("server"), "")
-            self.assertEqual(server1.get("dictionary"), "")
-            self.assertEqual(server1.get("description"), "")
+            self.assertEquals(res.status_code, 401)
+            result = json.loads(res.data.decode('utf8')).get("result")
+            self.assertIn("do not have the necessary role", result["error"]["message"])
 
         delete_radius("server1")


### PR DESCRIPTION
This PR adds endpoints ``/system/names/{caconnector,radius}`` which are accessible for users and admins with the respective ``enrollCERTIFICATE``/``enrollRADIUS`` rights. These are now used to retrieve the CA connectors and RADIUS servers during enrollment of CERTIFICATE and RADIUS tokens.

As a consequence, the ``/radius/`` and ``/caconnector/`` endpoints are not accessible for users anymore.

Likewise, the ``/privacyideaserver/`` endpoints are not accessible to users anymore, because REMOTE tokens cannot be enrolled by users anyway.

This PR also fixes the enrollment of CERTIFICATE tokens: Without this PR, users cannot choose a certificate template.

Closes #1749 