### PR TITLE
add ng-hide to token description divs in enrollment templates

### DIFF
--- a/privacyidea/static/components/token/views/token.enroll.email.html
+++ b/privacyidea/static/components/token/views/token.enroll.email.html
@@ -21,9 +21,12 @@
            class="form-control"
            placeholder="Users email address..."
            ng-model="form.email" name="email" />
+</div>
+
+<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
     <label for="description" translate>Description</label>
     <input type="text" class="form-control"
-            placeholder="Some nice words..."
+            placeholder="{{ 'Some nice words...'|translate }}"
             ng-model="form.description" />
 </div>
 

--- a/privacyidea/static/components/token/views/token.enroll.hotp.html
+++ b/privacyidea/static/components/token/views/token.enroll.hotp.html
@@ -84,7 +84,8 @@
         The Google Authenticator only supports the SHA1 algorithm.
     </p>
 </div>
-<div class="form-group">
+
+<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
     <label for="description" translate>Description</label>
     <input type="text" class="form-control"
             placeholder="{{ 'Some nice words...'|translate }}"

--- a/privacyidea/static/components/token/views/token.enroll.indexedsecret.html
+++ b/privacyidea/static/components/token/views/token.enroll.indexedsecret.html
@@ -19,10 +19,9 @@
     The value of the indexed secret will be set by a policy.
 </div>
 
-<div class="form-group">
+<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
     <label for="description" translate>Description</label>
     <input type="text" class="form-control"
-            id="description"
             placeholder="{{ 'Some nice words...'|translate }}"
             ng-model="form.description" />
 </div>

--- a/privacyidea/static/components/token/views/token.enroll.sms.html
+++ b/privacyidea/static/components/token/views/token.enroll.sms.html
@@ -29,7 +29,7 @@
     </div>
 </div>
 
-<div class="form-group">
+<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
     <label for="description" translate>Description</label>
     <input type="text" class="form-control"
             placeholder="{{ 'Some nice words...'|translate }}"

--- a/privacyidea/static/components/token/views/token.enroll.sshkey.html
+++ b/privacyidea/static/components/token/views/token.enroll.sshkey.html
@@ -14,9 +14,13 @@
            placeholder="{{ 'Paste the ssh PUBLIC key'|translate }}"
            ng-model="form.sshkey" name="sshkey"
            ng-change="sshkeyChanged()"></textarea>
+</div>
+
+<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
     <label for="description" translate>Description</label>
     <input type="text" class="form-control"
             placeholder="{{ 'Some nice words...'|translate }}"
             ng-model="form.description" />
 </div>
+
 

--- a/privacyidea/static/components/token/views/token.enroll.totp.html
+++ b/privacyidea/static/components/token/views/token.enroll.totp.html
@@ -94,7 +94,8 @@
         The Google Authenticator only supports the SHA1 algorithm.
     </p>
 </div>
-<div class="form-group">
+
+<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
     <label for="description" translate>Description</label>
     <input type="text" class="form-control"
             placeholder="{{ 'Some nice words...'|translate }}"


### PR DESCRIPTION
Hide description form elements whenever the setdescription policy is not set.
Closes #2173