### PR TITLE
Fix missing options parameter

### DIFF
--- a/privacyidea/lib/tokens/radiustoken.py
+++ b/privacyidea/lib/tokens/radiustoken.py
@@ -191,7 +191,7 @@ class RadiusTokenClass(RemoteTokenClass):
         # should we check the pin locally?
         if self.check_pin_local:
             # With a local PIN the challenge response is always a privacyIDEA challenge response!
-            res = self.check_pin(passw)
+            res = self.check_pin(passw, user=user, options=options)
             return res
 
         else:
@@ -406,7 +406,7 @@ class RadiusTokenClass(RemoteTokenClass):
             (_res, pin, otpval) = self.split_pin_pass(passw, user,
                                                       options=options)
 
-            if not self.check_pin(pin):
+            if not self.check_pin(pin, user=user, options=options):
                 return False, -1, {'message': "Wrong PIN"}
 
         # attempt to retrieve saved state/result

--- a/privacyidea/lib/tokens/remotetoken.py
+++ b/privacyidea/lib/tokens/remotetoken.py
@@ -203,7 +203,7 @@ class RemoteTokenClass(TokenClass):
             (_res, pin, otpval) = self.split_pin_pass(passw, user,
                                                       options=options)
 
-            if not TokenClass.check_pin(self, pin):
+            if not TokenClass.check_pin(self, pin, user=user, options=options):
                 return False, otp_counter, {'message': "Wrong PIN"}
 
         otp_count = self.check_otp(otpval, options=options)
@@ -312,8 +312,7 @@ class RemoteTokenClass(TokenClass):
         request_is_valid = False
 
         if self.check_pin_local:
-            pin_match = self.check_pin(passw, user=user,
-                                         options=options)
+            pin_match = self.check_pin(passw, user=user, options=options)
             if pin_match is True:
                 request_is_valid = True
 


### PR DESCRIPTION
Some token classes did not pass the options parameter to the `check_pin()`
function which results in not checking the otppin policy.

Fixes #2276