### PR TITLE
Add policy to allow application to choose token type

### DIFF
--- a/doc/policies/authorization.rst
+++ b/doc/policies/authorization.rst
@@ -44,6 +44,24 @@ this request
    while allowing access to less sensitive areas
    with other token types.
 
+.. _application_tokentype_policy:
+
+application_tokentype
+~~~~~~~~~~~~~~~~~~~~~
+
+type: bool
+
+If this policy is set, an application may add a parameter ``type`` as
+tokentype in the authentication request like ``validate/check``, ``validate/samlcheck``
+or ``validate/triggerchallenge``.
+
+Then the application can determine via this parameter, which tokens of a user
+should be checked.
+
+E.g. when using this in *triggerchallenge*, an application could assure, that only SMS tokens
+are used for authentication.
+
+
 serial
 ~~~~~~
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -369,6 +369,35 @@ def check_otp_pin(request=None, action=None):
     return True
 
 
+def check_application_tokentype(request=None, action=None):
+    """
+    This pre policy checks if the request is allowed to specify the tokentype.
+    If the policy is not set, a possibly set parameter "type" is removed
+    from the request.
+
+    Check ACTION.APPLICATION_TOKENTYPE
+
+    This decorator should wrap
+        /validate/check, /validate/samlcheck and /validate/triggerchallenge.
+
+    :param request: The request that is intercepted during the API call
+    :type request: Request Object
+    :param action: An optional Action
+    :type action: basestring
+    :returns: Always true. Modified the parameter request
+    """
+    application_allowed = Match.generic(g, scope=SCOPE.AUTHZ,
+                                        action=ACTION.APPLICATION_TOKENTYPE,
+                                        user_object=request.User,
+                                        active=True).any()
+
+    # if the application is not allowed, we remove the tokentype
+    if not application_allowed:
+        request.all_data["type"] = None
+
+    return True
+
+
 def sms_identifiers(request=None, action=None):
     """
     This is a token specific wrapper for sms tokens

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -391,9 +391,11 @@ def check_application_tokentype(request=None, action=None):
                                         user_object=request.User,
                                         active=True).any()
 
-    # if applications are not allowed to request a certain token type, we remove it
-    if not application_allowed:
-        request.all_data["type"] = None
+    # if the application is not allowed, we remove the tokentype
+    if not application_allowed and "type" in request.all_data:
+        log.info("Removing parameter 'type' from request, "
+                 "since application is not allowed to authenticate by token type.")
+        del request.all_data["type"]
 
     return True
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -391,7 +391,7 @@ def check_application_tokentype(request=None, action=None):
                                         user_object=request.User,
                                         active=True).any()
 
-    # if the application is not allowed, we remove the tokentype
+    # if applications are not allowed to request a certain token type, we remove it
     if not application_allowed:
         request.all_data["type"] = None
 

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -215,6 +215,7 @@ class ACTION(object):
     __doc__ = """This is the list of usual actions."""
     ASSIGN = "assign"
     APPIMAGEURL = "appimageurl"
+    APPLICATION_TOKENTYPE = "application_tokentype"
     AUDIT = "auditlog"
     AUDIT_AGE = "auditlog_age"
     AUDIT_DOWNLOAD = "auditlog_download"
@@ -1980,6 +1981,13 @@ def get_static_policy_definitions(scope=None):
             }
         },
         SCOPE.AUTHZ: {
+            ACTION.APPLICATION_TOKENTYPE: {
+                'type': 'bool',
+                'desc': _("Allow the application to choose which token types should be used "
+                          "for authentication. Application may set the parameter 'type' in "
+                          "the request. Works with validate/check, validate/samlcheck and "
+                          "validate/triggerchallenge.")
+            },
             ACTION.AUTHMAXSUCCESS: {
                 'type': 'str',
                 'desc': _("You can specify how many successful authentication "

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1985,7 +1985,8 @@ def check_user_pass(user, passw, options=None):
     :return: tuple of result (True, False) and additional dict
     :rtype: tuple
     """
-    tokenobject_list = get_tokens(user=user)
+    token_type = options.pop("token_type", None)
+    tokenobject_list = get_tokens(user=user, tokentype=token_type)
     reply_dict = {}
     if not tokenobject_list:
         # The user has no tokens assigned

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -43,7 +43,7 @@ from privacyidea.api.lib.prepolicy import (check_token_upload,
                                            indexedsecret_force_attribute,
                                            check_admin_tokenlist, pushtoken_disable_wait, webauthntoken_auth,
                                            webauthntoken_authz, webauthntoken_enroll, webauthntoken_request,
-                                           webauthntoken_allowed)
+                                           webauthntoken_allowed, check_application_tokentype)
 from privacyidea.lib.realm import set_realm as create_realm
 from privacyidea.lib.realm import delete_realm
 from privacyidea.api.lib.postpolicy import (check_serial, check_tokentype,
@@ -2851,6 +2851,37 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
             scope=SCOPE.ENROLL,
             action=''
         )
+
+    def test_34_application_tokentype(self):
+        builder = EnvironBuilder(method='POST',
+                                 data={'user': "cornelius"},
+                                 headers={})
+        env = builder.get_environ()
+        # Set the remote address so that we can filter for it
+        env["REMOTE_ADDR"] = "10.0.0.1"
+        g.client_ip = env["REMOTE_ADDR"]
+        req = Request(env)
+
+        # Set a policy, that the application is allowed to specify tokentype
+        set_policy(name="pol1",
+                   scope=SCOPE.AUTHZ,
+                   action=ACTION.APPLICATION_TOKENTYPE)
+        g.policy_object = PolicyClass()
+
+        # check for
+        req.all_data = {"type": "tokentype"}
+        req.User = User("cornelius", self.realm1)
+        check_application_tokentype(req)
+        # Check, that the realm was not set, since there was no user in the request
+        self.assertEqual(req.all_data.get("type"), "tokentype")
+
+        # delete the policy, then the application is not allowed to specify the tokentype
+        delete_policy("pol1")
+        g.policy_object = PolicyClass()
+
+        check_application_tokentype(req)
+        # Check that the tokentype was removed
+        self.assertEqual(req.all_data.get("type"), None)
 
 
 class PostPolicyDecoratorTestCase(MyApiTestCase):

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -2872,7 +2872,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         req.all_data = {"type": "tokentype"}
         req.User = User("cornelius", self.realm1)
         check_application_tokentype(req)
-        # Check, that the realm was not set, since there was no user in the request
+        # Check for the tokentype
         self.assertEqual(req.all_data.get("type"), "tokentype")
 
         # delete the policy, then the application is not allowed to specify the tokentype

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -2683,9 +2683,7 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            #result = res.json.get("result")
             detail = res.json.get("detail")
-            #transaction_id = detail.get("transaction_id")
 
         # check, that both challenges were triggered, although
         # the application tried to trigger only hotp

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -2665,12 +2665,12 @@ class ValidateAPITestCase(MyApiTestCase):
         r = init_token({"type": "hotp",
                         "genkey": 1,
                         "pin": "trigpin",
-                        "serial": "tok1"},
+                        "serial": "tok_hotp"},
                        user=User("cornelius", self.realm1))
         r = init_token({"type": "totp",
                         "genkey": 1,
                         "pin": "trigpin",
-                        "serial": "tok2"},
+                        "serial": "tok_totp"},
                        user=User("cornelius", self.realm1))
         # Hotp and totp are allowed for trigger challenge
         set_policy(name="pol_chalresp", scope=SCOPE.AUTH,
@@ -2683,23 +2683,38 @@ class ValidateAPITestCase(MyApiTestCase):
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = res.json.get("result")
+            #result = res.json.get("result")
             detail = res.json.get("detail")
-            transaction_id = detail.get("transaction_id")
+            #transaction_id = detail.get("transaction_id")
 
         # check, that both challenges were triggered, although
         # the application tried to trigger only hotp
+        triggered_serials = [item['serial'] for item in detail.get("multi_challenge")]
+        self.assertTrue("tok_hotp" in triggered_serials and "tok_totp" in triggered_serials)
 
-        # Allow application to choose token type
+        # Set a policy, that the application is allowed to specify tokentype
+        set_policy(name="pol_application_tokentype",
+                   scope=SCOPE.AUTHZ,
+                   action=ACTION.APPLICATION_TOKENTYPE)
 
-        # Trigger challenge for HOTP
+        # Trigger another challenge for HOTP
+        with self.app.test_request_context('/validate/triggerchallenge',
+                                           method='POST',
+                                           data={"user": "cornelius", "type": "hotp"},
+                                           headers={"Authorization": self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            detail = res.json.get("detail")
 
         # check that only HOTP was triggered
+        triggered_serials = [item['serial'] for item in detail.get("multi_challenge")]
+        self.assertTrue("tok_hotp" in triggered_serials and "tok_totp" not in triggered_serials)
 
         # Delete tokens and policies
-        remove_token("tok1")
-        remove_token("tok2")
+        remove_token("tok_hotp")
+        remove_token("tok_totp")
         delete_policy("pol_chalresp")
+        delete_policy("pol_application_tokentype")
 
 
 


### PR DESCRIPTION
With the given policy an application is allowed to
define, which tokentype should be used for authentication.
To do this, the application can send the parameter
"type" in the requests /validate/check, ./samlcheck
or ./triggerchallenge - given that the policy allows to
do so.

Closes #2047