### PR TITLE
Log usage of '/smsgateway' endpoint to audit

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -215,6 +215,7 @@ def before_request():
 @smtpserver_blueprint.after_request
 @eventhandling_blueprint.after_request
 @radiusserver_blueprint.after_request
+@smsgateway_blueprint.after_request
 @periodictask_blueprint.after_request
 @privacyideaserver_blueprint.after_request
 @client_blueprint.after_request

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import json
 import mock
 
 from privacyidea.app import create_app
@@ -190,6 +189,9 @@ class MyTestCase(unittest.TestCase):
                                            data=sorted_filter,
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
+            self.assertTrue(res.is_json, res)
+            result = res.json['result']
+            self.assertIn('auditdata', result['value'])
             # return the last entry
             return res.json["result"]["value"]["auditdata"][0]
 

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -1,6 +1,8 @@
-import json
+# -*- coding: utf-8 -*-
+
 from .base import MyApiTestCase
 from privacyidea.lib.policy import set_policy, delete_policy, SCOPE, ACTION
+
 
 class APISmsGatewayTestCase(MyApiTestCase):
 
@@ -16,6 +18,10 @@ class APISmsGatewayTestCase(MyApiTestCase):
             result = res.json.get("result")
             detail = res.json.get("detail")
             self.assertEqual(result.get("value"), [])
+
+        # check that we have an entry in the audit log
+        audit_entry = self.find_most_recent_audit_entry(action="GET /smsgateway*")
+        self.assertEqual(audit_entry['success'], 1, audit_entry)
 
         # create an sms gateway definition
         param = {


### PR DESCRIPTION
Add missing `after_request` decorator for `smsgateway`.
Also test that the call is correctly logged in the audit log.

Fixes #1884