### PR TITLE
Fix the PIN policy docs and add char-list

### DIFF
--- a/doc/policies/admin.rst
+++ b/doc/policies/admin.rst
@@ -201,7 +201,7 @@ characters ``+`` and ``-``.
 
    The PIN must not contain a character and must not contain a number.
    *test1234* would not be a valid PIN, since it does contains numbers and characters.
-   *test///* would not be a valid PIN, since it contains numbers.
+   *test///* would not be a valid PIN, since it contains characters.
 
 ``-s`` (denial)
 
@@ -214,7 +214,8 @@ characters ``+`` and ``-``.
    characters from the sum of the two groups.
    *test1234*, *test12$$*, *test*
    and *1234* would all be valid OTP PINs.
-   Note, how this is different to ``-s``.
+   Note, how this is different to ``-s``, since it allows special characters to be
+   included.
 
 ``[123456]``
 

--- a/doc/policies/admin.rst
+++ b/doc/policies/admin.rst
@@ -165,6 +165,8 @@ range: 0 - 31
 This is the minimum required PIN the admin must use when setting the
 OTP PIN.
 
+.. _admin_policies_otp_pin_contents:
+
 otp_pin_contents
 ~~~~~~~~~~~~~~~~
 
@@ -179,7 +181,9 @@ sets it.
 
 **n** are digits matching [0-9].
 
-**s** are special characters matching [.:,;-_<>+*!/()=?$§%&#~\^].
+**s** are special characters matching [\[\].:,;-_<>+*!/()=?$§%&#~\^].
+
+**[allowedchars]** is a specific list of allowed characters.
 
 **Example:** The policy action ``otp_pin_contents=cn, otp_pin_minlength=8`` would
 require the admin to choose OTP PINs that consist of letters and digits
@@ -193,14 +197,16 @@ which have a minimum length of 8.
 The logic of the ``otp_pin_contents`` can be enhanced and reversed using the
 characters ``+`` and ``-``.
 
-``-cn`` would still mean, that the OTP PIN needs to contain letters and digits
-and it must not contain any other characters.
+``-cn`` (denial)
 
-``-cn`` (substraction)
+   The PIN must not contain a character and must not contain a number.
+   *test1234* would not be a valid PIN, since it does contains numbers and characters.
+   *test///* would not be a valid PIN, since it contains numbers.
 
-   *test1234* would be a valid OTP PIN, but *test12$$* and *testABCS* would
-   not be valid OTP PINs. The later since it does not contain digits, the first
-   (*test12$$*) since it does contain a special character ($), which it should not.
+``-s`` (denial)
+
+   The PIN must not contain a special character.
+   **test1234* would be a valid PIN. *test12$$* would not.
 
 ``+cn`` (grouping)
 
@@ -208,6 +214,14 @@ and it must not contain any other characters.
    characters from the sum of the two groups.
    *test1234*, *test12$$*, *test*
    and *1234* would all be valid OTP PINs.
+   Note, how this is different to ``-s``.
+
+``[123456]``
+
+   allows the digtits 1-6 to be used.
+   *1122* would be a valid PIN.
+   *1177* would not be a valid PIN.
+
 
 otp_pin_set_random
 ~~~~~~~~~~~~~~~~~~

--- a/doc/policies/user.rst
+++ b/doc/policies/user.rst
@@ -169,40 +169,7 @@ contents: cns
 This defines what characters an OTP PIN should contain when the user
 sets it.
 
-**c** are letters matching [a-zA-Z].
-
-**n** are digits matching [0-9].
-
-**s** are special characters matching [.:,;-_<>+*!/()=?$§%&#~\^].
-
-**Example:** The policy action ``otp_pin_contents=cn, otp_pin_minlength=8`` would
-require the user to choose OTP PINs that consist of letters and digits
-which have a minimum length of 8.
-
-``cn``
-
-   *test1234* and *test12$$* would be valid OTP PINs. *testABCD* would 
-   not be a valid OTP PIN.
-
-The logic of the ``otp_pin_contents`` can be enhanced and reversed using the
-characters ``+`` and ``-``.
-
-``-cn`` would still mean, that the OTP PIN needs to contain letters and digits
-and it must not contain any other characters.
-
-``-cn`` (substraction)
-
-   *test1234* would be a valid OTP PIN, but *test12$$* and *testABCS* would
-   not be valid OTP PINs. The later since it does not contain digits, the first 
-   (*test12$$*) since it does contain a special character ($), which it should not.
-
-``+cn`` (grouping)
-
-   combines the two required groups. I.e. the OTP PIN should contain
-   characters from the sum of the two groups.
-   *test1234*, *test12$$*, *test*
-   and *1234* would all be valid OTP PINs.
-
+This takes the same values like the admin policy :ref:`admin_policies_otp_pin_contents`.
 
 auditlog
 ~~~~~~~~

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1567,7 +1567,8 @@ def get_static_policy_definitions(scope=None):
                                     "desc": _("Specifiy the required "
                                               "contents of the OTP PIN. "
                                               "(c)haracters, (n)umeric, "
-                                              "(s)pecial, (o)thers. [+/-]!"),
+                                              "(s)pecial. Use modifiers +/- or a list "
+                                              "of allowed characters [1234567890]"),
                                     'group': GROUP.PIN},
             ACTION.OTPPINSETRANDOM: {
                 'type': 'int',
@@ -1788,7 +1789,8 @@ def get_static_policy_definitions(scope=None):
                                     "desc": _("Specifiy the required "
                                               "contents of the OTP PIN. "
                                               "(c)haracters, (n)umeric, "
-                                              "(s)pecial, (o)thers. [+/-]!"),
+                                              "(s)pecial. Use modifiers +/- or a list "
+                                              "of allowed characters [1234567890]"),
                                     'group': GROUP.PIN},
 
             ACTION.AUDIT: {

--- a/privacyidea/lib/utils/__init__.py
+++ b/privacyidea/lib/utils/__init__.py
@@ -1121,9 +1121,9 @@ def check_pin_policy(pin, policy):
     :param policy: The policy that describes the allowed contents of the PIN.
     :return: Tuple of True or False and a description
     """
-    chars = {"c": "[a-zA-Z]",
-             "n": "[0-9]",
-             "s": "[\[\].:,;_<>+*!/()=?$§%&#~\^-]"}
+    chars = {"c": r"[a-zA-Z]",
+             "n": r"[0-9]",
+             "s": r"[\[\].:,;_<>+*!/()=?$§%&#~^-]"}
     ret = True
     comment = []
 

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -532,12 +532,12 @@ class UtilsTestCase(MyTestCase):
 
         r, c = check_pin_policy("123", "nc")
         self.assertFalse(r)
-        self.assertEqual("Missing character in PIN: [a-zA-Z]", c)
+        self.assertEqual(r"Missing character in PIN: [a-zA-Z]", c)
 
         r, c = check_pin_policy("123", "ncs")
         self.assertFalse(r)
-        self.assertTrue("Missing character in PIN: [a-zA-Z]" in c, c)
-        self.assertTrue("Missing character in PIN: [\[\].:,;_<>+*!/()=?$§%&#~\^-]" in c, c)
+        self.assertTrue(r"Missing character in PIN: [a-zA-Z]" in c, c)
+        self.assertTrue(r"Missing character in PIN: [\[\].:,;_<>+*!/()=?$§%&#~^-]" in c, c)
 
         r, c = check_pin_policy("1234", "")
         self.assertFalse(r)


### PR DESCRIPTION
The documentation of the PIN policies was wrong.

We also added an additional PIN policy to define a
specific list of allowed characters.

Closes #2049