### PR TITLE
Add tokentype specifc limits

### DIFF
--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -41,6 +41,10 @@ type: int
 
 Limit the maximum number of tokens per user in this realm.
 
+There are also token type specific policies to limit the
+number of tokens of a specific token type, that a user is
+allowed to have assigned.
+
 .. note:: If you do not set this action, a user may have
    unlimited tokens assigned.
 
@@ -54,6 +58,10 @@ max_active_token_per_user
 type: int
 
 Limit the maximum number of active tokens per user.
+
+There are also token type specific policies to limit the
+number of tokens of a specific token type, that a user is
+allowed to have assigned.
 
 .. note:: Inactive tokens will not be taken into account.
    If the token already exists, it can be recreated if the token

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -63,8 +63,6 @@ Wrapping the functions in a decorator class enables easy modular testing.
 The functions of this module are tested in tests/test_api_lib_policy.py
 """
 import logging
-
-log = logging.getLogger(__name__)
 from privacyidea.lib.error import PolicyError, RegistrationError, TokenAdminError
 from flask import g, current_app
 from privacyidea.lib.policy import SCOPE, ACTION, PolicyClass
@@ -87,6 +85,8 @@ import importlib
 from privacyidea.lib.tokens.u2ftoken import (U2FACTION, parse_registration_data)
 from privacyidea.lib.tokens.u2f import x509name_to_string
 from privacyidea.lib.tokens.pushtoken import PUSH_ACTION
+
+log = logging.getLogger(__name__)
 
 optional = True
 required = False
@@ -637,8 +637,12 @@ def check_max_token_user(request=None, action=None):
     if user_object.login:
         serial = getParam(params, "serial")
         tokentype = getParam(params, "type")
-        if not tokentype:
+        if not tokentype and serial:
+            # If we have a serial but no tokentype, we can specify the tokentype
             tokentype = get_token_type(serial)
+        else:
+            # In some cases we have no serial and no tokentype.
+            tokentype = "hotp"
 
         # check maximum number of type specific tokens of user
         limit_list = Match.user(g, scope=SCOPE.ENROLL,

--- a/privacyidea/lib/tokens/certificatetoken.py
+++ b/privacyidea/lib/tokens/certificatetoken.py
@@ -42,6 +42,7 @@ from privacyidea.lib.user import get_user_from_param
 from OpenSSL import crypto
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 optional = True
 required = False
@@ -156,9 +157,21 @@ class CertificateTokenClass(TokenClass):
                'user':  ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of certificates assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active certificates assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
                }
-
+               }
         if key:
             ret = res.get(key, {})
         else:

--- a/privacyidea/lib/tokens/daplugtoken.py
+++ b/privacyidea/lib/tokens/daplugtoken.py
@@ -42,6 +42,7 @@ from privacyidea.lib.config import get_prepend_pin
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.utils import to_bytes, to_unicode
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 optional = True
 required = False
 
@@ -119,6 +120,19 @@ class DaplugTokenClass(HotpTokenClass):
                'title': 'Daplug Event Token',
                'description': _("event based OTP token using "
                                 "the HOTP algorithm"),
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of daplug tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active daplug tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }}
                }
 
         if key:

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -72,7 +72,7 @@ from privacyidea.lib.tokens.smstoken import HotpTokenClass
 from privacyidea.lib.config import get_from_config
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.utils import is_true, create_tag_dict
-from privacyidea.lib.policy import SCOPE, ACTION, get_action_values_from_options
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP, get_action_values_from_options
 from privacyidea.lib.policy import Match
 from privacyidea.lib.log import log_with
 from privacyidea.lib import _
@@ -177,6 +177,18 @@ class EmailTokenClass(HotpTokenClass):
                        'type': 'str',
                        'desc': _('Use an alternate challenge text for telling the '
                                  'user to enter the code from the eMail.')
+                   },
+               },
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of email tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active email tokens assigned."),
+                           'group': GROUP.TOKEN
                    }
                }
            }

--- a/privacyidea/lib/tokens/foureyestoken.py
+++ b/privacyidea/lib/tokens/foureyestoken.py
@@ -41,6 +41,7 @@ from privacyidea.lib.error import ParameterError
 from privacyidea.lib.token import check_realm_pass
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib import _
+from privacyidea.lib.policy import ACTION, SCOPE, GROUP
 
 log = logging.getLogger(__name__)
 optional = True
@@ -129,7 +130,20 @@ class FourEyesTokenClass(TokenClass):
                'user':  [],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of 4eyes tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active 4eyes tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -61,7 +61,7 @@ from privacyidea.lib.apps import create_oathtoken_url as cr_oath
 from privacyidea.lib.utils import (create_img, is_true, b32encode_and_unicode,
                                    hexlify_and_unicode)
 from privacyidea.lib.decorators import check_token_locked
-from privacyidea.lib.policy import SCOPE, ACTION
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 from privacyidea.lib import _
 import traceback
 import logging
@@ -130,6 +130,16 @@ class HotpTokenClass(TokenClass):
                'ui_enroll': ["admin", "user"],
                'policy': {
                    SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of HOTP tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active HOTP tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
                        'yubikey_access_code': {
                            'type': 'str',
                            'desc': _("The Yubikey access code used to "

--- a/privacyidea/lib/tokens/motptoken.py
+++ b/privacyidea/lib/tokens/motptoken.py
@@ -50,6 +50,7 @@ from privacyidea.lib.decorators import check_token_locked
 import traceback
 import logging
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 optional = True
 required = False
@@ -97,7 +98,20 @@ class MotpTokenClass(TokenClass):
                'user': ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy': {}
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of mOTP tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active mOTP tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               }
                }
 
         if key:

--- a/privacyidea/lib/tokens/ocratoken.py
+++ b/privacyidea/lib/tokens/ocratoken.py
@@ -41,6 +41,7 @@ from privacyidea.lib.tokens.ocra import OCRASuite, OCRA
 from privacyidea.lib import _
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.crypto import get_alphanum_str
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 OCRA_DEFAULT_SUITE = "OCRA-1:HOTP-SHA1-8:QH40"
 
@@ -93,7 +94,20 @@ class OcraTokenClass(TokenClass):
                #'user':  ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': [],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of OCRA tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active OCRA tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/papertoken.py
+++ b/privacyidea/lib/tokens/papertoken.py
@@ -29,9 +29,8 @@ import logging
 from privacyidea.lib.log import log_with
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.tokens.hotptoken import HotpTokenClass
-from privacyidea.lib.policy import SCOPE
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 from privacyidea.lib import _
-from privacyidea.lib.policydecorators import libpolicy
 
 log = logging.getLogger(__name__)
 DEFAULT_COUNT = 100
@@ -107,7 +106,18 @@ class PaperTokenClass(HotpTokenClass):
                            "type": "int",
                            "desc": _("The number of OTP values, which are "
                                      "printed on the paper.")
+                       },
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of paper tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active paper tokens assigned."),
+                           'group': GROUP.TOKEN
                        }
+
                    }
                }
                }

--- a/privacyidea/lib/tokens/passwordtoken.py
+++ b/privacyidea/lib/tokens/passwordtoken.py
@@ -26,6 +26,8 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.utils import to_bytes
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
+
 
 optional = True
 required = False
@@ -106,7 +108,20 @@ class PasswordTokenClass(TokenClass):
                'user':  [],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': [],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of password tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active password tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
         # I don't think we need to define the lost token policies here...
 

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -36,7 +36,7 @@ from privacyidea.lib.utils import prepare_result, to_bytes
 from privacyidea.lib.error import ResourceNotFoundError, ValidateError
 
 from privacyidea.lib.config import get_from_config
-from privacyidea.lib.policy import SCOPE, ACTION, get_action_values_from_options
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP, get_action_values_from_options
 from privacyidea.lib.log import log_with
 from privacyidea.lib import _
 
@@ -227,6 +227,16 @@ class PushTokenClass(TokenClass):
                            'desc': _('The smartphone needs to verify SSL during the enrollment. (default 1)'),
                            'group':  "PUSH",
                            'value': ["0", "1"]
+                       },
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of Push tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active Push tokens assigned."),
+                           'group': GROUP.TOKEN
                        }
                    },
                    SCOPE.AUTH: {

--- a/privacyidea/lib/tokens/questionnairetoken.py
+++ b/privacyidea/lib/tokens/questionnairetoken.py
@@ -34,6 +34,7 @@ from privacyidea.models import Challenge
 from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib import _
 from privacyidea.lib.decorators import check_token_locked
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 import random
 import json
 
@@ -93,7 +94,20 @@ class QuestionnaireTokenClass(TokenClass):
                'user':  ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of questionaire tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of active questionaire tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/radiustoken.py
+++ b/privacyidea/lib/tokens/radiustoken.py
@@ -66,6 +66,7 @@ from pyrad.client import Client, Timeout
 from pyrad.dictionary import Dictionary
 from pyrad.packet import AccessChallenge, AccessAccept, AccessReject
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 optional = True
 required = False
@@ -109,7 +110,21 @@ class RadiusTokenClass(RemoteTokenClass):
                'user': ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of RADIUS tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active RADIUS tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/registrationtoken.py
+++ b/privacyidea/lib/tokens/registrationtoken.py
@@ -35,6 +35,7 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.crypto import generate_password
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 optional = True
 required = False
@@ -127,7 +128,21 @@ class RegistrationTokenClass(PasswordTokenClass):
                'user':  [],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of registration tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active registration tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/remotetoken.py
+++ b/privacyidea/lib/tokens/remotetoken.py
@@ -52,6 +52,7 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.policydecorators import challenge_response_allowed
 from privacyidea.lib.tokenclass import TokenClass, TOKENKIND
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 optional = True
 required = False
@@ -114,7 +115,21 @@ class RemoteTokenClass(TokenClass):
                'user': [],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of remote tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active remote tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -56,7 +56,7 @@ from privacyidea.api.lib.utils import required, optional
 from privacyidea.lib.utils import is_true
 
 from privacyidea.lib.config import get_from_config
-from privacyidea.lib.policy import SCOPE, ACTION, get_action_values_from_options
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP, get_action_values_from_options
 from privacyidea.lib.log import log_with
 from privacyidea.lib.policy import Match
 from privacyidea.lib.smsprovider.SMSProvider import (get_sms_provider_class,
@@ -235,6 +235,19 @@ class SmsTokenClass(HotpTokenClass):
                                " ".join(sms_gateways))
                        }
                    },
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of SMS tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active SMS tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
                },
         }
 

--- a/privacyidea/lib/tokens/spasstoken.py
+++ b/privacyidea/lib/tokens/spasstoken.py
@@ -41,7 +41,7 @@ from privacyidea.lib import _
 from privacyidea.lib.log import log_with
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.decorators import check_token_locked
-from privacyidea.lib.policy import SCOPE
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 optional = True
 required = False
@@ -92,7 +92,21 @@ class SpassTokenClass(TokenClass):
                # SPASS token can have specific PIN policies in the scopes
                # admin and user
                'pin_scopes': [SCOPE.ADMIN, SCOPE.USER],
-               'policy': {}
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of SPASS tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active SPASS tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               }
                }
 
         # do we need to define the lost token policies here...

--- a/privacyidea/lib/tokens/sshkeytoken.py
+++ b/privacyidea/lib/tokens/sshkeytoken.py
@@ -28,11 +28,12 @@ The code is tested in tests/test_lib_tokens_ssh
 
 import logging
 from privacyidea.lib import _
-log = logging.getLogger(__name__)
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.log import log_with
 from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
+log = logging.getLogger(__name__)
 
 
 optional = True
@@ -86,7 +87,21 @@ class SSHkeyTokenClass(TokenClass):
                'user': ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of SSH keys assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active SSH keys assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
         if key:
             ret = res.get(key, {})

--- a/privacyidea/lib/tokens/tantoken.py
+++ b/privacyidea/lib/tokens/tantoken.py
@@ -27,11 +27,9 @@ import logging
 from privacyidea.lib.log import log_with
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.tokens.papertoken import PaperTokenClass
-from privacyidea.lib.policy import SCOPE
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 from privacyidea.lib import _
-from privacyidea.lib.policydecorators import libpolicy
 from privacyidea.lib.crypto import geturandom, hash
-import binascii
 
 log = logging.getLogger(__name__)
 DEFAULT_COUNT = 100
@@ -108,6 +106,17 @@ class TanTokenClass(PaperTokenClass):
                            "type": "int",
                            "desc": _("The number of OTP values, which are "
                                      "printed on the paper.")
+                       },
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of TAN tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active TAN tokens assigned."),
+                           'group': GROUP.TOKEN
                        }
                    }
                }

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -99,6 +99,7 @@ from privacyidea.models import cleanup_challenges
 from privacyidea.lib import _
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib.tokens.ocratoken import OcraTokenClass
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 log = logging.getLogger(__name__)
 optional = True
@@ -160,7 +161,21 @@ class TiqrTokenClass(OcraTokenClass):
                'user':  ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of TiQR tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active TiQR tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -45,7 +45,7 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.tokens.hotptoken import HotpTokenClass
 from privacyidea.lib.decorators import check_token_locked
-from privacyidea.lib.policy import ACTION, SCOPE
+from privacyidea.lib.policy import ACTION, SCOPE, GROUP
 from privacyidea.lib import _
 
 optional = True
@@ -169,7 +169,19 @@ class TotpTokenClass(HotpTokenClass):
                            'type': 'bool',
                            'desc': _('Enforce setting an app pin for the privacyIDEA '
                                      'Authenticator App')
+                       },
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of remote tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active remote tokens assigned."),
+                           'group': GROUP.TOKEN
                        }
+
                    }
                },
                }

--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -271,6 +271,17 @@ class U2fTokenClass(TokenClass):
                            'type': 'bool',
                            'desc': _("Do not verify the U2F attestation certificate."),
                            'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of U2F tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active U2F tokens assigned."),
+                           'group': GROUP.TOKEN
                        }
                    }
                }

--- a/privacyidea/lib/tokens/vascotoken.py
+++ b/privacyidea/lib/tokens/vascotoken.py
@@ -33,6 +33,7 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.tokens.vasco import vasco_otp_check
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 optional = True
 required = False
@@ -102,7 +103,21 @@ class VascoTokenClass(TokenClass):
                #'user': ["enroll"],
                # only administrators can enroll the token in the UI
                'ui_enroll': ["admin"],
-               'policy': {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of Vasco tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active Vasco tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/yubicotoken.py
+++ b/privacyidea/lib/tokens/yubicotoken.py
@@ -54,6 +54,7 @@ from privacyidea.lib.tokens.yubikeytoken import (yubico_check_api_signature,
                                                  yubico_api_signature)
 from six.moves.urllib.parse import urlencode
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 YUBICO_LEN_ID = 12
 YUBICO_LEN_OTP = 44
@@ -104,7 +105,21 @@ class YubicoTokenClass(TokenClass):
                'user':  ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy' : {},
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of Yubico tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active Yubico tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               },
                }
 
         if key:

--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -68,6 +68,7 @@ from hashlib import sha1
 from privacyidea.lib.config import get_from_config
 from privacyidea.lib.tokenclass import TOKENKIND
 from privacyidea.lib import _
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP
 
 optional = True
 required = False
@@ -162,7 +163,21 @@ class YubikeyTokenClass(TokenClass):
                'user': ['enroll'],
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
-               'policy': {}
+               'policy': {
+                   SCOPE.ENROLL: {
+                       ACTION.MAXTOKENUSER: {
+                           'type': 'int',
+                           'desc': _("The user may only have this maximum number of Yubikey tokens assigned."),
+                           'group': GROUP.TOKEN
+                       },
+                       ACTION.MAXACTIVETOKENUSER: {
+                           'type': 'int',
+                           'desc': _(
+                               "The user may only have this maximum number of active Yubikey tokens assigned."),
+                           'group': GROUP.TOKEN
+                       }
+                   }
+               }
         }
 
         if key:


### PR DESCRIPTION
The admin can define policies to limit the
number of tokens a user may enroll based on the
specific tokentype.

Working on #1375