### PR TITLE
Fix broken policy template links

### DIFF
--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -134,7 +134,8 @@ myApp.controller("policyDetailsController", function($scope, $stateParams,
                     realm: data.realm || [],
                     action: data.action || [],
                     resolver: data.resolver || [],
-                    adminrealm: data.adminrealm || []});
+                    adminrealm: data.adminrealm || [],
+                    pinode: []});
         });
     };
 


### PR DESCRIPTION
Since #2239 clicking on a policy template link won't fill in the policy
view and an error was thrown.
Passing an empty `pinode` data when pre-filling the policy view fixes this.

Fixes #2248