### PR TITLE
catch missing "priority"

### DIFF
--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -267,11 +267,8 @@ def get_priority_from_param(param):
     """
     priority = {}
     for k, v in param.items():
-        if k.startswith("priority."):
-            try:
-                priority[k[len("priority."):]] = int(v)
-            except TypeError:
-                priority[k[len("priority."):]] = None
+        if k.startswith("priority.") and isinstance(v,int):
+            priority[k[len("priority."):]] = int(v)
     return priority
 
 

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -268,7 +268,10 @@ def get_priority_from_param(param):
     priority = {}
     for k, v in param.items():
         if k.startswith("priority."):
-            priority[k[len("priority."):]] = int(v)
+            try:
+                priority[k[len("priority."):]] = int(v)
+            except TypeError:
+                priority[k[len("priority."):]] = None
     return priority
 
 

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -267,7 +267,7 @@ def get_priority_from_param(param):
     """
     priority = {}
     for k, v in param.items():
-        if k.startswith("priority.") and isinstance(v,int):
+        if k.startswith("priority.") and isinstance(v, int):
             priority[k[len("priority."):]] = int(v)
     return priority
 

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -6,7 +6,7 @@ from .base import MyApiTestCase
 
 from privacyidea.api.lib.utils import (getParam,
                                        check_policy_name,
-                                       verify_auth_token, is_fqdn, attestation_certificate_allowed)
+                                       verify_auth_token, is_fqdn, attestation_certificate_allowed, get_priority_from_param)
 from privacyidea.lib.error import ParameterError
 import jwt
 import mock
@@ -193,3 +193,10 @@ class UtilsTestCase(MyApiTestCase):
                 }
             )
         )
+
+    def test_07_get_priority_from_param(self):
+        # check if only keys with given integer values are returned
+        param = {'priority.resolver1': 1, 'priority.resolver2': None,
+                 'resolvers': 'resolver1,resolver2,resolver3'}
+        priority = get_priority_from_param(param)
+        self.assertEqual(priority, {'resolver1': 1})

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -6,7 +6,8 @@ from .base import MyApiTestCase
 
 from privacyidea.api.lib.utils import (getParam,
                                        check_policy_name,
-                                       verify_auth_token, is_fqdn, attestation_certificate_allowed, get_priority_from_param)
+                                       verify_auth_token, is_fqdn, attestation_certificate_allowed,
+                                       get_priority_from_param)
 from privacyidea.lib.error import ParameterError
 import jwt
 import mock


### PR DESCRIPTION
When no priority is given this change will result in a multi-resolver realm with no dedicated priorities.

If this causes no further problem, this PR closes #2171