### PR TITLE
Use named parameters for redis setex

### DIFF
--- a/authmodules/apache2/privacyidea_apache.py
+++ b/authmodules/apache2/privacyidea_apache.py
@@ -65,7 +65,7 @@ def check_password(environ, username, password):
     value = rd.get(key)
     if value and passlib.hash.pbkdf2_sha512.verify(password, value):
         # update the timeout
-        rd.setex(key, _generate_digest(password), TIMEOUT)
+        rd.setex(key, value=_generate_digest(password), time=TIMEOUT)
         r_value = OK
 
     else:
@@ -86,7 +86,7 @@ def check_password(environ, username, password):
                 syslog.syslog(syslog.LOG_DEBUG, "{0!s}".format(traceback.format_exc()))
 
             if json_response.get("result", {}).get("value"):
-                rd.setex(key, _generate_digest(password), TIMEOUT)
+                rd.setex(key, value=_generate_digest(password), time=TIMEOUT)
                 r_value = OK
         else:
             syslog.syslog(syslog.LOG_ERR, "Error connecting to privacyIDEA: "


### PR DESCRIPTION
In newer versions (tested on Debian 10) the `setex(name, value, time)` call no longer works.
According to the documentation (https://redis-py.readthedocs.io/en/latest/#redis.Redis.setex) setex is supposed to be called like `setex(name, time, value)` (please notice the change in the order of the parameters).
The use of the named parameters value and time makes sure that parameters are not being confused when calling setex.