### PR TITLE
Only re-read event handler definitions if the configuration has changed

### DIFF
--- a/privacyidea/lib/event.py
+++ b/privacyidea/lib/event.py
@@ -22,9 +22,9 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
+from privacyidea.lib.config import get_config_object
 from privacyidea.lib.utils import fetch_one_resource
 from privacyidea.models import EventHandler, EventHandlerOption, db
-from privacyidea.lib.error import ParameterError
 from privacyidea.lib.audit import getAudit
 import functools
 import logging
@@ -244,17 +244,19 @@ def delete_event(event_id):
 class EventConfiguration(object):
     """
     This class is supposed to contain the event handling configuration during
-    the Request. It can be read initially (in the init method) an can be
-    accessed later during the request.
+    the Request.
+    The currently defined events are fetched from the request-local config object.
     """
 
     def __init__(self):
-        self.eventlist = []
-        self._read_events()
+        pass
 
     @property
     def events(self):
-        return self.eventlist
+        """
+        Shortcut for retrieving the currently defined event handlers from the request-local config object.
+        """
+        return get_config_object().events
 
     def get_handled_events(self, eventname, position="post"):
         """
@@ -265,7 +267,7 @@ class EventConfiguration(object):
         :param position: the position of the event definition
         :return:
         """
-        eventlist = [e for e in self.eventlist if (
+        eventlist = [e for e in self.events if (
             eventname in e.get("event") and e.get("active") and e.get("position") == position)]
         return eventlist
 
@@ -280,13 +282,7 @@ class EventConfiguration(object):
         """
         if eventid is not None:
             eventid = int(eventid)
-            eventlist = [e for e in self.eventlist if e.get("id") == eventid]
+            eventlist = [e for e in self.events if e.get("id") == eventid]
             return eventlist
         else:
-            return self.eventlist
-
-    def _read_events(self):
-        q = EventHandler.query.order_by(EventHandler.ordering)
-        for e in q:
-            self.eventlist.append(e.get())
-
+            return self.events

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -1759,7 +1759,6 @@ class EventHandler(MethodsMixin, db.Model):
         if self.id is None:
             # create a new one
             db.session.add(self)
-            db.session.commit()
         else:
             # update
             EventHandler.query.filter_by(id=self.id).update({
@@ -1772,7 +1771,8 @@ class EventHandler(MethodsMixin, db.Model):
                 "condition": self.condition,
                 "action": self.action
             })
-            db.session.commit()
+        save_config_timestamp()
+        db.session.commit()
         return self.id
 
     def delete(self):
@@ -1786,6 +1786,7 @@ class EventHandler(MethodsMixin, db.Model):
         db.session.query(EventHandlerCondition) \
             .filter(EventHandlerCondition.eventhandler_id == ret) \
             .delete()
+        save_config_timestamp()
         db.session.commit()
         return ret
 


### PR DESCRIPTION
This is achieved by storing the currently defined event handlers in the
shared config object.

Fixes #1823