### PR TITLE
/validate/triggerchallenges writes serials to the audit log

### DIFF
--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -530,12 +530,14 @@ def trigger_challenge():
     create_challenges_from_tokens(chal_resp_tokens, details, options)
     result_obj = len(details.get("multi_challenge"))
 
+    challenge_serials = [challenge_info["serial"] for challenge_info in details["multi_challenge"]]
     g.audit_object.log({
         "user": user.login,
         "resolver": user.resolver,
         "realm": user.realm,
         "success": result_obj > 0,
-        "info": log_used_user(user, "triggered {0!s} challenges".format(result_obj))
+        "info": log_used_user(user, "triggered {0!s} challenges".format(result_obj)),
+        "serial": ",".join(challenge_serials),
     })
 
     return send_result(result_obj, details=details)

--- a/tests/base.py
+++ b/tests/base.py
@@ -176,6 +176,22 @@ class MyTestCase(unittest.TestCase):
             self.assertTrue(role == "user", result)
             self.assertEqual(result.get("value").get("realm"), "realm1")
 
+    def find_most_recent_audit_entry(self, **filter_data):
+        """
+        Given audit log entry filters, return the most recent entry matching the criteria,
+        or raise an IndexError if there is no such entry.
+        This is useful for testing the audit log behavior.
+        """
+        sorted_filter = filter_data.copy()
+        sorted_filter["sortorder"] = "desc"
+        with self.app.test_request_context('/audit/',
+                                           method='GET',
+                                           data=sorted_filter,
+                                           headers={"Authorization": self.at}):
+            res = self.app.full_dispatch_request()
+            # return the last entry
+            return res.json["result"]["value"]["auditdata"][0]
+
 
 class OverrideConfigTestCase(MyTestCase):
     """


### PR DESCRIPTION
This also adds a method ``find_most_recent_audit_entry`` that can be used in API test cases. I found it pretty useful for testing the audit log functionality, so I thought it might be nice to make it available for other tests as well.
 
Closes #1862 