### PR TITLE
Write remote serial in tokeninfo of a remote token

### DIFF
--- a/doc/configuration/tokens/remote.rst
+++ b/doc/configuration/tokens/remote.rst
@@ -17,6 +17,9 @@ When forwarding the authentication request, you can
 
 and mangle the password.
 
+The serial number of the token, that was used on the other privacyIDEA server, is stored in the tokeninfo
+of the remote token object in the key ``last_matching_remote_serial``. This serial number can then be used in
+further workflows and e.g. be processed in event handlers.
 
 .. figure:: images/enroll_remote.png
    :width: 500

--- a/privacyidea/lib/tokens/remotetoken.py
+++ b/privacyidea/lib/tokens/remotetoken.py
@@ -282,6 +282,8 @@ class RemoteTokenClass(TokenClass):
                 result = response.get("result")
                 if result.get("value"):
                     otp_count = 1
+                    # Add the serial of the used remote token in the tokeninfo parameters
+                    self.add_tokeninfo("last_matching_remote_serial", response.get("detail", {}).get("serial"))
 
         except Exception as exx:  # pragma: no cover
             log.error("Error getting response from "

--- a/tests/test_lib_tokens_remote.py
+++ b/tests/test_lib_tokens_remote.py
@@ -110,6 +110,8 @@ class RemoteTokenTestCase(MyTestCase):
         otpcount = token.check_otp("123456")
         self.assertTrue(otpcount > 0, otpcount)
 
+        remote_serial = token.get_tokeninfo("last_matching_remote_serial")
+        self.assertEqual("PISP0000AB00", remote_serial)
 
     @responses.activate
     def test_05_do_request_fail(self):


### PR DESCRIPTION
In case a remote token is used to authenticate against another
privacyIDEA machine, the serial number of the token on this other
privacyIDEA machine, that was used successfully is stored in the
tokeninfo of the local remotetoken object.

This can be used for workflows in event handlers.
E.g. to act on this serial number, if the "other" privacyIDEA
machine is actually the same system.

Closes #2031