### PR TITLE
Also allow Registration token to do chal resp

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1354,11 +1354,10 @@ class TokenClass(object):
         :return: true or false
         :rtype: bool
         """
-
         request_is_challenge = False
         options = options or {}
         pin_match = self.check_pin(passw, user=user, options=options)
-        if pin_match is True and "data" in options or "challenge" in options:
+        if pin_match is True:
             request_is_challenge = True
 
         return request_is_challenge

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -350,31 +350,6 @@ class HotpTokenClass(TokenClass):
                      get_from_config("hotp.hashlib", u'sha1')
         return hashlibStr
 
-    # challenge interfaces starts here
-    @log_with(log)
-    @challenge_response_allowed
-    def is_challenge_request(self, passw, user=None, options=None):
-        """
-        check, if the request would start a challenge
-
-        - default: if the passw contains only the pin, this request would
-        trigger a challenge
-
-        - in this place as well the policy for a token is checked
-
-        :param passw: password, which might be pin or pin+otp
-        :param options: dictionary of additional request parameters
-
-        :return: returns true or false
-        """
-        trigger_challenge = False
-        options = options or {}
-        pin_match = self.check_pin(passw, user=user, options=options)
-        if pin_match is True:
-            trigger_challenge = True
-
-        return trigger_challenge
-
 
     @log_with(log)
     @check_token_locked

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -540,15 +540,14 @@ class TokenBaseTestCase(MyTestCase):
         transaction_id = "123456789"
 
         db_token.set_pin("test")
-        # No challenge request
-        req = token.is_challenge_request("test", User(login="cornelius",
+        # No challenge request, since we have the wrong pin
+        req = token.is_challenge_request("testX", User(login="cornelius",
                                                       realm=self.realm1))
         self.assertFalse(req, req)
-        # A challenge request
+        # A challenge request, since we have the correct pin
         req = token.is_challenge_request("test",
                                          User(login="cornelius",
-                                              realm=self.realm1),
-                                         {"data": "a challenge"})
+                                              realm=self.realm1))
         self.assertTrue(req, req)
 
         resp = token.is_challenge_response(User(login="cornelius",


### PR DESCRIPTION
Some tokens like the Registration code could not be
used with challenge response, even if the policy was set.
We changed the Token Base Class to do challenge response,
when the right OTP PIN is given.

Closes #1897