### PR TITLE
Fix searching of token, users and machines

### DIFF
--- a/privacyidea/static/components/directives/views/directive.assigntoken.html
+++ b/privacyidea/static/components/directives/views/directive.assigntoken.html
@@ -9,10 +9,15 @@ This is the directive for assigning tokens to users.
            ng-keypress="toggleLoadSerials($event.which==13)"
            typeahead-wait-ms="100"
            typeahead-focus-first="false"
-           typeahead="serial for serial in loadSerials($viewValue) | filter: $viewValue"
+           uib-typeahead="serial for serial in loadSerials($viewValue)"
+           typeahead-no-results="noResults"
            typeahead-loading="loadingSerials" class="form-control" >
-    <i ng-show="loadingSerials" class="glyphicon glyphicon-refresh"
-            translate>Loading serials...</i>
+    <div ng-show="loadingSerials">
+        <i class="glyphicon glyphicon-refresh"></i><span translate>Loading serials...</span>
+    </div>
+    <div ng-show="noResults">
+        <i class="glyphicon glyphicon-remove"></i><span translate>No serial found</span>
+    </div>
 </div>
 <div class="form-group">
     <!-- we could add a checkRight("enrollpin") here,

--- a/privacyidea/static/components/directives/views/directive.assignuser.html
+++ b/privacyidea/static/components/directives/views/directive.assignuser.html
@@ -17,11 +17,16 @@ This is the directive for assigning users.
            placeholder="{{ 'start typing a username'|translate }}"
            ng-keypress="toggleLoadUsers($event.which==13)"
            typeahead-wait-ms="100"
-           typeahead-focus-first="false"
-           typeahead="newuser for newuser in loadUsers($viewValue) | filter: $viewValue"
+           typeahead-focus-first="true"
+           uib-typeahead="newuser for newuser in loadUsers($viewValue)"
+           typeahead-no-results="noResults"
            typeahead-loading="loadingUsers" class="form-control" >
-    <i ng-show="loadingUsers" class="glyphicon glyphicon-refresh"
-            translate>Loading users...</i>
+    <div ng-show="loadingUsers">
+        <i class="glyphicon glyphicon-refresh"></i><span translate>Loading users...</span>
+    </div>
+    <div ng-show="noResults">
+        <i class="glyphicon glyphicon-remove"></i><span translate>No user found</span>
+    </div>
 </div>
 <div class="form-group">
     <!-- we could add a checkRight("enrollpin") here,

--- a/privacyidea/static/components/directives/views/directive.attachmachine.html
+++ b/privacyidea/static/components/directives/views/directive.attachmachine.html
@@ -6,8 +6,15 @@ This is the directive for attaching machines to tokens.
     <input name="serial" type="text" ng-model="newMachine"
            autocomplete="off"
            placeholder="{{ 'start typing a machine.'|translate }}"
-           typeahead="serial for serial in loadMachines($viewValue)"
-           typeahead-loading="loadingMachines" class="form-control" >
-    <i ng-show="loadingMachines" class="glyphicon glyphicon-refresh"
-            translate>Loading Machines...</i>
+           typeahead-wait-ms="100"
+           uib-typeahead="serial for serial in loadMachines($viewValue)"
+           typeahead-no-results="noResults"
+           typeahead-loading="loadingUsers" class="form-control" >
+    <div ng-show="loadingMachines">
+        <i class="glyphicon glyphicon-refresh"></i><span translate>Loading Machines...</span>
+    </div>
+    <div ng-show="noResults">
+        <i class="glyphicon glyphicon-remove"></i><span translate>No machine found</span>
+    </div>
+
 </div>

--- a/privacyidea/static/components/directives/views/directive.attachtoken.html
+++ b/privacyidea/static/components/directives/views/directive.attachtoken.html
@@ -7,8 +7,14 @@ This is the directive for attach tokens to machines.
            autocomplete="off"
            placeholder="{{ 'start typing a serial number of a token.'|
            translate }}"
-           typeahead="serial for serial in loadSerials($viewValue)"
+           typeahead-wait-ms="100"
+           uib-typeahead="serial for serial in loadSerials($viewValue)"
+           typeahead-no-results="noResults"
            typeahead-loading="loadingSerials" class="form-control" >
-    <i ng-show="loadingSerials" class="glyphicon glyphicon-refresh"
-            translate>Loading serials...</i>
+    <div ng-show="loadingSerials">
+        <i class="glyphicon glyphicon-refresh"></i><span translate>Loading serials...</span>
+    </div>
+    <div ng-show="noResults">
+        <i class="glyphicon glyphicon-remove"></i><span translate>No serial found</span>
+    </div>
 </div>


### PR DESCRIPTION
The update of angularjs and bootstrap changed the typeahead to uib-typeahead.
It also required skipping the filter.
See:
https://angular-ui.github.io/bootstrap/versioned-docs/1.0.3/

Fixes #2117