### PR TITLE
Remove greetings from PR

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request, issues]
+on: [issues]
 
 jobs:
   greeting:
@@ -9,5 +9,6 @@ jobs:
     - uses: actions/first-interaction@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'Thank you for filing an issue and sharing your observations or ideas. Please be sure to provide as many information as possible to help us working on this issue.'
-        pr-message: 'Thank you for filing a Pull Request and thus contributing your ideas and code to privacyIDEA. Please be sure to comply to our development guidelines here: https://github.com/privacyidea/privacyidea/blob/master/CONTRIBUTING.md#develop'
+        issue-message: 'Thank you for filing an issue and sharing your observations or ideas.
+                        Please be sure to provide as many information as possible to help us
+                        working on this issue.'


### PR DESCRIPTION
Usually a pull request from a new user comes from a forked repository so
the provided github token does not have the right to comment on the pull
request.
New users who can create branches in the repository aren't really new.