### PR TITLE
Add a /validate/polltransaction endpoint for out-of-band tokens

### DIFF
--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -542,10 +542,11 @@ def trigger_challenge():
 
 
 @validate_blueprint.route('/polltransaction', methods=['GET'])
+@validate_blueprint.route('/polltransaction/<transaction_id>', methods=['GET'])
 @prepolicy(mangle, request=request)
 @CheckSubscription(request)
 @prepolicy(api_key_required, request=request)
-def poll_transaction():
+def poll_transaction(transaction_id=None):
     """
     Given a mandatory transaction ID, check if any non-expired challenge for this transaction ID
     has been answered. In this case, return true. If this is not the case, return false.
@@ -556,7 +557,8 @@ def poll_transaction():
 
     :jsonparam transaction_id: a transaction ID
     """
-    transaction_id = getParam(request.all_data, "transaction_id", required)
+    if transaction_id is None:
+        transaction_id = getParam(request.all_data, "transaction_id", required)
     # Fetch a list of challenges with the given transaction ID
     # and determine whether it contains at least one non-expired answered challenge.
     matching_challenges = get_challenges(transaction_id=transaction_id)

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -559,9 +559,10 @@ def poll_transaction(transaction_id=None):
     """
     if transaction_id is None:
         transaction_id = getParam(request.all_data, "transaction_id", required)
-    # Fetch a list of challenges with the given transaction ID
+    # Fetch a list of non-exired challenges with the given transaction ID
     # and determine whether it contains at least one non-expired answered challenge.
-    matching_challenges = get_challenges(transaction_id=transaction_id)
+    matching_challenges = [challenge for challenge in get_challenges(transaction_id=transaction_id)
+                           if challenge.is_valid()]
     answered_challenges = extract_answered_challenges(matching_challenges)
 
     if answered_challenges:

--- a/privacyidea/lib/challenge.py
+++ b/privacyidea/lib/challenge.py
@@ -30,6 +30,7 @@ import logging
 import six
 from .log import log_with
 from ..models import Challenge
+from privacyidea.lib.error import ParameterError
 log = logging.getLogger(__name__)
 
 
@@ -150,3 +151,21 @@ def _create_challenge_query(serial=None, transaction_id=None):
             sql_query = sql_query.filter(Challenge.transaction_id == transaction_id)
 
     return sql_query
+
+
+def extract_answered_challenges(challenges):
+    """
+    Given a list of challenge objects, extract and return a list of *answered* challenge.
+    A challenge is answered if it is not expired yet *and* if its ``otp_valid`` attribute
+    is set to True.
+    :param challenges: a list of challenge objects
+    :return: a list of answered challenge objects
+    """
+    answered_challenges = []
+    for challenge in challenges:
+        # check if we are still in time.
+        if challenge.is_valid():
+            _, status = challenge.get_otp_status()
+            if status is True:
+                answered_challenges.append(challenge)
+    return answered_challenges

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -453,7 +453,6 @@ class TiqrTokenClass(OcraTokenClass):
         if transaction_id is not None:
             challengeobject_list = get_challenges(serial=self.token.serial,
                                                   transaction_id=transaction_id)
-
             for challengeobject in challengeobject_list:
                 # check if we are still in time.
                 if challengeobject.is_valid():

--- a/privacyidea/static/components/audit/controllers/auditControllers.js
+++ b/privacyidea/static/components/audit/controllers/auditControllers.js
@@ -76,6 +76,9 @@ myApp.controller("auditController", function (AuditFactory, $scope, $rootScope,
                         });
                         $scope.auditdata.auditdata[key].policies = uniquePolnameList;
                     }
+                    if (auditentry.serial != null) {
+                        auditentry.serial_list = auditentry.serial.split(",");
+                    }
                 });
             });
         }

--- a/privacyidea/static/components/audit/views/audit.log.html
+++ b/privacyidea/static/components/audit/views/audit.log.html
@@ -107,9 +107,11 @@
                 {{ audit.success }}
             </span></td>
                 <td>{{ audit.action_detail }}</td>
-                <td><a ui-sref="token.details({tokenSerial:audit.serial})"
+                <td>
+                    <a ng-repeat="serial in audit.serial_list" ui-sref="token.details({tokenSerial:serial})"
                        ng-click="$rootScope.returnTo=audit;">
-                    {{ audit.serial }}</a></td>
+                    {{ serial }}</a>
+                </td>
                 <td>{{ audit.token_type }}</td>
                 <td>{{ audit.administrator }}</td>
                 <td><a ui-sref="user.details({username:audit.user,

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -3437,9 +3437,9 @@ class AChallengeResponse(MyApiTestCase):
         self.assertEqual(entry["resolver"], "resolver1")
         self.assertEqual(entry["realm"], self.realm1)
 
-        # polling the transaction again gives the same result
-        with self.app.test_request_context("/validate/polltransaction", method="GET",
-                                           data={"transaction_id": transaction_id}):
+        # polling the transaction again gives the same result, even with the more REST-y endpoint
+        with self.app.test_request_context("/validate/polltransaction/{}".format(transaction_id), method="GET",
+                                           data={}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             self.assertTrue(res.json["result"]["status"])
@@ -3449,7 +3449,7 @@ class AChallengeResponse(MyApiTestCase):
         remove_token("tok2")
 
         # polling the transaction now gives false
-        with self.app.test_request_context("/validate/polltransaction", method="GET",
+        with self.app.test_request_context("/validate/polltransaction/{}".format(transaction_id), method="GET",
                                            data={"transaction_id": transaction_id}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -4,7 +4,7 @@ import json
 from .base import MyApiTestCase
 from privacyidea.lib.user import (User)
 from privacyidea.lib.tokens.totptoken import HotpTokenClass
-from privacyidea.models import (Token, Challenge, AuthCache)
+from privacyidea.models import (Token, Challenge, AuthCache, db)
 from privacyidea.lib.authcache import _hash_password
 from privacyidea.lib.config import (set_privacyidea_config, get_token_types,
                                     get_inc_fail_count_on_false_pin,
@@ -3327,6 +3327,134 @@ class AChallengeResponse(MyApiTestCase):
             self.assertTrue(data.get("result").get("status"))
             self.assertTrue(data.get("result").get("value"))
         remove_token("rad1")
+
+    def test_12_polltransaction(self):
+        # Assign token to user:
+        r = init_token({"serial": "tok1", "type": "hotp", "otpkey": self.otpkey},
+                       user=User("cornelius", self.realm1))
+        self.assertTrue(r)
+        r = init_token({"serial": "tok2", "type": "tiqr", "otpkey": self.otpkey},
+                       user=User("cornelius", self.realm1))
+        self.assertTrue(r)
+
+        with self.app.test_request_context('/validate/triggerchallenge',
+                                           method='POST',
+                                           data={"user": "cornelius"},
+                                           headers={"authorization": self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            data = res.json
+            self.assertTrue(data.get("result").get("status"))
+            self.assertEqual(data.get("result").get("value"), 2)
+            # The two challenges should be the same
+            multichallenge = data.get("detail").get("multi_challenge")
+            transaction_id = data.get("detail").get("transaction_id")
+            self.assertEqual(multichallenge[0].get("transaction_id"), transaction_id)
+            self.assertEqual(multichallenge[1].get("transaction_id"), transaction_id)
+
+        # Check behavior of the polltransaction endpoint
+        # POST is not allowed
+        with self.app.test_request_context("/validate/polltransaction", method="POST"):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 405)
+
+        # transaction_id is required
+        with self.app.test_request_context("/validate/polltransaction", method="GET",
+                                           data={}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400)
+            self.assertFalse(res.json["result"]["status"])
+            self.assertIn("Missing parameter: 'transaction_id'", res.json["result"]["error"]["message"])
+
+        def _find_most_recent_polltransaction_in_audit():
+            with self.app.test_request_context('/audit/',
+                                               method='GET',
+                                               data={"action": "*/validate/polltransaction*",
+                                                     "sortorder": "desc"},
+                                               headers={"Authorization": self.at}):
+                res = self.app.full_dispatch_request()
+                # return the last entry
+                return res.json["result"]["value"]["auditdata"][0]
+
+        # wildcards do not work
+        with self.app.test_request_context("/validate/polltransaction", method="GET",
+                                           data={"transaction_id": "*"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            self.assertTrue(res.json["result"]["status"])
+            self.assertFalse(res.json["result"]["value"])
+
+        # a non-existent transaction_id just returns false
+        with self.app.test_request_context("/validate/polltransaction", method="GET",
+                                           data={"transaction_id": "123456"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            self.assertTrue(res.json["result"]["status"])
+            self.assertFalse(res.json["result"]["value"])
+
+        # check audit log
+        entry = _find_most_recent_polltransaction_in_audit()
+        self.assertEqual(entry["info"], "transaction_id: 123456")
+        self.assertEqual(entry["serial"], None)
+        self.assertEqual(entry["user"], None)
+
+        # polling the transaction returns false, because no challenge has been answered
+        with self.app.test_request_context("/validate/polltransaction", method="GET",
+                                           data={"transaction_id": transaction_id}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            self.assertTrue(res.json["result"]["status"])
+            self.assertFalse(res.json["result"]["value"])
+
+        # but audit log contains both serials and the user
+        entry = _find_most_recent_polltransaction_in_audit()
+        self.assertEqual(entry["info"], "transaction_id: {}".format(transaction_id))
+        self.assertIn("tok1", entry["serial"])
+        self.assertIn("tok2", entry["serial"])
+        self.assertFalse(entry["success"])
+        self.assertEqual(entry["user"], "cornelius")
+        self.assertEqual(entry["resolver"], "resolver1")
+        self.assertEqual(entry["realm"], self.realm1)
+
+        # Mark one challenge as answered
+        Challenge.query.filter_by(serial="tok1", transaction_id=transaction_id).update({"otp_valid": True})
+        db.session.commit()
+
+        # polling the transaction returns true, because the challenge has been answered
+        with self.app.test_request_context("/validate/polltransaction", method="GET",
+                                           data={"transaction_id": transaction_id}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            self.assertTrue(res.json["result"]["status"])
+            self.assertTrue(res.json["result"]["value"])
+
+        entry = _find_most_recent_polltransaction_in_audit()
+        self.assertEqual(entry["info"], "transaction_id: {}".format(transaction_id))
+        # tok2 is not written to the audit log
+        self.assertEqual(entry["serial"], "tok1")
+        self.assertTrue(entry["success"])
+        self.assertEqual(entry["user"], "cornelius")
+        self.assertEqual(entry["resolver"], "resolver1")
+        self.assertEqual(entry["realm"], self.realm1)
+
+        # polling the transaction again gives the same result
+        with self.app.test_request_context("/validate/polltransaction", method="GET",
+                                           data={"transaction_id": transaction_id}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            self.assertTrue(res.json["result"]["status"])
+            self.assertTrue(res.json["result"]["value"])
+
+        remove_token("tok1")
+        remove_token("tok2")
+
+        # polling the transaction now gives false
+        with self.app.test_request_context("/validate/polltransaction", method="GET",
+                                           data={"transaction_id": transaction_id}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            self.assertTrue(res.json["result"]["status"])
+            self.assertFalse(res.json["result"]["value"])
 
 
 class TriggeredPoliciesTestCase(MyApiTestCase):

--- a/tests/test_lib_challenges.py
+++ b/tests/test_lib_challenges.py
@@ -5,9 +5,10 @@ This tests the token functions on an interface level
 """
 from .base import MyTestCase
 from privacyidea.lib.error import (TokenAdminError, ParameterError)
-from privacyidea.lib.challenge import get_challenges
+from privacyidea.lib.challenge import get_challenges, extract_answered_challenges
 from privacyidea.lib.policy import (set_policy, delete_policy, SCOPE,
                                     ACTION)
+from privacyidea.models import Challenge, db
 from privacyidea.lib.token import init_token
 from privacyidea.lib import _
 
@@ -43,4 +44,30 @@ class ChallengeTestCase(MyTestCase):
 
         delete_policy("chalresp")
 
-
+    def test_02_extract_answered_challenges(self):
+        token = init_token({"genkey": 1, "serial": "CHAL2", "pin": "pin"})
+        # no challenges yet
+        challenges = get_challenges(serial="CHAL2")
+        self.assertEqual(challenges, [])
+        self.assertEqual(extract_answered_challenges(challenges), [])
+        # we trigger two challenges
+        from privacyidea.lib.token import check_serial_pass
+        r = check_serial_pass(token.token.serial, "pin")
+        self.assertEqual(r[0], False)
+        transaction_id1 = r[1].get("transaction_id")
+        r = check_serial_pass(token.token.serial, "pin")
+        self.assertEqual(r[0], False)
+        transaction_id2 = r[1].get("transaction_id")
+        # two challenges, but no answered challenges
+        challenges = get_challenges(serial="CHAL2")
+        self.assertEqual(len(challenges), 2)
+        self.assertEqual(extract_answered_challenges(challenges), [])
+        # answer one challenge
+        Challenge.query.filter_by(transaction_id=transaction_id1).update({"otp_valid": True})
+        db.session.commit()
+        # two challenges, one answered challenge
+        challenges = get_challenges(serial="CHAL2")
+        answered = extract_answered_challenges(challenges)
+        self.assertEqual(len(challenges), 2)
+        self.assertEqual(len(answered), 1)
+        self.assertEqual(answered[0].transaction_id, transaction_id1)


### PR DESCRIPTION
This implements the endpoint specified in #1838. I'm happy about any comments, especially regarding naming :)

I'd like to move the documentation part mentioned in #1838 to another PR.