### PR TITLE
Add information about Indexed Token and admin policies

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,7 +2,10 @@ Version 3.3, *2020-XX-XX*
 
   Features:
     * New token type: WebAuthn/FIDO2 token (#1468)
-      * WebAuthn hardware tokens can now be used with privacyIDEA
+      WebAuthn hardware tokens can now be used with privacyIDEA
+    * New token type: Indexed Secret token allows user
+      to authenticate with a pre-known secret that can be
+      initialized from the user store. (#1986)
 
   Enhancements:
     * Added the remote serial to the tokeninfo of a remote token to better track

--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -2,6 +2,13 @@
 
 ## Update from 3.2 to 3.3
 
+* Admin policies now do have a destinct admin username field.
+
+  The normal username field will not be used for the admin user
+  anymore but can be used for normal users.
+  The SQL migration script migrates existing admin policies by moving
+  the usernames of administrators to the new username field.
+
 * PostgreSQL database adapter removed from default installation
 
   When installing privacyIDEA from github or via Pypi, the ``psycopg2`` package


### PR DESCRIPTION
The Indexed Secret Token is added in the Changelog as
main feature.

The READ_BEFORE_UPDATE needs the information about
the admi usernames. If the SQL migration script is not run,
some admin policies might not work as expected anymore!