### PR TITLE
algorithm has to be upper case for Google Authenticator on iOS

### DIFF
--- a/privacyidea/lib/apps.py
+++ b/privacyidea/lib/apps.py
@@ -148,7 +148,7 @@ def create_google_authenticator_url(key=None, user=None,
     url_issuer = quote(issuer.encode("utf-8"))
 
     if hash_algo.lower() != "sha1":
-        hash_algo = "algorithm={0!s}&".format(hash_algo)
+        hash_algo = "algorithm={0!s}&".format(hash_algo.upper())
     else:
         # If the hash_algo is SHA1, we do not add it to the QR code to keep
         # the QR code simpler


### PR DESCRIPTION
The "algorithm=" parameter has to be in upper case to be valid in Google Authenticator App on iOS. Microsoft Authenticator takes it in upper and lower case
I have not tested on any other platforms.