### PR TITLE
fix check_max_active_token on enabling token

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -133,6 +133,9 @@ def before_request():
     # from the Form data or from JSON in the request body.
     ensure_no_config_object()
     request.all_data = get_all_params(request.values, request.data)
+    # get additional request information such as parameters in the
+    # call path from the view_args
+    request.all_data.update(request.view_args)
     if g.logged_in_user.get("role") == "user":
         # A user is calling this API. First thing we do is restricting the user parameter.
         # ...to restrict token view, audit view or token actions.

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -694,8 +694,11 @@ def check_max_token_user(request=None, action=None):
     params = request.all_data
     serial = getParam(params, "serial")
     user_object = get_user_from_param(params)
-    if not user_object.login and serial:
-        user_object = get_token_owner(serial)
+    if user_object.is_empty() and serial:
+        try:
+            user_object = get_token_owner(serial) or User()
+        except:
+            user_object = User()
     if user_object.login:
         tokentype = getParam(params, "type")
         if not tokentype:

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -699,7 +699,7 @@ def check_max_token_user(request=None, action=None):
         try:
             user_object = get_token_owner(serial) or User()
         except ResourceNotFoundError:
-            user_object = User()
+            pass
     if user_object.login:
         tokentype = getParam(params, "type")
         if not tokentype:

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -76,7 +76,7 @@ from privacyidea.lib.policy import SCOPE, ACTION, PolicyClass
 from privacyidea.lib.policy import Match
 from privacyidea.lib.user import (get_user_from_param, get_default_realm,
                                   split_user, User)
-from privacyidea.lib.token import (get_tokens, get_realms_of_token, get_token_type)
+from privacyidea.lib.token import (get_tokens, get_realms_of_token, get_token_type, get_token_owner)
 from privacyidea.lib.utils import (get_client_ip,
                                    parse_timedelta, is_true, generate_charlists_from_pin_policy,
                                    check_pin_policy, get_module_class,
@@ -693,6 +693,8 @@ def check_max_token_user(request=None, action=None):
     ERROR_ACTIVE_TYPE = "The number of active tokens of type {0!s} for this user is limited!"
     params = request.all_data
     user_object = get_user_from_param(params)
+    if not user_object.login and params.get("serial", None):
+        user_object = get_token_owner(params["serial"])
     if user_object.login:
         serial = getParam(params, "serial")
         tokentype = getParam(params, "type")

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -695,10 +695,11 @@ def check_max_token_user(request=None, action=None):
     serial = getParam(params, "serial")
     tokentype = getParam(params, "type")
     user_object = get_user_from_param(params)
-    if user_object.is_empty() and (serial or tokentype is "certificate"):
+    if user_object.is_empty() and serial:
         try:
             user_object = get_token_owner(serial) or User()
         except ResourceNotFoundError:
+            # in case of token init the token does not yet exist in the db
             pass
     if user_object.login:
         tokentype = getParam(params, "type")

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -70,7 +70,7 @@ import string
 
 from OpenSSL import crypto
 
-from privacyidea.lib.error import PolicyError, RegistrationError, TokenAdminError
+from privacyidea.lib.error import PolicyError, RegistrationError, TokenAdminError, ResourceNotFoundError
 from flask import g, current_app
 from privacyidea.lib.policy import SCOPE, ACTION, PolicyClass
 from privacyidea.lib.policy import Match
@@ -693,11 +693,12 @@ def check_max_token_user(request=None, action=None):
     ERROR_ACTIVE_TYPE = "The number of active tokens of type {0!s} for this user is limited!"
     params = request.all_data
     serial = getParam(params, "serial")
+    tokentype = getParam(params, "type")
     user_object = get_user_from_param(params)
-    if user_object.is_empty() and serial:
+    if user_object.is_empty() and (serial or tokentype is "certificate"):
         try:
             user_object = get_token_owner(serial) or User()
-        except:
+        except ResourceNotFoundError:
             user_object = User()
     if user_object.login:
         tokentype = getParam(params, "type")

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -692,11 +692,11 @@ def check_max_token_user(request=None, action=None):
     ERROR_ACTIVE = "The number of active tokens for this user is limited!"
     ERROR_ACTIVE_TYPE = "The number of active tokens of type {0!s} for this user is limited!"
     params = request.all_data
+    serial = getParam(params, "serial")
     user_object = get_user_from_param(params)
-    if not user_object.login and params.get("serial", None):
-        user_object = get_token_owner(params["serial"])
+    if not user_object.login and serial:
+        user_object = get_token_owner(serial)
     if user_object.login:
-        serial = getParam(params, "serial")
         tokentype = getParam(params, "type")
         if not tokentype:
             if serial:

--- a/tests/test_api_caconnector.py
+++ b/tests/test_api_caconnector.py
@@ -22,7 +22,9 @@ class CAConnectorTestCase(MyApiTestCase):
     def test_02_create_ca_connector(self):
         # create a CA connector
         with self.app.test_request_context('/caconnector/con1',
-                                           data={'type': 'local'},
+                                           data={'type': 'local',
+                                                 'cacert': '/etc/key.pem',
+                                                 'cakey': '/etc/cert.pem'},
                                            method='POST',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
@@ -51,7 +53,8 @@ class CAConnectorTestCase(MyApiTestCase):
         ca_list = get_caconnector_list()
         self.assertEqual(len(ca_list), 1)
         self.assertEqual(ca_list[0].get("data"), {u'cacert': u'/etc/cert.pem',
-                                                  u'cakey': u'/etc/key.pem'})
+                                                  u'cakey': u'/etc/key.pem',
+                                                  u'name': u'con1'})
 
     def test_04_read_ca_connector(self):
         with self.app.test_request_context('/caconnector/',

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -385,7 +385,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         self.assertRaises(PolicyError,
                           check_max_token_user, req)
 
-        # not we unassign the token and try to enable it which suceeds, since
+        # not we unassign the token and try to enable it which succeeds, since
         # there is no tokenowner anymore
         unassign_token("NEW001")
         req.all_data = {"serial": "NEW001"}

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -381,12 +381,12 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
                                                 realm=self.realm1))
         self.assertTrue(len(tokenobject_list) == 2)
         # now we enable the first hotp token again, which fails due to the policy
-        req.all_data = {"user": "cornelius",
-                        "realm": self.realm1,
-                        "serial": "NEW001"}
+        req.all_data = {"serial": "NEW001"}
         self.assertRaises(PolicyError,
                           check_max_token_user, req)
 
+        # not we unassign the token and try to enable it which suceeds, since
+        # there is no tokenowner anymore
         unassign_token("NEW001")
         req.all_data = {"serial": "NEW001"}
         self.assertTrue(check_max_token_user(req))

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -387,6 +387,10 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         self.assertRaises(PolicyError,
                           check_max_token_user, req)
 
+        unassign_token("NEW001")
+        req.all_data = {"serial": "NEW001"}
+        self.assertTrue(check_max_token_user(req))
+
         # clean up
         delete_policy("pol1")
         remove_token("NEW001")


### PR DESCRIPTION
closes #2215 

On checking the max_token_user policy, we not get the tokenowner from the serial if no user_obj is present.