### PR TITLE
Models: Remove obsolete relationships

### DIFF
--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -2029,7 +2029,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # unassign all tokens from the user autoassignuser
         try:
             unassign_token(None, user=user_obj)
-        except Exception:
+        except Exception as e:
             print("no need to unassign token")
 
         # The request with an OTP value and a PIN of a user, who has not

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -384,8 +384,8 @@ class APISelfserviceTestCase(MyApiTestCase):
 
         # Check, who is the owner of the new token!
         tokenobject = get_tokens(serial=serial)[0]
-        self.assertEqual(tokenobject.token.owners.first().user_id, "1004")
-        self.assertEqual(tokenobject.token.owners.first().resolver, "resolver1")
+        self.assertEqual(tokenobject.token.first_owner.user_id, "1004")
+        self.assertEqual(tokenobject.token.first_owner.resolver, "resolver1")
 
         # user can delete his own token
         with self.app.test_request_context('/token/{0!s}'.format(serial),
@@ -523,8 +523,8 @@ class APISelfserviceTestCase(MyApiTestCase):
                             response.get("result"))
 
         tokenobject = get_tokens(serial=self.foreign_serial)[0]
-        self.assertTrue(tokenobject.token.owners.first().user_id == "1004",
-                         tokenobject.token.owners.first().user_id)
+        self.assertTrue(tokenobject.token.first_owner.user_id == "1004",
+                         tokenobject.token.first_owner.user_id)
 
         # User can unassign token
         with self.app.test_request_context('/token/unassign',
@@ -539,7 +539,7 @@ class APISelfserviceTestCase(MyApiTestCase):
                             response.get("result"))
 
         tokenobject = get_tokens(serial=self.foreign_serial)[0]
-        self.assertEqual(tokenobject.token.owners.first(), None)
+        self.assertEqual(tokenobject.token.first_owner, None)
 
 
         # User can not unassign token, which does not belong to him

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1000,7 +1000,7 @@ class APITokenTestCase(MyApiTestCase):
         tokenobject_list = get_tokens(serial="TO001")
         token = tokenobject_list[0]
         # check the user
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.user_id, "1000")
         # check if the TO001 has a pin
         self.assertTrue(len(token.token.pin_hash) == 64,
                         len(token.token.pin_hash))

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -377,7 +377,7 @@ class AValidateOfflineTestCase(MyApiTestCase):
         self.assertTrue(token.token.serial == self.serials[0], token)
         token.add_user(User("cornelius", self.realm1))
         token.set_pin("pin")
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.user_id, "1000")
 
     def test_01_validate_offline(self):
         pass
@@ -580,13 +580,13 @@ class ValidateAPITestCase(MyApiTestCase):
         self.assertTrue(token.token.serial == self.serials[0], token)
         token.add_user(User("cornelius", self.realm1))
         token.set_pin("pin")
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.user_id, "1000")
 
     def test_02_validate_check(self):
         # is the token still assigned?
         tokenbject_list = get_tokens(serial=self.serials[0])
         tokenobject = tokenbject_list[0]
-        self.assertEqual(tokenobject.token.owners.first().user_id, "1000")
+        self.assertEqual(tokenobject.token.first_owner.user_id, "1000")
 
         """                  Truncated
            Count    Hexadecimal    Decimal        HOTP

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -120,7 +120,7 @@ class TokenModelTestCase(MyTestCase):
         t2 = Token.query\
                   .filter_by(serial="serial2")\
                   .first()
-        self.assertEqual(t2.owners.first().resolver, "resolver1")
+        self.assertEqual(t2.first_owner.resolver, "resolver1")
         # check the realm list of the token
         realm_found = False
         for realm_entry in t2.realm_list:
@@ -599,12 +599,12 @@ class TokenModelTestCase(MyTestCase):
         self.assertEqual(eh1.handlermodule, handlermodule)
         self.assertEqual(eh1.action, action)
         self.assertEqual(eh1.condition, condition)
-        self.assertEqual(eh1.option_list[0].Key, "mailserver")
-        self.assertEqual(eh1.option_list[0].Value, "blafoo")
-        self.assertEqual(eh1.option_list[1].Key, "option2")
-        self.assertEqual(eh1.option_list[1].Value, "value2")
-        self.assertEqual(eh1.condition_list[0].Key, "user_type")
-        self.assertEqual(eh1.condition_list[0].Value, "admin")
+        self.assertEqual(eh1.options[0].Key, "mailserver")
+        self.assertEqual(eh1.options[0].Value, "blafoo")
+        self.assertEqual(eh1.options[1].Key, "option2")
+        self.assertEqual(eh1.options[1].Value, "value2")
+        self.assertEqual(eh1.conditions[0].Key, "user_type")
+        self.assertEqual(eh1.conditions[0].Value, "admin")
 
         id = eh1.id
 
@@ -616,23 +616,23 @@ class TokenModelTestCase(MyTestCase):
 
         # Update option value
         EventHandlerOption(id, Key="mailserver", Value="mailserver")
-        self.assertEqual(eh1.option_list[0].Value, "mailserver")
+        self.assertEqual(eh1.options[0].Value, "mailserver")
 
         # Add Option
         EventHandlerOption(id, Key="option3", Value="value3")
-        self.assertEqual(eh1.option_list[2].Key, "option3")
-        self.assertEqual(eh1.option_list[2].Value, "value3")
+        self.assertEqual(eh1.options[2].Key, "option3")
+        self.assertEqual(eh1.options[2].Value, "value3")
 
         # Update condition value
         EventHandlerCondition(id, Key="user_type", Value="user")
-        self.assertEqual(eh1.condition_list[0].Value, "user")
+        self.assertEqual(eh1.conditions[0].Value, "user")
 
         # Add condition
         EventHandlerCondition(id, Key="result_value", Value="True")
-        self.assertEqual(eh1.condition_list[0].Key, "result_value")
-        self.assertEqual(eh1.condition_list[0].Value, "True")
-        self.assertEqual(eh1.condition_list[1].Key, "user_type")
-        self.assertEqual(eh1.condition_list[1].Value, "user")
+        self.assertEqual(eh1.conditions[0].Key, "result_value")
+        self.assertEqual(eh1.conditions[0].Value, "True")
+        self.assertEqual(eh1.conditions[1].Key, "user_type")
+        self.assertEqual(eh1.conditions[1].Value, "user")
 
         # Delete event handler
         eh1.delete()
@@ -652,8 +652,8 @@ class TokenModelTestCase(MyTestCase):
         SMSGateway(name, provider_module2,
                    options={"k1": "v1"})
         self.assertEqual(gw.providermodule, provider_module2)
-        self.assertEqual(gw.ref_option_list[0].Key, "k1")
-        self.assertEqual(gw.ref_option_list[0].Value, "v1")
+        self.assertEqual(gw.options[0].Key, "k1")
+        self.assertEqual(gw.options[0].Value, "v1")
 
         # Delete gateway
         gw.delete()

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -2583,11 +2583,11 @@ class UserNotificationTestCase(MyTestCase):
 
         # Unassign any user from this token - we need to do this, since the token can have more users.
         unassign_token(tok.token.serial)
-        self.assertEqual(tok.token.owners.first(), None)
+        self.assertEqual(tok.token.first_owner, None)
         # Set an existing user for the token.
         tok.add_user(User("cornelius", "realm1"))
-        self.assertEqual(tok.token.owners.first().user_id, "1000")
-        self.assertEqual(tok.token.owners.first().realm.name, "realm1")
+        self.assertEqual(tok.token.first_owner.user_id, "1000")
+        self.assertEqual(tok.token.first_owner.realm.name, "realm1")
 
         r = uhandler.check_condition(
             {"g": {},

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -404,7 +404,7 @@ class TokenTestCase(MyTestCase):
 
         r = assign_token(serial, user, pin="1234")
         self.assertTrue(r)
-        self.assertEqual(tokenobject.token.owners.first().user_id, "1000")
+        self.assertEqual(tokenobject.token.first_owner.user_id, "1000")
 
         # token already assigned...
         self.assertRaises(TokenAdminError, assign_token, serial,
@@ -413,7 +413,7 @@ class TokenTestCase(MyTestCase):
         # unassign token
         r = unassign_token(serial)
         self.assertTrue(r)
-        self.assertEqual(tokenobject.token.owners.first(), None)
+        self.assertEqual(tokenobject.token.first_owner, None)
 
         remove_token(serial)
         # assign or unassign a token, that does not exist
@@ -621,8 +621,8 @@ class TokenTestCase(MyTestCase):
 
         r = copy_token_user(serial1, serial2)
         assert isinstance(tobject2, TokenClass)
-        self.assertEqual(tobject2.token.owners.first().user_id, "1000")
-        self.assertEqual(tobject2.token.owners.first().resolver, self.resolvername1)
+        self.assertEqual(tobject2.token.first_owner.user_id, "1000")
+        self.assertEqual(tobject2.token.first_owner.resolver, self.resolvername1)
 
         # check if the realms where copied:
         self.assertTrue(tobject2.get_realms() == [self.realm1])

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -173,7 +173,7 @@ class TokenBaseTestCase(MyTestCase):
         # reset failcount
         token.token.failcount = 8
         
-        self.assertTrue(token.get_user_id() == token.token.owners.first().user_id)
+        self.assertTrue(token.get_user_id() == token.token.first_owner.user_id)
         
         self.assertTrue(token.get_serial() == "SE123456", token.token.serial)
         self.assertTrue(token.get_tokentype() == "newtype",

--- a/tests/test_lib_tokens_daplug.py
+++ b/tests/test_lib_tokens_daplug.py
@@ -79,8 +79,8 @@ class DaplugTokenTestCase(MyTestCase):
 
         token.add_user(User(login="cornelius",
                             realm=self.realm1))
-        self.assertEqual(token.token.owners.first().resolver, self.resolvername1)
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.resolver, self.resolvername1)
+        self.assertEqual(token.token.first_owner.user_id, "1000")
 
         user_object = token.user
         self.assertTrue(user_object.login == "cornelius",
@@ -134,7 +134,7 @@ class DaplugTokenTestCase(MyTestCase):
         token.token.maxfail = 12
         self.assertTrue(token.get_max_failcount() == 12)
 
-        self.assertEqual(token.get_user_id(), token.token.owners.first().user_id)
+        self.assertEqual(token.get_user_id(), token.token.first_owner.user_id)
 
         self.assertTrue(token.get_serial() == "SE123456", token.token.serial)
         self.assertTrue(token.get_tokentype() == "daplug",

--- a/tests/test_lib_tokens_email.py
+++ b/tests/test_lib_tokens_email.py
@@ -103,8 +103,8 @@ class EmailTokenTestCase(MyTestCase):
         self.assertTrue(token.type == "email", token.type)
 
         token.add_user(User(login="cornelius", realm=self.realm1))
-        self.assertEqual(token.token.owners.first().resolver, self.resolvername1)
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.resolver, self.resolvername1)
+        self.assertEqual(token.token.first_owner.user_id, "1000")
 
         user_object = token.user
         self.assertTrue(user_object.login == "cornelius",

--- a/tests/test_lib_tokens_hotp.py
+++ b/tests/test_lib_tokens_hotp.py
@@ -87,8 +87,8 @@ class HOTPTokenTestCase(MyTestCase):
 
         token.add_user(User(login="cornelius",
                             realm=self.realm1))
-        self.assertEqual(token.token.owners.first().resolver, self.resolvername1)
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.resolver, self.resolvername1)
+        self.assertEqual(token.token.first_owner.user_id, "1000")
 
         user_object = token.user
         self.assertTrue(user_object.login == "cornelius",
@@ -142,7 +142,7 @@ class HOTPTokenTestCase(MyTestCase):
         token.token.maxfail = 12
         self.assertTrue(token.get_max_failcount() == 12)
 
-        self.assertEqual(token.get_user_id(), token.token.owners.first().user_id)
+        self.assertEqual(token.get_user_id(), token.token.first_owner.user_id)
 
         self.assertTrue(token.get_serial() == "SE123456", token.token.serial)
         self.assertTrue(token.get_tokentype() == "hotp",

--- a/tests/test_lib_tokens_motp.py
+++ b/tests/test_lib_tokens_motp.py
@@ -98,8 +98,8 @@ class MotpTokenTestCase(MyTestCase):
         token.add_user(User(login="cornelius",
                             realm=self.realm1))
         token.save()
-        self.assertEqual(token.token.owners.first().resolver, self.resolvername1)
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.resolver, self.resolvername1)
+        self.assertEqual(token.token.first_owner.user_id, "1000")
 
         user_object = token.user
         self.assertTrue(user_object.login == "cornelius",

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -113,8 +113,8 @@ class SMSTokenTestCase(MyTestCase):
 
         token.add_user(User(login="cornelius",
                             realm=self.realm1))
-        self.assertEqual(token.token.owners.first().resolver, self.resolvername1)
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.resolver, self.resolvername1)
+        self.assertEqual(token.token.first_owner.user_id, "1000")
 
         user_object = token.user
         self.assertTrue(user_object.login == "cornelius",
@@ -170,7 +170,7 @@ class SMSTokenTestCase(MyTestCase):
         token.token.maxfail = 12
         self.assertTrue(token.get_max_failcount() == 12)
 
-        self.assertEqual(token.get_user_id(), token.token.owners.first().user_id)
+        self.assertEqual(token.get_user_id(), token.token.first_owner.user_id)
 
         self.assertTrue(token.get_serial() == "SE123456", token.token.serial)
         self.assertTrue(token.get_tokentype() == "sms",

--- a/tests/test_lib_tokens_totp.py
+++ b/tests/test_lib_tokens_totp.py
@@ -90,8 +90,8 @@ class TOTPTokenTestCase(MyTestCase):
         
         token.add_user(User(login="cornelius",
                             realm=self.realm1))
-        self.assertEqual(token.token.owners.first().resolver, self.resolvername1)
-        self.assertEqual(token.token.owners.first().user_id, "1000")
+        self.assertEqual(token.token.first_owner.resolver, self.resolvername1)
+        self.assertEqual(token.token.first_owner.user_id, "1000")
         
         user_object = token.user
         self.assertTrue(user_object.login == "cornelius",
@@ -145,7 +145,7 @@ class TOTPTokenTestCase(MyTestCase):
         token.token.maxfail = 12
         self.assertTrue(token.get_max_failcount() == 12)
         
-        self.assertEqual(token.get_user_id(), token.token.owners.first().user_id)
+        self.assertEqual(token.get_user_id(), token.token.first_owner.user_id)
         
         self.assertTrue(token.get_serial() == "SE123456", token.token.serial)
         self.assertTrue(token.get_tokentype() == "totp",


### PR DESCRIPTION
This only removes some cases of duplicated relationships: e.g. there was a relationship ``info`` from ``Token`` to ``TokenInfo`` with a backref called ``info``, *and* a relationship ``token`` from ``TokenInfo`` to ``Token`` with a backref called ``info_list``: Hence, ``Token`` had both ``info`` and ``info_list``, and ``TokenInfo`` had both ``info`` and ``token``. With this PR, ``Token`` has only ``info_list`` and ``TokenInfo`` has only ``token``.

In the unit tests, this PR also replaces all occurrences of ``Token.owners.first()`` with ``Token.first_owner`` in order to make it easier to change the relationship loading technique of ``owners`` from ``dynamic`` to something else in the future.

This commit does not alter the relationship loading techniques and should not have any performance impact.

Working on #1444