### PR TITLE
Propagate finalize_log() call for ContainerAudit

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -236,7 +236,7 @@ def after_request(response):
     """
     # In certain error cases the before_request was not handled
     # completely so that we do not have an audit_object
-    if "audit_object" in g and g.audit_object.audit_data:
+    if "audit_object" in g and g.audit_object.has_data:
         g.audit_object.finalize_log()
 
     # No caching!

--- a/privacyidea/lib/auditmodules/base.py
+++ b/privacyidea/lib/auditmodules/base.py
@@ -89,8 +89,10 @@ class Audit(object):  # pragma: no cover
         """
         self.name = "AuditBase"
         self.audit_data = {}
+        self.config = config or {}
         self.private = ""
         self.public = ""
+        self.have_data = False
 
     @log_with(log)
     def initialize(self):
@@ -160,6 +162,10 @@ class Audit(object):  # pragma: no cover
         """
         return None
 
+    @property
+    def has_data(self):
+        return self.have_data
+
     @log_with(log)
     def log(self, param):
         """
@@ -175,6 +181,7 @@ class Audit(object):  # pragma: no cover
         """
         for k, v in param.items():
             self.audit_data[k] = v
+        self.have_data = True
 
     def add_to_log(self, param, add_with_comma=False):
         """

--- a/privacyidea/lib/auditmodules/base.py
+++ b/privacyidea/lib/auditmodules/base.py
@@ -92,7 +92,6 @@ class Audit(object):  # pragma: no cover
         self.config = config or {}
         self.private = ""
         self.public = ""
-        self.have_data = False
 
     @log_with(log)
     def initialize(self):
@@ -164,7 +163,7 @@ class Audit(object):  # pragma: no cover
 
     @property
     def has_data(self):
-        return self.have_data
+        return bool(self.audit_data)
 
     @log_with(log)
     def log(self, param):
@@ -181,7 +180,6 @@ class Audit(object):  # pragma: no cover
         """
         for k, v in param.items():
             self.audit_data[k] = v
-        self.have_data = True
 
     def add_to_log(self, param, add_with_comma=False):
         """

--- a/privacyidea/lib/auditmodules/containeraudit.py
+++ b/privacyidea/lib/auditmodules/containeraudit.py
@@ -57,13 +57,16 @@ class Audit(AuditBase):
         if not self.read_module.is_readable:
             log.warning(u"The specified PI_AUDIT_CONTAINER_READ {0!s} is not readable.".format(self.read_module))
 
+    @property
+    def has_data(self):
+        return any([x.has_data for x in self.write_modules])
+
     def log(self, param):
         """
         Call the log method for all writeable modules
         """
         for module in self.write_modules:
             module.log(param)
-        self.have_data = True
 
     def search(self, search_dict, page_size=15, page=1, sortorder="asc",
                timelimit=None):
@@ -91,4 +94,3 @@ class Audit(AuditBase):
         """
         for module in self.write_modules:
             module.finalize_log()
-        self.have_data = False

--- a/privacyidea/lib/auditmodules/containeraudit.py
+++ b/privacyidea/lib/auditmodules/containeraudit.py
@@ -47,9 +47,8 @@ class Audit(AuditBase):
     """
 
     def __init__(self, config=None):
+        super(Audit, self).__init__(config)
         self.name = "containeraudit"
-        self.audit_data = {}
-        self.config = config or {}
         write_conf = self.config.get('PI_AUDIT_CONTAINER_WRITE')
         read_conf = self.config.get('PI_AUDIT_CONTAINER_READ')
         # Initialize all modules
@@ -64,6 +63,7 @@ class Audit(AuditBase):
         """
         for module in self.write_modules:
             module.log(param)
+        self.have_data = True
 
     def search(self, search_dict, page_size=15, page=1, sortorder="asc",
                timelimit=None):
@@ -91,4 +91,4 @@ class Audit(AuditBase):
         """
         for module in self.write_modules:
             module.finalize_log()
-
+        self.have_data = False

--- a/privacyidea/lib/auditmodules/loggeraudit.py
+++ b/privacyidea/lib/auditmodules/loggeraudit.py
@@ -83,6 +83,5 @@ class Audit(AuditBase):
         self.audit_data["timestamp"] = datetime.datetime.utcnow()
         log.info(u"{0!s}".format(self.audit_data))
         self.audit_data = {}
-        self.have_data = False
 
 

--- a/privacyidea/lib/auditmodules/loggeraudit.py
+++ b/privacyidea/lib/auditmodules/loggeraudit.py
@@ -71,9 +71,8 @@ class Audit(AuditBase):
     """
 
     def __init__(self, config=None):
+        super(Audit, self).__init__(config)
         self.name = "loggeraudit"
-        self.audit_data = {}
-        self.config = config or {}
 
     def finalize_log(self):
         """
@@ -83,5 +82,7 @@ class Audit(AuditBase):
         self.audit_data["policies"] = ",".join(self.audit_data.get("policies", []))
         self.audit_data["timestamp"] = datetime.datetime.utcnow()
         log.info(u"{0!s}".format(self.audit_data))
+        self.audit_data = {}
+        self.have_data = False
 
 

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -87,9 +87,8 @@ class Audit(AuditBase):
     is_readable = True
     
     def __init__(self, config=None):
+        super(Audit, self).__init__(config)
         self.name = "sqlaudit"
-        self.config = config or {}
-        self.audit_data = {}
         self.sign_data = not self.config.get("PI_AUDIT_NO_SIGN")
         self.sign_object = None
         self.verify_old_sig = self.config.get('PI_CHECK_OLD_SIGNATURES')
@@ -267,6 +266,7 @@ class Audit(AuditBase):
             self.session.close()
             # clear the audit data
             self.audit_data = {}
+            self.have_data = False
 
     def _check_missing(self, audit_id):
         """

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -266,7 +266,6 @@ class Audit(AuditBase):
             self.session.close()
             # clear the audit data
             self.audit_data = {}
-            self.have_data = False
 
     def _check_missing(self, audit_id):
         """

--- a/tests/test_api_audit.py
+++ b/tests/test_api_audit.py
@@ -11,8 +11,6 @@ from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.realm import set_realm
 
 PWFILE = "tests/testdata/passwords"
-POLICYFILE = "tests/testdata/policy.cfg"
-POLICYEMPTY = "tests/testdata/policy_empty_file.cfg"
 
 
 class APIAuditTestCase(MyApiTestCase):
@@ -27,6 +25,10 @@ class APIAuditTestCase(MyApiTestCase):
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertTrue(json_response.get("result").get("value").get(
                 "current") == 1, res)
+        # check for entry in audit log
+        aentry = self.find_most_recent_audit_entry(action='GET /audit/')
+        self.assertEqual(aentry['action'], 'GET /audit/', aentry)
+        self.assertEqual(aentry['success'], 1, aentry)
 
     def test_01_get_audit_csv(self):
         @contextmanager
@@ -227,4 +229,3 @@ class APIAuditTestCase(MyApiTestCase):
         # delete policy
         delete_policy("audit01")
         delete_policy("audit02")
-

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -24,6 +24,9 @@ class AuthApiTestCase(MyApiTestCase):
             self.assertTrue(result.get("status"), result)
             self.assertIn('token', result.get("value"), result)
             self.assertEqual('realm1', result['value']['realm'], result)
+        aentry = self.find_most_recent_audit_entry(action='POST /auth')
+        self.assertEqual(aentry['action'], 'POST /auth', aentry)
+        self.assertEqual(aentry['success'], 1, aentry)
 
         # test failed auth
         with self.app.test_request_context('/auth',


### PR DESCRIPTION
The `ContainerAudit` module did not propagate the `finalize_log()` call to
its sub-modules in all cases.
This is fixed together with a little reorganization of the test cases.

Fixes #2029