### PR TITLE
Notification Handler can write to a file

### DIFF
--- a/doc/eventhandler/usernotification.rst
+++ b/doc/eventhandler/usernotification.rst
@@ -40,16 +40,42 @@ administrator managed the users token.
   * The SMS Gateway configuration.
 
 
-Options for both actions
-~~~~~~~~~~~~~~~~~~~~~~~~
+savefile
+........
 
-Both actions **sendmail** and **sendsms** take several common options.
+The *savefile* action saves a file to a spool directory.
+Each time the event handler is triggered a new file is saved.
+
+**spooldirectory**
+
+  * *required* option
+  * The directory where all files are written to. It must
+    be writable for privacyidea.
+
+**filename**
+
+  * *required* option
+  * The filename of the saved file. It can contain the tag
+    ``{random}`` which will create a 16 characters long
+    alpha numeric string. Thus you could have a filename like
+    ``notification-{random}.csv``.
+
+In addition you can use all tags that can be used in the body
+also in the filename (some of them might not make a lot of sense!).
+
+.. note:: Existing files are overwritten.
+
+Body for all actions
+~~~~~~~~~~~~~~~~~~~~
+
+All actions take the common option *body*:
 
 **body**
 
-  * optional
+  * optional for sendsms and sendemail
+  * required for savefile
 
-Here the administrator can specify the body of the email, that is sent.
+Here the administrator can specify the body of the notification, that is sent or saved.
 The body may contain the following tags
 
   * {admin} name of the logged in user.
@@ -73,6 +99,13 @@ The body may contain the following tags
   * {client_ip} the client IP of the client, which issued the original request.
   * {ua_browser} the user agent of the client, which issued the original request.
   * {ua_string} the complete user agent string (including version number), which issued the original request.
+
+
+
+Options for sendmail and sendsms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both actions **sendmail** and **sendsms** take several common options.
 
 **subject**
 

--- a/doc/eventhandler/usernotification.rst
+++ b/doc/eventhandler/usernotification.rst
@@ -46,11 +46,10 @@ savefile
 The *savefile* action saves a file to a spool directory.
 Each time the event handler is triggered a new file is saved.
 
-**spooldirectory**
-
-  * *required* option
-  * The directory where all files are written to. It must
-    be writable for privacyidea.
+In the ``pi.cfg`` file you can use the setting ``PI_NOTIFICATION_HANDLER_SPOOLDIRECTORY``
+to configure a spool directory, where the notification files will be written.
+The default file location is ``/var/lib/privacyidea/notifications/``.
+The directory needs to be writable for the user *privacyidea*.
 
 **filename**
 

--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -50,6 +50,7 @@ class TestingConfig(Config):
     PI_GNUPG_HOME = "tests/testdata/gpg"
     CACHE_TYPE = "None"
     PI_SCRIPT_HANDLER_DIRECTORY = "tests/testdata/scripts/"
+    PI_NOTIFICATION_HANDLER_SPOOLDIRECTORY = "tests/testdata/"
     PI_NODE = "Node1"
     PI_NODES = ["Node2"]
     PI_ENGINE_REGISTRY_CLASS = "null"

--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -361,7 +361,7 @@ class UserNotificationEventHandler(BaseEventHandler):
                 random = get_alphanum_str(16)
                 filename = filename.format(random=random, **tags)
                 try:
-                    with open(spooldir + "/" + filename, "wb") as f:
+                    with open(spooldir + "/" + filename, "w") as f:
                         f.write(body)
                 except Exception as err:
                     log.error(u"Failed to write notification file: {0!s}".format(err))

--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -48,6 +48,7 @@ from privacyidea.lib.smtpserver import get_smtpservers
 from privacyidea.lib.smsprovider.SMSProvider import get_smsgateway
 from privacyidea.lib.user import User, get_user_list
 from privacyidea.lib.utils import create_tag_dict
+from privacyidea.lib.crypto import get_alphanum_str
 from privacyidea.lib import _
 import logging
 import datetime
@@ -182,7 +183,25 @@ class UserNotificationEventHandler(BaseEventHandler):
                                       "description": _("Send notification to "
                                                        "this user."),
                                       "value": [NOTIFY_TYPE.TOKENOWNER]}
-                               }
+                               },
+                   "savefile": {"spooldirectory":
+                                    {"type": "str",
+                                     "required": True,
+                                     "description": _("Save the notification file to "
+                                                      "this directory.")},
+                                "body":
+                                    {"type": "text",
+                                     "required": True,
+                                     "description": _("This is the template content of "
+                                                      "the new file. Can contain the tags "
+                                                      "as specified in the documentation.")},
+                                "filename":
+                                    {"type": "str",
+                                     "required": True,
+                                     "description": _("The filename of the notification. Existing files "
+                                                      "are overwritten. The name can contain tags as specified "
+                                                      "in the documentation and can also contain the tag {random}.")}
+                   }
                    }
         return actions
 
@@ -275,7 +294,8 @@ class UserNotificationEventHandler(BaseEventHandler):
             log.warning("Was not able to determine the recipient for the user "
                         "notification: {0!s}".format(handler_def))
 
-        if recipient:
+        if recipient or action.lower() == "savefile":
+            # In case of "savefile" we do not need a recipient
             # Collect all data
             body = handler_options.get("body") or DEFAULT_BODY
             subject = handler_options.get("subject") or \
@@ -334,6 +354,17 @@ class UserNotificationEventHandler(BaseEventHandler):
                 else:
                     log.warning("Failed to send a notification email to user "
                                 "{0}".format(recipient))
+
+            elif action.lower() == "savefile":
+                spooldir = handler_options.get("spooldirectory", ".")
+                filename = handler_options.get("filename")
+                random = get_alphanum_str(16)
+                filename = filename.format(random=random, **tags)
+                try:
+                    with open(spooldir + "/" + filename, "wb") as f:
+                        f.write(body)
+                except Exception as err:
+                    log.error(u"Failed to write notification file: {0!s}".format(err))
 
             elif action.lower() == "sendsms":
                 smsconfig = handler_options.get("smsconfig")

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -2940,7 +2940,7 @@ class UserNotificationTestCase(MyTestCase):
         # create a file, that is not writable
         with open("tests/testdata/testOATH123456.txt", "w") as f:
             f.write("empty")
-        os.chmod("tests/testdata/testOATH123456.txt", 0x400)
+        os.chmod("tests/testdata/testOATH123456.txt", 0o400)
         un_handler = UserNotificationEventHandler()
         un_handler.do("savefile", options=options)
         # Check the log file for an error. There might be faster possibilities but more robust


### PR DESCRIPTION
The notification handler can create a file with
a lot of tags in a spool directory.

Closes #717