### PR TITLE
Add missing packages to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ install_requires = ["Flask>=0.10.1",
                     "flask-babel>=0.9",
                     "croniter>=0.3.8",
                     "oauth2client>=2.0.1",
-                    "configobj>=5.0.6"
+                    "configobj>=5.0.6",
+                    "flask-versioned>=0.9.4"
                     ]
 
 # For python 2.6 we need additional dependency importlib


### PR DESCRIPTION
Add missing `flask-versioned` package to `install_requires` in `setup.py`

Fixes #1977 