### PR TITLE
Make all data available in container audit

### DIFF
--- a/privacyidea/lib/auditmodules/containeraudit.py
+++ b/privacyidea/lib/auditmodules/containeraudit.py
@@ -68,6 +68,20 @@ class Audit(AuditBase):
         for module in self.write_modules:
             module.log(param)
 
+    def add_to_log(self, param, add_with_comma=False):
+        """
+        Call the add_to_log method for all writeable modules
+        """
+        for module in self.write_modules:
+            module.add_to_log(param, add_with_comma)
+
+    def add_policy(self, policyname):
+        """
+        Call the add_policy method for all writeable modules
+        """
+        for module in self.write_modules:
+            module.add_policy(policyname)
+
     def search(self, search_dict, page_size=15, page=1, sortorder="asc",
                timelimit=None):
         """

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -406,15 +406,21 @@ class ContainerAuditTestCase(OverrideConfigTestCase):
                             "PI_AUDIT_NO_SIGN": True,
                             "PI_AUDIT_SQL_URI": 'sqlite:///' + os.path.join(basedir, 'data-test.sqlite')})
         a.log({"action": "something_test_35"})
+        a.add_to_log({'action_detail': 'some detail'})
+        a.add_policy('some policy')
         a.finalize_log()
         r = a.search({"action": "*something_test_35*"})
         # The search should go to the sql audit
         self.assertEqual(r.total, 1)
         self.assertEqual(r.auditdata[0].get("action"), u"something_test_35")
+        self.assertEqual(r.auditdata[0].get("action_detail"), u"some detail")
+        self.assertEqual(r.auditdata[0].get("policies"), u"some policy")
         # now check the log file
         with open("audit.log") as file:
             c = file.readlines()
             self.assertIn("something_test_35", c[-1])
+            self.assertIn("some detail", c[-1])
+            self.assertIn("some policy", c[-1])
         os.unlink('audit.log')
 
     def test_20_container_audit_wrong_module(self):


### PR DESCRIPTION
Some data was not added to the writable container audit modules.
Calling the functions add_to_log() and add_policy() for each writable audit
module fixes this.

Fixes #2264