### PR TITLE
Read YAML based logging configuration

### DIFF
--- a/.codespell_skip
+++ b/.codespell_skip
@@ -1,2 +1,4 @@
 ./privacyidea/static/contrib/*
+./privacyidea/static/components/translation/*
 ./privacyidea/translations/*
+./po/*

--- a/doc/installation/system/logging.rst
+++ b/doc/installation/system/logging.rst
@@ -21,12 +21,53 @@ Usually it is set to::
 Advanced Logging
 ~~~~~~~~~~~~~~~~
 
-You can also define a more detailed logging by specifying a log configuration
-file like this::
+You can also define a more detailed logging by specifying a
+log configuration file in :ref:`cfgfile` like this::
 
-   PI_LOGCONFIG = "/etc/privacyidea/logging.cfg"
+   PI_LOGCONFIG = "/etc/privacyidea/logging.yml"
 
-Such a configuration could look like this::
+Such a YAML [#yaml]_ based configuration could look like this:
+
+.. code-block:: yaml
+
+    version: 1
+    formatters:
+      detail:
+        class: privacyidea.lib.log.SecureFormatter
+        format: '[%(asctime)s][%(process)d][%(thread)d][%(levelname)s][%(name)s:%(lineno)d] %(message)s'
+
+    handlers:
+      mail:
+        class: logging.handlers.SMTPHandler
+        mailhost: mail.example.com
+        fromaddr: privacyidea@example.com
+        toaddrs:
+        - admin1@example.com
+        - admin2@example.com
+        subject: PI Error
+        formatter: detail
+        level: ERROR
+      file:
+        # Rollover the logfile at midnight
+        class: logging.handlers.RotatingFileHandler
+        backupCount: 5
+        maxBytes: 1000000
+        formatter: detail
+        level: INFO
+        filename: /var/log/privacyidea/privacyidea.log
+    loggers:
+      privacyidea:
+        handlers:
+        - file
+        - mail
+        qualname: privacyidea
+        level: DEBUG
+
+Different handlers can be used to send log messages to log-aggregators like
+splunk [#splunk]_ or logstash [#logstash]_.
+
+The old `python logging config file format <https://docs.python.org/3/library/logging.config
+.html#logging-config-fileformat>`_ is also still supoorted::
 
    [formatters]
    keys=detail
@@ -66,13 +107,12 @@ Such a configuration could look like this::
    level=ERROR
    handlers=file
 
-
-The file structure follows [#fileconfig]_ and can be used to define additional
-handlers like logging errors to email addresses.
-
-.. note:: In this example a mail handler is defined, that will send emails
-   to certain email addresses, if an ERROR occurs.
+.. note:: These examples define a mail handler, that will send emails
+   to certain email addresses, if an ERROR occurs. All other DEBUG messages will
+   be logged to a file.
 
 .. rubric:: Footnotes
 
-.. [#fileconfig] https://docs.python.org/2/library/logging.config.html#configuration-file-format
+.. [#yaml] https://yaml.org/
+.. [#splunk] https://www.splunk.com/
+.. [#logstash] https://www.elastic.co/logstash

--- a/doc/installation/system/logging.rst
+++ b/doc/installation/system/logging.rst
@@ -22,11 +22,15 @@ Advanced Logging
 ~~~~~~~~~~~~~~~~
 
 You can also define a more detailed logging by specifying a
-log configuration file in :ref:`cfgfile` like this::
+log configuration file. By default the file is ``/etc/privacyidea/logging.cfg``.
 
-   PI_LOGCONFIG = "/etc/privacyidea/logging.yml"
+You can change the location of the logging configuration file
+in :ref:`cfgfile` like this::
 
-Such a YAML [#yaml]_ based configuration could look like this:
+   PI_LOGCONFIG = "/path/to/logging.yml"
+
+Since Version 3.3 the logging configuration can be written in YAML [#yaml]_.
+Such a YAML based configuration could look like this:
 
 .. code-block:: yaml
 
@@ -56,18 +60,20 @@ Such a YAML [#yaml]_ based configuration could look like this:
         level: INFO
         filename: /var/log/privacyidea/privacyidea.log
     loggers:
+      # The logger name is the qualname
       privacyidea:
         handlers:
         - file
         - mail
-        qualname: privacyidea
-        level: DEBUG
+        level: INFO
+    root:
+      level: WARNING
 
 Different handlers can be used to send log messages to log-aggregators like
 splunk [#splunk]_ or logstash [#logstash]_.
 
 The old `python logging config file format <https://docs.python.org/3/library/logging.config
-.html#logging-config-fileformat>`_ is also still supoorted::
+.html#logging-config-fileformat>`_ is also still supported::
 
    [formatters]
    keys=detail
@@ -110,6 +116,8 @@ The old `python logging config file format <https://docs.python.org/3/library/lo
 .. note:: These examples define a mail handler, that will send emails
    to certain email addresses, if an ERROR occurs. All other DEBUG messages will
    be logged to a file.
+
+.. note:: The filename extension is irrelevant in this case
 
 .. rubric:: Footnotes
 

--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -174,13 +174,13 @@ def create_app(config_name="development",
     # Setup logging
     log_read_func = {
         'yaml': lambda x: logging.config.dictConfig(yaml.safe_load(open(x, 'r').read())),
-        'cnf': lambda x: logging.config.fileConfig(x)
+        'cfg': lambda x: logging.config.fileConfig(x)
     }
     have_config = False
     log_exx = None
     log_config_file = app.config.get("PI_LOGCONFIG", "/etc/privacyidea/logging.cfg")
     if os.path.isfile(log_config_file):
-        for cnf_type in ['cnf', 'yaml']:
+        for cnf_type in ['cfg', 'yaml']:
             try:
                 log_read_func[cnf_type](log_config_file)
                 if not silent:

--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -25,6 +25,7 @@ WQIDAQAB
 -----END PUBLIC KEY-----
 """
 
+
 class Config(object):
     SECRET_KEY = os.environ.get('SECRET_KEY')
     # SQL_ALCHEMY_DATABASE_URI = "mysql://privacyidea:XmbSrlqy5d4IS08zjz"
@@ -36,7 +37,6 @@ class Config(object):
     PI_AUDIT_KEY_PUBLIC = os.path.join(basedir, "tests/testdata/public.pem")
     PI_LOGFILE = "privacyidea.log"
     PI_LOGLEVEL = logging.INFO
-    PI_LOGLEVEL = 9
     CACHE_TYPE = "simple"
     PI_EXTERNAL_LINKS = True
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -66,7 +66,6 @@ class TestingConfig(Config):
     PI_PEPPER = ""
     # This is only for testing encrypted files
     PI_ENCFILE_ENC = "tests/testdata/enckey.enc"
-    PI_LOGLEVEL = logging.DEBUG
     PI_LOGLEVEL = logging.INFO
     PI_GNUPG_HOME = "tests/testdata/gpg"
     CACHE_TYPE = "None"
@@ -96,25 +95,23 @@ class TestingConfig(Config):
 
 
 class ProductionConfig(Config):
-    config_path = basedir
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
-        'sqlite:///' + os.path.join(config_path, 'data.sqlite')
+        'sqlite:///' + os.path.join(basedir, 'data.sqlite')
     #SQLALCHEMY_DATABASE_URI = "mysql://pi2:pi2@localhost/pi2"
     # This is used to encrypt the auth_token
     SECRET_KEY = os.environ.get('SECRET_KEY') or 't0p s3cr3t'
     # This is used to encrypt the admin passwords
     PI_PEPPER = "Never know..."
     # This is used to encrypt the token data and token passwords
-    PI_ENCFILE = os.path.join(config_path, "enckey")
+    PI_ENCFILE = os.path.join(basedir, "enckey")
     # This is used to sign the audit log
-    PI_AUDIT_KEY_PRIVATE = os.path.join(config_path, "private.pem")
-    PI_AUDIT_KEY_PUBLIC = os.path.join(config_path, "public.pem")
+    PI_AUDIT_KEY_PRIVATE = os.path.join(basedir, "private.pem")
+    PI_AUDIT_KEY_PUBLIC = os.path.join(basedir, "public.pem")
     PI_LOGLEVEL = logging.INFO
     SUPERUSER_REALM = ['superuser']
 
 
 class HerokuConfig(Config):
-    config_path = basedir
     SQLALCHEMY_DATABASE_URI = "postgres://mvfkmtkwzuwojj:" \
                               "wqy_btZE3CPPNWsmkfdmeorxy6@" \
                               "ec2-54-83-0-61.compute-1." \
@@ -125,11 +122,11 @@ class HerokuConfig(Config):
     # This is used to encrypt the admin passwords
     PI_PEPPER = "Never know..."
     # This is used to encrypt the token data and token passwords
-    PI_ENCFILE = os.path.join(config_path, "deploy/heroku/enckey")
+    PI_ENCFILE = os.path.join(basedir, "deploy/heroku/enckey")
     # This is used to sign the audit log
-    PI_AUDIT_KEY_PRIVATE = os.path.join(config_path,
+    PI_AUDIT_KEY_PRIVATE = os.path.join(basedir,
                                         "deploy/heroku/private.pem")
-    PI_AUDIT_KEY_PUBLIC = os.path.join(config_path, "deploy/heroku/public.pem")
+    PI_AUDIT_KEY_PUBLIC = os.path.join(basedir, "deploy/heroku/public.pem")
     SUPERUSER_REALM = ['superuser']
 
 

--- a/privacyidea/lib/log.py
+++ b/privacyidea/lib/log.py
@@ -34,13 +34,13 @@ log = logging.getLogger(__name__)
 
 DEFAULT_LOGGING_CONFIG = {
     "version": 1,
-    "formatters": {"detail": {"class":
+    "formatters": {"detail": {"()":
                                   "privacyidea.lib.log.SecureFormatter",
                               "format": "[%(asctime)s][%(process)d]"
                                         "[%(thread)d][%(levelname)s]"
                                         "[%(name)s:%(lineno)d] "
                                         "%(message)s"}
-                       },
+                   },
     "handlers": {"file": {"formatter": "detail",
                           "class":
                               "logging.handlers.RotatingFileHandler",
@@ -48,12 +48,13 @@ DEFAULT_LOGGING_CONFIG = {
                           "maxBytes": 10000000,
                           "level": logging.DEBUG,
                           "filename": "privacyidea.log"}
-                         },
+                 },
     "loggers": {"privacyidea": {"handlers": ["file"],
                                 "qualname": "privacyidea",
                                 "level": logging.INFO}
                 }
 }
+
 
 class SecureFormatter(Formatter):
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,8 +7,8 @@ cookies==2.2.1; python_version < '3.0'
 coverage==5.0.3
 funcsigs==1.0.2; python_version < '3.0'
 importlib-metadata==1.5.0
-mock==4.0.2; python_version > '3.0'
-mock==3.0.5; python_version < '3.0'
+mock==4.0.2; python_version > '3.5'
+mock==3.0.5; python_version <= '3.5'
 more-itertools==5.0.0; python_version < '3.0'
 more-itertools==8.1.0; python_version > '3.0'
 packaging==20.3
@@ -23,5 +23,5 @@ responses==0.10.12
 scandir==1.10.0; python_version < '3.0'
 testfixtures==6.14.0
 wcwidth==0.1.8
-zipp==3.1.0; python_version > '3.0'
-zipp==1.2.0; python_version < '3.0'
+zipp==3.1.0; python_version > '3.5'
+zipp==1.2.0; python_version <= '3.5'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,11 +6,12 @@ contextlib2==0.6.0.post1; python_version < '3.0'
 cookies==2.2.1; python_version < '3.0'
 coverage==5.0.3
 funcsigs==1.0.2; python_version < '3.0'
-importlib-metadata==1.4.0
-mock==3.0.5
+importlib-metadata==1.5.0
+mock==4.0.2; python_version > '3.0'
+mock==3.0.5; python_version < '3.0'
 more-itertools==5.0.0; python_version < '3.0'
 more-itertools==8.1.0; python_version > '3.0'
-packaging==20.0
+packaging==20.3
 pathlib2==2.3.5; python_version < '3.0'
 pluggy==0.13.1
 py==1.8.1
@@ -18,7 +19,9 @@ pyparsing==2.4.6
 pytest==4.6.9; python_version < '3.0'
 pytest==5.3.2; python_version > '3.0'
 pytest-cov==2.8.1
-responses==0.10.9
+responses==0.10.12
 scandir==1.10.0; python_version < '3.0'
+testfixtures==6.14.0
 wcwidth==0.1.8
-zipp==0.6.0
+zipp==3.1.0; python_version > '3.0'
+zipp==1.2.0; python_version < '3.0'

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -147,3 +147,25 @@ class AppTestCase(unittest.TestCase):
                            formatter=None,
                            strict=False)
             ], logger.handlers)
+
+    def test_05_logging_config_broken_yaml(self):
+        class Config(TestingConfig):
+            PI_LOGCONFIG = "tests/testdata/logging_broken.yaml"
+        with mock.patch.dict("privacyidea.config.config", {"testing": Config}):
+            app = create_app(config_name='testing')
+            # check the correct initialization of the logging with the default
+            # values since the yaml file is broken
+            logger = logging.getLogger('privacyidea')
+            self.assertEqual(logger.level, logging.INFO, logger)
+            compare([
+                Comparison('logging.handlers.RotatingFileHandler',
+                           baseFilename=os.path.join(dirname, 'privacyidea.log'),
+                           formatter=Comparison('privacyidea.lib.log.SecureFormatter',
+                                                _fmt="[%(asctime)s][%(process)d]"
+                                                     "[%(thread)d][%(levelname)s]"
+                                                     "[%(name)s:%(lineno)d] "
+                                                     "%(message)s",
+                                                strict=False),
+                           level=logging.INFO,
+                           strict=False)
+            ], logger.handlers)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""
+This testfile tests the basic app functionality of the privacyIDEA app
+"""
+import os
+import unittest
+import flask
+import inspect
+import logging
+import mock
+from testfixtures import Comparison, compare
+from privacyidea.app import create_app, PiResponseClass
+from privacyidea.config import config, TestingConfig
+
+dirname = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+
+
+class AppTestCase(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger()
+        self.orig_handlers = self.logger.handlers
+        self.logger.handlers = []
+        self.level = self.logger.level
+
+    def tearDown(self):
+        self.logger.handlers = self.orig_handlers
+        self.logger.level = self.level
+
+    def test_01_create_default_app(self):
+        # This will create the app with the 'development' configuration
+        app = create_app()
+        self.assertIsInstance(app, flask.app.Flask, app)
+        self.assertEqual(app.env, 'production', app)
+        self.assertTrue(app.debug, app)
+        self.assertFalse(app.testing, app)
+        self.assertEqual(app.import_name, 'privacyidea.app', app)
+        self.assertEqual(app.name, 'privacyidea.app', app)
+        self.assertTrue(app.response_class == PiResponseClass, app)
+        blueprints = ['validate_blueprint', 'token_blueprint', 'system_blueprint',
+                      'resolver_blueprint', 'realm_blueprint', 'defaultrealm_blueprint',
+                      'policy_blueprint', 'login_blueprint', 'jwtauth', 'user_blueprint',
+                      'audit_blueprint', 'machineresolver_blueprint', 'machine_blueprint',
+                      'application_blueprint', 'caconnector_blueprint', 'cert_blueprint',
+                      'ttype_blueprint', 'register_blueprint', 'smtpserver_blueprint',
+                      'recover_blueprint', 'radiusserver_blueprint', 'periodictask_blueprint',
+                      'privacyideaserver_blueprint', 'eventhandling_blueprint',
+                      'smsgateway_blueprint', 'client_blueprint', 'subscriptions_blueprint',
+                      'monitoring_blueprint']
+        self.assertTrue(all(k in app.before_request_funcs for k in blueprints), app)
+        self.assertTrue(all(k in app.blueprints for k in blueprints), app)
+        extensions = ['sqlalchemy', 'migrate', 'babel']
+        self.assertTrue(all(k in extensions for k in app.extensions), app)
+        self.assertEqual(app.secret_key, 't0p s3cr3t', app)
+        # TODO: check url_map and view_functions
+        # check that the configuration was loaded successfully
+        # the default configuration is 'development'
+        dc = config['development']()
+        members = inspect.getmembers(dc, lambda a: not(inspect.isroutine(a)))
+        conf = [m for m in members if not (m[0].startswith('__') and m[0].endswith('__'))]
+        self.assertTrue(all(app.config[k] == v for k, v in conf), app)
+        # check the correct initialization of the logging
+        logger = logging.getLogger('privacyidea')
+        self.assertEqual(logger.level, logging.DEBUG, logger)
+        compare([
+            Comparison('logging.handlers.RotatingFileHandler',
+                       baseFilename=os.path.join(dirname, 'privacyidea.log'),
+                       formatter=Comparison('privacyidea.lib.log.SecureFormatter',
+                                            _fmt="[%(asctime)s][%(process)d]"
+                                                 "[%(thread)d][%(levelname)s]"
+                                                 "[%(name)s:%(lineno)d] "
+                                                 "%(message)s",
+                                            strict=False),
+                       level=logging.DEBUG,
+                       strict=False)
+        ], logger.handlers)
+
+    def test_02_create_production_app(self):
+        app = create_app(config_name='production')
+        dc = config['production']()
+        members = inspect.getmembers(dc, lambda a: not(inspect.isroutine(a)))
+        conf = [m for m in members if not (m[0].startswith('__') and m[0].endswith('__'))]
+        self.assertTrue(all(app.config[k] == v for k, v in conf), app)
+
+    def test_03_logging_config_file(self):
+        class Config(TestingConfig):
+            PI_LOGCONFIG = "tests/testdata/logging.cfg"
+        with mock.patch.dict("privacyidea.config.config", {"testing": Config}):
+            app = create_app(config_name='testing')
+            # check the correct initialization of the logging from config file
+            logger = logging.getLogger('privacyidea')
+            self.assertEqual(logger.level, logging.DEBUG, logger)
+            compare([
+                Comparison('logging.handlers.RotatingFileHandler',
+                           baseFilename=os.path.join(dirname, 'privacyidea.log'),
+                           formatter=Comparison('privacyidea.lib.log.SecureFormatter',
+                                                _fmt="[%(asctime)s][%(process)d]"
+                                                     "[%(thread)d][%(levelname)s]"
+                                                     "[%(name)s:%(lineno)d] "
+                                                     "%(message)s",
+                                                strict=False),
+                           level=logging.DEBUG,
+                           strict=False)
+            ], logger.handlers)
+            logger = logging.getLogger('privacyidea.lib.auditmodules.loggeraudit')
+            self.assertEqual(logger.level, logging.INFO, logger)
+            compare([
+                Comparison('logging.handlers.RotatingFileHandler',
+                           baseFilename=os.path.join(dirname, 'audit.log'),
+                           formatter=Comparison('privacyidea.lib.log.SecureFormatter',
+                                                _fmt="[%(asctime)s][%(process)d]"
+                                                     "[%(thread)d][%(levelname)s]"
+                                                     "[%(name)s:%(lineno)d] "
+                                                     "%(message)s",
+                                                strict=False),
+                           level=logging.INFO,
+                           strict=False)
+            ], logger.handlers)
+
+    def test_04_logging_config_yaml(self):
+        class Config(TestingConfig):
+            PI_LOGCONFIG = "tests/testdata/logging.yml"
+        with mock.patch.dict("privacyidea.config.config", {"testing": Config}):
+            app = create_app(config_name='testing')
+            # check the correct initialization of the logging from config file
+            logger = logging.getLogger('privacyidea')
+            self.assertEqual(logger.level, logging.INFO, logger)
+            compare([
+                Comparison('logging.handlers.RotatingFileHandler',
+                           baseFilename=os.path.join(dirname, 'privacyidea.log'),
+                           formatter=Comparison('privacyidea.lib.log.SecureFormatter',
+                                                _fmt="[%(asctime)s][%(process)d]"
+                                                     "[%(thread)d][%(levelname)s]"
+                                                     "[%(name)s:%(lineno)d] "
+                                                     "%(message)s",
+                                                strict=False),
+                           backupCount=5,
+                           level=logging.DEBUG,
+                           strict=False)
+            ], logger.handlers)
+            logger = logging.getLogger('audit')
+            self.assertEqual(logger.level, logging.INFO, logger)
+            compare([
+                Comparison('logging.handlers.RotatingFileHandler',
+                           backupCount=14,
+                           baseFilename=os.path.join(dirname, 'audit.log'),
+                           level=logging.INFO,
+                           formatter=None,
+                           strict=False)
+            ], logger.handlers)

--- a/tests/testdata/logging.yml
+++ b/tests/testdata/logging.yml
@@ -1,0 +1,31 @@
+formatters:
+  detail:
+    (): privacyidea.lib.log.SecureFormatter
+    format: '[%(asctime)s][%(process)d][%(thread)d][%(levelname)s][%(name)s:%(lineno)d]
+      %(message)s'
+handlers:
+  file:
+    backupCount: 5
+    class: logging.handlers.RotatingFileHandler
+    filename: privacyidea.log
+    formatter: detail
+    level: DEBUG
+    maxBytes: 10000000
+  file_audit:
+    class: logging.handlers.RotatingFileHandler
+    backupCount: 14
+    filename: audit.log
+    level: INFO
+    maxBytes: 10000000
+loggers:
+  privacyidea:
+    handlers:
+    - file
+    level: INFO
+    qualname: privacyidea
+  audit:
+    handlers:
+    - file_audit
+    level: INFO
+    qualname: pi-audit
+version: 1

--- a/tests/testdata/logging_broken.yaml
+++ b/tests/testdata/logging_broken.yaml
@@ -1,0 +1,15 @@
+handlers:
+  file:
+    backupCount: 5
+    class: logging.handlers.RotatingFileHandler
+    filename: privacyidea.log
+    formatter: detail
+    level: BLABLA
+    maxBytes: 10000000
+loggers:
+  privacyidea:
+    handlers:
+    - filehandler
+    level: INFO
+    qualname: privacyidea
+version: 1


### PR DESCRIPTION
The python docs suggest using `dictConfig()` instead of `fileConfig()` for
complex logging configurations.
This PR adds the possibility to read logging configuration from a config
file as well as a YAML file. The YAML based configuration will be passed to
`dictConfig()` and takes precedence over a config-file based configuration.
If both files don't exist (or could not be read), the default logging
configuration from `privacyidea.lib.log` will be used.

Working on #2059