### PR TITLE
Add input pattern for phone numbers

### DIFF
--- a/privacyidea/static/components/token/views/token.enroll.email.html
+++ b/privacyidea/static/components/token/views/token.enroll.email.html
@@ -18,6 +18,7 @@
     <label for="email" translate>Email Address</label>
     <input type="email" id="email"
            autofocus
+           ng-required="! form.dynamic_email"
            class="form-control"
            placeholder="Users email address..."
            ng-model="form.email" name="email" />

--- a/privacyidea/static/components/token/views/token.enroll.sms.html
+++ b/privacyidea/static/components/token/views/token.enroll.sms.html
@@ -18,7 +18,10 @@
     <label for="phone" translate>Phone number</label>
     <input type="text" id="phone"
            autofocus
+           ng-required="! form.dynamic_phone"
            class="form-control"
+           placeholder="+1234567890"
+           pattern="(\+[1-9])?\d{1,14}"
            ng-model="form.phone" name="phone" />
     <div>
         <button class="btn btn-default btn-xs" ng-repeat="phone in phone_list"

--- a/privacyidea/static/components/token/views/token.enroll.sms.html
+++ b/privacyidea/static/components/token/views/token.enroll.sms.html
@@ -16,12 +16,12 @@
 </div>
 <div ng-hide="form.dynamic_phone" class="form-group">
     <label for="phone" translate>Phone number</label>
-    <input type="text" id="phone"
+    <input type="tel" id="phone"
            autofocus
            ng-required="! form.dynamic_phone"
            class="form-control"
            placeholder="+1234567890"
-           pattern="(\+[1-9])?\d{1,14}"
+           pattern="^(\+[1-9]+)?([0-9][, .-]?){1,14}$"
            ng-model="form.phone" name="phone" />
     <div>
         <button class="btn btn-default btn-xs" ng-repeat="phone in phone_list"


### PR DESCRIPTION
When enrolling an SMS Token the phone number input accepts any characters.
With the new pattern only numbers and an optional '+' at the beginning are
allowed.
Also the input field for phone and email are required now unless the 'read
from userstore' option is enabled.

Fixes #1141 #1158