### PR TITLE
Add trailing slash to event endpoint URL

### DIFF
--- a/privacyidea/static/components/config/factories/config.js
+++ b/privacyidea/static/components/config/factories/config.js
@@ -120,7 +120,7 @@ myApp.factory("ConfigFactory", function (AuthFactory, $http, $state, $rootScope,
             ).error(AuthFactory.authError);
         },
         getEvents: function(callback) {
-            $http.get(eventUrl, {
+            $http.get(eventUrl + "/", {
                 headers: {'PI-Authorization': AuthFactory.getAuthToken()}
             }).success(callback
             ).error(AuthFactory.authError);

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -16,6 +16,14 @@ class APIEventsTestCase(MyApiTestCase):
             self.assertEqual(res.status_code, 401, res)
             self.assertEqual(res.json['result']['error']['code'], 4033, res.json)
 
+        # check for automatic redirect on missing trailing slash from flask
+        with self.app.test_request_context('/event',
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 308, res)
+            self.assertIn('Location', res.headers, res)
+
         param = {
             "name": "Send an email",
             "event": "token_init",


### PR DESCRIPTION
The missing slash resulted in an automatic redirect from flask which
distracts one-way proxies.

Fixes #1999