### PR TITLE
1963/headers smsgateway new column

### DIFF
--- a/migrations/versions/e360c56bcf8c_.py
+++ b/migrations/versions/e360c56bcf8c_.py
@@ -1,4 +1,4 @@
-"""empty message
+"""Add constraint for smsoptions and set default type to "option"
 
 Revision ID: e360c56bcf8c
 Revises: a7e91b18a460

--- a/migrations/versions/e360c56bcf8c_.py
+++ b/migrations/versions/e360c56bcf8c_.py
@@ -1,0 +1,83 @@
+"""empty message
+
+Revision ID: e360c56bcf8c
+Revises: a7e91b18a460
+Create Date: 2020-06-15 09:18:43.855589
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e360c56bcf8c'
+down_revision = 'a7e91b18a460'
+
+from alembic import op, context
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.schema import Sequence, CreateSequence
+from sqlalchemy import orm
+
+Base = declarative_base()
+
+class SMSGateway(Base):
+    __tablename__ = 'smsgateway'
+    __table_args__ = {'mysql_row_format': 'DYNAMIC'}
+    id = sa.Column(sa.Integer, Sequence("smsgateway_seq"), primary_key=True)
+    identifier = sa.Column(sa.Unicode(255), nullable=False, unique=True)
+    description = sa.Column(sa.Unicode(1024), default=u"")
+    providermodule = sa.Column(sa.Unicode(1024), nullable=False)
+    options = orm.relationship('SMSGatewayOption',
+                              lazy='dynamic',
+                              backref='smsgw')
+
+class SMSGatewayOption(Base):
+    __tablename__ = 'smsgatewayoption'
+    id = sa.Column(sa.Integer, Sequence("smsgwoption_seq"), primary_key=True)
+    Key = sa.Column(sa.Unicode(255), nullable=False)
+    Value = sa.Column(sa.UnicodeText(), default=u'')
+    Type = sa.Column(sa.Unicode(100), default=u'option')
+    gateway_id = sa.Column(sa.Integer(),
+                           sa.ForeignKey('smsgateway.id'), index=True)
+    __table_args__ = (sa.UniqueConstraint('gateway_id',
+                                          'Key', 'Type',
+                                          name='sgix_1'),
+                      {'mysql_row_format': 'DYNAMIC'})
+
+# Check if the SQL dialect uses sequences
+# (from https://stackoverflow.com/a/17196812/7036742)
+def dialect_supports_sequences():
+    migration_context = context.get_context()
+    return migration_context.dialect.supports_sequences
+
+def create_seq(seq):
+    if dialect_supports_sequences():
+        op.execute(CreateSequence(seq))
+
+def upgrade():
+    try:
+        with op.batch_alter_table("smsgatewayoption") as batch_op:
+            batch_op.drop_constraint('sgix_1', type_='unique')
+            batch_op.create_unique_constraint('sgix_1', ['gateway_id', 'Key', 'Type'])
+    except Exception as exx:
+        print("Cannot change constraint 'sgix_1' in table smsgatewayoption.")
+        print (exx)
+
+    try:
+        bind = op.get_bind()
+        session = orm.Session(bind=bind)
+        # add default type 'option' for all rows
+        for row in session.query(SMSGatewayOption):
+            if not row.Type:
+                row.Type = "option"
+
+    except Exception as exx:
+        session.rollback()
+        print("Failed to add option type for all existing entries in table smsgatewayoption!")
+        print (exx)
+
+    session.commit()
+
+
+def downgrade():
+    with op.batch_alter_table("smsgatewayoption") as batch_op:
+        batch_op.drop_constraint('sgix_1', 'smsgatewayoption', type_='unique')
+        batch_op.create_unique_constraint('sgix_1', 'smsgatewayoption', ['gateway_id', 'Key'])

--- a/migrations/versions/e360c56bcf8c_.py
+++ b/migrations/versions/e360c56bcf8c_.py
@@ -18,6 +18,7 @@ from sqlalchemy import orm
 
 Base = declarative_base()
 
+
 class SMSGateway(Base):
     __tablename__ = 'smsgateway'
     __table_args__ = {'mysql_row_format': 'DYNAMIC'}
@@ -28,6 +29,7 @@ class SMSGateway(Base):
     options = orm.relationship('SMSGatewayOption',
                               lazy='dynamic',
                               backref='smsgw')
+
 
 class SMSGatewayOption(Base):
     __tablename__ = 'smsgatewayoption'
@@ -42,15 +44,18 @@ class SMSGatewayOption(Base):
                                           name='sgix_1'),
                       {'mysql_row_format': 'DYNAMIC'})
 
+
 # Check if the SQL dialect uses sequences
 # (from https://stackoverflow.com/a/17196812/7036742)
 def dialect_supports_sequences():
     migration_context = context.get_context()
     return migration_context.dialect.supports_sequences
 
+
 def create_seq(seq):
     if dialect_supports_sequences():
         op.execute(CreateSequence(seq))
+
 
 def upgrade():
     try:
@@ -59,7 +64,7 @@ def upgrade():
             batch_op.create_unique_constraint('sgix_1', ['gateway_id', 'Key', 'Type'])
     except Exception as exx:
         print("Cannot change constraint 'sgix_1' in table smsgatewayoption.")
-        print (exx)
+        print(exx)
 
     try:
         bind = op.get_bind()
@@ -72,7 +77,7 @@ def upgrade():
     except Exception as exx:
         session.rollback()
         print("Failed to add option type for all existing entries in table smsgatewayoption!")
-        print (exx)
+        print(exx)
 
     session.commit()
 

--- a/privacyidea/api/smsgateway.py
+++ b/privacyidea/api/smsgateway.py
@@ -139,8 +139,9 @@ def delete_gateway_option(gwid=None, key=None):
     :param gwid: The id of the sms gateway definition
     :return: json with success or fail
     """
-    type = key.split('.')[0]
-    key = ".".join(key.split('.')[1:])
+    type = "option"
+    if "." in key:
+        type, key = key.split(".", 1)
 
     res = delete_smsgateway_key_generic(gwid, key, Type=type)
     g.audit_object.log({"success": res,

--- a/privacyidea/api/smsgateway.py
+++ b/privacyidea/api/smsgateway.py
@@ -38,8 +38,7 @@ from ..lib.policy import ACTION
 from privacyidea.lib.smsprovider.SMSProvider import (SMS_PROVIDERS,
                                                      get_smsgateway,
                                                      set_smsgateway,
-                                                     delete_smsgateway_option,
-                                                     delete_smsgateway_header,
+                                                     delete_smsgateway_key_generic,
                                                      delete_smsgateway,
                                                      get_sms_provider_class)
 
@@ -130,28 +129,23 @@ def delete_gateway(identifier=None):
     return send_result(res)
 
 
-@smsgateway_blueprint.route('/option/<gwid>/<option>', methods=['DELETE'])
-@smsgateway_blueprint.route('/header/<gwid>/<header>', methods=['DELETE'])
+@smsgateway_blueprint.route('/<type>/<gwid>/<key>', methods=['DELETE'])
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.SMSGATEWAYWRITE)
-def delete_gateway_option(gwid=None, option=None, header=None):
+def delete_gateway_option(gwid=None, key=None, type=None):
     """
     this function deletes an option of a gateway definition
 
     :param gwid: The id of the sms gateway definition
     :return: json with success or fail
     """
-    if option:
-        if option.startswith("option."):
-            option = option[7:]
-        res = delete_smsgateway_option(gwid, option)
-        g.audit_object.log({"success": res,
-                            "info": u"{0!s}/{1!s}".format(gwid, option)})
-    if header:
-        if header.startswith("header."):
-            header = header[7:]
-        res = delete_smsgateway_header(gwid, header)
-        g.audit_object.log({"success": res,
-                            "info": u"{0!s}/{1!s}".format(gwid, header)})
+    if key.startswith("option."):
+        key = key[7:]
+    elif key.startswith("header."):
+        key = key[7:]
+
+    res = delete_smsgateway_key_generic(gwid, key, Type=type)
+    g.audit_object.log({"success": res,
+                        "info": u"{0!s}/{1!s}".format(gwid, key)})
 
     return send_result(res)

--- a/privacyidea/api/smsgateway.py
+++ b/privacyidea/api/smsgateway.py
@@ -39,6 +39,7 @@ from privacyidea.lib.smsprovider.SMSProvider import (SMS_PROVIDERS,
                                                      get_smsgateway,
                                                      set_smsgateway,
                                                      delete_smsgateway_option,
+                                                     delete_smsgateway_header,
                                                      delete_smsgateway,
                                                      get_sms_provider_class)
 
@@ -90,6 +91,8 @@ def set_gateway():
     :jsonparam description: An optional description of the definition
     :jsonparam option.*: Additional options for the provider module (module
         specific)
+    :jsonparam header.*: Additional headers for the provider module (module
+        specific)
     """
     param = request.all_data
     identifier = getParam(param, "name", optional=False)
@@ -128,20 +131,27 @@ def delete_gateway(identifier=None):
 
 
 @smsgateway_blueprint.route('/option/<gwid>/<option>', methods=['DELETE'])
+@smsgateway_blueprint.route('/header/<gwid>/<header>', methods=['DELETE'])
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.SMSGATEWAYWRITE)
-def delete_gateway_option(gwid=None, option=None):
+def delete_gateway_option(gwid=None, option=None, header=None):
     """
     this function deletes an option of a gateway definition
 
     :param gwid: The id of the sms gateway definition
     :return: json with success or fail
     """
-    if option.startswith("option."):
-        option = option[7:]
-
-    res = delete_smsgateway_option(gwid, option)
-    g.audit_object.log({"success": res,
-                        "info": u"{0!s}/{1!s}".format(gwid, option)})
+    if option:
+        if option.startswith("option."):
+            option = option[7:]
+        res = delete_smsgateway_option(gwid, option)
+        g.audit_object.log({"success": res,
+                            "info": u"{0!s}/{1!s}".format(gwid, option)})
+    if header:
+        if header.startswith("header."):
+            header = header[7:]
+        res = delete_smsgateway_header(gwid, header)
+        g.audit_object.log({"success": res,
+                            "info": u"{0!s}/{1!s}".format(gwid, header)})
 
     return send_result(res)

--- a/privacyidea/api/smsgateway.py
+++ b/privacyidea/api/smsgateway.py
@@ -129,20 +129,18 @@ def delete_gateway(identifier=None):
     return send_result(res)
 
 
-@smsgateway_blueprint.route('/<type>/<gwid>/<key>', methods=['DELETE'])
+@smsgateway_blueprint.route('/option/<gwid>/<key>', methods=['DELETE'])
 @log_with(log)
 @prepolicy(check_base_action, request, ACTION.SMSGATEWAYWRITE)
-def delete_gateway_option(gwid=None, key=None, type=None):
+def delete_gateway_option(gwid=None, key=None):
     """
     this function deletes an option of a gateway definition
 
     :param gwid: The id of the sms gateway definition
     :return: json with success or fail
     """
-    if key.startswith("option."):
-        key = key[7:]
-    elif key.startswith("header."):
-        key = key[7:]
+    type = key.split('.')[0]
+    key = ".".join(key.split('.')[1:])
 
     res = delete_smsgateway_key_generic(gwid, key, Type=type)
     g.audit_object.log({"success": res,

--- a/privacyidea/api/smsgateway.py
+++ b/privacyidea/api/smsgateway.py
@@ -96,12 +96,15 @@ def set_gateway():
     providermodule = getParam(param, "module", optional=False)
     description = getParam(param, "description", optional=True)
     options = {}
+    headers = {}
     for k, v in param.items():
         if k.startswith("option."):
             options[k[7:]] = v
+        elif k.startswith("header."):
+            headers[k[7:]] = v
 
     res = set_smsgateway(identifier, providermodule, description,
-                         options=options)
+                         options=options, headers=headers)
     g.audit_object.log({"success": True,
                         "info": res})
     return send_result(res)

--- a/privacyidea/lib/smsprovider/FirebaseProvider.py
+++ b/privacyidea/lib/smsprovider/FirebaseProvider.py
@@ -212,6 +212,7 @@ class FirebaseProvider(ISMSProvider):
         :return: dict
         """
         params = {"options_allowed": False,
+                  "headers_allowed": False,
                   "parameters": {
                       FIREBASE_CONFIG.REGISTRATION_URL: {
                           "required": True,

--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -79,6 +79,7 @@ class HttpSMSProvider(ISMSProvider):
         """
         log.debug("submitting message {0!r} to {1!s}".format(message, phone))
         parameter = {}
+        headers = {}
         if self.smsgateway:
             phone = self._mangle_phone(phone, self.smsgateway.option_dict)
             url = self.smsgateway.option_dict.get("URL")
@@ -96,6 +97,7 @@ class HttpSMSProvider(ISMSProvider):
                 if k not in self.parameters().get("parameters"):
                     # This is an additional option
                     parameter[k] = v.format(otp=message, phone=phone)
+            headers = self.smsgateway.header_dict
         else:
             phone = self._mangle_phone(phone, self.config)
             url = self.config.get('URL')
@@ -145,10 +147,11 @@ class HttpSMSProvider(ISMSProvider):
             params = {}
             data = parameter
 
-        log.debug("issuing request with parameters %s and method %s and "
-                  "authentication %s to url %s." % (parameter, method,
+        log.debug("issuing request with parameters %s, headers %s and method %s and "
+                  "authentication %s to url %s." % (params, headers, method,
                                                     basic_auth, url))
-        r = requestor(url, params=params,
+        # Todo: drop basic auth if Authorization-Header is given?
+        r = requestor(url, params=params, headers=headers,
                       data=data,
                       verify=ssl_verify,
                       auth=basic_auth,
@@ -231,6 +234,7 @@ class HttpSMSProvider(ISMSProvider):
         :return: dict
         """
         params = {"options_allowed": True,
+                  "headers_allowed": True,
                   "parameters": {
                       "URL": {
                           "required": True,

--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -147,9 +147,9 @@ class HttpSMSProvider(ISMSProvider):
             params = {}
             data = parameter
 
-        log.debug("issuing request with parameters %s, headers %s and method %s and "
-                  "authentication %s to url %s." % (params, headers, method,
-                                                    basic_auth, url))
+        log.debug(u"issuing request with parameters {0!s} headers {1!s} and method {2!s} and"
+                  "authentication {3!s} to url {4!s}.".format(params, headers, method,
+                                                              basic_auth, url))
         # Todo: drop basic auth if Authorization-Header is given?
         r = requestor(url, params=params, headers=headers,
                       data=data,

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -175,8 +175,8 @@ def set_smsgateway(identifier, providermodule, description=None,
     :param description: A description of this gateway definition
     :param options: Options and Parameter for this module
     :param headers: Headers for this module
-    :type options: dict, headers: dict
     :type options: dict
+    :type headers: dict
     :return: The id of the event.
     """
     smsgateway = SMSGateway(identifier, providermodule,
@@ -204,7 +204,30 @@ def delete_smsgateway_option(id, option_key):
     :param option_key: The identifier/key of the option
     :return: True
     """
-    return fetch_one_resource(SMSGatewayOption, gateway_id=id, Key=option_key).delete()
+    return delete_smsgateway_key_generic(id, option_key, Type="option")
+
+
+def delete_smsgateway_header(id, header_key):
+    """
+    Delete the SMS gateway header
+
+    :param id: The id of the SMS Gateway definition
+    :param header_key: The identifier/key of the header
+    :return: True
+    """
+    return delete_smsgateway_key_generic(id, header_key, Type="header")
+
+
+def delete_smsgateway_key_generic(id, key, Type="option"):
+    """
+    Delete the SMS gateway header
+
+    :param id: The id of the SMS Gateway definition
+    :param key: The identifier/key
+    :param type: The type of the key
+    :return: True
+    """
+    return fetch_one_resource(SMSGatewayOption, gateway_id=id, Key=key, Type=Type).delete()
 
 
 def get_smsgateway(identifier=None, id=None, gwtype=None):

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -122,6 +122,7 @@ class ISMSProvider(object):
         :return: dict
         """
         params = {"options_allowed": False,
+                  "headers_allowed": False,
                   "parameters": {
                       "PARAMETER1": {
                           "required": True,
@@ -160,7 +161,7 @@ def get_sms_provider_class(packageName, className):
 
 
 def set_smsgateway(identifier, providermodule, description=None,
-                   options=None):
+                   options=None, headers=None):
 
     """
     Set an SMS Gateway configuration
@@ -173,12 +174,14 @@ def set_smsgateway(identifier, providermodule, description=None,
     :type providermodule: basestring
     :param description: A description of this gateway definition
     :param options: Options and Parameter for this module
+    :param headers: Headers for this module
+    :type options: dict, headers: dict
     :type options: dict
     :return: The id of the event.
     """
     smsgateway = SMSGateway(identifier, providermodule,
                             description=description,
-                            options=options)
+                            options=options, headers=headers)
     create_sms_instance(identifier).check_configuration()
     return smsgateway.id
 

--- a/privacyidea/lib/smsprovider/SipgateSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SipgateSMSProvider.py
@@ -107,6 +107,7 @@ class SipgateSMSProvider(ISMSProvider):
         """
         from privacyidea.lib.smtpserver import get_smtpservers
         params = {"options_allowed": False,
+                  "headers_allowed": False,
                   "parameters": {
                       "USERNAME": {
                           "required": True,

--- a/privacyidea/lib/smsprovider/SmppSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmppSMSProvider.py
@@ -122,6 +122,7 @@ class SmppSMSProvider(ISMSProvider):
         :return: dict
         """
         params = {"options_allowed": False,
+                  "headers_allowed": False,
                     "parameters": {
                         "SMSC_HOST": {
                             "required": True,

--- a/privacyidea/lib/smsprovider/SmtpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmtpSMSProvider.py
@@ -106,6 +106,7 @@ class SmtpSMSProvider(ISMSProvider):
         """
         from privacyidea.lib.smtpserver import get_smtpservers
         params = {"options_allowed": False,
+                  "headers_allowed": False,
                   "parameters": {
                       "MAILTO": {
                           "required": True,

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2132,7 +2132,7 @@ class SMSGateway(MethodsMixin, db.Model):
         """
         res = {}
         for option in self.options:
-            if option.Type == "option" or option.Type is None:
+            if option.Type == "option" or not option.Type:
                 res[option.Key] = option.Value
         return res
 

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2174,7 +2174,7 @@ class SMSGatewayOption(MethodsMixin, db.Model):
     id = db.Column(db.Integer, Sequence("smsgwoption_seq"), primary_key=True)
     Key = db.Column(db.Unicode(255), nullable=False)
     Value = db.Column(db.UnicodeText(), default=u'')
-    Type = db.Column(db.Unicode(100), default=u'')
+    Type = db.Column(db.Unicode(100), default=u'option')
     gateway_id = db.Column(db.Integer(),
                            db.ForeignKey('smsgateway.id'), index=True)
     __table_args__ = (db.UniqueConstraint('gateway_id',

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2135,7 +2135,7 @@ class SMSGateway(MethodsMixin, db.Model):
         """
         res = {}
         for option in self.options:
-            if option.Type == "option" or option.Type == None:
+            if option.Type == "option" or option.Type is None:
                 res[option.Key] = option.Value
         return res
 

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2064,9 +2064,6 @@ class SMSGateway(MethodsMixin, db.Model):
     options = db.relationship('SMSGatewayOption',
                               lazy='dynamic',
                               backref='smsgw')
-    headers = db.relationship('SMSGatewayOption',
-                              lazy='dynamic',
-                              backref='smsgwheaders')
 
     def __init__(self, identifier, providermodule, description=None,
                  options=None, headers=None):
@@ -2142,14 +2139,14 @@ class SMSGateway(MethodsMixin, db.Model):
     @property
     def header_dict(self):
         """
-        Return all connected options as a dictionary
+        Return all connected headers as a dictionary
 
         :return: dict
         """
         res = {}
-        for header in self.headers:
-            if header.Type == "header":
-                res[header.Key] = header.Value
+        for option in self.options:
+            if option.Type == "header":
+                res[option.Key] = option.Value
         return res
 
     def as_dict(self):
@@ -2181,7 +2178,7 @@ class SMSGatewayOption(MethodsMixin, db.Model):
     gateway_id = db.Column(db.Integer(),
                            db.ForeignKey('smsgateway.id'), index=True)
     __table_args__ = (db.UniqueConstraint('gateway_id',
-                                          'Key',
+                                          'Key', 'Type',
                                           name='sgix_1'),
                       {'mysql_row_format': 'DYNAMIC'})
 
@@ -2200,7 +2197,7 @@ class SMSGatewayOption(MethodsMixin, db.Model):
         # See, if there is this option or header for this this gateway
         # The first match takes precedence
         go = SMSGatewayOption.query.filter_by(gateway_id=self.gateway_id,
-                                               Key=self.Key).first()
+                                               Key=self.Key, Type=self.Type).first()
         if go is None:
             # create a new one
             db.session.add(self)
@@ -2209,7 +2206,7 @@ class SMSGatewayOption(MethodsMixin, db.Model):
         else:
             # update
             SMSGatewayOption.query.filter_by(gateway_id=self.gateway_id,
-                                              Key=self.Key
+                                              Key=self.Key, Type=self.Type
                                               ).update({'Value': self.Value,
                                                         'Type': self.Type})
             ret = go.id

--- a/privacyidea/static/components/config/controllers/smsgatewayController.js
+++ b/privacyidea/static/components/config/controllers/smsgatewayController.js
@@ -43,7 +43,7 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
                 $scope.form = $scope.smsgateways[0];
                 $scope.form.module = $scope.form.providermodule;
                 var option_array = Object.keys($scope.smsproviders[$scope.form.module].parameters);
-                // fill all parameters (options)
+                // fill all parameters (default options and additional options)
                 angular.forEach(Object.keys($scope.form.options),
                     function (optionname) {
                         if (option_array.indexOf(optionname)>-1) {
@@ -53,17 +53,8 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
                             $scope.opts[optionname] = $scope.form.options[optionname];
                         }
                     });
-                var header_array = Object.keys($scope.smsproviders[$scope.form.module].parameters);
                 // fill all parameters (headers)
-                angular.forEach(Object.keys($scope.form.headers),
-                    function (headername) {
-                        if (header_array.indexOf(headername)>-1) {
-                            $scope.form["header." + headername] = $scope.form.headers[headername];
-                        } else {
-                            // file the headers!
-                            $scope.headers[headername] = $scope.form.headers[headername];
-                        }
-                    });
+                $scope.headers = $scope.form.headers
             }
         });
     };

--- a/privacyidea/static/components/config/controllers/smsgatewayController.js
+++ b/privacyidea/static/components/config/controllers/smsgatewayController.js
@@ -31,6 +31,7 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
     $scope.form = {};
     $scope.gateway_id = $stateParams.gateway_id;
     $scope.opts = {};
+    $scope.headers = {};
 
     // Get all gateway definitions
     $scope.getSMSGateways = function (gwid) {
@@ -42,7 +43,7 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
                 $scope.form = $scope.smsgateways[0];
                 $scope.form.module = $scope.form.providermodule;
                 var option_array = Object.keys($scope.smsproviders[$scope.form.module].parameters);
-                // fill all parameters
+                // fill all parameters (options)
                 angular.forEach(Object.keys($scope.form.options),
                     function (optionname) {
                         if (option_array.indexOf(optionname)>-1) {
@@ -50,6 +51,17 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
                         } else {
                             // file the optionals!
                             $scope.opts[optionname] = $scope.form.options[optionname];
+                        }
+                    });
+                var header_array = Object.keys($scope.smsproviders[$scope.form.module].parameters);
+                // fill all parameters (headers)
+                angular.forEach(Object.keys($scope.form.headers),
+                    function (headername) {
+                        if (header_array.indexOf(headername)>-1) {
+                            $scope.form["header." + headername] = $scope.form.headers[headername];
+                        } else {
+                            // file the headers!
+                            $scope.headers[headername] = $scope.form.headers[headername];
                         }
                     });
             }
@@ -80,8 +92,15 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
                 $scope.form["option." + option] = $scope.opts[option];
             }
         }
+        // transform the event headers to form parameters
+        for (var header in $scope.headers) {
+            if ($scope.headers.hasOwnProperty(header)) {
+                $scope.form["header." + header] = $scope.headers[header];
+            }
+        }
 
         delete $scope.form.options;
+        delete $scope.form.headers;
         ConfigFactory.setSMSGateway($scope.form, function() {
             $state.go("config.smsgateway.list");
             $('html,body').scrollTop(0);
@@ -102,6 +121,16 @@ myApp.controller("smsgatewayController", function($scope, $stateParams,
         $scope.opts[$scope.newoption] = $scope.newvalue;
         $scope.newoption = "";
         $scope.newvalue = "";
+    };
+
+     $scope.deleteHeader = function(headername) {
+        delete $scope.headers[headername];
+    };
+
+    $scope.addHeader = function() {
+        $scope.headers[$scope.newheader] = $scope.newheadervalue;
+        $scope.newheader = "";
+        $scope.newheadervalue = "";
     };
 
     // listen to the reload broadcast

--- a/privacyidea/static/components/config/views/config.smsgateway.edit.html
+++ b/privacyidea/static/components/config/views/config.smsgateway.edit.html
@@ -112,6 +112,41 @@
     </table>
     </div>
 
+    <!-- headers -->
+    <div ng-show="smsproviders[form.module]['headers_allowed']">
+    <h3 translate>Headers</h3>
+        <table class="table table-hover">
+        <tr ng-repeat="(headername, header) in headers">
+            <td>
+                <b>{{ headername }}</b>
+            </td>
+            <td>
+                {{ header }}
+            </td>
+            <td>
+                <button ng-click="deleteHeader(headername)"
+                class="btn btn-danger">Delete</button>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <input class="form-control"
+                       ng-model="newheader">
+            </td>
+            <td>
+                <input class="form-control"
+                       ng-model="newheadervalue">
+            </td>
+            <td>
+                <button ng-click="addHeader()"
+                        ng-disabled="newheader===''"
+                        class="btn btn-success">Add</button>
+            </td>
+        </tr>
+    </table>
+    </div>
+
     <!-- button -->
     <div class="text-center"
          ng-show="checkRight('smsgateway_write')">

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -162,7 +162,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertEqual(sms_gw.get("headers").get("header2"), "headervalue2")
 
         # delete option "URL"
-        with self.app.test_request_context('/smsgateway/optsion/1/URL',
+        with self.app.test_request_context('/smsgateway/option/1/URL',
                                            method='DELETE',
                                            headers={
                                                'Authorization': self.at}):
@@ -171,8 +171,17 @@ class APISmsGatewayTestCase(MyApiTestCase):
             result = res.json.get("result")
             detail = res.json.get("detail")
 
-        # delete header "header1"
+        # try to delete header "header1" at the wrong endpoint
         with self.app.test_request_context('/smsgateway/option/1/header1',
+                                           method='DELETE',
+                                           headers={
+                                               'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 404, res)
+            result = res.json.get("result")
+
+        # delete header "header1"
+        with self.app.test_request_context('/smsgateway/header/1/header1',
                                            method='DELETE',
                                            headers={
                                                'Authorization': self.at}):

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -180,6 +180,15 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 404, res)
             result = res.json.get("result")
 
+        # try to delete header "header1" with a wrong type
+        with self.app.test_request_context('/smsgateway/nonexistent_type/1/header1',
+                                           method='DELETE',
+                                           headers={
+                                               'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 404, res)
+            result = res.json.get("result")
+
         # delete header "header1"
         with self.app.test_request_context('/smsgateway/header/1/header1',
                                            method='DELETE',

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -162,7 +162,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertEqual(sms_gw.get("headers").get("header2"), "headervalue2")
 
         # delete option "URL"
-        with self.app.test_request_context('/smsgateway/option/1/URL',
+        with self.app.test_request_context('/smsgateway/option/1/option.URL',
                                            method='DELETE',
                                            headers={
                                                'Authorization': self.at}):
@@ -172,16 +172,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
             detail = res.json.get("detail")
 
         # try to delete header "header1" at the wrong endpoint
-        with self.app.test_request_context('/smsgateway/option/1/header1',
-                                           method='DELETE',
-                                           headers={
-                                               'Authorization': self.at}):
-            res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 404, res)
-            result = res.json.get("result")
-
-        # try to delete header "header1" with a wrong type
-        with self.app.test_request_context('/smsgateway/nonexistent_type/1/header1',
+        with self.app.test_request_context('/smsgateway/option/1/option.header1',
                                            method='DELETE',
                                            headers={
                                                'Authorization': self.at}):
@@ -190,7 +181,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
             result = res.json.get("result")
 
         # delete header "header1"
-        with self.app.test_request_context('/smsgateway/header/1/header1',
+        with self.app.test_request_context('/smsgateway/option/1/header.header1',
                                            method='DELETE',
                                            headers={
                                                'Authorization': self.at}):

--- a/tests/test_api_smsgateway.py
+++ b/tests/test_api_smsgateway.py
@@ -119,7 +119,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
             "name": "myGW",
             "module": "privacyidea.lib.smsprovider.SMSProvider.ISMSProvider",
             "description": "myGateway",
-            "option.URL": "http://example.com"
+            "option.URL": "http://example.com",
+            "header.header1": "headervalue1"
         }
         with self.app.test_request_context('/smsgateway',
                                            data=param,
@@ -133,6 +134,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
 
         # add option
         param["option.HTTP_METHOD"] = "POST"
+        # add header
+        param["header.header2"] = "headervalue2"
         param["id"] = 1
         with self.app.test_request_context('/smsgateway',
                                            method='POST',
@@ -143,7 +146,7 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
 
-        # check options
+        # check options and headers
         with self.app.test_request_context('/smsgateway/',
                                            method='GET',
                                            headers={
@@ -155,9 +158,21 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertEqual(sms_gw.get("options").get("URL"),
                              "http://example.com")
             self.assertEqual(sms_gw.get("options").get("HTTP_METHOD"), "POST")
+            self.assertEqual(sms_gw.get("headers").get("header1"), "headervalue1")
+            self.assertEqual(sms_gw.get("headers").get("header2"), "headervalue2")
 
         # delete option "URL"
-        with self.app.test_request_context('/smsgateway/option/1/URL',
+        with self.app.test_request_context('/smsgateway/optsion/1/URL',
+                                           method='DELETE',
+                                           headers={
+                                               'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            detail = res.json.get("detail")
+
+        # delete header "header1"
+        with self.app.test_request_context('/smsgateway/option/1/header1',
                                            method='DELETE',
                                            headers={
                                                'Authorization': self.at}):
@@ -178,6 +193,8 @@ class APISmsGatewayTestCase(MyApiTestCase):
             self.assertEqual(sms_gw.get("options").get("URL"), None)
             self.assertEqual(sms_gw.get("options").get("HTTP_METHOD"),
                              "POST")
+            self.assertEqual(sms_gw.get("headers").get("header1"), None)
+            self.assertEqual(sms_gw.get("headers").get("header2"), "headervalue2")
 
     def test_04_sms_provider_modules(self):
         with self.app.test_request_context('/smsgateway/providers',

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -91,19 +91,19 @@ class SMSTestCase(MyTestCase):
         set_smsgateway(identifier, provider_module,
                        options={"HTTP_METHOD": "POST",
                                 "URL": "example.com",
-                                "new key": "value"},
+                                "IDENTICAL_KEY": "new option"},
                        headers={"Authorization": "ValueChanged",
-                                "new header": "new value",
-                                "new header 2": "new value 2"})
+                                "IDENTICAL_KEY": "new header",
+                                "URL": "URL_in_headers"})
         gw = get_smsgateway(id=id)
         self.assertEqual(len(gw[0].option_dict), 3)
         self.assertEqual(gw[0].option_dict.get("HTTP_METHOD"), "POST")
         self.assertEqual(gw[0].option_dict.get("URL"), "example.com")
-        self.assertEqual(gw[0].option_dict.get("new key"), "value")
+        self.assertEqual(gw[0].option_dict.get("IDENTICAL_KEY"), "new option")
         self.assertEqual(gw[0].header_dict.get("Authorization"), "ValueChanged")
         self.assertEqual(gw[0].header_dict.get("BANANA"), None)
-        self.assertEqual(gw[0].header_dict.get("new header"), "new value")
-        self.assertEqual(gw[0].header_dict.get("new header 2"), "new value 2")
+        self.assertEqual(gw[0].header_dict.get("IDENTICAL_KEY"), "new header")
+        self.assertEqual(gw[0].header_dict.get("URL"), "URL_in_headers")
 
         # delete a single option
         r = delete_smsgateway_option(id, "URL")
@@ -111,17 +111,17 @@ class SMSTestCase(MyTestCase):
         self.assertEqual(len(gw[0].option_dict), 2)
         self.assertEqual(gw[0].option_dict.get("HTTP_METHOD"), "POST")
         self.assertEqual(gw[0].option_dict.get("URL"), None)
-        self.assertEqual(gw[0].option_dict.get("new key"), "value")
+        self.assertEqual(gw[0].option_dict.get("IDENTICAL_KEY"), "new option")
 
         # delete a single header
-        r = delete_smsgateway_header(id, "new header")
+        r = delete_smsgateway_header(id, "IDENTICAL_KEY")
         gw = get_smsgateway(id=id)
-        self.assertEqual(gw[0].option_dict.get("new header"), None)
+        self.assertEqual(gw[0].header_dict.get("IDENTICAL_KEY"), None)
 
-        # delete a single header
-        r = delete_smsgateway_key_generic(id, "new header 2", Type="header")
+        # delete a single header via generic function
+        r = delete_smsgateway_key_generic(id, "URL", Type="header")
         gw = get_smsgateway(id=id)
-        self.assertEqual(gw[0].option_dict.get("new header 2"), None)
+        self.assertEqual(gw[0].header_dict.get("URL"), None)
 
         # finally delete the gateway definition
         r = delete_smsgateway(identifier)

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -20,6 +20,7 @@ from privacyidea.lib.smsprovider.SMSProvider import (SMSError,
                                                      delete_smsgateway,
                                                      delete_smsgateway_option,
                                                      delete_smsgateway_header,
+                                                     delete_smsgateway_key_generic,
                                                      create_sms_instance)
 from privacyidea.lib.smtpserver import add_smtpserver
 import responses
@@ -92,7 +93,8 @@ class SMSTestCase(MyTestCase):
                                 "URL": "example.com",
                                 "new key": "value"},
                        headers={"Authorization": "ValueChanged",
-                                "new header": "new value"})
+                                "new header": "new value",
+                                "new header 2": "new value 2"})
         gw = get_smsgateway(id=id)
         self.assertEqual(len(gw[0].option_dict), 3)
         self.assertEqual(gw[0].option_dict.get("HTTP_METHOD"), "POST")
@@ -101,6 +103,7 @@ class SMSTestCase(MyTestCase):
         self.assertEqual(gw[0].header_dict.get("Authorization"), "ValueChanged")
         self.assertEqual(gw[0].header_dict.get("BANANA"), None)
         self.assertEqual(gw[0].header_dict.get("new header"), "new value")
+        self.assertEqual(gw[0].header_dict.get("new header 2"), "new value 2")
 
         # delete a single option
         r = delete_smsgateway_option(id, "URL")
@@ -114,6 +117,11 @@ class SMSTestCase(MyTestCase):
         r = delete_smsgateway_header(id, "new header")
         gw = get_smsgateway(id=id)
         self.assertEqual(gw[0].option_dict.get("new header"), None)
+
+        # delete a single header
+        r = delete_smsgateway_key_generic(id, "new header 2", Type="header")
+        gw = get_smsgateway(id=id)
+        self.assertEqual(gw[0].option_dict.get("new header 2"), None)
 
         # finally delete the gateway definition
         r = delete_smsgateway(identifier)

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -19,6 +19,7 @@ from privacyidea.lib.smsprovider.SMSProvider import (SMSError,
                                                      get_smsgateway,
                                                      delete_smsgateway,
                                                      delete_smsgateway_option,
+                                                     delete_smsgateway_header,
                                                      create_sms_instance)
 from privacyidea.lib.smtpserver import add_smtpserver
 import responses
@@ -108,6 +109,11 @@ class SMSTestCase(MyTestCase):
         self.assertEqual(gw[0].option_dict.get("HTTP_METHOD"), "POST")
         self.assertEqual(gw[0].option_dict.get("URL"), None)
         self.assertEqual(gw[0].option_dict.get("new key"), "value")
+
+        # delete a single header
+        r = delete_smsgateway_header(id, "new header")
+        gw = get_smsgateway(id=id)
+        self.assertEqual(gw[0].option_dict.get("new header"), None)
 
         # finally delete the gateway definition
         r = delete_smsgateway(identifier)

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -72,7 +72,9 @@ class SMSTestCase(MyTestCase):
         provider_module = "privacyidea.lib.smsprovider.HttpSMSProvider.HttpSMSProvider"
         id = set_smsgateway(identifier, provider_module, description="test",
                             options={"HTTP_METHOD": "POST",
-                                     "URL": "example.com"})
+                                     "URL": "example.com"},
+                            headers={"Authorization": "QWERTZ",
+                                     "BANANA": "will be eaten"})
         self.assertTrue(id > 0)
 
         gw = get_smsgateway(id=id)
@@ -87,12 +89,17 @@ class SMSTestCase(MyTestCase):
         set_smsgateway(identifier, provider_module,
                        options={"HTTP_METHOD": "POST",
                                 "URL": "example.com",
-                                "new key": "value"})
+                                "new key": "value"},
+                       headers={"Authorization": "ValueChanged",
+                                "new header": "new value"})
         gw = get_smsgateway(id=id)
         self.assertEqual(len(gw[0].option_dict), 3)
         self.assertEqual(gw[0].option_dict.get("HTTP_METHOD"), "POST")
         self.assertEqual(gw[0].option_dict.get("URL"), "example.com")
         self.assertEqual(gw[0].option_dict.get("new key"), "value")
+        self.assertEqual(gw[0].header_dict.get("Authorization"), "ValueChanged")
+        self.assertEqual(gw[0].header_dict.get("BANANA"), None)
+        self.assertEqual(gw[0].header_dict.get("new header"), "new value")
 
         # delete a single option
         r = delete_smsgateway_option(id, "URL")
@@ -117,7 +124,8 @@ class SMSTestCase(MyTestCase):
                           ".HttpSMSProvider"
         id = set_smsgateway(identifier, provider_module, description="test",
                             options={"HTTP_METHOD": "POST",
-                                     "URL": "example.com"})
+                                     "URL": "example.com"},
+                            headers={"Authorization": "QWERTZ"})
         self.assertTrue(id > 0)
 
         sms = create_sms_instance(identifier)
@@ -125,6 +133,8 @@ class SMSTestCase(MyTestCase):
         self.assertEqual(sms.smsgateway.option_dict.get("URL"), "example.com")
         self.assertEqual(sms.smsgateway.option_dict.get("HTTP_METHOD"),
                          "POST")
+        self.assertEqual(sms.smsgateway.header_dict.get("Authorization"), "QWERTZ")
+        self.assertEqual(sms.smsgateway.option_dict.get("Authorization"), None)
 
 
 class SmtpSMSTestCase(MyTestCase):
@@ -474,7 +484,8 @@ class HttpSMSTestCase(MyTestCase):
                                      "URL": "http://example.com",
                                      "RETURN_SUCCESS": "ID",
                                      "text": "{otp}",
-                                     "phone": "{phone}"})
+                                     "phone": "{phone}"},
+                            headers={"Authorization": "QWERTZ"})
         self.assertTrue(id > 0)
 
         sms = create_sms_instance(identifier)


### PR DESCRIPTION
This pull request provides the initial headers support for SMS gateways.

1. It requires a change in the database scheme of the smsgatewayoption table to relax the "Key" uniqueness constraint to "per Type".

CREATE TABLE smsgatewayoption (
id INTEGER NOT NULL,
"Key" VARCHAR(255) NOT NULL,
"Value" TEXT, "Type" VARCHAR(100), 
gateway_id INTEGER,PRIMARY KEY (id), 
CONSTRAINT sgix_1 UNIQUE (gateway_id, "Key", **"Type"**),
FOREIGN KEY(gateway_id) REFERENCES smsgateway_new (id)
);

2. We must add `type = "option"` to all rows in smsgatewayoption to prevent orphan (unchangeable) entries in the table.

closes #2213