### PR TITLE
fix failing test for special characters []\ in pin

### DIFF
--- a/privacyidea/lib/utils/__init__.py
+++ b/privacyidea/lib/utils/__init__.py
@@ -61,7 +61,7 @@ ALLOWED_SERIAL = "^[0-9a-zA-Z\-_]+$"
 # character lists for the identifiers in the pin content policy
 CHARLIST_CONTENTPOLICY = {"c": string.ascii_letters, # characters
                           "n": string.digits,        # numbers
-                          "s": string.punctuation}   # special
+                          "s": r'!"#$%&()*+,./:;<=>?@_{|}~^-'}   # special
 
 def check_time_in_range(time_range, check_time=None):
     """

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -571,18 +571,13 @@ class UtilsTestCase(MyTestCase):
         r, c = check_pin_policy("1234", "n")
         self.assertTrue(r)
 
-        r, c = check_pin_policy(r"[[[", "n")
+        r, c = check_pin_policy(r"+#", "n")
         self.assertFalse(r)
 
-        r, c = check_pin_policy(r"[[[", "c")
+        r, c = check_pin_policy(r"+#", "c")
         self.assertFalse(r)
 
-        r, c = check_pin_policy(r"[[[", "s")
-        self.assertTrue(r)
-
-        # check the validation of a generated password with square brackets
-        password = generate_password(size=3, requirements=['[', '[', '['])
-        r, c = check_pin_policy(password, "s")
+        r, c = check_pin_policy(r"+#", "s")
         self.assertTrue(r)
 
         r, c = check_pin_policy("abc", "nc")


### PR DESCRIPTION
related to #2121 

string.punctuation should not plainly be used as character list for generated pins.

Backslashes let the pin policy checking fail. Removing \ [ ] from the lists of strings remove the problem.