### PR TITLE
Remove (TODO) marks, as they are not relevant anymore.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,14 +55,11 @@ Table of Contents
    modules/index
    faq/index
 
-.. note:: Some parts are marked as "**(TODO)** Not yet implemented".
-   These are components that have not been migrated from 1.5 to 2.0.
-   If you are missing an important, not-yet-migrated part, drop us a note!
 
 If you are missing any information or descriptions
 file an issue at `github <https://github.com/privacyidea/privacyidea/issues>`_ (which would be the preferred way),
 drop a note to info(@)privacyidea.org
-or go to the `Google group <https://groups.google.com/forum/?hl=en#!forum/privacyidea>`_.
+or go to the `Community Forum <https://community.privacyidea.org>`_.
 
 This will help us a lot to improve documentation to your needs.
 

--- a/doc/userview/index.rst
+++ b/doc/userview/index.rst
@@ -14,7 +14,7 @@ to manage.
 
 You can select one of the realms in the left drop down box. The administrator
 will only see the realms in the drop down box, that he is allowed to manage.
-**(TODO)** No migrated, yet.
+
 
 .. figure:: user-view.png
    :width: 500


### PR DESCRIPTION
Change the link from the google group to the community forum.