### PR TITLE
Fix disabled phone number input field

### DIFF
--- a/privacyidea/static/components/token/views/token.enroll.sms.html
+++ b/privacyidea/static/components/token/views/token.enroll.sms.html
@@ -4,7 +4,7 @@
 
 <h4 translate>Token data</h4>
 
-<div translate class="bg-info">
+<div ng-hide="loggedInUser.role==='user'" translate class="bg-info">
     For SMS tokens to work properly you need to set the
     <a ui-sref="config.tokens({tokentype:'sms'})">SMS Token Config</a>!
 </div>
@@ -14,7 +14,7 @@
            name="dynamic_phone" id="dynamic_phone">
     <label for="dynamic_phone" translate>Read number dynamically from user source on each request.</label>
 </div>
-<div ng-hide="form.dynamic_phone || loggedInUser.role==='user'" class="form-group">
+<div ng-hide="form.dynamic_phone" class="form-group">
     <label for="phone" translate>Phone number</label>
     <input type="text"
            autofocus


### PR DESCRIPTION
The phone number input field was disabled when enrolling an SMS token as a
user.
Fixes #1929