### PR TITLE
Fix doc to show gpg fingerprint on Ubuntu 18.04

### DIFF
--- a/doc/installation/ubuntu.rst
+++ b/doc/installation/ubuntu.rst
@@ -34,7 +34,7 @@ On Ubuntu 16.04 check the fingerprint of the key::
 
 On 18.04 you need to run::
 
-   gpg --dry-run --import --with-fingerprint NetKnights-Release.asc
+   gpg --dry-run --import --import-options import-show NetKnights-Release.asc
 
 The fingerprint of the key is::
 

--- a/doc/installation/ubuntu.rst
+++ b/doc/installation/ubuntu.rst
@@ -34,7 +34,7 @@ On Ubuntu 16.04 check the fingerprint of the key::
 
 On 18.04 you need to run::
 
-   gpg --dry-run --import --import-options import-show NetKnights-Release.asc
+   gpg --import --import-options show-only --with-fingerprint NetKnights-Release.asc
 
 The fingerprint of the key is::
 


### PR DESCRIPTION
The gpg command shown in the documentation does not work on Ubuntu 18.04.4
```
gpg --dry-run --import --with-fingerprint NetKnights-Release.asc
```
I have used the following command and updated the documentation.
```
gpg --dry-run --import --import-options import-show NetKnights-Release.asc
```