### PR TITLE
Enable deleting validity time with empty string

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -77,6 +77,7 @@ This method is supposed to be overwritten by the corresponding token classes.
 """
 import logging
 import hashlib
+import traceback
 from datetime import datetime, timedelta
 
 from .error import (TokenAdminError,
@@ -963,9 +964,16 @@ class TokenClass(object):
                          throw an exception
         :type end_date: string
         """
-        #  upper layer will catch. we just try to verify the date format
-        d = parse_date_string(end_date)
-        self.add_tokeninfo("validity_period_end", d.strftime(DATE_FORMAT))
+        if not end_date:
+            self.del_tokeninfo("validity_period_end")
+        else:
+            #  upper layer will catch. we just try to verify the date format
+            try:
+                d = parse_date_string(end_date)
+            except ValueError as _e:
+                log.debug('{0!s}'.format(traceback.format_exc()))
+                raise TokenAdminError('Could not parse validity period end date!')
+            self.add_tokeninfo("validity_period_end", d.strftime(DATE_FORMAT))
 
     def get_validity_period_start(self):
         """
@@ -988,8 +996,16 @@ class TokenClass(object):
                            throw an exception
         :type start_date: string
         """
-        d = parse_date_string(start_date)
-        self.add_tokeninfo("validity_period_start", d.strftime(DATE_FORMAT))
+        if not start_date:
+            self.del_tokeninfo("validity_period_start")
+        else:
+            try:
+                d = parse_date_string(start_date)
+            except ValueError as _e:
+                log.debug('{0!s}'.format(traceback.format_exc()))
+                raise TokenAdminError('Could not parse validity period start date!')
+
+            self.add_tokeninfo("validity_period_start", d.strftime(DATE_FORMAT))
 
     def set_next_pin_change(self, diff=None, password=False):
         """

--- a/privacyidea/static/components/token/controllers/tokenDetailController.js
+++ b/privacyidea/static/components/token/controllers/tokenDetailController.js
@@ -64,6 +64,7 @@ myApp.controller("tokenDetailController", function ($scope,
     $scope.machinesPerPage = 15;
     $scope.params = {page: 1};
     $scope.form = {options: {}};
+    $scope.editTokenInfo = 0;
     $scope.testTokenPlaceholder = gettextCatalog.getString('Enter PIN and OTP to check the' +
         ' token.');
     ConfigFactory.getSystemConfig(function(data) {
@@ -170,6 +171,12 @@ myApp.controller("tokenDetailController", function ($scope,
         $scope.cancelEditRealm();
     };
 
+    $scope.startEditTokenInfo = function() {
+        $scope.validity_period_start = string_to_date_object($scope.token.info.validity_period_start);
+        $scope.validity_period_end = string_to_date_object($scope.token.info.validity_period_end);
+        $scope.editTokenInfo = 1;
+    };
+
     $scope.saveTokenInfo = function () {
         var start = date_object_to_string($scope.validity_period_start);
         var end = date_object_to_string($scope.validity_period_end);
@@ -179,6 +186,7 @@ myApp.controller("tokenDetailController", function ($scope,
              validity_period_end: end,
              validity_period_start: start},
             $scope.get);
+        $scope.editTokenInfo = 0;
     };
 
     $scope.assignUser = function () {

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -188,6 +188,7 @@
                         <input ng-model="max_auth_count"
                                class="form-control"
                                name="max_auth_count"
+                               id="max_auth_count"
                                type="number"
                                placeholder="Max allowed auths">
                     </div>
@@ -196,6 +197,7 @@
                                 translate>Maximum Success Auth Count
                         </label>
                         <input ng-model="max_success_auth_count"
+                               id="max_success_auth_count"
                                class="form-control"
                                type="number"
                                placeholder="Max allowed successful auths"
@@ -208,13 +210,13 @@
                         </label>
                         <p class="input-group">
                             <input type="text" class="form-control"
-                                   name="validity_start"
+                                   name="validity_start" id="validity_start"
                                    uib-datepicker-popup="yyyy-MM-ddTHH:mmZ"
                                    ng-model="validity_period_start"
                                    is-open="startOpened"
                                    min-date="today"
                                    show-button-bar="false"
-                                   ng-required="true" close-text="Close"/>
+                                   close-text="Close"/>
                           <span class="input-group-btn">
                             <button type="button" class="btn btn-default"
                                     ng-click="startOpened = openDate($event)">
@@ -223,6 +225,11 @@
                           </span>
                         </p>
                     </div>
+                    <div class="alert alert-warning"
+                         ng-show="validity_period_start > validity_period_end"
+                         translate>
+                        End Date before Start Date!
+                    </div>
                     <div class="form-group">
                         <label for="validity_end"
                                 translate>Validity End
@@ -230,12 +237,13 @@
                         <p class="input-group">
                             <input type="text" class="form-control"
                                    name="validity_end"
+                                   id="validity_end"
                                    uib-datepicker-popup="yyyy-MM-ddTHH:mmZ"
                                    ng-model="validity_period_end"
                                    is-open="endOpened"
                                    min-date="today"
                                    show-button-bar="false"
-                                   ng-required="true" close-text="Close"/>
+                                   close-text="Close"/>
                           <span class="input-group-btn">
                             <button type="button" class="btn btn-default"
                                     ng-click="endOpened = openDate($event)">
@@ -253,13 +261,13 @@
                             id="tiEditButton"
                             ng-hide="editTokenInfo || (!checkRight('set') && hide_buttons)"
                             ng-disable="!checkRight('set')"
-                            ng-click="editTokenInfo=1"
+                            ng-click="startEditTokenInfo()"
                             translate>Edit
                     </button>
                     <button class="btn btn-primary"
                             id="tiSaveButton"
                             ng-show="editTokenInfo"
-                            ng-click="editTokenInfo=0; saveTokenInfo()"
+                            ng-click="saveTokenInfo()"
                             translate>Save Token Info
                     </button>
                     <button class="btn btn-danger"

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -841,6 +841,19 @@ class APITokenTestCase(MyApiTestCase):
             self.assertEqual(tokeninfo.get("validity_period_end"),
                              "2014-05-22T23:00+0200")
 
+        # check for broken validity dates
+        with self.app.test_request_context('/token/set/SET001',
+                                           method="POST",
+                                           data={"validity_period_start": "unknown"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 400, res)
+            result = res.json.get("result")
+            self.assertEqual(result['error']['code'], 301, result)
+            self.assertEqual(result['error']['message'],
+                             "ERR301: Could not parse validity period start date!",
+                             result)
+
     def test_10_set_token_realms(self):
         self._create_temp_token("REALM001")
 

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -3,7 +3,6 @@ This test file tests the lib.tokenclass
 
 The lib.tokenclass depends on the DB model and lib.user
 """
-
 from .base import MyTestCase, FakeFlaskG
 from privacyidea.lib.resolver import (save_resolver, delete_resolver)
 from privacyidea.lib.realm import (set_realm, delete_realm)
@@ -14,6 +13,7 @@ from privacyidea.lib.config import (set_privacyidea_config,
                                     delete_privacyidea_config)
 from privacyidea.lib.crypto import geturandom
 from privacyidea.lib.utils import hexlify_and_unicode, to_unicode
+from privacyidea.lib.error import TokenAdminError
 from privacyidea.models import (Token,
                                 Config,
                                 Challenge)
@@ -306,18 +306,27 @@ class TokenBaseTestCase(MyTestCase):
         token.set_validity_period_end("2014-12-30T16:00+0400")
         end = token.get_validity_period_end()
         self.assertTrue(end == "2014-12-30T16:00+0400", end)
-        self.assertRaises(Exception,
+        self.assertRaises(TokenAdminError,
                           token.set_validity_period_end, "wrong date")
         # handle validity start date
         token.set_validity_period_start("2014-12-30T16:00+0400")
         start = token.get_validity_period_start()
         self.assertTrue(start == "2014-12-30T16:00+0400", start)
-        self.assertRaises(Exception,
+        self.assertRaises(TokenAdminError,
                           token.set_validity_period_start, "wrong date")
         
         self.assertFalse(token.check_validity_period())
-        # THe token is valid till 2021, this should be enough!
-        token.set_validity_period_end("2021-12-30T16:00+0200")
+        # delete the validity period end by passing an empty string
+        token.set_validity_period_end('')
+        end = token.get_validity_period_end()
+        self.assertTrue(end == "", end)
+        self.assertTrue(token.check_validity_period())
+
+        # try the same for the validity period start
+        start_date_5d = datetime.datetime.now(tzlocal()) + datetime.timedelta(5)
+        token.set_validity_period_start(start_date_5d.strftime(DATE_FORMAT))
+        self.assertFalse(token.check_validity_period())
+        token.set_validity_period_start('')
         self.assertTrue(token.check_validity_period())
 
         token.set_validity_period_end("2015-05-22T22:00:00.000Z")


### PR DESCRIPTION
Currently it is not possible to delete a validity time start/end through
the webUI. Passing an empty string lead to a server error.
This will be fixed with this PR and passing an empty string deletes the
validity start/end.
Also the UI displays a warning if the end date is before the start date.

Fixes #2263