### PR TITLE
Store clientapplication "last seen" info per privacyIDEA node

### DIFF
--- a/migrations/versions/0c7123345224_.py
+++ b/migrations/versions/0c7123345224_.py
@@ -1,0 +1,38 @@
+"""Store privacyIDEA node in clientapplication table
+
+Revision ID: 0c7123345224
+Revises: d756b34061ff
+Create Date: 2019-09-06 13:27:12.020779
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0c7123345224'
+down_revision = 'd756b34061ff'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm
+
+from privacyidea.lib.config import get_privacyidea_node
+
+
+def upgrade():
+    node = get_privacyidea_node()
+    try:
+        # The ``node`` field is not nullable. Hence, We set the server_default to the current node to ensure that
+        # the ``node`` of all existing rows is set to the current node.
+        op.add_column('clientapplication', sa.Column('node', sa.Unicode(length=255),
+                                                     nullable=False, server_default=node))
+        op.drop_constraint(u'caix', 'clientapplication', type_='unique')
+        op.create_unique_constraint('caix', 'clientapplication', ['ip', 'clienttype', 'node'])
+    except Exception as exx:
+        print("Failed to add 'node' column to 'clientapplication' table")
+        print(exx)
+
+
+def downgrade():
+    op.drop_constraint('caix', 'clientapplication', type_='unique')
+    op.create_unique_constraint(u'caix', 'clientapplication', ['ip', 'clienttype'])
+    # This will probably raise errors about violated UNIQUE constraints
+    op.drop_column('clientapplication', 'node')

--- a/migrations/versions/d756b34061ff_.py
+++ b/migrations/versions/d756b34061ff_.py
@@ -52,7 +52,8 @@ def create_seq(seq):
 
 
 def upgrade():
-
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
     try:
         # Step 1: Create sequence on Postgres
         seq = sa.Sequence('eventcounter_seq')
@@ -71,8 +72,6 @@ def upgrade():
                         )
         # Step 3: Migrate data from eventcounter to eventcounter_new
         node = get_privacyidea_node()
-        bind = op.get_bind()
-        session = orm.Session(bind=bind)
         for old_ctr in session.query(OldEventCounter).all():
             new_ctr = NewEventCounter(counter_name=old_ctr.counter_name,
                                       counter_value=old_ctr.counter_value,

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2405,35 +2405,33 @@ class ClientApplication(MethodsMixin, db.Model):
     hostname = db.Column(db.Unicode(255))
     clienttype = db.Column(db.Unicode(255), nullable=False, index=True)
     lastseen = db.Column(db.DateTime)
+    node = db.Column(db.Unicode(255), nullable=False)
     __table_args__ = (db.UniqueConstraint('ip',
                                           'clienttype',
+                                          'node',
                                           name='caix'),
                       {'mysql_row_format': 'DYNAMIC'})
 
     def save(self):
         clientapp = ClientApplication.query.filter(
             ClientApplication.ip == self.ip,
-            ClientApplication.clienttype == self.clienttype).first()
+            ClientApplication.clienttype == self.clienttype,
+            ClientApplication.node == self.node).first()
         self.lastseen = datetime.now()
         if clientapp is None:
             # create a new one
             db.session.add(self)
-            db.session.commit()
-            ret = self.id
         else:
             # update
             values = {"lastseen": self.lastseen}
             if self.hostname is not None:
                 values["hostname"] = self.hostname
-            ClientApplication.query.filter(
-                ClientApplication.id == clientapp.id).update(values)
-            ret = clientapp.id
+            ClientApplication.query.filter(ClientApplication.id == clientapp.id).update(values)
         db.session.commit()
-        return ret
 
     def __repr__(self):
-        return "<ClientApplication [{0!s}][{1!s}:{2!s}]>".format(
-            self.id, self.ip, self.clienttype)
+        return "<ClientApplication [{0!s}][{1!s}:{2!s}] on {3!s}>".format(
+            self.id, self.ip, self.clienttype, self.node)
 
 
 class Subscription(MethodsMixin, db.Model):

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -667,6 +667,8 @@ class TokenModelTestCase(MyTestCase):
         self.assertEqual(c.clienttype, "PAM")
         t1 = c.lastseen
 
+        self.assertIn("localnode", repr(c))
+
         ClientApplication(ip="1.2.3.4", hostname="host1",
                           clienttype="PAM", node="localnode").save()
         c = ClientApplication.query.filter(ClientApplication.ip == "1.2.3.4").first()

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -659,21 +659,21 @@ class TokenModelTestCase(MyTestCase):
         gw.delete()
 
     def test_21_add_update_delete_clientapp(self):
-        cid = ClientApplication(ip="1.2.3.4", hostname="host1",
-                                clienttype="PAM").save()
-        c = ClientApplication.query.filter(ClientApplication.id == cid).first()
+        ClientApplication(ip="1.2.3.4", hostname="host1",
+                          clienttype="PAM", node="localnode").save()
+        c = ClientApplication.query.filter(ClientApplication.ip == "1.2.3.4").first()
         self.assertEqual(c.hostname, "host1")
         self.assertEqual(c.ip, "1.2.3.4")
         self.assertEqual(c.clienttype, "PAM")
         t1 = c.lastseen
 
-        cid = ClientApplication(ip="1.2.3.4", hostname="host1",
-                              clienttype="PAM").save()
-        c = ClientApplication.query.filter(ClientApplication.id == cid).first()
+        ClientApplication(ip="1.2.3.4", hostname="host1",
+                          clienttype="PAM", node="localnode").save()
+        c = ClientApplication.query.filter(ClientApplication.ip == "1.2.3.4").first()
         self.assertTrue(c.lastseen > t1)
 
-        ClientApplication.query.filter(ClientApplication.id == cid).delete()
-        c = ClientApplication.query.filter(ClientApplication.id == cid).first()
+        ClientApplication.query.filter(ClientApplication.id == c.id).delete()
+        c = ClientApplication.query.filter(ClientApplication.ip == "1.2.3.4").first()
         self.assertEqual(c, None)
 
     def test_22_subscription(self):

--- a/tests/test_lib_clientapplication.py
+++ b/tests/test_lib_clientapplication.py
@@ -1,8 +1,12 @@
 """
 This test file tests the lib.clientapplicaton.py
 """
+import mock
+from datetime import datetime, timedelta
+from contextlib import contextmanager
+
+from privacyidea.models import ClientApplication
 from .base import MyTestCase
-from datetime import datetime
 from privacyidea.lib.clientapplication import (get_clientapplication,
                                                save_clientapplication)
 
@@ -38,3 +42,86 @@ class ClientApplicationTestCase(MyTestCase):
         self.assertEqual(r["PAM"][0]["ip"], "1.2.3.4")
         self.assertTrue(r["RADIUS"][0]["lastseen"] < datetime.now())
         self.assertTrue(r["SAML"][0]["lastseen"] < datetime.now())
+
+    def test_02_multiple_nodes(self):
+        @contextmanager
+        def _set_node(node):
+            """ context manager that sets the current node name """
+            with mock.patch("privacyidea.lib.clientapplication.get_privacyidea_node") as mock_node:
+                mock_node.return_value = node
+                yield
+
+        @contextmanager
+        def _fake_time(t):
+            """ context manager that fakes the current time that is written to the ``lastseen`` column """
+            with mock.patch("privacyidea.models.datetime") as mock_dt:
+                mock_dt.now.return_value = t
+                yield
+
+        # remove all rows first
+        ClientApplication.query.delete()
+
+        # create some fake timestamps
+        t1 = datetime.now()
+        t2 = t1 + timedelta(minutes=5)
+        t3 = t2 + timedelta(minutes=5)
+
+        with _fake_time(t1):
+            with _set_node("pinode1"):
+                save_clientapplication("1.2.3.4", "PAM")
+            with _set_node("pinode2"):
+                save_clientapplication("1.2.3.4", "RADIUS")
+                save_clientapplication("2.3.4.5", "PAM")
+
+        # check that the rows are written correctly
+        row1 = ClientApplication.query.filter_by(ip="1.2.3.4", clienttype="PAM").one()
+        self.assertEqual(row1.lastseen, t1)
+        self.assertEqual(row1.node, "pinode1")
+        row2 = ClientApplication.query.filter_by(ip="1.2.3.4", clienttype="RADIUS").one()
+        self.assertEqual(row2.lastseen, t1)
+        self.assertEqual(row2.node, "pinode2")
+        row3 = ClientApplication.query.filter_by(ip="2.3.4.5", clienttype="PAM").one()
+        self.assertEqual(row3.lastseen, t1)
+        self.assertEqual(row3.node, "pinode2")
+
+        # check that the apps are returned correctly
+        apps = get_clientapplication(clienttype="PAM")
+        self.assertEqual(list(apps.keys()), ["PAM"])
+        self.assertEqual(len(apps["PAM"]), 2)
+        self.assertIn({"ip": "1.2.3.4", "hostname": None, "lastseen": t1}, apps["PAM"])
+        self.assertIn({"ip": "2.3.4.5", "hostname": None, "lastseen": t1}, apps["PAM"])
+
+        with _fake_time(t2):
+            with _set_node("pinode1"):
+                save_clientapplication("1.2.3.4", "RADIUS")
+            with _set_node("pinode2"):
+                save_clientapplication("1.2.3.4", "PAM")
+
+        # check that the rows are written correctly
+        # 1.2.3.4 + PAM was last seen on pinode1 at t1 ...
+        row1 = ClientApplication.query.filter_by(ip="1.2.3.4", clienttype="PAM", node="pinode1").one()
+        self.assertEqual(row1.lastseen, t1)
+        # but on pinode2, it was t2!
+        row2 = ClientApplication.query.filter_by(ip="1.2.3.4", clienttype="PAM", node="pinode2").one()
+        self.assertEqual(row2.lastseen, t2)
+        # 1.2.3.4 + RADIUS was last seen on pinode1 at t2 ...
+        row3 = ClientApplication.query.filter_by(ip="1.2.3.4", clienttype="RADIUS", node="pinode1").one()
+        self.assertEqual(row3.lastseen, t2)
+        # ... but on pinode2, it was t1!
+        row4 = ClientApplication.query.filter_by(ip="1.2.3.4", clienttype="RADIUS", node="pinode2").one()
+        self.assertEqual(row4.lastseen, t1)
+
+        # check that the apps are returned correctly
+        apps = get_clientapplication(ip="1.2.3.4")
+        self.assertEqual(set(apps.keys()), {"PAM", "RADIUS"})
+        self.assertEqual(apps["PAM"], [{"ip": "1.2.3.4", "hostname": None, "lastseen": t2}])
+        self.assertEqual(apps["RADIUS"], [{"ip": "1.2.3.4", "hostname": None, "lastseen": t2}])
+
+        apps = get_clientapplication(group_by="ip")
+        self.assertEqual(set(apps.keys()), {"1.2.3.4", "2.3.4.5"})
+        self.assertEqual(len(apps["1.2.3.4"]), 2)
+        self.assertIn({"clienttype": "PAM", "hostname": None, "lastseen": t2}, apps["1.2.3.4"])
+        self.assertIn({"clienttype": "RADIUS", "hostname": None, "lastseen": t2}, apps["1.2.3.4"])
+        self.assertEqual(apps["2.3.4.5"], [{"clienttype": "PAM", "hostname": None, "lastseen": t1}])
+
+


### PR DESCRIPTION
This also adds a corresponding migration script and tests and reduces the number of deadlocks to zero in the setup mentioned in #1819.

The migration script has two disadvantages:
* It doesn't work on SQLite, because it doesn't allow removing constraints
* Downgrading probably doesn't work, because removing the ``node`` field may violate UNIQUE constraints. But I'm not sure if downgrading currently works at all? :)

Fixes #1819