### PR TITLE
Initialize rtype in user_object

### DIFF
--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -94,6 +94,7 @@ class User(object):
             resolver = ""
         self.resolver = resolver or ""
         self.uid = None
+        self.rtype = None
         # Enrich user object with information from the userstore or from the
         # usercache
         if login:


### PR DESCRIPTION
Add the rtype attribute, even if the user object is missing
the login attribute - in cased of orphaned tokens

Closes #2007