### PR TITLE
Add some diagrams to the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -273,3 +273,5 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+plantuml = 'java -Djava.awt.headless=true -jar /usr/share/plantuml/plantuml.jar'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -58,7 +58,7 @@ sys.path.insert(0, os.path.abspath('../privacyidea'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.imgmath', 'sphinx.ext.viewcode', 
-              'sphinxcontrib.autohttp.flask']
+              'sphinxcontrib.autohttp.flask', 'sphinxcontrib.planuml']
 http_index_ignore_prefixes = ['/token']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -58,7 +58,7 @@ sys.path.insert(0, os.path.abspath('../privacyidea'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.imgmath', 'sphinx.ext.viewcode', 
-              'sphinxcontrib.autohttp.flask', 'sphinxcontrib.planuml']
+              'sphinxcontrib.autohttp.flask', 'sphinxcontrib.plantuml']
 http_index_ignore_prefixes = ['/token']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -275,3 +275,4 @@ texinfo_documents = [
 #texinfo_show_urls = 'footnote'
 
 plantuml = 'java -Djava.awt.headless=true -jar /usr/share/plantuml/plantuml.jar'
+plantuml_output_format = 'svg'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -274,5 +274,12 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
+#
+# PlantUML
+#
+
+# Run plantUML under Java in headless mode. This is needed for compatibility with readthedocs.io.
 plantuml = 'java -Djava.awt.headless=true -jar /usr/share/plantuml/plantuml.jar'
+
+# Use SVG inside <object> in supported browsers (all except IE8), falling back to PNG.
 plantuml_output_format = 'svg'

--- a/doc/configuration/authentication_modes.rst
+++ b/doc/configuration/authentication_modes.rst
@@ -47,17 +47,17 @@ modes in more detail.
   Service -> PrivacyIDEA: POST /validate/check
   Service <-- PrivacyIDEA
 
- * The user enters a OTP PIN along with an OTP value.
- * The plugin sends a request to the ``/validate/check`` endpoint:
+* The user enters a OTP PIN along with an OTP value.
+* The plugin sends a request to the ``/validate/check`` endpoint:
 
-   .. code-block:: text
+  .. code-block:: text
 
-     POST /validate/check
+    POST /validate/check
 
-     user=<user>&pass=<PIN+OTP>
+    user=<user>&pass=<PIN+OTP>
 
-  and privacyIDEA returns whether the authentication request has succeeded
-  or not.
+ and privacyIDEA returns whether the authentication request has succeeded
+ or not.
 
 .. _authentication_mode_challenge:
 
@@ -86,37 +86,37 @@ modes in more detail.
   Service -> PrivacyIDEA: POST /validate/check
   Service <-- PrivacyIDEA
 
- * The plugin triggers a challenge, for example via the
-   ``/validate/triggerchallenge`` endpoint:
+* The plugin triggers a challenge, for example via the
+  ``/validate/triggerchallenge`` endpoint:
 
-   .. code-block:: text
+  .. code-block:: text
 
-     POST /validate/triggerchallenge
+    POST /validate/triggerchallenge
 
-     user=<user>
+    user=<user>
 
-   Alternatively, a challenge can be triggered via the ``/validate/check``
-   endpoint with the PIN of a challenge-response token:
+  Alternatively, a challenge can be triggered via the ``/validate/check``
+  endpoint with the PIN of a challenge-response token:
 
-   .. code-block:: text
+  .. code-block:: text
 
-     POST /validate/check
+    POST /validate/check
 
-     user=<user>&pass=<PIN>
+    user=<user>&pass=<PIN>
 
-   In both variants, the plugin receives a transaction ID which we call
-   ``transaction_id`` and asks the user for the challenge response.
- * The user enters the challenge response, which we call ``OTP``.
-   The plugin forwards the response to privacyIDEA along with the
-   transaction ID:
+  In both variants, the plugin receives a transaction ID which we call
+  ``transaction_id`` and asks the user for the challenge response.
+* The user enters the challenge response, which we call ``OTP``.
+  The plugin forwards the response to privacyIDEA along with the
+  transaction ID:
 
-   .. code-block:: text
+  .. code-block:: text
 
-     POST /validate/check
+    POST /validate/check
 
-     user=<user>&transaction_id=<transaction_id>&pass=<OTP>
+    user=<user>&transaction_id=<transaction_id>&pass=<OTP>
 
-  and privacyIDEA returns whether the authentication request succeeded or not.
+ and privacyIDEA returns whether the authentication request succeeded or not.
 
 .. _authentication_mode_outofband:
 
@@ -160,59 +160,59 @@ modes in more detail.
   Service -> PrivacyIDEA: POST /validate/check
   Service <-- PrivacyIDEA
 
- * The plugin triggers a challenge, for example via the
-   ``/validate/triggerchallenge`` endpoint:
+* The plugin triggers a challenge, for example via the
+  ``/validate/triggerchallenge`` endpoint:
 
-   .. code-block:: text
+  .. code-block:: text
 
-     POST /validate/triggerchallenge
+    POST /validate/triggerchallenge
 
-     user=<user>
+    user=<user>
 
-   or via the ``/validate/check`` endpoint with the PIN of a out-of-band token:
+  or via the ``/validate/check`` endpoint with the PIN of a out-of-band token:
 
-   .. code-block:: text
+  .. code-block:: text
 
-     POST /validate/check
+    POST /validate/check
 
-     user=<user>&pass=<PIN>
+    user=<user>&pass=<PIN>
 
-   In both variants, the plugin receives a transaction ID which we call
-   ``transaction_id``.
-   The plugin may now periodically query the status of the challenge by
-   polling the ``/validate/polltransaction`` endpoint:
+  In both variants, the plugin receives a transaction ID which we call
+  ``transaction_id``.
+  The plugin may now periodically query the status of the challenge by
+  polling the ``/validate/polltransaction`` endpoint:
 
-   .. code-block:: text
+  .. code-block:: text
 
-     GET /validate/polltransaction
+    GET /validate/polltransaction
 
-     transaction_id=<transaction_id>
+    transaction_id=<transaction_id>
 
-   If this endpoint returns ``false``, the challenge has not been answered yet.
- * The user approves the challenge on a separate device, e.g. their
-   smartphone app. The app communicates with a tokentype-specific endpoint of
-   privacyIDEA, which marks the challenge as answered.
-   The exact communication depends on the token type.
- * Once ``/validate/polltransaction`` returns ``true``, the plugin *must*
-   finalize the authentication via the ``/validate/check`` endpoint:
+  If this endpoint returns ``false``, the challenge has not been answered yet.
+* The user approves the challenge on a separate device, e.g. their
+  smartphone app. The app communicates with a tokentype-specific endpoint of
+  privacyIDEA, which marks the challenge as answered.
+  The exact communication depends on the token type.
+* Once ``/validate/polltransaction`` returns ``true``, the plugin *must*
+  finalize the authentication via the ``/validate/check`` endpoint:
 
-   .. code-block:: text
+  .. code-block:: text
 
-     POST /validate/check
+    POST /validate/check
 
-     user=<user>&transaction_id=<transaction_id>&pass=
+    user=<user>&transaction_id=<transaction_id>&pass=
 
-   For the ``pass`` parameter, the plugin sends an empty string.
+  For the ``pass`` parameter, the plugin sends an empty string.
 
-   This step is crucial because the ``/validate/check`` endpoint takes defined
-   authentication and authorization policies into account to decide whether
-   the authentication was successful or not.
+  This step is crucial because the ``/validate/check`` endpoint takes defined
+  authentication and authorization policies into account to decide whether
+  the authentication was successful or not.
 
-   .. note:: The ``/validate/polltransaction`` endpoint does not require
-       authentication and does not increase the failcounters of tokens. Hence, attackers
-       may try to brute-force transaction IDs of correctly answered challenges.
-       Due to the short expiration timeout and the length of the randomly-generated
-       transaction IDs, it is unlikely that attackers correctly guess a
-       transaction ID in time.
-       Nonetheless, plugins must not allow users to inject transaction
-       IDs, and plugins must not leak transaction IDs to users.
+  .. note:: The ``/validate/polltransaction`` endpoint does not require
+      authentication and does not increase the failcounters of tokens. Hence, attackers
+      may try to brute-force transaction IDs of correctly answered challenges.
+      Due to the short expiration timeout and the length of the randomly-generated
+      transaction IDs, it is unlikely that attackers correctly guess a
+      transaction ID in time.
+      Nonetheless, plugins must not allow users to inject transaction
+      IDs, and plugins must not leak transaction IDs to users.

--- a/doc/configuration/authentication_modes.rst
+++ b/doc/configuration/authentication_modes.rst
@@ -41,6 +41,12 @@ modes in more detail.
 ``authenticate`` mode
 ---------------------
 
+.. uml::
+  :width: 500
+
+  Service -> PrivacyIDEA: POST /validate/check
+  Service <-- PrivacyIDEA
+
  * The user enters a OTP PIN along with an OTP value.
  * The plugin sends a request to the ``/validate/check`` endpoint:
 
@@ -57,6 +63,28 @@ modes in more detail.
 
 ``challenge`` mode
 ------------------
+
+.. uml::
+  :width: 500
+
+  alt with pin
+
+    Service -> PrivacyIDEA: POST /validate/check
+    Service <-- PrivacyIDEA: transaction_id
+
+  else without pin
+
+    Service -> PrivacyIDEA: POST /validate/triggerchallenge
+    Service <-- PrivacyIDEA: transaction_id
+
+  end
+
+  PrivacyIDEA -> "SMS Gateway": OTP
+
+  ...User enters OTP from SMS...
+
+  Service -> PrivacyIDEA: POST /validate/check
+  Service <-- PrivacyIDEA
 
  * The plugin triggers a challenge, for example via the
    ``/validate/triggerchallenge`` endpoint:
@@ -94,6 +122,43 @@ modes in more detail.
 
 ``outofband`` mode
 ------------------
+
+.. uml::
+  :width: 500
+
+  alt with pin
+
+    Service -> PrivacyIDEA: POST /validate/check
+    Service <-- PrivacyIDEA: transaction_id
+
+  else without pin
+
+    Service -> PrivacyIDEA: POST /validate/triggerchallenge
+    Service <-- PrivacyIDEA: transaction_id
+
+  end
+
+  PrivacyIDEA -> Firebase: PUSH Notification
+  Firebase -> Phone: PUSH Notification
+
+  loop until confirmed
+
+    Service -> PrivacyIDEA: GET /validate/polltransaction
+    Service <-- PrivacyIDEA: false
+
+  end
+
+  ...User confirms sign in on phone...
+
+  Phone -> PrivacyIDEA: POST /ttype/push
+
+  Service -> PrivacyIDEA: GET /validate/polltransaction
+  Service <-- PrivacyIDEA: true
+
+  |||
+
+  Service -> PrivacyIDEA: POST /validate/check
+  Service <-- PrivacyIDEA
 
  * The plugin triggers a challenge, for example via the
    ``/validate/triggerchallenge`` endpoint:

--- a/doc/configuration/authentication_modes.rst
+++ b/doc/configuration/authentication_modes.rst
@@ -44,11 +44,13 @@ modes in more detail.
 .. uml::
   :width: 500
 
-  Service -> PrivacyIDEA: POST /validate/check
-  Service <-- PrivacyIDEA
+  Service -> privacyIDEA: POST /validate/check
+  Service <-- privacyIDEA
 
-* The user enters a OTP PIN along with an OTP value.
-* The plugin sends a request to the ``/validate/check`` endpoint:
+The *Service* is an application that is protected with a second factor by privacyIDEA.
+
+* The user enters a OTP PIN along with an OTP value at the *Service*.
+* The plugin sends a request to the ``/validate/check`` endpoint of privacyIDEA:
 
   .. code-block:: text
 
@@ -69,22 +71,22 @@ modes in more detail.
 
   alt with pin
 
-    Service -> PrivacyIDEA: POST /validate/check
-    Service <-- PrivacyIDEA: transaction_id
+    Service -> privacyIDEA: POST /validate/check
+    Service <-- privacyIDEA: transaction_id
 
   else without pin
 
-    Service -> PrivacyIDEA: POST /validate/triggerchallenge
-    Service <-- PrivacyIDEA: transaction_id
+    Service -> privacyIDEA: POST /validate/triggerchallenge
+    Service <-- privacyIDEA: transaction_id
 
   end
 
-  PrivacyIDEA -> "SMS Gateway": OTP
+  privacyIDEA -> "SMS Gateway": OTP
 
   ...User enters OTP from SMS...
 
-  Service -> PrivacyIDEA: POST /validate/check
-  Service <-- PrivacyIDEA
+  Service -> privacyIDEA: POST /validate/check
+  Service <-- privacyIDEA
 
 * The plugin triggers a challenge, for example via the
   ``/validate/triggerchallenge`` endpoint:
@@ -128,37 +130,37 @@ modes in more detail.
 
   alt with pin
 
-    Service -> PrivacyIDEA: POST /validate/check
-    Service <-- PrivacyIDEA: transaction_id
+    Service -> privacyIDEA: POST /validate/check
+    Service <-- privacyIDEA: transaction_id
 
   else without pin
 
-    Service -> PrivacyIDEA: POST /validate/triggerchallenge
-    Service <-- PrivacyIDEA: transaction_id
+    Service -> privacyIDEA: POST /validate/triggerchallenge
+    Service <-- privacyIDEA: transaction_id
 
   end
 
-  PrivacyIDEA -> Firebase: PUSH Notification
+  privacyIDEA -> Firebase: PUSH Notification
   Firebase -> Phone: PUSH Notification
 
   loop until confirmed
 
-    Service -> PrivacyIDEA: GET /validate/polltransaction
-    Service <-- PrivacyIDEA: false
+    Service -> privacyIDEA: GET /validate/polltransaction
+    Service <-- privacyIDEA: false
 
   end
 
   ...User confirms sign in on phone...
 
-  Phone -> PrivacyIDEA: POST /ttype/push
+  Phone -> privacyIDEA: POST /ttype/push
 
-  Service -> PrivacyIDEA: GET /validate/polltransaction
-  Service <-- PrivacyIDEA: true
+  Service -> privacyIDEA: GET /validate/polltransaction
+  Service <-- privacyIDEA: true
 
   |||
 
-  Service -> PrivacyIDEA: POST /validate/check
-  Service <-- PrivacyIDEA
+  Service -> privacyIDEA: POST /validate/check
+  Service <-- privacyIDEA
 
 * The plugin triggers a challenge, for example via the
   ``/validate/triggerchallenge`` endpoint:

--- a/doc/configuration/tokens/push.rst
+++ b/doc/configuration/tokens/push.rst
@@ -20,8 +20,7 @@ logs the user in automatically. For an example of how the components in a
 typical deployment of push tokens interact reference the following diagram.
 
 .. uml::
-    :scale: 50%
-    :align: center
+    :width: 500
     :caption: A typical push token deployment
 
     rectangle "On Prem" {

--- a/doc/configuration/tokens/push.rst
+++ b/doc/configuration/tokens/push.rst
@@ -16,7 +16,58 @@ service. The user can simply accept this request.
 The smartphone sends a cryptographically signed response to the
 privacyIDEA server and the login request gets marked as confirmed
 in the privacyIDEA server. The application checks for this mark and
-logs the user in automatically.
+logs the user in automatically. For an example of how the components in a
+typical deployment of push tokens interact reference the following diagram.
+
+.. uml::
+    :scale: 50%
+    :align: center
+    :caption: A typical push token deployment
+
+    rectangle "On Prem" {
+        card SAML {
+            node "Service Provider" as SP
+            node "Identity Provider" as IDP
+        }
+        card "1st Factor" {
+            database LDAP
+        }
+        card "2nd Factor" {
+            node PrivacyIDEA as PI
+            file "User Resolver" as Users
+            file "Machine Resolver" as Machines
+        }
+    }
+
+    together {
+        actor User
+        node iPhone
+        node Client
+    }
+
+    cloud Cloud {
+        node Firebase
+        node APN
+    }
+
+    User ~~> iPhone
+    User ~~> Client
+
+    Client -- SP
+    SP -- IDP
+    SP ..> Client : Require Auth
+
+    Client --> IDP : Request Auth
+    IDP -- LDAP
+    IDP -- PI
+
+    PI -- Users
+    PI -- Machines
+
+    PI --> Firebase : Push Token
+    Firebase --> APN
+    APN --> iPhone
+    iPhone --> PI : Confirm Token
 
 To allow privacyIDEA to send push notifications, a Firebase service
 needs to be configured. To do so see :ref:`firebase_provider`.

--- a/doc/configuration/tokens/push.rst
+++ b/doc/configuration/tokens/push.rst
@@ -20,53 +20,53 @@ logs the user in automatically. For an example of how the components in a
 typical deployment of push tokens interact reference the following diagram.
 
 .. uml::
-    :width: 500
-    :caption: A typical push token deployment
+  :width: 500
+  :caption: A typical push token deployment
 
-    rectangle "On Prem" {
-        card SAML {
-            node "Service Provider" as SP
-            node "Identity Provider" as IDP
-        }
-        card "1st Factor" {
-            database LDAP
-        }
-        card "2nd Factor" {
-            node PrivacyIDEA as PI
-            file "User Resolver" as Users
-            file "Machine Resolver" as Machines
-        }
+  rectangle "On Prem" {
+    card SAML {
+      node "Service Provider" as SP
+      node "Identity Provider" as IDP
     }
-
-    together {
-        actor User
-        node iPhone
-        node Client
+    card "1st Factor" {
+      database LDAP
     }
-
-    cloud Cloud {
-        node Firebase
-        node APN
+    card "2nd Factor" {
+      node PrivacyIDEA as PI
+      file "User Resolver" as Users
+      file "Machine Resolver" as Machines
     }
+  }
 
-    User ~~> iPhone
-    User ~~> Client
+  together {
+    actor User
+    node iPhone
+    node Client
+  }
 
-    Client -- SP
-    SP -- IDP
-    SP ..> Client : Require Auth
+  cloud Cloud {
+    node Firebase
+    node APN
+  }
 
-    Client --> IDP : Request Auth
-    IDP -- LDAP
-    IDP -- PI
+  User ~~> iPhone
+  User ~~> Client
 
-    PI -- Users
-    PI -- Machines
+  Client -- SP
+  SP -- IDP
+  SP ..> Client : Require Auth
 
-    PI --> Firebase : Push Token
-    Firebase --> APN
-    APN --> iPhone
-    iPhone --> PI : Confirm Token
+  Client --> IDP : Request Auth
+  IDP -- LDAP
+  IDP -- PI
+
+  PI -- Users
+  PI -- Machines
+
+  PI --> Firebase : Push Token
+  Firebase --> APN
+  APN --> iPhone
+  iPhone --> PI : Confirm Token
 
 To allow privacyIDEA to send push notifications, a Firebase service
 needs to be configured. To do so see :ref:`firebase_provider`.

--- a/doc/configuration/tokens/push.rst
+++ b/doc/configuration/tokens/push.rst
@@ -12,7 +12,7 @@ The token type *push* sends a cryptographic challenge via the
 Google Firebase service to the smartphone of the user. This push
 notification is displayed on the smartphone of the user with a text
 that tells the user that he or somebody else requests to login to a
-service. The can simply accept this request.
+service. The user can simply accept this request.
 The smartphone sends a cryptographically signed response to the
 privacyIDEA server and the login request gets marked as confirmed
 in the privacyIDEA server. The application checks for this mark and

--- a/doc/configuration/tokens/push.rst
+++ b/doc/configuration/tokens/push.rst
@@ -32,9 +32,8 @@ typical deployment of push tokens interact reference the following diagram.
       database LDAP
     }
     card "2nd Factor" {
-      node PrivacyIDEA as PI
+      node privacyIDEA as PI
       file "User Resolver" as Users
-      file "Machine Resolver" as Machines
     }
   }
 
@@ -61,7 +60,6 @@ typical deployment of push tokens interact reference the following diagram.
   IDP -- PI
 
   PI -- Users
-  PI -- Machines
 
   PI --> Firebase : Push Token
   Firebase --> APN

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,3 +6,4 @@ sphinxcontrib-httpdomain==1.7.0
 sphinx-rtd-theme==0.4.3
 docutils==0.14
 Pygments>=2.0.2
+sphinxcontrib-plantuml==0.18


### PR DESCRIPTION
This adds sphinxcontrib-plantuml, along with the necessary configuration that
*should* allow it to work with readthedocs.io (no real way to test that locally).
Four diagrams are included. A deployment diagram for a typical setup of push tokens,
and diagrams for the different authentication modes. For the latter a whitespace
change was necessary due to the way ReST parses the uml-directive, sorry about the
somewhat ugly diff :|

Fixes #1914 