### PR TITLE
Add failcounter to event conditions

### DIFF
--- a/doc/eventhandler/index.rst
+++ b/doc/eventhandler/index.rst
@@ -138,6 +138,14 @@ less than 99 or exactly 100.
 This can be '>100', '<99', or '=100', to trigger the action, if the tokeninfo field
 'count_auth_success' is bigger than 100, less than 99 or exactly 100.
 
+**failcounter**
+
+This is the ``failcount`` of the token. It is increased on failed authentication
+attempts. If it reaches ``max_failcount`` increasing will stop and the token is locked.
+See :ref:`failcounter`.
+
+The condition can be set to '>9', '=10', or '<5' and it will trigger the action accordingly.
+
 **detail_error_message**
 
 This condition checks a regular expression against the ``detail`` section in

--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -64,6 +64,7 @@ class CONDITION(object):
     COUNT_AUTH = "count_auth"
     COUNT_AUTH_SUCCESS = "count_auth_success"
     COUNT_AUTH_FAIL = "count_auth_fail"
+    FAILCOUNTER = 'failcounter'
     TOKENINFO = "tokeninfo"
     DETAIL_ERROR_MESSAGE = "detail_error_message"
     DETAIL_MESSAGE = "detail_message"
@@ -236,6 +237,13 @@ class BaseEventHandler(object):
                           "the action, if the difference between the tokeninfo "
                           "field 'count_auth' and 'count_auth_success is "
                           "bigger than 100, less than 99 or exactly 100.")
+            },
+            CONDITION.FAILCOUNTER: {
+                "type": "str",
+                "desc": _("This can be '>9', '<9', or '=10', to trigger "
+                          "the action, if the failcounter of a token matches this value. "
+                          "Note that the failcounter stops increasing, if the max_failcount is "
+                          "reached.")
             },
             CONDITION.TOKENINFO: {
                 "type": "str",
@@ -512,6 +520,12 @@ class BaseEventHandler(object):
                 c_fail = count - c_success
                 cond = conditions.get(CONDITION.COUNT_AUTH_FAIL)
                 if not compare_condition(cond, c_fail):
+                    return False
+
+            if CONDITION.FAILCOUNTER in conditions:
+                failcount = token_obj.get_failcount()
+                cond = conditions.get(CONDITION.FAILCOUNTER)
+                if not compare_condition(cond, failcount):
                     return False
 
             if CONDITION.TOKENINFO in conditions:

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -272,6 +272,36 @@ class BaseEventHandlerTestCase(MyTestCase):
              }
         )
         self.assertFalse(r)
+
+        # check for failcounter
+        tok.set_failcount(8)
+        r = uhandler.check_condition(
+            {"g": {},
+             "handler_def": {"conditions": {CONDITION.FAILCOUNTER: "<9"}},
+             "request": req,
+             "response": resp
+             }
+        )
+        self.assertTrue(r)
+
+        r = uhandler.check_condition(
+            {"g": {},
+             "handler_def": {"conditions": {CONDITION.FAILCOUNTER: ">9"}},
+             "request": req,
+             "response": resp
+             }
+        )
+        self.assertFalse(r)
+
+        r = uhandler.check_condition(
+            {"g": {},
+             "handler_def": {"conditions": {CONDITION.FAILCOUNTER: "=8"}},
+             "request": req,
+             "response": resp
+             }
+        )
+        self.assertTrue(r)
+
         remove_token(serial)
 
     def test_04_tokeninfo_condition(self):


### PR DESCRIPTION
An event condition can have the check <, =, >
for the failcounter of a token.

Closes #2162