### PR TITLE
Finish transaction before script is run

### DIFF
--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -36,6 +36,7 @@ from privacyidea.lib.utils import is_true
 from privacyidea.lib.framework import get_app_config_value
 from privacyidea.lib.error import ServerError
 from privacyidea.lib import _
+from privacyidea.app import db
 import logging
 import subprocess
 import os
@@ -189,6 +190,7 @@ class ScriptEventHandler(BaseEventHandler):
         rcode = 0
         try:
             log.info("Starting script {script!r}.".format(script=script_name))
+            db.session.commit()
             p = subprocess.Popen(proc_args, cwd=self.script_directory, universal_newlines=True)
             if handler_options.get("background") == SCRIPT_WAIT:
                 rcode = p.wait()


### PR DESCRIPTION
Changes to the database done in a script called from the
script-(pre)-handler don't show up in the continuing request. This is due
to the database isolation level of the SQLAlchemy configuration.
Finishing the running transaction before the script is run fixes this.

Fixes #2293