### PR TITLE
Fix broken response signature on error

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -257,7 +257,6 @@ def after_request(response):
 @eventhandling_blueprint.app_errorhandler(AuthError)
 @subscriptions_blueprint.app_errorhandler(AuthError)
 @monitoring_blueprint.app_errorhandler(AuthError)
-@postrequest(sign_response, request=request)
 def auth_error(error):
     if "audit_object" in g:
         message = ''
@@ -292,7 +291,6 @@ def auth_error(error):
 @recover_blueprint.app_errorhandler(PolicyError)
 @subscriptions_blueprint.app_errorhandler(PolicyError)
 @monitoring_blueprint.app_errorhandler(PolicyError)
-@postrequest(sign_response, request=request)
 def policy_error(error):
     if "audit_object" in g:
         g.audit_object.add_to_log({"info": error.message}, add_with_comma=True)
@@ -314,7 +312,6 @@ def policy_error(error):
 @register_blueprint.app_errorhandler(ResourceNotFoundError)
 @recover_blueprint.app_errorhandler(ResourceNotFoundError)
 @subscriptions_blueprint.app_errorhandler(ResourceNotFoundError)
-@postrequest(sign_response, request=request)
 def resource_not_found_error(error):
     """
     This function is called when an ResourceNotFoundError occurs.
@@ -341,7 +338,6 @@ def resource_not_found_error(error):
 @recover_blueprint.app_errorhandler(privacyIDEAError)
 @subscriptions_blueprint.app_errorhandler(privacyIDEAError)
 @monitoring_blueprint.app_errorhandler(privacyIDEAError)
-@postrequest(sign_response, request=request)
 def privacyidea_error(error):
     """
     This function is called when an privacyIDEAError occurs.
@@ -369,7 +365,6 @@ def privacyidea_error(error):
 @recover_blueprint.app_errorhandler(500)
 @subscriptions_blueprint.app_errorhandler(500)
 @monitoring_blueprint.app_errorhandler(500)
-@postrequest(sign_response, request=request)
 def internal_error(error):
     """
     This function is called when an internal error (500) occurs.


### PR DESCRIPTION
If the request fails with an error, the error handler signs the response.
But the after_request handler will also sign the response and is called
after the error handler. The final signature can thus not be verified since
it includes the signature calculated by the error handler and then
overwrites it.
Only the after_request handler should be decorated to sign the response
since it is always called.

Fixes #2267