### PR TITLE
Allow to switch off or on the translation warning

### DIFF
--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -81,6 +81,9 @@ own UI and you do not want to present the UI to the user or the outside world.
 .. note:: The API calls are all still accessible, i.e. privacyIDEA is
    technically fully functional.
 
+The parameter ``PI_TRANSLATION_WARNING`` can be used to provide a prefix, that is
+set in front of every string in the UI, that is not translated to the language your browser
+is using.
 
 .. _engine-registry:
 

--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -53,6 +53,7 @@ class DevelopmentConfig(Config):
     SQLALCHEMY_DATABASE_URI = os.environ.get('DEV_DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'data-dev.sqlite')
     PI_LOGLEVEL = logging.DEBUG
+    PI_TRANSLATION_WARNING = "[Missing]"
 
 
 class TestingConfig(Config):

--- a/privacyidea/static/app.js
+++ b/privacyidea/static/app.js
@@ -101,7 +101,6 @@ myApp.run(['$rootScope', '$state', '$stateParams', 'gettextCatalog',
             $rootScope.$state = $state;
             $rootScope.$stateParams = $stateParams;
             gettextCatalog.setCurrentLanguage(browserLanguage);
-            gettextCatalog.debug = true;
 
             // we set this, so we can use it in templates
             $rootScope.browserLanguage = browserLanguage;

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -66,7 +66,13 @@ angular.module("privacyideaApp")
     obj = angular.element(document.querySelector('#HAS_JOB_QUEUE'));
     $scope.hasJobQueue = obj.val() == "True";
     obj = angular.element(document.querySelector('#LOGIN_TEXT'));
-    $scope.piLoginText= obj.val();
+    $scope.piLoginText = obj.val();
+    obj = angular.element(document.querySelector('#PI_TRANSLATION_WARNING'));
+    $scope.piTranslationWarning = obj.val() !== "False";
+    $scope.piTranslationPrefix = obj.val();
+    gettextCatalog.debug = $scope.piTranslationWarning;
+    gettextCatalog.debugPrefix = $scope.piTranslationPrefix;
+
     // Check if registration is allowed
     $scope.registrationAllowed = false;
     RegisterFactory.status(function (data) {

--- a/privacyidea/static/templates/index.html
+++ b/privacyidea/static/templates/index.html
@@ -18,6 +18,7 @@
 <input type=hidden id="HAS_JOB_QUEUE" value="{{ has_job_queue }}">
 <input type=hidden id="LOGIN_TEXT" value="{{ login_text }}">
 <input type=hidden id="PRIVACYIDEA_VERSION_NUMBER" value="{{ privacyideaVersionNumber }}">
+<input type=hidden id=PI_TRANSLATION_WARNING value="{{ translation_warning }}">
 
 <!-- Include baseline -->
 

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -86,6 +86,8 @@ def single_page_application():
     #    PI_CUSTOMIZATION/views/includes/token.enroll.post.bottom.html
     # Get the hidden external links
     external_links = current_app.config.get("PI_EXTERNAL_LINKS", True)
+    # Read the UI translation warning
+    translation_warning = current_app.config.get("PI_TRANSLATION_WARNING", False)
     # Get the logo file
     logo = current_app.config.get("PI_LOGO", "privacyIDEA1.png")
     browser_lang = request.accept_languages.best_match(["en", "de", "de-DE"], default="en").split("-")[0]
@@ -152,6 +154,7 @@ def single_page_application():
         'browser_lang': browser_lang,
         'remote_user': remote_user,
         'theme': theme,
+        'translation_warning': translation_warning,
         'password_reset': password_reset,
         'hsm_ready': hsm_ready,
         'has_job_queue': str(has_job_queue()),


### PR DESCRIPTION
The WebUI prepends all non-translated strings with
the warning [MISSING]. This is often annoying and
irritating. The prefix now needs to be explicitly
turned on using PI_TRANSLATION_WARNING.

Closes #2223