### PR TITLE
Fix the sorting of token table

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenChallengesController.js
+++ b/privacyidea/static/components/token/controllers/tokenChallengesController.js
@@ -17,7 +17,7 @@ myApp.controller("tokenChallengesController", function ($scope,
     // define functions
     $scope.get = function () {
         $scope.params.serial = "*" + ($scope.serialFilter || "") + "*";
-        $scope.params.sortBy = $scope.sortBy;
+        $scope.params.sortby = $scope.sortby;
         if ($scope.reverse) {
             $scope.params.sortdir = "desc";
         } else {

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -46,7 +46,7 @@ myApp.controller("tokenController", function (TokenFactory, ConfigFactory,
             $scope.params.userid = "*" + ($scope.userIdFilter || "") + "*";
             $scope.params.resolver = "*" + ($scope.resolverFilter || "") + "*";
             $scope.params.pagesize = $scope.token_page_size;
-            $scope.params.sortBy = $scope.sortBy;
+            $scope.params.sortby = $scope.sortby;
             if ($scope.reverse) {
                 $scope.params.sortdir = "desc";
             } else {


### PR DESCRIPTION
The API expects a lowercase "sortby".
The directive returns a lowercase "sortby".
So lowercasing the parameters.

Fixes #2111