### PR TITLE
Save challenge timestamps in UTC

### DIFF
--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -1217,7 +1217,7 @@ class Challenge(MethodsMixin, db.Model):
     session = db.Column(db.Unicode(512), default=u'', quote=True, name="session")
     # The token serial number
     serial = db.Column(db.Unicode(40), default=u'', index=True)
-    timestamp = db.Column(db.DateTime, default=datetime.now())
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow())
     expiration = db.Column(db.DateTime)
     received_count = db.Column(db.Integer(), default=0)
     otp_valid = db.Column(db.Boolean, default=False)
@@ -1230,11 +1230,11 @@ class Challenge(MethodsMixin, db.Model):
         self.challenge = challenge
         self.serial = serial
         self.data = data
-        self.timestamp = datetime.now()
+        self.timestamp = datetime.utcnow()
         self.session = session
         self.received_count = 0
         self.otp_valid = False
-        self.expiration = datetime.now() + timedelta(seconds=validitytime)
+        self.expiration = datetime.utcnow() + timedelta(seconds=validitytime)
 
     @staticmethod
     def create_transaction_id(length=20):
@@ -1247,8 +1247,8 @@ class Challenge(MethodsMixin, db.Model):
         :rtype: bool
         """
         ret = False
-        c_now = datetime.now()
-        if c_now < self.expiration:
+        c_now = datetime.utcnow()
+        if self.timestamp <= c_now < self.expiration:
             ret = True
         return ret
 
@@ -1337,7 +1337,7 @@ def cleanup_challenges():
 
     :return: None
     """
-    c_now = datetime.now()
+    c_now = datetime.utcnow()
     Challenge.query.filter(Challenge.expiration < c_now).delete()
     db.session.commit()
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -6,7 +6,7 @@ from privacyidea.lib.user import (User)
 from privacyidea.lib.tokens.totptoken import HotpTokenClass
 from privacyidea.lib.tokens.registrationtoken import RegistrationTokenClass
 from privacyidea.lib.tokenclass import DATE_FORMAT
-from privacyidea.models import (Token, Challenge, AuthCache, db)
+from privacyidea.models import (Token, Policy, Challenge, AuthCache, db)
 from privacyidea.lib.authcache import _hash_password
 from privacyidea.lib.config import (set_privacyidea_config,
                                     get_inc_fail_count_on_false_pin,
@@ -23,6 +23,7 @@ from privacyidea.lib.realm import set_realm, set_default_realm, delete_realm
 from privacyidea.lib.radiusserver import add_radius
 from privacyidea.lib import _
 
+from testfixtures import Replace, test_datetime
 import datetime
 import time
 import responses
@@ -1268,6 +1269,75 @@ class ValidateAPITestCase(MyApiTestCase):
         # delete the tokens
         for serial in chalresp_serials:
             remove_token(serial=serial)
+
+    def test_11c_challenge_response_timezone(self):
+        # Since we write the challenge timestamps in UTC there is no easy way
+        # to test servers in different timezones with mocking.
+        # We would need to verify some timestamp the server emits in local time.
+        self.setUp_user_realms()
+        serial = "CHALRESP1"
+        pin = "chalresp1"
+        # create a token and assign to the user
+        init_token({'serial': serial,
+                    'type': 'hotp',
+                    'otpkey': self.otpkey,
+                    'pin': pin},
+                   user=User("cornelius", self.realm1))
+
+        # set a chalresp policy for HOTP
+        pol = Policy('pol_chal_resp_tz', action='challenge_response=hotp',
+                     scope='authentication', realm='', active=True)
+        pol.save()
+
+        # create the challenge by authenticating with the OTP PIN
+        with Replace('privacyidea.models.datetime',
+                     test_datetime(2020, 6, 13, 1, 2, 3,
+                                   tzinfo=datetime.timezone(datetime.timedelta(hours=+2)))):
+            with self.app.test_request_context('/validate/check',
+                                               method='POST',
+                                               data={"user": "cornelius",
+                                                     "pass": pin}):
+                res = self.app.full_dispatch_request()
+                self.assertTrue(res.status_code == 200, res)
+                result = res.json.get("result")
+                detail = res.json.get("detail")
+                self.assertFalse(result.get("value"))
+                self.assertEqual(detail.get("message"), _("please enter otp: "))
+                transaction_id = detail.get("transaction_id")
+
+        # send the OTP value while being an hour too early (timezone +1)
+        # This should not happen unless there is a server misconfiguration
+        # The transaction should not be removed by the janitor
+        with Replace('privacyidea.models.datetime',
+                     test_datetime(2020, 6, 13, 1, 2, 4,
+                                   tzinfo=datetime.timezone(datetime.timedelta(hours=+3)))):
+            with self.app.test_request_context('/validate/check',
+                                               method='POST',
+                                               data={"user": "cornelius",
+                                                     "transaction_id": transaction_id,
+                                                     "pass": "755224"}):
+                res = self.app.full_dispatch_request()
+                self.assertTrue(res.status_code == 200, res)
+                result = res.json.get("result")
+                self.assertFalse(result.get("value"))
+
+        # send the OTP value while being an hour too late (timezone -1)
+        with Replace('privacyidea.models.datetime',
+                     test_datetime(2020, 6, 13, 1, 2, 4,
+                                   tzinfo=datetime.timezone(datetime.timedelta(hours=+1)))):
+            with self.app.test_request_context('/validate/check',
+                                               method='POST',
+                                               data={"user": "cornelius",
+                                                     "transaction_id": transaction_id,
+                                                     "pass": "755224"}):
+                res = self.app.full_dispatch_request()
+                self.assertTrue(res.status_code == 200, res)
+                result = res.json.get("result")
+                self.assertFalse(result.get("value"))
+
+        # delete the token
+        remove_token(serial=serial)
+        pol.delete()
 
     def test_12_challenge_response_sms(self):
         # set a chalresp policy for SMS

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -22,6 +22,7 @@ from privacyidea.lib.error import ERROR
 from privacyidea.lib.resolver import save_resolver, get_resolver_list, delete_resolver
 from privacyidea.lib.realm import set_realm, set_default_realm, delete_realm
 from privacyidea.lib.radiusserver import add_radius
+from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib import _
 
 from testfixtures import Replace, test_datetime
@@ -1358,6 +1359,9 @@ class ValidateAPITestCase(MyApiTestCase):
                 self.assertTrue(res.status_code == 200, res)
                 result = res.json.get("result")
                 self.assertFalse(result.get("value"))
+
+        # check that the challenge is removed
+        self.assertFalse(get_challenges(transaction_id=transaction_id))
 
         # delete the token
         remove_token(serial=serial)


### PR DESCRIPTION
The challenge timestamps were saved in local time in the database. This
leads to false results when running servers in different timezones.
Saving the timestamps in UTC solves this (assuming the Server-Time is set
correctly).
This also fixes if a server checking the challenge is running fast.

Working on #1586