### PR TITLE
Add closed issues to changelog

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,42 @@
+Version 3.4dev1, 2020-06-26
+
+  Features:
+   * Add ScriptSMSProvider, that can send SMS through external
+     Gateways using arbitrary scripts (#2236)
+   * Add a basic dashboard as start screen in the WebUI (#2177)
+
+  Enhancements:
+   * Allow deletion of validity period via UI (#2263)
+   * Remove missing translation marker and allow to set a
+     customer marker (#2223)
+   * Add support for Python 3.8 (#2190)
+   * Allow hiding description field for users during
+     token enrollment (#2173)
+   * Improve error message during token import (#2073)
+   * Allow application to choose tokentypes in
+     /validate/check and /validate/triggerchallenge (#2047)
+   * HTTPSMSProvider can now have header parameters in the
+     provider definition (#1963)
+   * Events
+     * Add failcounter as condition in event handlers (#2147)
+   * Policies
+     * Allow to define characters for set_random_pin policy (#2121)
+     * Add privacyIDEA nodes to policy condition (#2108)
+
+  Fixes:
+   * Add missing audit data to container audit (#2264)
+   * Add tokeninfo failsafe for LinOTP migration script (#2253)
+   * Fix certain problems with the type of the userid
+     in SQL-Resolvers with Oracle DB (#2219)
+   * Fix default empty string problems with Oracle DB (#2218)
+   * Fix a policy issue that would require admin policies to
+     import tokens (#2209)
+   * Fix inconsistent enrollment templates. Have description
+     field for all tokentypes (#2208)
+   * Fix floating problems with multiple QR images in enrollment UI (#2175)
+   * Allow to edit realms without resolver priority (#2171)
+
+
 Version 3.3.3, 2020-05-19
 
   Fixes:

--- a/Changelog
+++ b/Changelog
@@ -7,8 +7,8 @@ Version 3.4dev1, 2020-06-26
 
   Enhancements:
    * Allow deletion of validity period via UI (#2263)
-   * Remove missing translation marker and allow to set a
-     customer marker (#2223)
+   * Remove marker for missing translations and allow to set a
+     custom marker (#2223)
    * Add support for Python 3.8 (#2190)
    * Allow hiding description field for users during
      token enrollment (#2173)

--- a/migrations/versions/140ba0ca4f07_.py
+++ b/migrations/versions/140ba0ca4f07_.py
@@ -1,0 +1,22 @@
+"""merge SMS options and privacyIDEA nodes
+
+Revision ID: 140ba0ca4f07
+Revises: ('e360c56bcf8c', '631ec59e1ca6')
+Create Date: 2020-06-26 12:40:39.663531
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '140ba0ca4f07'
+down_revision = ('e360c56bcf8c', '631ec59e1ca6')
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ idna==2.9
 ipaddress==1.0.23; python_version < '3.0'
 itsdangerous==1.1.0
 Jinja2==2.11.2
-ldap3==2.7
+ldap3==2.6.1
 lxml==4.5.0
 Mako==1.1.2
 MarkupSafe==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import stat
 import sys
 
 #VERSION = "2.1dev4"
-VERSION = "3.3.3"
+VERSION = "3.4dev1"
 
 # Taken from kennethreitz/requests/setup.py
 package_directory = os.path.realpath(os.path.dirname(__file__))


### PR DESCRIPTION
This creates a tag for 3.4dev1 so that we
can do a devel snapshot.

This way we can keep track of the changelog and build a debian package snapshot.

I also reverted ldap3 to 2.6.1 so that we will not run into issues.