### PR TITLE
Make remote_user aware of Split@Sign option

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -207,12 +207,9 @@ def get_auth_token():
         raise AuthError(_("Authentication failure. Missing Username"),
                         id=ERROR.AUTHENTICATE_MISSING_USERNAME)
 
-    loginname = username
-    split_at_sign = get_from_config(SYSCONF.SPLITATSIGN, return_bool=True)
-    if split_at_sign:
-        (loginname, realm) = split_user(username)
+    loginname, realm = split_user(username)
 
-    # overwrite the splitted realm if we have a realm parameter
+    # overwrite the split realm if we have a realm parameter
     if realm_param:
         realm = realm_param
 

--- a/tests/testdata/passwords
+++ b/tests/testdata/passwords
@@ -13,3 +13,4 @@ lockeduser:DgT1djMaFfpEs:1113:1113:::
 usernotoken::1114:1114:::
 multichal::1115:1115:::
 nönäscii:IXsH4ttQlw2xA:1116:1116:Nön,field2,field3,field4,field5::
+user@test::1117:1117:::


### PR DESCRIPTION
Move the check for Split@Sign into the `split_user()` function. This way it
applies to all calls for (not) splitting the username into user and realm.

Also the remote user policy wasn't checked correctly. If set to `disable`,
the log-in with a remote user was still possible. This is fixed now.

Fixes #1954