### PR TITLE
Fix broken travis exclude file matching

### DIFF
--- a/.travis_check.sh
+++ b/.travis_check.sh
@@ -14,7 +14,12 @@ ignore_patterns=(
   "READ_BEFORE_UPDATE.md"
   "README.rst"
   "SECURITY.md"
-  "^.*/"
+  "^\.circleci/"
+  "^\.codespell_skip"
+  "^\.github/"
+  "^\.gitignore"
+  "^\.pep8speaks.yml"
+  "^\.readthedocs.yaml"
   )
 
 # get the base branch for checking changes
@@ -60,3 +65,4 @@ if [[ ${IGNORE_BUILD} == True ]]; then
 else
   echo "Changes to build-essential files found, continuing with tests."
 fi
+


### PR DESCRIPTION
By trying to exclude changes to dot-files from triggering a travis run i
accidentally excluded all files...

This should be fixed with this PR