### PR TITLE
Add a link to READ_BEFORE_UPDATE in update section

### DIFF
--- a/doc/installation/upgrade.rst
+++ b/doc/installation/upgrade.rst
@@ -3,6 +3,12 @@
 Upgrading
 ---------
 
+In any case before upgrading a major version read the document
+[READ_BEFORE_UPDATE](https://github.com/privacyidea/privacyidea/blob/master/READ_BEFORE_UPDATE.md)
+which is continously updated in the Github repository.
+Note, that when you are upgrading over several major versions, read all the comments
+for all versions.
+
 If you installed privacyIDEA via DEB or RPM repository you can use the normal
 system ways of *apt-get*, *aptitude* and *rpm* to upgrade privacyIDEA to the
 current version.

--- a/doc/installation/upgrade.rst
+++ b/doc/installation/upgrade.rst
@@ -5,7 +5,7 @@ Upgrading
 
 In any case before upgrading a major version read the document
 [READ_BEFORE_UPDATE](https://github.com/privacyidea/privacyidea/blob/master/READ_BEFORE_UPDATE.md)
-which is continously updated in the Github repository.
+which is continuously updated in the Github repository.
 Note, that when you are upgrading over several major versions, read all the comments
 for all versions.
 


### PR DESCRIPTION
All users should read READ_BEFORE_UPDATE. No matter if
they have a pip install, a deb or rpm.

So we put the link to RBU just at the beginning of the
section

Working on #1967