### PR TITLE
Move token details input into base template

### DIFF
--- a/privacyidea/static/components/token/views/token.enroll.email.html
+++ b/privacyidea/static/components/token/views/token.enroll.email.html
@@ -15,18 +15,10 @@
     <label for="dynamic_email" translate>Read email address dynamically from user source on each request.</label>
 </div>
 <div class="form-group" ng-hide="form.dynamic_email">
-    <label for="phone" translate>Email Address</label>
-    <input type="email"
+    <label for="email" translate>Email Address</label>
+    <input type="email" id="email"
            autofocus
            class="form-control"
            placeholder="Users email address..."
            ng-model="form.email" name="email" />
 </div>
-
-<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
-    <label for="description" translate>Description</label>
-    <input type="text" class="form-control"
-            placeholder="{{ 'Some nice words...'|translate }}"
-            ng-model="form.description" />
-</div>
-

--- a/privacyidea/static/components/token/views/token.enroll.hotp.html
+++ b/privacyidea/static/components/token/views/token.enroll.hotp.html
@@ -84,10 +84,3 @@
         The Google Authenticator only supports the SHA1 algorithm.
     </p>
 </div>
-
-<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
-    <label for="description" translate>Description</label>
-    <input type="text" class="form-control"
-            placeholder="{{ 'Some nice words...'|translate }}"
-            ng-model="form.description" />
-</div>

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -23,6 +23,14 @@
          + form.type + '.html'">
         </ng-include>
 
+        <!-- The description input field for all token types -->
+        <div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
+            <label for="description" translate>Description</label>
+            <input type="text" class="form-control" id="description"
+                   placeholder="{{ 'Some nice words...'|translate }}"
+                   ng-model="form.description" />
+        </div>
+
         <!-- User Assignment -->
         <div ng-if="loggedInUser.role == 'admin'">
             <h4 translate>Assign token to user</h4>

--- a/privacyidea/static/components/token/views/token.enroll.indexedsecret.html
+++ b/privacyidea/static/components/token/views/token.enroll.indexedsecret.html
@@ -18,10 +18,3 @@
 <div class="help-block" translate ng-show="tokensettings.indexedsecret.force_attibute">
     The value of the indexed secret will be set by a policy.
 </div>
-
-<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
-    <label for="description" translate>Description</label>
-    <input type="text" class="form-control"
-            placeholder="{{ 'Some nice words...'|translate }}"
-            ng-model="form.description" />
-</div>

--- a/privacyidea/static/components/token/views/token.enroll.sms.html
+++ b/privacyidea/static/components/token/views/token.enroll.sms.html
@@ -16,7 +16,7 @@
 </div>
 <div ng-hide="form.dynamic_phone" class="form-group">
     <label for="phone" translate>Phone number</label>
-    <input type="text"
+    <input type="text" id="phone"
            autofocus
            class="form-control"
            ng-model="form.phone" name="phone" />
@@ -29,16 +29,9 @@
     </div>
 </div>
 
-<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
-    <label for="description" translate>Description</label>
-    <input type="text" class="form-control"
-            placeholder="{{ 'Some nice words...'|translate }}"
-            ng-model="form.description" />
-</div>
-
 <div class="form-group" ng-show="getRightsValue('sms_gateways').split(' ')">
     <label for="identifier" translate>A token specific SMS gateway</label>
-    <select class="form-control"
+    <select class="form-control" id="identifier"
             ng-model="form['sms.identifier']"
             name="identifier"
             ng-options="identifier for identifier in getRightsValue('sms_gateways').split(' ')">

--- a/privacyidea/static/components/token/views/token.enroll.sshkey.html
+++ b/privacyidea/static/components/token/views/token.enroll.sshkey.html
@@ -7,7 +7,7 @@
 
 <div class="form-group">
     <label for="sshkey" translate>SSH public Key</label>
-    <textarea type="text"
+    <textarea type="text" id="sshkey"
            autofocus
            rows="5"
            class="form-control"
@@ -15,12 +15,3 @@
            ng-model="form.sshkey" name="sshkey"
            ng-change="sshkeyChanged()"></textarea>
 </div>
-
-<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
-    <label for="description" translate>Description</label>
-    <input type="text" class="form-control"
-            placeholder="{{ 'Some nice words...'|translate }}"
-            ng-model="form.description" />
-</div>
-
-

--- a/privacyidea/static/components/token/views/token.enroll.totp.html
+++ b/privacyidea/static/components/token/views/token.enroll.totp.html
@@ -54,7 +54,7 @@
 </div>
 <div class="form-group" ng-hide="form.genkey">
     <label for="otpkey" translate>OTP Key</label>
-    <input type="text" ng-pattern="/^[0-9a-fA-F]*$/"
+    <input type="text" ng-pattern="/^[0-9a-fA-F]*$/" id="otpkey"
            autofocus
            class="form-control"
            placeholder="{{ 'Enter OTP key...'|translate }}"
@@ -75,7 +75,7 @@
 <div class="form-group"
     ng-hide="checkRight('totp_timestep')">
     <label for="timestep" translate>Timestep</label>
-    <select class="form-control"
+    <select class="form-control" id="timestep"
             ng-model="form.timeStep"
             name="timestep"
             ng-options="timestep for timestep in formInit.timesteps"></select>
@@ -93,11 +93,4 @@
     <p class="help-block" ng-show="form.genkey" translate>
         The Google Authenticator only supports the SHA1 algorithm.
     </p>
-</div>
-
-<div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
-    <label for="description" translate>Description</label>
-    <input type="text" class="form-control"
-            placeholder="{{ 'Some nice words...'|translate }}"
-            ng-model="form.description" />
 </div>


### PR DESCRIPTION
Since the token detail input field should be the same for all token, it can
reside in the basic token enrollment template and not in each individual
template file.

Fixes #2208