### PR TITLE
Allow to set an empty PIN when enrolling a new token

### DIFF
--- a/privacyidea/static/components/token/factories/token.js
+++ b/privacyidea/static/components/token/factories/token.js
@@ -205,7 +205,7 @@ angular.module("TokenModule", ["privacyideaAuth"])
                     params.genkey = 1;
                     params.otpkey = null;
                 }
-                params.pin = userObject.pin;
+                params.pin = userObject.pin || "";
                 if (username) {
                     params.user = username;
                     params.realm = userObject.realm;


### PR DESCRIPTION
Allow to set an empty PIN when enrolling a new token.