### PR TITLE
Avoid password error in sqlresolver

### DIFF
--- a/privacyidea/api/user.py
+++ b/privacyidea/api/user.py
@@ -176,7 +176,8 @@ def create_user_api():
     # Remove the password from the attributes, so that we can hide it in the
     # logs
     password = attributes.get("password")
-    del attributes["password"]
+    if hasattr(attributes, "password"):
+        del attributes["password"]
     r = create_user(resolvername, attributes, password=password)
     g.audit_object.log({"success": True,
                         "info": u"{0!s}: {1!s}/{2!s}".format(r, username,

--- a/privacyidea/api/user.py
+++ b/privacyidea/api/user.py
@@ -176,7 +176,7 @@ def create_user_api():
     # Remove the password from the attributes, so that we can hide it in the
     # logs
     password = attributes.get("password")
-    if hasattr(attributes, "password"):
+    if "password" in attributes:
         del attributes["password"]
     r = create_user(resolvername, attributes, password=password)
     g.audit_object.log({"success": True,


### PR DESCRIPTION
If a editable SQL resolver is defined without a password mapping,
then the line

   del attributes("password")

will cause a Keyerror. Thus it was not possible to define SQL resolvers
without a password. Deleting the password, only if it exists, now
actually allows us to create users in a SQL resolver without a password
mapping.

Fixes #2030