### PR TITLE
FirebaseProvider Enhancements for Push Tokens

### DIFF
--- a/privacyidea/lib/smsprovider/FirebaseProvider.py
+++ b/privacyidea/lib/smsprovider/FirebaseProvider.py
@@ -127,7 +127,31 @@ class FirebaseProvider(ISMSProvider):
         fcm_message = {
             "message": {
                         "data": data,
-                        "token": firebase_token
+                        "token": firebase_token,
+                        "android": {
+                                    "priority": "HIGH",
+                                    "ttl": "120s",
+                                    "fcm_options": {"analytics_label": "AndroidPushToken"}
+                                   },
+                        "apns": {
+                                 "headers": {
+                                             "apns-priority": "10",
+                                             "apns-push-type": "alert",
+                                             "apns-collapse-id": "privacyidea.pushtoken",
+                                             "apns-expiration": str(int(time.time()) + 120)
+                                            },
+                                 "payload": {
+                                             "aps": {
+                                                     "alert": {
+                                                               "title": data.get("title"),
+                                                               "body": data.get("question"),
+                                                              },
+                                                     "sound": "default",
+                                                     "category": "PUSH_AUTHENTICATION"
+                                                    },
+                                            },
+                                 "fcm_options": {"analytics_label": "iOSPushToken"}
+                                }
                        }
             }
 


### PR DESCRIPTION
Changes to FCM message payload are required for push notifications to work properly on iOS in all app states (foreground, background, terminated).  The apns-* and aps sections are required/recommended per Apple's developer documentation.  Adding the category tag for Apple Push Services enables the 'Allow' button to work at the notification screen on iOS as well as from notifications that are pushed to the Apple Watch.

Added TTL for push notifications so they automatically remove themselves from Firebase storage if they are too old to be useful for both iOS and Android.

Added FCM tags for reporting/analytics on the Firebase Console per Google's recommendation.