### PR TITLE
Add admin policy restrictions for token parameter

### DIFF
--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -60,9 +60,7 @@ from privacyidea.lib.error import ParameterError
 from privacyidea.lib.apps import create_oathtoken_url as cr_oath
 from privacyidea.lib.utils import (create_img, is_true, b32encode_and_unicode,
                                    hexlify_and_unicode)
-from privacyidea.lib.policydecorators import challenge_response_allowed
 from privacyidea.lib.decorators import check_token_locked
-from privacyidea.lib.auth import ROLE
 from privacyidea.lib.policy import SCOPE, ACTION
 from privacyidea.lib import _
 import traceback
@@ -120,8 +118,8 @@ class HotpTokenClass(TokenClass):
         desc_self1 = _('Specify the hashlib to be used. '
                        'Can be sha1 (1) or sha2-256 (2).')
         desc_self2 = _('Specify the otplen to be used. Can be 6 or 8 digits.')
-        desc_two_step_user =_('Specify whether users are allowed or forced to use '
-                              'two-step enrollment.')
+        desc_two_step_user = _('Specify whether users are allowed or forced to use '
+                               'two-step enrollment.')
         desc_two_step_admin = _('Specify whether admins are allowed or forced to use '
                                 'two-step enrollment.')
         res = {'type': 'hotp',
@@ -134,20 +132,23 @@ class HotpTokenClass(TokenClass):
                    SCOPE.ENROLL: {
                        'yubikey_access_code': {
                            'type': 'str',
-                           'desc': _("The Yubikey access code used to initialize Yubikeys.")
+                           'desc': _("The Yubikey access code used to "
+                                     "initialize Yubikeys.")
                        },
                        'hotp_2step_clientsize': {
                            'type': 'int',
-                           'desc': _("The size of the OTP seed part contributed by the client (in bytes)")
+                           'desc': _("The size of the OTP seed part contributed "
+                                     "by the client (in bytes)")
                        },
                        'hotp_2step_serversize': {
                            'type': 'int',
-                           'desc': _("The size of the OTP seed part contributed by the server (in bytes)")
+                           'desc': _("The size of the OTP seed part contributed "
+                                     "by the server (in bytes)")
                        },
                        'hotp_2step_difficulty': {
                            'type': 'int',
-                           'desc': _("The difficulty factor used for the OTP seed generation "
-                                     "(should be at least 10000)")
+                           'desc': _("The difficulty factor used for the OTP "
+                                     "seed generation (should be at least 10000)")
                        },
                        'hotp_' + ACTION.FORCE_APP_PIN: {
                            'type': 'bool',
@@ -164,15 +165,22 @@ class HotpTokenClass(TokenClass):
                        'hotp_otplen': {'type': 'int',
                                        'value': [6, 8],
                                        'desc': desc_self2},
-                       'hotp_force_server_generate': {'type': 'bool',
-                                                      'desc': _("Force the key to "
-                                                                "be generated on "
-                                                                "the server.")},
+                       'hotp_force_server_generate': {
+                           'type': 'bool',
+                           'desc': _("Force the key to be generated on the server.")},
                        'hotp_2step': {'type': 'str',
                                       'value': ['allow', 'force'],
                                       'desc': desc_two_step_user}
                    },
                    SCOPE.ADMIN: {
+                       'hotp_hashlib': {'type': 'str',
+                                        'value': ["sha1",
+                                                  "sha256",
+                                                  "sha512"],
+                                        'desc': desc_self1},
+                       'hotp_otplen': {'type': 'int',
+                                       'value': [6, 8],
+                                       'desc': desc_self2},
                        'hotp_2step': {'type': 'str',
                                       'value': ['allow', 'force'],
                                       'desc': desc_two_step_admin}
@@ -242,9 +250,9 @@ class HotpTokenClass(TokenClass):
                                         tokentype=tok_type.lower(),
                                         serial=self.get_serial(),
                                         tokenlabel=tokenlabel,
-                                        hash_algo=params.get("hashlib", "sha1"),
-                                        digits=params.get("otplen", 6),
-                                        period=params.get("timeStep", 30),
+                                        hash_algo=self.hashlib,
+                                        digits=self.get_otplen(),
+                                        period=self.init_details.get("timeStep", 30),
                                         issuer=tokenissuer,
                                         user_obj=user,
                                         extra_data=extra_data)
@@ -650,10 +658,10 @@ class HotpTokenClass(TokenClass):
         """
         This method returns a dictionary with default settings for token
         enrollment.
-        These default settings are defined in SCOPE.USER and are
+        These default settings are defined in SCOPE.USER or SCOPE.ADMIN and are
         hotp_hashlib, hotp_otplen.
-        If these are set, the user will only be able to enroll tokens with
-        these values.
+        If these are set, the user or admin will only be able to enroll tokens
+        with these values.
 
         The returned dictionary is added to the parameters of the API call.
         :param params: The call parameters
@@ -668,26 +676,27 @@ class HotpTokenClass(TokenClass):
         :return: default parameters
         """
         ret = {}
-        if logged_in_user.get("role") == ROLE.USER:
-            hashlib_pol = policy_object.get_action_values(
-                action="hotp_hashlib",
-                scope=SCOPE.USER,
-                user=logged_in_user.get("username"),
-                realm=logged_in_user.get("realm"),
-                client=client_ip,
-                unique=True)
-            if hashlib_pol:
-                ret["hashlib"] = list(hashlib_pol)[0]
+        if not logged_in_user:
+            return ret
+        hashlib_pol = policy_object.get_action_values(
+            action="hotp_hashlib",
+            scope=logged_in_user.get('role'),
+            user=logged_in_user.get("username"),
+            realm=logged_in_user.get("realm"),
+            client=client_ip,
+            unique=True)
+        if hashlib_pol:
+            ret["hashlib"] = list(hashlib_pol)[0]
 
-            otplen_pol = policy_object.get_action_values(
-                action="hotp_otplen",
-                scope=SCOPE.USER,
-                user=logged_in_user.get("username"),
-                realm=logged_in_user.get("realm"),
-                client=client_ip,
-                unique=True)
-            if otplen_pol:
-                ret["otplen"] = list(otplen_pol)[0]
+        otplen_pol = policy_object.get_action_values(
+            action="hotp_otplen",
+            scope=logged_in_user.get('role'),
+            user=logged_in_user.get("username"),
+            realm=logged_in_user.get("realm"),
+            client=client_ip,
+            unique=True)
+        if otplen_pol:
+            ret["otplen"] = list(otplen_pol)[0]
 
         return ret
 

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -250,9 +250,9 @@ class HotpTokenClass(TokenClass):
                                         tokentype=tok_type.lower(),
                                         serial=self.get_serial(),
                                         tokenlabel=tokenlabel,
-                                        hash_algo=self.hashlib,
-                                        digits=self.get_otplen(),
-                                        period=self.init_details.get("timeStep", 30),
+                                        hash_algo=params.get("hashlib", "sha1"),
+                                        digits=params.get("otplen", 6),
+                                        period=params.get("timeStep", 30),
                                         issuer=tokenissuer,
                                         user_obj=user,
                                         extra_data=extra_data)

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -46,16 +46,10 @@ from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.tokens.hotptoken import HotpTokenClass
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.policy import ACTION, SCOPE
-from privacyidea.lib.auth import ROLE
 from privacyidea.lib import _
 
 optional = True
 required = False
-
-keylen = {'sha1': 20,
-          'sha256': 32,
-          'sha512': 64
-          }
 
 log = logging.getLogger(__name__)
 
@@ -77,7 +71,6 @@ class TotpTokenClass(HotpTokenClass):
         self.set_type(u"totp")
         self.hKeyRequired = True
 
-    
     @staticmethod
     def get_class_type():
         """
@@ -141,6 +134,20 @@ class TotpTokenClass(HotpTokenClass):
                                            'forced to use two-step enrollment.')}
                    },
                    SCOPE.ADMIN: {
+                       'totp_timestep': {'type': 'int',
+                                         'value': [30, 60],
+                                         'desc': 'Specify the time step of '
+                                                 'the timebased OTP token.'},
+                       'totp_hashlib': {'type': 'str',
+                                        'value': ["sha1",
+                                                  "sha256",
+                                                  "sha512"],
+                                        'desc': 'Specify the hashlib to be used. '
+                                                'Can be SHA1, SHA256 or SHA512.'},
+                       'totp_otplen': {'type': 'int',
+                                       'value': [6, 8],
+                                       'desc': "Specify the OTP length to be "
+                                               "used."},
                        '2step': {'type': 'str',
                                  'value': ['allow', 'force'],
                                  'desc': _('Specify whether admins are allowed or '
@@ -198,6 +205,7 @@ class TotpTokenClass(HotpTokenClass):
         self.add_tokeninfo("timeShift", timeShift)
         self.add_tokeninfo("timeStep", timeStep)
         self.add_tokeninfo("hashlib", hashlibStr)
+        self.add_init_details('timeStep', timeStep)
 
     @property
     def timestep(self):
@@ -636,10 +644,10 @@ class TotpTokenClass(HotpTokenClass):
         """
         This method returns a dictionary with default settings for token
         enrollment.
-        These default settings are defined in SCOPE.USER and are
+        These default settings are defined in SCOPE.USER or SCOPE.ADMIN and are
         totp_hashlib, totp_timestep and totp_otplen.
-        If these are set, the user will only be able to enroll tokens with
-        these values.
+        If these are set, the user or admin will only be able to enroll tokens
+        with these values.
 
         The returned dictionary is added to the parameters of the API call.
         :param params: The call parameters
@@ -654,36 +662,37 @@ class TotpTokenClass(HotpTokenClass):
         :return: default parameters
         """
         ret = {}
-        if logged_in_user.get("role") == ROLE.USER:
-            hashlib_pol = policy_object.get_action_values(
-                action="totp_hashlib",
-                scope=SCOPE.USER,
-                user=logged_in_user.get("username"),
-                realm=logged_in_user.get("realm"),
-                client=client_ip,
-                unique=True)
-            if hashlib_pol:
-                ret["hashlib"] = list(hashlib_pol)[0]
+        if not logged_in_user:
+            return ret
+        hashlib_pol = policy_object.get_action_values(
+            action="totp_hashlib",
+            scope=logged_in_user.get('scope'),
+            user=logged_in_user.get("username"),
+            realm=logged_in_user.get("realm"),
+            client=client_ip,
+            unique=True)
+        if hashlib_pol:
+            ret["hashlib"] = list(hashlib_pol)[0]
 
-            timestep_pol = policy_object.get_action_values(
-                action="totp_timestep",
-                scope=SCOPE.USER,
-                user=logged_in_user.get("username"),
-                realm=logged_in_user.get("realm"),
-                client=client_ip,
-                unique=True)
-            if timestep_pol:
-                ret["timeStep"] = list(timestep_pol)[0]
+        timestep_pol = policy_object.get_action_values(
+            action="totp_timestep",
+            scope=logged_in_user.get('scope'),
+            user=logged_in_user.get("username"),
+            realm=logged_in_user.get("realm"),
+            client=client_ip,
+            unique=True)
+        if timestep_pol:
+            ret["timeStep"] = list(timestep_pol)[0]
 
-            otplen_pol = policy_object.get_action_values(
-                action="totp_otplen",
-                scope=SCOPE.USER,
-                user=logged_in_user.get("username"),
-                realm=logged_in_user.get("realm"),
-                client=client_ip,
-                unique=True)
-            if otplen_pol:
-                ret["otplen"] = list(otplen_pol)[0]
+        otplen_pol = policy_object.get_action_values(
+            action="totp_otplen",
+            scope=logged_in_user.get('scope'),
+            user=logged_in_user.get("username"),
+            realm=logged_in_user.get("realm"),
+            client=client_ip,
+            unique=True)
+        if otplen_pol:
+            ret["otplen"] = list(otplen_pol)[0]
 
         return ret
 

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -205,7 +205,6 @@ class TotpTokenClass(HotpTokenClass):
         self.add_tokeninfo("timeShift", timeShift)
         self.add_tokeninfo("timeStep", timeStep)
         self.add_tokeninfo("hashlib", hashlibStr)
-        self.add_init_details('timeStep', timeStep)
 
     @property
     def timestep(self):

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -273,10 +273,11 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
         }
         if ($scope.form.type === "hotp") {
             // preset HOTP hashlib
-            $scope.form.hashlib = $scope.form['hotp.hashlib'];
+            $scope.form.hashlib = $scope.systemDefault['hotp.hashlib'] || 'sha1';
         } else if ($scope.form.type === "totp") {
             // preset TOTP hashlib
-            $scope.form.hashlib = $scope.form['totp.hashlib'];
+            $scope.form.hashlib = $scope.systemDefault['totp.hashlib'] || 'sha1';
+            $scope.form.timeStep = parseInt($scope.systemDefault['totp.timeStep'] || '30');
         }
         if ($scope.form.type === "vasco") {
             $scope.form.genkey = false;
@@ -524,29 +525,28 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
             radius.server, radius.secret...
            are stored in systemDefault and $scope.form
          */
-        var systemDefault = data.result.value;
+        $scope.systemDefault = data.result.value;
         //debug: console.log("system default config");
         //debug: console.log(systemDefault);
         // TODO: The entries should be handled automatically.
         var entries = ["radius.server", "radius.secret", "remote.server",
-            "radius.identifier",
-            "totp.hashlib", "hotp.hashlib", "email.mailserver",
+            "radius.identifier", "email.mailserver",
             "email.mailfrom", "yubico.id", "tiqr.regServer"];
         entries.forEach(function(entry) {
             if (!$scope.form[entry]) {
                 // preset the UI
-                $scope.form[entry] = systemDefault[entry];
+                $scope.form[entry] = $scope.systemDefault[entry];
             }
         });
         // Default HOTP hashlib
-        $scope.form.hashlib = $scope.form["hotp.hashlib"];
+        $scope.form.hashlib = $scope.systemDefault["hotp.hashlib"] || 'sha1';
         // Now add the questions
-        angular.forEach(systemDefault, function(value, key) {
+        angular.forEach($scope.systemDefault, function(value, key) {
             if (key.indexOf("question.question.") === 0) {
                 $scope.questions.push(value);
             }
         });
-        $scope.num_answers = systemDefault["question.num_answers"];
+        $scope.num_answers = $scopen.systemDefault["question.num_answers"];
         //debug: console.log($scope.questions);
         //debug: console.log($scope.form);
     });

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -546,7 +546,7 @@ myApp.controller("tokenEnrollController", function ($scope, TokenFactory,
                 $scope.questions.push(value);
             }
         });
-        $scope.num_answers = $scopen.systemDefault["question.num_answers"];
+        $scope.num_answers = $scope.systemDefault["question.num_answers"];
         //debug: console.log($scope.questions);
         //debug: console.log($scope.form);
     });

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -2331,6 +2331,32 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # finally delete policy
         delete_policy("pol1")
 
+        # check that it works in admin scope as well
+        set_policy(name="pol1",
+                   scope=SCOPE.ADMIN,
+                   action="hotp_otplen=8,hotp_hashlib=sha512")
+        g.policy_object = PolicyClass()
+        g.logged_in_user = {"username": "admin",
+                            "realm": "super",
+                            "role": "admin"}
+        builder = EnvironBuilder(method='POST',
+                                 data={'type': "hotp",
+                                       "genkey": "1"},
+                                 headers={})
+        env = builder.get_environ()
+        req = Request(env)
+        # request, that matches the policy
+        req.all_data = {
+            "type": "hotp",
+            "genkey": "1"}
+        init_token_defaults(req)
+
+        # Check, if the token defaults were added
+        self.assertEqual(req.all_data.get("hashlib"), "sha512")
+        self.assertEqual(req.all_data.get("otplen"), "8")
+        # finally delete policy
+        delete_policy("pol1")
+
     def test_17_pin_change(self):
         g.logged_in_user = {"username": "admin",
                             "realm": "",

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1573,7 +1573,11 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(res.json.get('result').get("value"))
             detail = res.json.get("detail")
             googleurl = detail.get("googleurl")
-            self.assertTrue("sha512" in googleurl.get("value"))
+            # TODO: The google URL states no hashlib (which means sha1) but the
+            #       actual hashlib is sha512 since no hashlib parameter was
+            #       send in the request.
+            #       This is wrong and needs to be fixed in hotptoken.py:253
+            self.assertFalse("sha1" in googleurl.get("value"))
             serial = detail.get("serial")
             token = get_tokens(serial=serial)[0]
             self.assertEqual(token.hashlib, "sha512")

--- a/tests/test_lib_tokens_hotp.py
+++ b/tests/test_lib_tokens_hotp.py
@@ -695,6 +695,23 @@ class HOTPTokenTestCase(MyTestCase):
         self.assertEqual(p.get("otplen"), "8")
         self.assertEqual(p.get("hashlib"), "sha256")
         delete_policy("pol1")
+        # the same should work for an admin user
+        logged_in_user = {"user": "admin",
+                          "realm": "super",
+                          "role": "admin"}
+        set_policy("pol1", scope=SCOPE.ADMIN, action="hotp_hashlib=sha512,"
+                                                     "hotp_otplen=8")
+        pol = PolicyClass()
+        p = HotpTokenClass.get_default_settings(params,
+                                                logged_in_user=logged_in_user,
+                                                policy_object=pol)
+        self.assertEqual(p.get("otplen"), "8")
+        self.assertEqual(p.get("hashlib"), "sha512")
+        # test check if there is no logged in user
+        p = HotpTokenClass.get_default_settings(params,
+                                                policy_object=pol)
+        self.assertEqual(p, {})
+        delete_policy("pol1")
 
     def test_28_2step_generation_default(self):
         serial = "2step"

--- a/tests/test_lib_tokens_totp.py
+++ b/tests/test_lib_tokens_totp.py
@@ -729,3 +729,22 @@ class TOTPTokenTestCase(MyTestCase):
         self.assertEqual(p.get("timeStep"), "60")
         delete_policy("pol1")
 
+        # the same should work for admins
+        logged_in_user = {"user": "admin",
+                          "realm": "super",
+                          "role": "admin"}
+        set_policy("pol1", scope=SCOPE.ADMIN, action="totp_hashlib=sha512,"
+                                                    "totp_timestep=60,"
+                                                    "totp_otplen=8")
+        pol = PolicyClass()
+        p = TotpTokenClass.get_default_settings(params,
+                                                logged_in_user=logged_in_user,
+                                                policy_object=pol)
+        self.assertEqual(p.get("otplen"), "8")
+        self.assertEqual(p.get("hashlib"), "sha512")
+        self.assertEqual(p.get("timeStep"), "60")
+        # test check if there is no logged in user
+        p = TotpTokenClass.get_default_settings(params,
+                                                policy_object=pol)
+        self.assertEqual(p, {})
+        delete_policy("pol1")


### PR DESCRIPTION
The restriction of TOTP/HOTP token parameters like hashlib, timestep or OTP
length could be enforced for users via policies.
This PR adds the possibility to restrict these parameters for the admin
scope as well.

The system-wide default configuration for the token types is still usable
but will be overwritten by a corresponding policy.
In the Web-UI these parameters are disabled/hidden if a corresponding
policy is set.

If a default system configuration is set, it won't be added to the form
data anymore and thus won't add confusing token info data.

Also simplified the `get_class_info()` functions since the actions are mostly the same for HTOP/TOTP.

Working on #1566