### PR TITLE
We need to fix the user -> username

### DIFF
--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -172,7 +172,7 @@ users and roles using the parameter ``PI_TRUSTED_JWT``::
                        "algorithm": "RS256",
                        "role": "user",
                        "realm": "realm1",
-                       "user": "userA",
+                       "username": "userA",
                        "resolver": "resolverX"}]
 
 
@@ -183,9 +183,15 @@ public key can sign a JWT, that can impersonate as the *userA* in resolver
 A JWT can be created like this::
 
    auth_token = jwt.encode(payload={"role": "user",
-                                    "user": "userA",
+                                    "username": "userA",
                                     "realm": "realm1",
                                     "resolver": "resolverX"},
                                     key=private_key,
                                     algorithm="RS256")
+
+.. note:: The user and the realm do not necessarily need to exist in any
+   resolver!
+   But there probably must be certain policies defined for this user.
+   If you are using an administrative user, the realm for this administrative
+   must be defined in ``pi.cfg`` in the list ``SUPERUSER_REALM``.
 

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -298,8 +298,8 @@ def verify_auth_token(auth_token, required_role=None):
                     j = jwt.decode(auth_token,
                                    trusted_jwt.get("public_key"),
                                    algorithms=TRUSTED_JWT_ALGOS)
-                    if dict((k, j.get(k)) for k in ("role", "user", "resolver", "realm")) == \
-                            dict((k, trusted_jwt.get(k)) for k in ("role", "user", "resolver", "realm")):
+                    if dict((k, j.get(k)) for k in ("role", "username", "resolver", "realm")) == \
+                            dict((k, trusted_jwt.get(k)) for k in ("role", "username", "resolver", "realm")):
                         r = j
                         break
                 else:

--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -79,19 +79,19 @@ class TestingConfig(Config):
                        "algorithm": "HS256",
                        "role": "user",
                        "realm": "realm1",
-                       "user": "userA",
+                       "username": "userA",
                        "resolver": "resolverX"},
                       {"public_key": non_matchin_pubkey,
                        "algorithm": "RS256",
                        "role": "user",
                        "realm": "realm1",
-                       "user": "userA",
+                       "username": "userA",
                        "resolver": "resolverX"},
                       {"public_key": pubtest_key,
                        "algorithm": "RS256",
                        "role": "user",
                        "realm": "realm1",
-                       "user": "userA",
+                       "username": "userA",
                        "resolver": "resolverX"}]
 
 


### PR DESCRIPTION
Otherwise the name of the user will not be passed to
the privacyIDEA processing, policies will not match and
the user will not be written to the audit log.

Fix in #1773