### PR TITLE
Set the default return type to 'application/json'

### DIFF
--- a/privacyidea/api/audit.py
+++ b/privacyidea/api/audit.py
@@ -32,7 +32,7 @@ It only provides the method
   GET /audit
 """
 from flask import (Blueprint, request, current_app, stream_with_context)
-from .lib.utils import (send_result)
+from .lib.utils import (send_result, send_file)
 from ..api.lib.prepolicy import (prepolicy, check_base_action, auditlog_age,
                                  allowed_audit_realm)
 from ..api.auth import admin_required
@@ -144,8 +144,5 @@ def download_csv(csvfile=None):
         del param["timelimit"]
     else:
         timelimit = None
-    return current_app.response_class(stream_with_context(audit.csv_generator(param=param,
-                                                                              timelimit=timelimit)),
-                                      mimetype='text/csv',
-                                      headers={"Content-Disposition": ("attachment; "
-                                                                       "filename=%s" % csvfile)})
+    return send_file(stream_with_context(audit.csv_generator(param=param, timelimit=timelimit)),
+                     csvfile)

--- a/privacyidea/api/audit.py
+++ b/privacyidea/api/audit.py
@@ -144,5 +144,6 @@ def download_csv(csvfile=None):
         del param["timelimit"]
     else:
         timelimit = None
-    return send_file(stream_with_context(audit.csv_generator(param=param, timelimit=timelimit)),
+    return send_file(stream_with_context(audit.csv_generator(param=param,
+                                                             timelimit=timelimit)),
                      csvfile)

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -780,7 +780,10 @@ def construct_radius_response(request, response):
                 # user was successfully authenticated
                 return_code = 204
         # send empty body
-        return make_response('', return_code)
+        resp = make_response('', return_code)
+        # tell other policies there is no JSON content
+        resp.mimetype = 'text/plain'
+        return resp
     else:
         return response
 

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -148,6 +148,18 @@ def send_error(errstring, rid=1, context=None, error_code=-311, details=None):
     return ret
 
 
+def send_html(output):
+    """
+    Send the ouput as HTML to the client with the correct mimetype.
+
+    :param output: The HTML to send to the client
+    :type output: str
+    :return: The generated response
+    :rtype: flask.Response
+    """
+    return current_app.response_class(output, mimetype='text/html')
+
+
 def send_file(output, filename, content_type='text/csv'):
     """
     Send the output to the client with the "Content-disposition" header to

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -148,6 +148,12 @@ def send_error(errstring, rid=1, context=None, error_code=-311, details=None):
     return ret
 
 
+def send_file(output, filename):
+    content_type = "application/force-download"
+    headers = {'Content-disposition': 'attachment; filename={0!s}'.format(filename)}
+    return current_app.response_class(output, headers=headers, mimetype=content_type)
+
+
 def send_csv_result(obj, data_key="tokens",
                     filename="privacyidea-tokendata.csv"):
     """
@@ -169,8 +175,6 @@ def send_csv_result(obj, data_key="tokens",
     :rtype: Response object
     """
     delim = "'"
-    content_type = "application/force-download"
-    headers = {'Content-disposition': 'attachment; filename={0!s}'.format(filename)}
     output = u""
     # Do the header
     for k, _v in obj.get(data_key, {})[0].items():
@@ -187,7 +191,7 @@ def send_csv_result(obj, data_key="tokens",
             output += "{0!s}{1!s}{2!s}, ".format(delim, value, delim)
         output += "\n"
 
-    return current_app.response_class(output, mimetype=content_type)
+    return send_file(output, filename)
 
 
 @log_with(log)

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -148,8 +148,20 @@ def send_error(errstring, rid=1, context=None, error_code=-311, details=None):
     return ret
 
 
-def send_file(output, filename):
-    content_type = "application/force-download"
+def send_file(output, filename, content_type='text/csv'):
+    """
+    Send the output to the client with the "Content-disposition" header to
+    declare it as a downloadable file.
+    :param output: The data that should be send as a file
+    :type output: str
+    :param filename: The proposed filename
+    :type filename: str
+    :param content_type: The proposed content type of the data
+    :type content_type: str (should be something from this list:
+                             https://www.iana.org/assignments/media-types/media-types.xhtml)
+    :return: The generated response
+    :rtype: flask.Response
+    """
     headers = {'Content-disposition': 'attachment; filename={0!s}'.format(filename)}
     return current_app.response_class(output, headers=headers, mimetype=content_type)
 
@@ -176,20 +188,22 @@ def send_csv_result(obj, data_key="tokens",
     """
     delim = "'"
     output = u""
-    # Do the header
-    for k, _v in obj.get(data_key, {})[0].items():
-        output += "{0!s}{1!s}{2!s}, ".format(delim, k, delim)
-    output += "\n"
-
-    # Do the data
-    for row in obj.get(data_key, {}):
-        for val in row.values():
-            if isinstance(val, six.string_types):
-                value = val.replace("\n", " ")
-            else:
-                value = val
-            output += "{0!s}{1!s}{2!s}, ".format(delim, value, delim)
+    # check if there is any data
+    if data_key in obj and len(obj[data_key]) > 0:
+        # Do the header
+        for k, _v in obj.get(data_key)[0].items():
+            output += "{0!s}{1!s}{2!s}, ".format(delim, k, delim)
         output += "\n"
+
+        # Do the data
+        for row in obj.get(data_key):
+            for val in row.values():
+                if isinstance(val, six.string_types):
+                    value = val.replace("\n", " ")
+                else:
+                    value = val
+                output += "{0!s}{1!s}{2!s}, ".format(delim, value, delim)
+            output += "\n"
 
     return send_file(output, filename)
 

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -283,7 +283,7 @@ def get_policy(name=None, export=None):
     else:
         # We want to export all policies
         pol = P.list_policies()
-        ret = send_file(export_policies(pol), export)
+        ret = send_file(export_policies(pol), export, content_type='text/plain')
 
     g.audit_object.log({"success": True,
                         'info': u"name = {0!s}, realm = {1!s}, scope = {2!s}".format(name, realm, scope)})

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -34,33 +34,29 @@ __doc__ = """
 The code of this module is tested in tests/test_api_system.py
 """
 from flask import (Blueprint,
-                   request,
-                   url_for)
+                   request)
 from .lib.utils import (getParam,
                         getLowerParams,
                         optional,
                         required,
                         send_result,
-                        check_policy_name)
+                        check_policy_name, send_file)
 from ..lib.log import log_with
-from ..lib.policy import (set_policy,
-                          PolicyClass, ACTION,
+from ..lib.policy import (set_policy, ACTION,
                           export_policies, import_policies,
                           delete_policy, get_static_policy_definitions,
-                          enable_policy, get_policy_condition_sections, get_policy_condition_comparators)
+                          enable_policy, get_policy_condition_sections,
+                          get_policy_condition_comparators)
 from ..lib.token import get_dynamic_policy_definitions
 from ..lib.error import (ParameterError)
 from privacyidea.lib.utils import to_unicode, is_true
 from ..api.lib.prepolicy import prepolicy, check_base_action
 
-from flask import (g,
-                    make_response)
-from flask_babel import gettext as _
+from flask import g
 from werkzeug.datastructures import FileStorage
 from cgi import FieldStorage
 
 import logging
-import re
 
 
 log = logging.getLogger(__name__)
@@ -287,10 +283,7 @@ def get_policy(name=None, export=None):
     else:
         # We want to export all policies
         pol = P.list_policies()
-        response = make_response(export_policies(pol))
-        response.headers["Content-Disposition"] = ("attachment; "
-                                                   "filename=%s" % export)
-        ret = response
+        ret = send_file(export_policies(pol), export)
 
     g.audit_object.log({"success": True,
                         'info': u"name = {0!s}, realm = {1!s}, scope = {2!s}".format(name, realm, scope)})

--- a/privacyidea/api/system.py
+++ b/privacyidea/api/system.py
@@ -50,7 +50,7 @@ from .lib.utils import (getParam,
                         getLowerParams,
                         optional,
                         required,
-                        send_result)
+                        send_result, send_file)
 from ..lib.log import log_with
 from ..lib.radiusserver import get_radiusservers
 from ..lib.caconnector import get_caconnector_list
@@ -109,8 +109,10 @@ def get_config_documentation():
 
     g.audit_object.log({"success": True})
     # Three or more line breaks will be changed to two.
-    return re.sub("\n{3,}", "\n\n", render_template("documentation.rst",
-                                               context=context))
+    return send_file(re.sub("\n{3,}", "\n\n", render_template("documentation.rst",
+                                                              context=context)),
+                     'documentation.rst')
+
 
 @system_blueprint.route('/gpgkeys', methods=['GET'])
 def get_gpg_keys():

--- a/privacyidea/api/system.py
+++ b/privacyidea/api/system.py
@@ -111,7 +111,7 @@ def get_config_documentation():
     # Three or more line breaks will be changed to two.
     return send_file(re.sub("\n{3,}", "\n\n", render_template("documentation.rst",
                                                               context=context)),
-                     'documentation.rst')
+                     'documentation.rst', content_type='text/plain')
 
 
 @system_blueprint.route('/gpgkeys', methods=['GET'])

--- a/privacyidea/api/ttype.py
+++ b/privacyidea/api/ttype.py
@@ -103,7 +103,7 @@ def token(ttype=None):
         return current_app.response_class(res[1], mimetype="text/{0!s}".format(res[0]))
     elif len(res) == 2:
         return current_app.response_class(json.dumps(res[1]),
-                        mimetype="application/{0!s}".format(res[0]))
+                                          mimetype="application/{0!s}".format(res[0]))
     else:
         return current_app.response_class(res[1], mimetype="application/octet-binary",
-                        headers=res[2])
+                                          headers=res[2])

--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -106,6 +106,8 @@ class PiResponseClass(Response):
         """
         return self.get_json(cache=False)
 
+    default_mimetype = 'application/json'
+
 
 def create_app(config_name="development",
                config_file='/etc/privacyidea/pi.cfg',

--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -301,14 +301,10 @@ class BaseEventHandler(object):
 
     @staticmethod
     def _get_response_content(response):
+        content = {}
         if response:
             if response.is_json:
                 content = response.json
-            else:
-                content = response.get_json(force=True, cache=False)
-        else:
-            # In Pre-Handling we have no response and no content
-            content = {}
         return content
 
     def check_condition(self, options):

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -1792,7 +1792,7 @@ class EventHandler(MethodsMixin, db.Model):
 
     def get(self):
         """
-        Return the serialized policy object including the options
+        Return the serialized eventhandler object including the options
 
         :return: complete dict
         :rytpe: dict

--- a/privacyidea/webui/certificate.py
+++ b/privacyidea/webui/certificate.py
@@ -25,7 +25,7 @@ This code is tested in test_ui_certificate.py
 """
 __author__ = "Cornelius Kölbel, <cornelius@privacyidea.org>"
 
-from flask import (Blueprint, render_template, request)
+from flask import (Blueprint, render_template, request, current_app)
 from privacyidea.api.lib.utils import (get_all_params,
                                        verify_auth_token)
 
@@ -58,9 +58,11 @@ def cert_form():
     backend_url = ""
     authtoken = request.all_data.get("authtoken")
     ca = request.all_data.get("ca")
-    return render_template("cert_request_form.html", instance=instance,
-                           backendUrl=backend_url, ca=ca,
-                           authtoken=authtoken)
+    return current_app.response_class(render_template("cert_request_form.html",
+                                                      instance=instance,
+                                                      backendUrl=backend_url, ca=ca,
+                                                      authtoken=authtoken),
+                                      mimetype='text/html')
 
 
 @cert_blueprint.route('/enroll', methods=['POST'])

--- a/privacyidea/webui/certificate.py
+++ b/privacyidea/webui/certificate.py
@@ -25,9 +25,9 @@ This code is tested in test_ui_certificate.py
 """
 __author__ = "Cornelius Kölbel, <cornelius@privacyidea.org>"
 
-from flask import (Blueprint, render_template, request, current_app)
+from flask import (Blueprint, render_template, request)
 from privacyidea.api.lib.utils import (get_all_params,
-                                       verify_auth_token)
+                                       verify_auth_token, send_html)
 
 
 cert_blueprint = Blueprint('cert_blueprint', __name__)
@@ -58,11 +58,10 @@ def cert_form():
     backend_url = ""
     authtoken = request.all_data.get("authtoken")
     ca = request.all_data.get("ca")
-    return current_app.response_class(render_template("cert_request_form.html",
-                                                      instance=instance,
-                                                      backendUrl=backend_url, ca=ca,
-                                                      authtoken=authtoken),
-                                      mimetype='text/html')
+    return send_html(render_template("cert_request_form.html",
+                                     instance=instance,
+                                     backendUrl=backend_url, ca=ca,
+                                     authtoken=authtoken))
 
 
 @cert_blueprint.route('/enroll', methods=['POST'])
@@ -108,6 +107,4 @@ emailAddress={4!s}
                       'serial': serial,
                       'certificate': certificate,
                       'cert_pem': cert_pem }
-    return current_app.response_class(render_template("token_enrolled.html",
-                                                      **render_context),
-                                      mimetype='text/html')
+    return send_html(render_template("token_enrolled.html", **render_context))

--- a/privacyidea/webui/certificate.py
+++ b/privacyidea/webui/certificate.py
@@ -85,10 +85,10 @@ def cert_enroll():
 CN={1!s},CN={2!s},O={3!s}
 emailAddress={4!s}
 """.format(request_key,
-       request.PI_username,
-       request.PI_role,
-       request.PI_realm,
-       email)
+           request.PI_username,
+           request.PI_role,
+           request.PI_realm,
+           email)
     # Take the CSR and run a token init
     from privacyidea.lib.token import init_token
     tokenobject = init_token({"request": csr,
@@ -100,14 +100,14 @@ emailAddress={4!s}
     cert_pem = certificate.replace('\r', "").replace('\n', "")
     cert_pem = cert_pem.replace("-----BEGIN CERTIFICATE-----", "")
     cert_pem = cert_pem.replace("-----END CERTIFICATE-----", "")
-    return render_template("token_enrolled.html",
-                           instance=instance,
-                           backendUrl=backend_url,
-                           username="{0!s}@{1!s}".format(request.PI_username,
-                                               request.PI_realm),
-                           role=request.PI_role,
-                           serial=serial,
-                           certificate=certificate,
-                           cert_pem=cert_pem)
-
-
+    render_context = {'instance': instance,
+                      'backendUrl': backend_url,
+                      'username': "{0!s}@{1!s}".format(request.PI_username,
+                                                       request.PI_realm),
+                      'role': request.PI_role,
+                      'serial': serial,
+                      'certificate': certificate,
+                      'cert_pem': cert_pem }
+    return current_app.response_class(render_template("token_enrolled.html",
+                                                      **render_context),
+                                      mimetype='text/html')

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -24,8 +24,6 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from privacyidea.lib.queue import has_job_queue
-
 __doc__ = """This is the starting point for the single web application.
 Other html code is dynamically loaded via angularJS and located in
 /static/views/...
@@ -34,6 +32,7 @@ __author__ = "Cornelius Kölbel <cornelius@privacyidea.org>"
 
 from flask import (Blueprint, render_template, request,
                    current_app)
+from privacyidea.api.lib.utils import send_html
 from privacyidea.api.lib.prepolicy import is_remote_user_allowed
 from privacyidea.lib.passwordreset import is_password_reset
 from privacyidea.lib.error import HSMException
@@ -42,6 +41,7 @@ from privacyidea.lib.policy import PolicyClass, ACTION, SCOPE
 from privacyidea.lib.subscriptions import subscription_status
 from privacyidea.lib.utils import get_client_ip
 from privacyidea.lib.config import get_from_config, SYSCONF
+from privacyidea.lib.queue import has_job_queue
 
 DEFAULT_THEME = "/static/contrib/css/bootstrap-theme.css"
 
@@ -58,8 +58,7 @@ def single_page_application():
 
     if current_app.config.get("PI_UI_DEACTIVATED"):
         # Do not provide the UI
-        return current_app.response_class(render_template("deactivated.html"),
-                                          mimetype='text/html')
+        return send_html(render_template("deactivated.html"))
 
     # The default theme. We can change this later
     theme = current_app.config.get("PI_CSS", DEFAULT_THEME)
@@ -102,7 +101,7 @@ def single_page_application():
                 client=client_ip)
             # Use the realms from the policy.
             realms = ",".join(realm_dropdown_values)
-        except AttributeError as ex:
+        except AttributeError as _e:
             # The policy is still a boolean realm_dropdown action
             # Thus we display ALL realms
             realms = ",".join(get_realms())
@@ -117,7 +116,7 @@ def single_page_application():
 
     # Use policies to determine the customization of menu
     # and baseline. get_action_values returns an array!
-    sub_state  = subscription_status()
+    sub_state = subscription_status()
     customization_menu_file = policy_object.get_action_values(
         allow_white_space_in_action=True,
         action=ACTION.CUSTOM_MENU,
@@ -170,6 +169,4 @@ def single_page_application():
         'page_title': page_title
     }
 
-    return current_app.response_class(render_template("index.html",
-                                                      **render_context),
-                                      mimetype='text/html')
+    return send_html(render_template("index.html", **render_context))

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -150,21 +150,26 @@ def single_page_application():
     else:
         login_text = ""
 
-    return current_app.response_class(render_template("index.html", instance=instance,
-                                                      backendUrl=backend_url,
-                                                      browser_lang=browser_lang,
-                                                      remote_user=remote_user,
-                                                      theme=theme,
-                                                      password_reset=password_reset,
-                                                      hsm_ready=hsm_ready,
-                                                      has_job_queue=str(has_job_queue()),
-                                                      customization=customization,
-                                                      custom_css=custom_css,
-                                                      customization_menu_file=customization_menu_file,
-                                                      customization_baseline_file=customization_baseline_file,
-                                                      realms=realms,
-                                                      external_links=external_links,
-                                                      login_text=login_text,
-                                                      logo=logo,
-                                                      page_title=page_title),
+    render_context = {
+        'instance': instance,
+        'backendUrl': backend_url,
+        'browser_lang': browser_lang,
+        'remote_user': remote_user,
+        'theme': theme,
+        'password_reset': password_reset,
+        'hsm_ready': hsm_ready,
+        'has_job_queue': str(has_job_queue()),
+        'customization': customization,
+        'custom_css': custom_css,
+        'customization_menu_file': customization_menu_file,
+        'customization_baseline_file': customization_baseline_file,
+        'realms': realms,
+        'external_links': external_links,
+        'login_text': login_text,
+        'logo': logo,
+        'page_title': page_title
+    }
+
+    return current_app.response_class(render_template("index.html",
+                                                      **render_context),
                                       mimetype='text/html')

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -58,7 +58,8 @@ def single_page_application():
 
     if current_app.config.get("PI_UI_DEACTIVATED"):
         # Do not provide the UI
-        return render_template("deactivated.html")
+        return current_app.response_class(render_template("deactivated.html"),
+                                          mimetype='text/html')
 
     # The default theme. We can change this later
     theme = current_app.config.get("PI_CSS", DEFAULT_THEME)
@@ -149,21 +150,21 @@ def single_page_application():
     else:
         login_text = ""
 
-    return render_template("index.html", instance=instance,
-                           backendUrl=backend_url,
-                           browser_lang=browser_lang,
-                           remote_user=remote_user,
-                           theme=theme,
-                           password_reset=password_reset,
-                           hsm_ready=hsm_ready,
-                           has_job_queue=str(has_job_queue()),
-                           customization=customization,
-                           custom_css=custom_css,
-                           customization_menu_file=customization_menu_file,
-                           customization_baseline_file=customization_baseline_file,
-                           realms=realms,
-                           external_links=external_links,
-                           login_text=login_text,
-                           logo=logo,
-                           page_title=page_title)
-
+    return current_app.response_class(render_template("index.html", instance=instance,
+                                                      backendUrl=backend_url,
+                                                      browser_lang=browser_lang,
+                                                      remote_user=remote_user,
+                                                      theme=theme,
+                                                      password_reset=password_reset,
+                                                      hsm_ready=hsm_ready,
+                                                      has_job_queue=str(has_job_queue()),
+                                                      customization=customization,
+                                                      custom_css=custom_css,
+                                                      customization_menu_file=customization_menu_file,
+                                                      customization_baseline_file=customization_baseline_file,
+                                                      realms=realms,
+                                                      external_links=external_links,
+                                                      login_text=login_text,
+                                                      logo=logo,
+                                                      page_title=page_title),
+                                      mimetype='text/html')

--- a/tests/test_api_audit.py
+++ b/tests/test_api_audit.py
@@ -42,7 +42,10 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertEqual(res.mimetype, 'application/force-download')
+            self.assertEqual(res.mimetype, 'text/csv', res)
+            self.assertIn('Content-disposition', res.headers, res.headers)
+            self.assertEqual('attachment; filename=test.csv',
+                             res.headers['Content-disposition'], res.headers)
             # we have at least 2 entries here, the authentication and this one
             self.assertGreater(len(list(res.response)), 1)
 
@@ -56,8 +59,9 @@ class APIAuditTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertEqual(res.mimetype, 'application/force-download')
-            # we have at least 2 entries here, the authentication and this one
+            self.assertEqual(res.mimetype, 'text/csv', res)
+            # The audit entry from (fake) 10 minutes ago should not be in the
+            # result data
             self.assertNotIn(b"'enroll','1','','','','foo'", res.data, res)
 
     def test_02_get_allowed_audit_realm(self):

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import print_function
 
 import os
@@ -840,6 +842,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.mimetype, 'text/plain', res)
             self.assertTrue(b"privacyIDEA configuration documentation" in
                             res.data)
 

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from .base import MyApiTestCase
 import json
 import os
@@ -300,11 +302,11 @@ class APITokenTestCase(MyApiTestCase):
     def test_02_list_tokens_csv(self):
         with self.app.test_request_context('/token/',
                                            method='GET',
-                                           query_string=urlencode({"outform":
-                                                                       "csv"}),
+                                           query_string=urlencode({"outform": "csv"}),
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.mimetype, 'text/csv', res)
             self.assertTrue(b"info" in res.data, res.data)
             self.assertTrue(b"username" in res.data, res.data)
             self.assertTrue(b"user_realm" in res.data, res.data)
@@ -1173,6 +1175,7 @@ class APITokenTestCase(MyApiTestCase):
             self.assertEqual(token.timestep, int(timestep))
 
     def test_17_enroll_certificate(self):
+        self.setUp_user_realms()
         cwd = os.getcwd()
         # setup ca connector
         r = save_caconnector({"cakey": CAKEY,

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 This file contains the event handlers tests. It tests:
 
@@ -145,7 +147,7 @@ class BaseEventHandlerTestCase(MyTestCase):
         events = BaseEventHandler().events
         self.assertEqual(events, ["*"])
 
-        base_handler =  BaseEventHandler()
+        base_handler = BaseEventHandler()
         r = base_handler.check_condition({})
         self.assertTrue(r)
 

--- a/tests/test_ui_certificate.py
+++ b/tests/test_ui_certificate.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 This file tests the web UI for creating certificate requests
 
@@ -30,8 +32,7 @@ class WebUICertificateTestCase(MyTestCase):
     def test_01_cert_request(self):
         with self.app.test_request_context('/auth',
                                            method='POST',
-                                           data={"username":
-                                                     "selfservice@realm1",
+                                           data={"username": "selfservice@realm1",
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
@@ -43,9 +44,7 @@ class WebUICertificateTestCase(MyTestCase):
         # Check the form
         with self.app.test_request_context('/certificate',
                                            method='POST',
-                                           data={"authtoken":
-                                                     authtoken.get(
-                                                         "token")}):
+                                           data={"authtoken": authtoken.get("token")}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertEqual(res.mimetype, 'text/html', res)
@@ -83,14 +82,13 @@ class WebUICertificateTestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json['result']
-            self.assertTrue(result["status"] is True, result)
+            self.assertTrue(result["status"], result)
             self.assertTrue(result["value"] == 1, result)
 
         # Get the users authtoken
         with self.app.test_request_context('/auth',
                                            method='POST',
-                                           data={"username":
-                                                     "selfservice@realm1",
+                                           data={"username": "selfservice@realm1",
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
@@ -102,13 +100,12 @@ class WebUICertificateTestCase(MyTestCase):
         # Check the form
         with self.app.test_request_context('/certificate/enroll',
                                            method='POST',
-                                           data={"authtoken":
-                                                     authtoken.get(
-                                                         "token"),
-                                               "requestkey": REQUESTKEY,
-                                                "ca": "localCA"}):
+                                           data={"authtoken": authtoken.get("token"),
+                                                 "requestkey": REQUESTKEY,
+                                                 "ca": "localCA"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.mimetype, 'text/html', res)
             # Check the form
             self.assertTrue(b"The certificate with token serial" in res.data)
             self.assertTrue(b"Certificate to Browser" in res.data)

--- a/tests/test_ui_certificate.py
+++ b/tests/test_ui_certificate.py
@@ -48,6 +48,7 @@ class WebUICertificateTestCase(MyTestCase):
                                                          "token")}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.mimetype, 'text/html', res)
             # Check the form
             self.assertTrue(b"privacyIDEA Certificate Request" in res.data)
             self.assertTrue(b"Key strength" in res.data)

--- a/tests/test_ui_login.py
+++ b/tests/test_ui_login.py
@@ -17,6 +17,7 @@ class LoginUITestCase(MyTestCase):
                                            method='GET'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.mimetype, 'text/html', res)
             self.assertTrue(b"/static/templates/baseline.html" in res.data)
             self.assertTrue(b"/static/templates/menu.html" in res.data)
 
@@ -25,6 +26,7 @@ class LoginUITestCase(MyTestCase):
         with self.app.test_request_context('/', method='GET'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.mimetype, 'text/html', res)
             self.assertTrue(b"The privacyIDEA WebUI is deactivated." in res.data)
         self.app.config['PI_UI_DEACTIVATED'] = False
 

--- a/tests/test_ui_login.py
+++ b/tests/test_ui_login.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 This file tests the web UI Login
 


### PR DESCRIPTION
Since we mostly return JSON data, it makes sense to the set it as the
default return type in out response class.
Also added a `send_file()` utility function which adjusts content type and
header accordingly.
Other mimetypes are set explicitly.

Fixes #1850 