### PR TITLE
Remove checkReloadListener

### DIFF
--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -113,10 +113,6 @@ angular.module("privacyideaApp")
                 params: oldParams
             };
         });
-    $transitions.onSuccess({},
-        function() {
-            $scope.checkReloadListeners();
-        });
 
     $scope.$on('IdleStart', function () {
         //debug: console.log("start idle");
@@ -509,24 +505,6 @@ angular.module("privacyideaApp")
     $scope.reload = function() {
         // emit a signal to the scope, that just listens
         $scope.$broadcast("piReload");
-    };
-
-    $scope.checkReloadListeners = function () {
-        /*
-         TODO: The a logic, that can hide the reload button.
-         This is not straighforward, since the current number of connected
-         listeners might be confusing:
-
-         connected numbers:
-         var currentListeners = $scope.$$listenerCount["piReload"];
-
-         When the state changes, the scope and thus the current listener is
-         destroyed. But the statechange-success is called, before the scope
-         is destroyed, so there can be two connected listeners, when
-         changing from a state to another state and both have a listener
-         defined.
-        */
-        $scope.reloadListeners = 1;
     };
 
 });

--- a/privacyidea/static/templates/menu.html
+++ b/privacyidea/static/templates/menu.html
@@ -96,8 +96,7 @@
                 <li>
                     <spinner name="spinner" show="false"></spinner>
                 </li>
-                <li ng-show="reloadListeners && loggedInUser.role &&
-                showReload">
+                <li ng-show="loggedInUser.role && showReload">
                     <a ng-click="reload()" style="cursor: pointer">
                     <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
                     <translate>Refresh</translate>


### PR DESCRIPTION
We also remove the hook for successful transitions.
If we ever need things to be done after successful
transitions we will readd this hook.

Closes #2127