### PR TITLE
Fix looping over all tokens when using pre-evens

### DIFF
--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -337,10 +337,13 @@ class BaseEventHandler(object):
         if serial:
             # We have determined the serial number from the request.
             token_obj_list = get_tokens(serial=serial)
-        else:
+        elif user:
             # We have to determine the token via the user object. But only if
             #  the user has only one token
             token_obj_list = get_tokens(user=user)
+        else:
+            token_obj_list = []
+
         if len(token_obj_list) == 1:
             # There is a token involved, so we determine it's resolvers and realms
             token_obj = token_obj_list[0]


### PR DESCRIPTION
When a pre-event handler is specified, we need to check if a token is
involved, either by checking for a serial or a user. But if no user was
given, `get_tokens()` returned all tokens, which could slow down the
request significantly if there were a lot of tokens.
By checking for a user before issuing `get_tokens()`, the response time
could be decreased by a magnitude in a setup with 14k Tokens.
Fixes #1686