### PR TITLE
Add some tests for pin checks

### DIFF
--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -381,11 +381,7 @@ class Token(MethodsMixin, db.Model):
         log.debug("hPin: {0!s}, pin: {1!r}, seed: {2!s}".format(hPin, pin,
                                                                 self.pin_seed))
         return hPin
-    
-    def check_hashed_pin(self, pin):
-        hp = self.get_hashed_pin(pin)
-        return hp == self.pin_hash
-        
+
     @log_with(log)
     def set_description(self, desc):
         if desc is None:

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -79,7 +79,7 @@ class TokenModelTestCase(MyTestCase):
         up = t.get_user_pin()
         self.assertTrue(up.getPin() == userpin.encode('utf8'))
 
-        self.assertTrue(t.check_hashed_pin("1234"))
+        self.assertTrue(t.check_pin("1234"))
 
         t.set_user_pin(b'HalloDuDa')
         self.assertTrue(t.get_user_pin().getPin() == b'HalloDuDa')
@@ -88,10 +88,24 @@ class TokenModelTestCase(MyTestCase):
         self.assertTrue(t.get_user_pin().getPin().decode('utf8') == u'HelloWörld')
 
         t.set_hashed_pin(b'1234')
-        self.assertTrue(t.check_hashed_pin(b'1234'))
+        self.assertTrue(t.check_pin(b'1234'))
 
         t.set_hashed_pin(u'HelloWörld')
-        self.assertTrue(t.check_hashed_pin(u'HelloWörld'))
+        self.assertTrue(t.check_pin(u'HelloWörld'))
+
+        t.pin_hash = None
+        self.assertTrue(t.check_pin(''))
+        self.assertFalse(t.check_pin(None))
+        self.assertFalse(t.check_pin('1234'))
+
+        t.pin_hash = ''
+        self.assertTrue(t.check_pin(''))
+        self.assertFalse(t.check_pin('1234'))
+
+        t.set_hashed_pin('')
+        self.assertTrue(len(t.pin_hash) > 0)
+        self.assertTrue(t.check_pin(''))
+        self.assertFalse(t.check_pin('1234'))
 
         # Delete the token
         t1.delete()


### PR DESCRIPTION
Remove unused function.
Ideally we could someday check the `models.py` against different databases
during the tests.

Fixes #2218