### PR TITLE
Fix sqlresolver connstring empty values "" vs None

### DIFF
--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -619,15 +619,15 @@ class IdResolver (UserIdResolver):
             password = u":{0!s}".format(param.get("Password"))
         if param.get("conParams"):
             conParams = u"?{0!s}".format(param.get("conParams"))
-        connect_string = u"{0!s}://{1!s}{2!s}{3!s}{4!s}{5!s}/{6!s}{7!s}".format(param.get("Driver", ""),
-                                                   param.get("User", ""),
+        connect_string = u"{0!s}://{1!s}{2!s}{3!s}{4!s}{5!s}/{6!s}{7!s}".format(param.get("Driver") or "",
+                                                   param.get("User") or "",
                                                    password,
                                                    "@" if (param.get("User")
                                                            or
                                                            password) else "",
-                                                   param.get("Server", ""),
+                                                   param.get("Server") or "",
                                                    port,
-                                                   param.get("Database", ""),
+                                                   param.get("Database") or "",
                                                    conParams)
         # SQLAlchemy does not like a unicode connect string!
 #        if param.get("Driver").lower() == "sqlite":


### PR DESCRIPTION
Fixes #2271

This slightly changes the way params are passed to the connect_string format string so the default value of "" applies when a parameter is empty instead of the string "None".