### PR TITLE
Fix failing chal-resp login to webUI

### DIFF
--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -198,8 +198,12 @@ angular.module("privacyideaApp")
         }, {
             withCredentials: true
         }).then(function (response) {
+            // successful authentication
             $scope.do_login_stuff(response.data);
+            // login data is not needed anymore, remove from scope
+            $scope.login = {username: "", password: ""};
         }, function (response) {
+            // failed auth request (may be challenge-response)
             //debug: console.log("challenge response");
             //debug: console.log(error);
             let error = response.data;
@@ -290,7 +294,6 @@ angular.module("privacyideaApp")
                     inform.add(gettextCatalog.getString("Challenge Response " +
                             "Authentication. Your response was not valid!"),
                         {type: "warning", ttl: 5000});
-                    $scope.login.password = "";
                     // in case of U2F we try for a 2nd signature
                     // In case of u2f we do:
                     if ($scope.u2f_first_error) {
@@ -321,12 +324,7 @@ angular.module("privacyideaApp")
                             {type: "danger", ttl: 10000});
                 }
             }
-        }).finally(function () {
-            // We delete the password from the login object, so that it is not
-            // contained in the scope
-            $scope.login.password = "";
-            }
-        );
+        });
     };
     $scope.check_authentication = function() {
         // This function is used to poll, if a challenge response

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -322,9 +322,9 @@ angular.module("privacyideaApp")
                 }
             }
         }).finally(function () {
-            // We delete the login object, so that the password is not
+            // We delete the password from the login object, so that it is not
             // contained in the scope
-            $scope.login = {username: "", password: ""};
+            $scope.login.password = "";
             }
         );
     };


### PR DESCRIPTION
While working on #830 the AngularJS promise-API was changed.
The `$http.post` request in the authenticate function had a promise to delete
the user data (username and password) from the scope.
While updating to the new promise-API, this was changed to a `finally`
construct which was called for every request (regardless if there was an
error or success). This way the username was not available in the following
view.
The `finally` function is changed to only remove the password from the
login data in the scope.

Fixes #2192