### PR TITLE
INitial writeup

### DIFF
--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -439,7 +439,7 @@ def migrate(config_obj):
                 # Add tokeninfo for this token
                 for (k, v) in ti.items():
                     if k in config_obj.MIGRATE.get("tokeninfo_unicode_keys", []):
-                        v = unicode(v, erros="ignore")
+                        v = unicode(v, errors="ignore")
                     tokeninfo_values.append(dict(
                         serial=r["LinOtpTokenSerialnumber"],
                         Key=k, Value=v,

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -439,7 +439,7 @@ def migrate(config_obj):
                 # Add tokeninfo for this token
                 for (k, v) in ti.items():
                     if k in config_obj.MIGRATE.get("tokeninfo_unicode_keys", []):
-                        v = unicode(v, errors="ignore")
+                        v = v.encode('ascii', 'ignore').decode('utf8')
                     tokeninfo_values.append(dict(
                         serial=r["LinOtpTokenSerialnumber"],
                         Key=k, Value=v,

--- a/tools/privacyidea-migrate-linotp.py
+++ b/tools/privacyidea-migrate-linotp.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
+#  2020-06-13 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Add failsafe for tokeninfo
 #  2019-10-04 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Allow encryption and config file
 #  2018-02-09 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -72,6 +74,7 @@ EXAMPLE_CONFIG_FILE = """{
     "MIGRATE": {
         "tokens": true,
         "tokeninfo": true,
+        "tokeninfo_unicode_keys": ["phone"],
         "assignments": false
     },
     "ASSIGNMENTS": {
@@ -435,6 +438,8 @@ def migrate(config_obj):
             if config_obj.MIGRATE.get("tokeninfo") and ti:
                 # Add tokeninfo for this token
                 for (k, v) in ti.items():
+                    if k in config_obj.MIGRATE.get("tokeninfo_unicode_keys", []):
+                        v = unicode(v, erros="ignore")
                     tokeninfo_values.append(dict(
                         serial=r["LinOtpTokenSerialnumber"],
                         Key=k, Value=v,


### PR DESCRIPTION
Add a failsafe (which only works with python2)
to remove non-ascii characters from configured tokeninfo keys.

Closes #2253