### PR TITLE
Replace stateChangeSuccess by transitions.onBefore and onSuccess

### DIFF
--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -106,10 +106,8 @@ angular.module("privacyideaApp")
         function () {
             // The stateParams or $state.params are always changed as a reference.
             // So we need to do a deep copy, to preserve it between state transitions
-            var oldParams = new Array();
-            for (let [key, value] of Object.entries($state.params)) {
-                oldParams[key] = value;
-            }
+            var oldParams = {};
+            angular.copy($state.params, oldParams);
             $rootScope.previousState = {
                 state: $state.current.name,
                 params: oldParams

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -35,7 +35,7 @@ angular.module("privacyideaApp")
                                       PolicyTemplateFactory, gettextCatalog,
                                       hotkeys, RegisterFactory,
                                       U2fFactory, webAuthnToken, instanceUrl,
-                                      PollingAuthFactory,
+                                      PollingAuthFactory, $transitions,
                                       resourceNamePatterns) {
 
     $scope.instanceUrl = instanceUrl;
@@ -102,19 +102,24 @@ angular.module("privacyideaApp")
     $scope.myCountdown = "";
     // We save the previous State in the $rootScope, so that we
     // can return there
-    $rootScope.$on('$stateChangeSuccess',
-        function (ev, to, toParams, from, fromParams) {
-            //debug: console.log("we changed the state from " + from + " to " + to);
-            //debug: console.log(from);
-            //debug: console.log(fromParams);
-            //debug: console.log(to);
+    $transitions.onBefore({},
+        function () {
+            // The stateParams or $state.params are always changed as a reference.
+            // So we need to do a deep copy, to preserve it between state transitions
+            var oldParams = new Array();
+            for (let [key, value] of Object.entries($state.params)) {
+                oldParams[key] = value;
+            }
             $rootScope.previousState = {
-                state: from.name,
-                params: fromParams
+                state: $state.current.name,
+                params: oldParams
             };
-
+        });
+    $transitions.onSuccess({},
+        function() {
             $scope.checkReloadListeners();
         });
+
     $scope.$on('IdleStart', function () {
         //debug: console.log("start idle");
     });


### PR DESCRIPTION
In the new angular-ui-router the event stateChangeSuccess has
been removed. The changing of a state is now handled by
hooks to transitions
onBefore and onSuccess.
In the onBefore hook we now need to save the *current* state
and parameters, so that we can return to this state, when needed.

Fixes #2122

In the onSuccess hook we if all Listeners have reloaed.

Fixes #2125