### PR TITLE
Allow sending images as attachments

### DIFF
--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -55,7 +55,7 @@ from email.mime.text import MIMEText
 from email.mime.image import MIMEImage
 try:
     from urllib.request import urlopen
-except ImportError:
+except ImportError:  # pragma: no cover
     from urllib import urlopen
 import logging
 import os
@@ -306,8 +306,7 @@ class UserNotificationEventHandler(BaseEventHandler):
                     with open(filename, "r", encoding="utf-8") as f:
                         body = f.read()
                 except Exception as e:
-                    log.warning(u"Failed to read email template from file "
-                                u"{0!r}: {1!r}".format(filename, e))
+                    log.warning(u"Failed to read email template from file {0!r}: {1!r}".format(filename, e))
                     log.debug(u"{0!s}".format(traceback.format_exc()))
 
             subject = handler_options.get("subject") or \
@@ -356,7 +355,6 @@ class UserNotificationEventHandler(BaseEventHandler):
                 if attachment and googleurl_img:
                     # get the image part of the googleurl
                     googleurl = urlopen(googleurl_img)
-                    assert googleurl.headers.get('Content-Type') == 'image/png'
                     mail_body = MIMEMultipart('related')
                     mail_body.attach(MIMEText(body, 'html'))
                     mail_img = MIMEImage(googleurl.read())

--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -155,19 +155,19 @@ class UserNotificationEventHandler(BaseEventHandler):
                         NOTIFY_TYPE.INTERNAL_ADMIN,
                         NOTIFY_TYPE.ADMIN_REALM,
                         NOTIFY_TYPE.EMAIL]},
-                "To "+NOTIFY_TYPE.ADMIN_REALM: {
+                "To " + NOTIFY_TYPE.ADMIN_REALM: {
                     "type": "str",
                     "value": get_app_config_value("SUPERUSER_REALM", []),
                     "visibleIf": "To",
                     "visibleValue": NOTIFY_TYPE.ADMIN_REALM},
-                "To "+NOTIFY_TYPE.INTERNAL_ADMIN: {
+                "To " + NOTIFY_TYPE.INTERNAL_ADMIN: {
                     "type": "str",
                     "value": [a.username for a in
                               get_db_admins()],
                     "visibleIf": "To",
                     "visibleValue":
                         NOTIFY_TYPE.INTERNAL_ADMIN},
-                "To "+NOTIFY_TYPE.EMAIL: {
+                "To " + NOTIFY_TYPE.EMAIL: {
                     "type": "str",
                     "description": _("Any email address, to which the notification "
                                      "should be sent."),

--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -50,6 +50,13 @@ from privacyidea.lib.user import User, get_user_list
 from privacyidea.lib.utils import create_tag_dict
 from privacyidea.lib.crypto import get_alphanum_str
 from privacyidea.lib import _
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.mime.image import MIMEImage
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib import urlopen
 import logging
 import os
 import traceback
@@ -111,94 +118,92 @@ class UserNotificationEventHandler(BaseEventHandler):
         smsgateway_dicts = get_smsgateway()
         smsgateways = [sms.identifier for sms in smsgateway_dicts]
         smtpservers = [s.config.identifier for s in smtpserver_objs]
-        actions = {"sendmail": {"emailconfig":
-                                     {"type": "str",
-                                      "required": True,
-                                      "description": _("Send notification "
-                                                       "email via this "
-                                                       "email server."),
-                                      "value": smtpservers},
-                                "mimetype": {"type": "str",
-                                             "description": _("Either send "
-                                                              "email as plain text or HTML."),
-                                             "value": ["plain", "html"]},
-                                "subject": {"type": "str",
-                                            "required": False,
-                                            "description": _("The subject of "
-                                                             "the mail that "
-                                                             "is sent.")},
-                                "reply_to": {"type": "str",
-                                             "required": False,
-                                             "description": _("The Reply-To "
-                                                              "header in the "
-                                                              "sent email.")},
-                                "body": {"type": "text",
-                                         "required": False,
-                                         "description": _("The body of the "
-                                                          "mail that is "
-                                                          "sent.")},
-                                "To": {"type": "str",
-                                       "required": True,
-                                       "description": _("Send notification to "
-                                                        "this user."),
-                                       "value": [
-                                           NOTIFY_TYPE.TOKENOWNER,
-                                           NOTIFY_TYPE.LOGGED_IN_USER,
-                                           NOTIFY_TYPE.INTERNAL_ADMIN,
-                                           NOTIFY_TYPE.ADMIN_REALM,
-                                           NOTIFY_TYPE.EMAIL]},
-                                "To "+NOTIFY_TYPE.ADMIN_REALM: {
-                                    "type": "str",
-                                    "value": get_app_config_value("SUPERUSER_REALM", []),
-                                    "visibleIf": "To",
-                                    "visibleValue": NOTIFY_TYPE.ADMIN_REALM},
-                                "To "+NOTIFY_TYPE.INTERNAL_ADMIN: {
-                                    "type": "str",
-                                    "value": [a.username for a in
-                                              get_db_admins()],
-                                    "visibleIf": "To",
-                                    "visibleValue":
-                                         NOTIFY_TYPE.INTERNAL_ADMIN},
-                                "To "+NOTIFY_TYPE.EMAIL: {
-                                    "type": "str",
-                                    "description": _("Any email address, to "
-                                                     "which the notification "
-                                                     "should be sent."),
-                                    "visibleIf": "To",
-                                    "visibleValue": NOTIFY_TYPE.EMAIL}
-                                },
-                   "sendsms": {"smsconfig":
-                                   {"type": "str",
-                                    "required": True,
-                                    "description": _("Send the user "
-                                                     "notification via a "
-                                                     "predefined SMS "
-                                                     "gateway."),
-                                    "value": smsgateways},
-                               "body": {"type": "text",
-                                        "required": False,
-                                        "description": _("The text of the "
-                                                         "SMS.")},
-                               "To": {"type": "str",
-                                      "required": True,
-                                      "description": _("Send notification to "
-                                                       "this user."),
-                                      "value": [NOTIFY_TYPE.TOKENOWNER]}
-                               },
-                   "savefile": {"body":
-                                    {"type": "text",
-                                     "required": True,
-                                     "description": _("This is the template content of "
-                                                      "the new file. Can contain the tags "
-                                                      "as specified in the documentation.")},
-                                "filename":
-                                    {"type": "str",
-                                     "required": True,
-                                     "description": _("The filename of the notification. Existing files "
-                                                      "are overwritten. The name can contain tags as specified "
-                                                      "in the documentation and can also contain the tag {random}.")}
-                   }
-                   }
+        actions = {
+            "sendmail": {
+                "emailconfig": {
+                    "type": "str",
+                    "required": True,
+                    "description": _("Send notification email via this email server."),
+                    "value": smtpservers},
+                "mimetype": {
+                    "type": "str",
+                    "description": _("Either send email as plain text or HTML."),
+                    "value": ["plain", "html"]},
+                "attachment": {
+                    "type": "bool",
+                    "description": _("Send QR-Code image as attachment "
+                                     "(cid URL: token_image)")},
+                "subject": {
+                    "type": "str",
+                    "required": False,
+                    "description": _("The subject of the mail that is sent.")},
+                "reply_to": {
+                    "type": "str",
+                    "required": False,
+                    "description": _("The Reply-To header in the sent email.")},
+                "body": {
+                    "type": "text",
+                    "required": False,
+                    "description": _("The body of the mail that is sent.")},
+                "To": {
+                    "type": "str",
+                    "required": True,
+                    "description": _("Send notification to this user."),
+                    "value": [
+                        NOTIFY_TYPE.TOKENOWNER,
+                        NOTIFY_TYPE.LOGGED_IN_USER,
+                        NOTIFY_TYPE.INTERNAL_ADMIN,
+                        NOTIFY_TYPE.ADMIN_REALM,
+                        NOTIFY_TYPE.EMAIL]},
+                "To "+NOTIFY_TYPE.ADMIN_REALM: {
+                    "type": "str",
+                    "value": get_app_config_value("SUPERUSER_REALM", []),
+                    "visibleIf": "To",
+                    "visibleValue": NOTIFY_TYPE.ADMIN_REALM},
+                "To "+NOTIFY_TYPE.INTERNAL_ADMIN: {
+                    "type": "str",
+                    "value": [a.username for a in
+                              get_db_admins()],
+                    "visibleIf": "To",
+                    "visibleValue":
+                        NOTIFY_TYPE.INTERNAL_ADMIN},
+                "To "+NOTIFY_TYPE.EMAIL: {
+                    "type": "str",
+                    "description": _("Any email address, to which the notification "
+                                     "should be sent."),
+                    "visibleIf": "To",
+                    "visibleValue": NOTIFY_TYPE.EMAIL}
+            },
+            "sendsms": {
+                "smsconfig": {
+                    "type": "str",
+                    "required": True,
+                    "description": _("Send the user notification via a "
+                                     "predefined SMS gateway."),
+                    "value": smsgateways},
+                "body": {"type": "text",
+                         "required": False,
+                         "description": _("The text of the SMS.")},
+                "To": {"type": "str",
+                       "required": True,
+                       "description": _("Send notification to this user."),
+                       "value": [NOTIFY_TYPE.TOKENOWNER]}
+            },
+            "savefile": {
+                "body": {
+                    "type": "text",
+                    "required": True,
+                    "description": _("This is the template content of "
+                                     "the new file. Can contain the tags "
+                                     "as specified in the documentation.")},
+                "filename": {
+                    "type": "str",
+                    "required": True,
+                    "description": _("The filename of the notification. Existing files "
+                                     "are overwritten. The name can contain tags as specified "
+                                     "in the documentation and can also contain the tag {random}.")}
+            }
+        }
         return actions
 
     def do(self, action, options=None):
@@ -301,7 +306,8 @@ class UserNotificationEventHandler(BaseEventHandler):
                     with open(filename, "r", encoding="utf-8") as f:
                         body = f.read()
                 except Exception as e:
-                    log.warning(u"Failed to read email template from file {0!r}: {1!r}".format(filename, e))
+                    log.warning(u"Failed to read email template from file "
+                                u"{0!r}: {1!r}".format(filename, e))
                     log.debug(u"{0!s}".format(traceback.format_exc()))
 
             subject = handler_options.get("subject") or \
@@ -345,7 +351,20 @@ class UserNotificationEventHandler(BaseEventHandler):
                 mimetype = handler_options.get("mimetype", "plain")
                 useremail = recipient.get("email")
                 reply_to = handler_options.get("reply_to")
+                attachment = handler_options.get("attachment", False)
 
+                if attachment and googleurl_img:
+                    # get the image part of the googleurl
+                    googleurl = urlopen(googleurl_img)
+                    assert googleurl.headers.get('Content-Type') == 'image/png'
+                    mail_body = MIMEMultipart('related')
+                    mail_body.attach(MIMEText(body, 'html'))
+                    mail_img = MIMEImage(googleurl.read())
+                    mail_img.add_header('Content-ID', '<token_image>')
+                    mail_img.add_header('Content-Disposition',
+                                        'inline; filename="{0!s}.png"'.format(serial))
+                    mail_body.attach(mail_img)
+                    body = mail_body
                 try:
                     ret = send_email_identifier(emailconfig,
                                                 recipient=useremail,

--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -129,9 +129,9 @@ class UserNotificationEventHandler(BaseEventHandler):
                     "type": "str",
                     "description": _("Either send email as plain text or HTML."),
                     "value": ["plain", "html"]},
-                "attachment": {
+                "attach_qrcode": {
                     "type": "bool",
-                    "description": _("Send QR-Code image as attachment "
+                    "description": _("Send QR-Code image as an attachment "
                                      "(cid URL: token_image)")},
                 "subject": {
                     "type": "str",
@@ -350,9 +350,9 @@ class UserNotificationEventHandler(BaseEventHandler):
                 mimetype = handler_options.get("mimetype", "plain")
                 useremail = recipient.get("email")
                 reply_to = handler_options.get("reply_to")
-                attachment = handler_options.get("attachment", False)
+                attach_qrcode = handler_options.get("attach_qrcode", False)
 
-                if attachment and googleurl_img:
+                if attach_qrcode and googleurl_img:
                     # get the image part of the googleurl
                     googleurl = urlopen(googleurl_img)
                     mail_body = MIMEMultipart('related')

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -3450,7 +3450,7 @@ class UserNotificationTestCase(MyTestCase):
                        "conditions": {"serial": "123.*"},
                        "options": {"body": "<img src='cid:token_image' />",
                                    "mimetype": "html",
-                                   "attachment": True,
+                                   "attach_qrcode": True,
                                    "emailconfig": "myserver"}}}
 
         un_handler = UserNotificationEventHandler()

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -47,7 +47,33 @@ from datetime import datetime, timedelta
 from dateutil.parser import parse as parse_date_string
 from dateutil.tz import tzlocal
 from privacyidea.app import PiResponseClass as Response
-import json
+
+PNG_IMAGE = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAeoAAAHqAQAAAADjFj" \
+            "CXAAAD+UlEQVR4nO2dTYrkSAxGn8aGWtowB6ij2Dcb5khzA/soeYABe9lgo1mE4q" \
+            "eKphdpN901+WlRpDP9iEwQUnySHGXOBVv/uEKDcOHChQsXLly48HtxC+sxG08DTm" \
+            "MdT7N5N7M5XUK6NDOz+b7Vhb8ajru7M7m7+9a5ux/A4O7L4MlgOIhP0y2ZWL70bx" \
+            "f+q/G9hC/AF05j2oDVenyhc7MxPjWz/ubVhb82bvP+loopZmaRa+E0Jj9++urCXx" \
+            "Rf3w/sr0dPinUM7jbvPbGv+8mrC38pfHD3Jb08jfX9AIYjuZ4vdO4Lp/kCxNbvzt" \
+            "WFvxYeaiKsc6btx3/yrVITwp83/2jx7nDgy3BEmHOPV6F1i8nrhD9ltQ6SAtm0dQ" \
+            "4ppXYOg5cI1xWfVOVE+BXLNZB9hPXdgf00Zx+NyU9z9v5wdmD650+A7gDOjH3p3y" \
+            "78V+E5w6YSMKTacMmmNddmwREBTxlW+AWrXhdpNvsakWYhXA+K/x1SE8KvWNYQJd" \
+            "YVXytFk6ph0y3uh2Kd8CsWamLLyoEP3dcqM1I4BGCS1wm/Zp81bOtrXeOEtfsPpY" \
+            "YirxP+lDX7uhrrlrJzSyl1gybDlmEUeZ3w56zNpnWWaQtfayRtEhfDoX2d8JtiXX" \
+            "hTqf7WzR0Q83X1EqRhhd+A7z0xWmJmsFsaHnb3A6ZHX6bqIuDdu7rw18LbDFtGhn" \
+            "NbLJSrL4N7Uq5Lqdwpwwq/iMdG7tFjM3WWuHObAaaHmf9dJ4hvXl34q+Fl5qQEsq" \
+            "JhS5O/zncmwbEM6v4Lv2TV66iTJuFckU2hvgdo5kT4LXh6FGfyA5vTgxIAlIrwRp" \
+            "5gH0JchP/9Dl9e+JfD017N1/nNYR9x9hEYDizy6oav798Mhn/NAQekYYVfstybIP" \
+            "dXPza+ylhA06pN05/KsMIv4uvYOexvbvZ+NAnXF04zG6Hd5qleJ/ya5Z5D6fRnlR" \
+            "oNio3y8ES5VB9W+DWLPtjGh+pveUai1Ivb6ROX1wm/Be/c5sGddQwNm1NqPPbvyx" \
+            "5n7+jECeE3qgnIw8PU0ZKt1PCaS3XEhN+FRx/iNKZHnw7WSQU6hm8p/sURO8OBzX" \
+            "evLvx18NL9d8/P43gefKq6glpIgTr4pFgn/Dn7pA/qmRLRbt1ywi3d13S6k+p1wp" \
+            "+3XDkB2rJw5zQH69SZz3LYibxO+PMW3uS5VFeH1yP1Hm01ZSplFmVY4c9bk1dLNo" \
+            "2QlhJpnvRsTFVi4bfi7o+3dFYdq/WkLtlMlRmhOmz+GasLf1G8qRLTOevId47pLM" \
+            "NQv9mXF/418O+ewd6UT+qJE/XozhhQUYYV/qx91rBTVg5VvjaVkxgjVr1O+BUz/f" \
+            "c64cKFCxcuXLjw/wX+HzgPbUakdjuaAAAAAElFTkSuQmCC"
+
+OAUTH_URL = "otpauth://hotp/OATH0001D8B6?secret=GQROHTUPBAK5N6T2HBUK4IP42R56E" \
+            "MV3&counter=1&digits=6&issuer=privacyIDEA"
 
 
 class EventHandlerLibTestCase(MyTestCase):
@@ -3404,29 +3430,29 @@ class UserNotificationTestCase(MyTestCase):
                         "user": "cornelius"}
         req.User = User("cornelius", self.realm1)
         resp = Response()
-        resp.data = """{
-            "detail": {
-                "googleurl": {
+        resp.data = """{{
+            "detail": {{
+                "googleurl": {{
                     "description": "URL for google Authenticator",
-                    "img": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAeoAAAHqAQAAAADjFjCXAAAD+UlEQVR4nO2dTYrkSAxGn8aGWtowB6ij2Dcb5khzA/soeYABe9lgo1mE4qeKphdpN901+WlRpDP9iEwQUnySHGXOBVv/uEKDcOHChQsXLly48HtxC+sxG08DTmMdT7N5N7M5XUK6NDOz+b7Vhb8ajru7M7m7+9a5ux/A4O7L4MlgOIhP0y2ZWL70bxf+q/G9hC/AF05j2oDVenyhc7MxPjWz/ubVhb82bvP+loopZmaRa+E0Jj9++urCXxRf3w/sr0dPinUM7jbvPbGv+8mrC38pfHD3Jb08jfX9AIYjuZ4vdO4Lp/kCxNbvztWFvxYeaiKsc6btx3/yrVITwp83/2jx7nDgy3BEmHOPV6F1i8nrhD9ltQ6SAtm0dQ4ppXYOg5cI1xWfVOVE+BXLNZB9hPXdgf00Zx+NyU9z9v5wdmD650+A7gDOjH3p3y78V+E5w6YSMKTacMmmNddmwREBTxlW+AWrXhdpNvsakWYhXA+K/x1SE8KvWNYQJdYVXytFk6ph0y3uh2Kd8CsWamLLyoEP3dcqM1I4BGCS1wm/Zp81bOtrXeOEtfsPpYYirxP+lDX7uhrrlrJzSyl1gybDlmEUeZ3w56zNpnWWaQtfayRtEhfDoX2d8JtiXXhTqf7WzR0Q83X1EqRhhd+A7z0xWmJmsFsaHnb3A6ZHX6bqIuDdu7rw18LbDFtGhnNbLJSrL4N7Uq5Lqdwpwwq/iMdG7tFjM3WWuHObAaaHmf9dJ4hvXl34q+Fl5qQEsqJhS5O/zncmwbEM6v4Lv2TV66iTJuFckU2hvgdo5kT4LXh6FGfyA5vTgxIAlIrwRp5gH0JchP/9Dl9e+JfD017N1/nNYR9x9hEYDizy6oav798Mhn/NAQekYYVfstybIPdXPza+ylhA06pN05/KsMIv4uvYOexvbvZ+NAnXF04zG6Hd5qleJ/ya5Z5D6fRnlRoNio3y8ES5VB9W+DWLPtjGh+pveUai1Ivb6ROX1wm/Be/c5sGddQwNm1NqPPbvyx5n7+jECeE3qgnIw8PU0ZKt1PCaS3XEhN+FRx/iNKZHnw7WSQU6hm8p/sURO8OBzXevLvx18NL9d8/P43gefKq6glpIgTr4pFgn/Dn7pA/qmRLRbt1ywi3d13S6k+p1wp+3XDkB2rJw5zQH69SZz3LYibxO+PMW3uS5VFeH1yP1Hm01ZSplFmVY4c9bk1dLNo2QlhJpnvRsTFVi4bfi7o+3dFYdq/WkLtlMlRmhOmz+GasLf1G8qRLTOevId47pLMNQv9mXF/418O+ewd6UT+qJE/XozhhQUYYV/qx91rBTVg5VvjaVkxgjVr1O+BUz/fc64cKFCxcuXLjw/wX+HzgPbUakdjuaAAAAAElFTkSuQmCC",
-                    "value": "otpauth://hotp/OATH0001D8B6?secret=GQROHTUPBAK5N6T2HBUK4IP42R56EMV3&counter=1&digits=6&issuer=privacyIDEA"
-                },
+                    "img": {0!s},
+                    "value": {1!s}
+                }},
                 "rollout_state": "",
                 "serial": "OATH0001D8B6",
                 "threadid": 140437172639168
-            },
+            }},
             "id": 1,
             "jsonrpc": "2.0",
-            "result": {
+            "result": {{
                 "status": true,
                 "value": true
-            },
+            }},
             "signature": "foo",
             "time": 1561549651.093083,
             "version": "privacyIDEA 3.0.1.dev2",
             "versionnumber": "3.0.1.dev2"
-        }
-        """
+        }}
+        """.format(PNG_IMAGE, OAUTH_URL)
         options = {"g": g,
                    "request": req,
                    "response": resp,
@@ -3446,7 +3472,7 @@ class UserNotificationTestCase(MyTestCase):
         assert len(payload) == 2
         assert payload[0].get_content_type() == "text/html"
         assert payload[1].get_content_type() == 'image/png'
-        assert payload[1].get_content_disposition() == 'inline'
+        assert payload[1]['Content-Disposition'] == 'inline; filename="SomeSerial.png"'
         assert payload[1].get_filename() == 'SomeSerial.png'
 
     def test_22_save_notification(self):

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -3434,8 +3434,8 @@ class UserNotificationTestCase(MyTestCase):
             "detail": {{
                 "googleurl": {{
                     "description": "URL for google Authenticator",
-                    "img": {0!s},
-                    "value": {1!s}
+                    "img": "{0!s}",
+                    "value": "{1!s}"
                 }},
                 "rollout_state": "",
                 "serial": "OATH0001D8B6",

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -3065,17 +3065,7 @@ class UserNotificationTestCase(MyTestCase):
         res = uhandler.do('sendmail', options)
         # TODO: the handler should return False here
         # TODO: Also we should check that no email was sent (i.e. call of smtpserver)
-        assert res
-        """
-        with self.app.test_request_context('/token/unassign',
-                                           method='POST',
-                                           data={"serial": "SPNOTIFY"},
-                                           headers={'Authorization': self.at}):
-            res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
-            result = res.json.get("result")
-            self.assertEqual(result.get("value"), 1)
-"""
+        self.assertTrue(res)
         # Cleanup
         delete_realm("notify_realm")
         delete_resolver("notify_resolver")
@@ -3465,15 +3455,16 @@ class UserNotificationTestCase(MyTestCase):
 
         un_handler = UserNotificationEventHandler()
         res = un_handler.do("sendmail", options=options)
-        assert res
+        self.assertTrue(res)
         parsed_email = email.message_from_string(smtpmock.get_sent_message())
-        assert parsed_email.get_content_maintype() == 'multipart'
+        self.assertEqual(parsed_email.get_content_maintype(), 'multipart', parsed_email)
         payload = parsed_email.get_payload()
-        assert len(payload) == 2
-        assert payload[0].get_content_type() == "text/html"
-        assert payload[1].get_content_type() == 'image/png'
-        assert payload[1]['Content-Disposition'] == 'inline; filename="SomeSerial.png"'
-        assert payload[1].get_filename() == 'SomeSerial.png'
+        self.assertEqual(len(payload), 2, payload)
+        self.assertEqual(payload[0].get_content_type(), "text/html", payload)
+        self.assertEqual(payload[1].get_content_type(), 'image/png', payload)
+        self.assertEqual(payload[1]['Content-Disposition'], 'inline; filename="SomeSerial.png"',
+                         payload)
+        self.assertEqual(payload[1].get_filename(), 'SomeSerial.png', payload)
 
     def test_22_save_notification(self):
         g = FakeFlaskG()

--- a/tests/test_lib_smtpserver.py
+++ b/tests/test_lib_smtpserver.py
@@ -15,11 +15,10 @@ from privacyidea.lib.smtpserver import (get_smtpservers, add_smtpserver,
 from . import smtpmock
 from smtplib import SMTPException
 
-PNG_IMG = 'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABmJLR0QA/wD/AP+gv' \
-          'aeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5AEeDxMYtXhk0QAAAB1pVF' \
-          'h0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAO0lEQVQY02P8///' \
-          '/fwYiABMDkYAFXYCRkRGFD7MQq4n///9nQHcRCzaF6KbiVIjNf0R7hnyFuIKVaBMB' \
-          '6yUTDUpeapUAAAAASUVORK5CYII='
+PNG_IMG = 'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAA' \
+          'ALEwEAmpwYAAAAB3RJTUUH5AEeDxMYtXhk0QAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBk' \
+          'LmUHAAAAO0lEQVQY02P8////fwYiABMDkYAFXYCRkRGFD7MQq4n///9nQHcRCzaF6KbiVIjNf0R7hnyFuIKVaB' \
+          'MB6yUTDUpeapUAAAAASUVORK5CYII='
 
 
 class SMTPServerTestCase(MyTestCase):
@@ -27,16 +26,21 @@ class SMTPServerTestCase(MyTestCase):
     def test_01_create_smtpserver(self):
         r = add_smtpserver(identifier="myserver", server="1.2.3.4")
         self.assertTrue(r > 0)
-        r = add_smtpserver(identifier="myserver1", server="1.2.3.4")
+        r = add_smtpserver(identifier="myserver1", server="5.4.3.2")
+        self.assertTrue(r)
         r = add_smtpserver(identifier="myserver2", server="1.2.3.4")
+        self.assertTrue(r)
 
         server_list = get_smtpservers()
         self.assertTrue(server_list)
         self.assertEqual(len(server_list), 3)
         server_list = get_smtpservers(identifier="myserver")
+        self.assertEqual(len(server_list), 1)
         self.assertTrue(server_list[0].config.identifier, "myserver")
         self.assertTrue(server_list[0].config.port, 25)
 
+        servers_by_ip = get_smtpservers(server='1.2.3.4')
+        self.assertEqual(len(servers_by_ip), 2)
         for server in ["myserver", "myserver1", "myserver2"]:
             r = delete_smtpserver(server)
             self.assertTrue(r > 0)
@@ -111,21 +115,21 @@ class SMTPServerTestCase(MyTestCase):
                                   "Test Email from privacyIDEA",
                                   "This is a test email from privacyIDEA. "
                                   "The configuration %s is working." % identifier)
-        assert r
+        self.assertTrue(r)
         parsed_email = email.message_from_string(smtpmock.get_sent_message())
-        assert parsed_email.get_content_type() == 'text/plain'
-        assert parsed_email.get('To') == recipient
-        assert parsed_email.get('Subject') == "Test Email from privacyIDEA"
+        self.assertEqual(parsed_email.get_content_type(), 'text/plain', parsed_email)
+        self.assertEqual(parsed_email.get('To'), recipient, parsed_email)
+        self.assertEqual(parsed_email.get('Subject'), "Test Email from privacyIDEA", parsed_email)
 
         # Now with an already prepared MIME email
         msg = MIMEImage(binascii.a2b_base64(PNG_IMG))
         r = SMTPServer.test_email(s, recipient, "Test Email with image",
                                   msg)
-        assert r
+        self.assertTrue(r)
         parsed_email = email.message_from_string(smtpmock.get_sent_message())
-        assert parsed_email.get_content_type() == 'image/png'
-        assert parsed_email.get('To') == recipient
-        assert parsed_email.get('Subject') == "Test Email with image"
+        self.assertEqual(parsed_email.get_content_type(), 'image/png', parsed_email)
+        self.assertEqual(parsed_email.get('To'), recipient, parsed_email)
+        self.assertEqual(parsed_email.get('Subject'), "Test Email with image", parsed_email)
 
 
 class SMTPServerQueueTestCase(MockQueueTestCase):


### PR DESCRIPTION
Some email programs and providers have problems with inline images or
data-URLs so this will be fixed with this commit.
The UserNotificationHandler gets an additional option 'attachment' which
triggers the creation of a multipart email (text and image) and pass it to
the smtp-server.

Working on #1226

TODO: Documentation