### PR TITLE
Allow "-" and " " in policy names

### DIFF
--- a/doc/policies/index.rst
+++ b/doc/policies/index.rst
@@ -46,7 +46,7 @@ Each policy can contain the following attributes:
   the policy is overwritten.
 
   .. note:: In the web UI and the API policies can only be created
-     with the characters 0-9, a-z, A-Z, "_" and ".".
+     with the characters 0-9, a-z, A-Z, "_", "-", " " and ".".
      On a library level or during migration scripts policies with
      other characters could be created.
 

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -34,6 +34,7 @@ import json
 import jwt
 import threading
 import six
+import re
 from flask import (jsonify,
                    current_app)
 
@@ -267,3 +268,18 @@ def verify_auth_token(auth_token, required_role=None):
                         "this resource!").format(required_role),
                         id=ERROR.AUTHENTICATE_MISSING_RIGHT)
     return r
+
+
+def check_policy_name(name):
+    """
+    This function checks, if the given name is a valid policy name.
+
+    :param name: The name of the policy
+    :return: Raises a ParameterError in case of an invalid name
+    """
+    if not re.match('^[a-zA-Z0-9_.\- ]*$', name):
+        raise ParameterError(_("The name of the policy may only contain "
+                               "the characters a-zA-Z0-9_.- "))
+
+    if name.lower() == "check":
+        raise ParameterError(_("T'check' is an invalid policy name."))

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -277,9 +277,14 @@ def check_policy_name(name):
     :param name: The name of the policy
     :return: Raises a ParameterError in case of an invalid name
     """
+    disallowed_patterns = [("^check$", re.IGNORECASE),
+                           ("^pi-update-policy-", re.IGNORECASE)]
+    for disallowed_pattern in disallowed_patterns:
+        if re.search(disallowed_pattern[0], name, flags=disallowed_pattern[1]):
+            raise ParameterError(_(u"'{0!s}' is an invalid policy name.").format(name))
+
     if not re.match('^[a-zA-Z0-9_.\- ]*$', name):
         raise ParameterError(_("The name of the policy may only contain "
                                "the characters a-zA-Z0-9_.- "))
 
-    if name.lower() == "check":
-        raise ParameterError(_("T'check' is an invalid policy name."))
+

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -40,7 +40,8 @@ from .lib.utils import (getParam,
                         getLowerParams,
                         optional,
                         required,
-                        send_result)
+                        send_result,
+                        check_policy_name)
 from ..lib.log import log_with
 from ..lib.policy import (set_policy,
                           PolicyClass, ACTION,
@@ -175,12 +176,7 @@ def set_policy_api(name=None):
     """
     res = {}
     param = request.all_data
-    if not re.match('^[a-zA-Z0-9_.]*$', name):
-        raise ParameterError(_("The name of the policy may only contain "
-                               "the characters a-zA-Z0-9_."))
-
-    if name.lower() == "check":
-        raise ParameterError(_("T'check' is an invalid policy name."))
+    check_policy_name(name)
 
     action = getParam(param, "action", required)
     scope = getParam(param, "scope", required)

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -4,7 +4,7 @@ This tests the file api.lib.utils
 """
 from .base import MyApiTestCase
 
-from privacyidea.api.lib.utils import (getParam)
+from privacyidea.api.lib.utils import (getParam, check_policy_name)
 from privacyidea.lib.error import ParameterError
 
 
@@ -25,3 +25,11 @@ class UtilsTestCase(MyApiTestCase):
 
         v = getParam({}, "sslverify", allowed_values=["0", "1"], default="1")
         self.assertEqual("1", v)
+
+    def test_02_check_policy_name(self):
+        check_policy_name("This is a new valid Name")
+        check_policy_name("THis-is-a-valid-Name")
+        # The name "check" is reserved
+        self.assertNotEqual(ParameterError, check_policy_name, "check")
+        # This is an invalid name
+        self.assertNotEqual(ParameterError, check_policy_name, "~invalid name")

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -30,13 +30,13 @@ class UtilsTestCase(MyApiTestCase):
         check_policy_name("This is a new valid Name")
         check_policy_name("THis-is-a-valid-Name")
         # The name "check" is reserved
-        self.assertNotEqual(ParameterError, check_policy_name, "check")
+        self.assertRaises(ParameterError, check_policy_name, "check")
         # This is an invalid name
-        self.assertNotEqual(ParameterError, check_policy_name, "~invalid name")
+        self.assertRaises(ParameterError, check_policy_name, "~invalid name")
 
         # some disallowed patterns:
-        self.assertNotEqual(ParameterError, check_policy_name, "Check")
-        self.assertNotEqual(ParameterError, check_policy_name, "pi-update-policy-something")
+        self.assertRaises(ParameterError, check_policy_name, "Check")
+        self.assertRaises(ParameterError, check_policy_name, "pi-update-policy-something")
         # Some patterns that work
         check_policy_name("check this out.")
         check_policy_name("my own pi-update-policy-something")

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -33,3 +33,12 @@ class UtilsTestCase(MyApiTestCase):
         self.assertNotEqual(ParameterError, check_policy_name, "check")
         # This is an invalid name
         self.assertNotEqual(ParameterError, check_policy_name, "~invalid name")
+
+        # some disallowed patterns:
+        self.assertNotEqual(ParameterError, check_policy_name, "Check")
+        self.assertNotEqual(ParameterError, check_policy_name, "pi-update-policy-something")
+        # Some patterns that work
+        check_policy_name("check this out.")
+        check_policy_name("my own pi-update-policy-something")
+        check_policy_name("pi-update-policysomething")
+


### PR DESCRIPTION
I personally find it easier to use these two characters in
policy names.

Closes #1813