### PR TITLE
Fix token handler options with Python 3

### DIFF
--- a/privacyidea/lib/eventhandler/tokenhandler.py
+++ b/privacyidea/lib/eventhandler/tokenhandler.py
@@ -140,7 +140,7 @@ class TokenEventHandler(BaseEventHandler):
                            {"type": "int",
                             "required": True,
                             "description": _("set the PIN of the token to a random PIN of this length."),
-                            "value": range(1,32)}
+                            "value": list(range(1,32))}
                    },
                    ACTION_TYPE.INIT:
                        {"tokentype":

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -260,6 +260,17 @@ class APIEventsTestCase(MyApiTestCase):
             self.assertTrue("sendsms" in result.get("value"))
             detail = res.json.get("detail")
 
+        with self.app.test_request_context('/event/actions/Token',
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            set_random_pin = result.get("value").get("set random pin")
+            # The valid OTP PIN length is returned as list
+            self.assertTrue(type(set_random_pin.get("length").get("value")), "list")
+
     def test_05_get_handler_conditions(self):
         with self.app.test_request_context('/event/conditions/UserNotification',
                                            method='GET',


### PR DESCRIPTION
The options of the token handler returned a range,
which is an generator in python 3.
This would break during serialization.

Casting it to a list.