### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/authmodules/apache2/privacyidea_apache.py
+++ b/authmodules/apache2/privacyidea_apache.py
@@ -97,9 +97,8 @@ def check_password(environ, username, password):
 
 
 def _generate_digest(password):
-    pw_dig = passlib.hash.pbkdf2_sha512.encrypt(password,
-                                                rounds=ROUNDS,
-                                                salt_size=SALT_SIZE)
+    pw_dig = passlib.hash.pbkdf2_sha512.using(rounds=ROUNDS,
+                                              salt_size=SALT_SIZE).hash(password)
     return pw_dig
 
 

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -352,7 +352,7 @@ def check_policy_name(name):
         if re.search(disallowed_pattern[0], name, flags=disallowed_pattern[1]):
             raise ParameterError(_(u"'{0!s}' is an invalid policy name.").format(name))
 
-    if not re.match('^[a-zA-Z0-9_.\- ]*$', name):
+    if not re.match(r'^[a-zA-Z0-9_.\- ]*$', name):
         raise ParameterError(_("The name of the policy may only contain "
                                "the characters a-zA-Z0-9_. -"))
 

--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -27,7 +27,7 @@ from privacyidea.lib.applications import MachineApplicationBase
 from privacyidea.lib.crypto import geturandom
 from privacyidea.lib.error import ValidateError, ParameterError
 import logging
-import passlib.hash
+from passlib.hash import pbkdf2_sha512
 from privacyidea.lib.token import get_tokens
 log = logging.getLogger(__name__)
 ROUNDS = 6549
@@ -81,10 +81,8 @@ class MachineApplication(MachineApplicationBase):
         otps = otp_dict.get("otp")
         for key in otps.keys():
             # Return the hash of OTP PIN and OTP values
-            otps[key] = passlib.hash. \
-                pbkdf2_sha512.encrypt(otppin + otps.get(key),
-                                      rounds=rounds,
-                                      salt_size=10)
+            otps[key] = pbkdf2_sha512.using(
+                rounds=rounds, salt_size=10).hash(otppin + otps.get(key))
         # We do not disable the token, so if all offline OTP values
         # are used, the token can be used the authenticate online again.
         # token_obj.enable(False)

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -74,12 +74,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
 
 import passlib.hash
-if hasattr(passlib.hash.pbkdf2_sha512, "encrypt"):
-    hash_admin_pw = passlib.hash.pbkdf2_sha512.encrypt
-elif hasattr(passlib.hash.pbkdf2_sha512, "hash"):
-    hash_admin_pw = passlib.hash.pbkdf2_sha512.hash
-else:
-    raise Exception("No password hashing method available")
+hash_admin_pw = passlib.hash.pbkdf2_sha512.hash
 
 if not PY2:
     long = int

--- a/privacyidea/lib/queues/huey_queue.py
+++ b/privacyidea/lib/queues/huey_queue.py
@@ -28,8 +28,7 @@ log = logging.getLogger(__name__)
 class HueyQueue(BaseQueue):
     def __init__(self, options):
         BaseQueue.__init__(self, options)
-        # TODO: We should rethink ``store_errors=False`` -- how do we notice errors?
-        self._huey = RedisHuey(result_store=False, store_none=False, store_errors=False, **options)
+        self._huey = RedisHuey(results=False, store_none=False, **options)
         self._jobs = {}
 
     @property

--- a/privacyidea/lib/realm.py
+++ b/privacyidea/lib/realm.py
@@ -199,7 +199,7 @@ def set_realm(realm, resolvers=None, priority=None):
     realm_created = False
     realm = realm.lower().strip()
     realm = realm.replace(" ", "-")
-    nameExp = "^[A-Za-z0-9_\-\.]*$"
+    nameExp = r"^[A-Za-z0-9_\-\.]*$"
     sanity_name_check(realm, nameExp)
 
     # create new realm if it does not exist

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -322,7 +322,7 @@ class IdResolver (UserIdResolver):
             # In fact we need the sAMAccountName. If the username mapping is
             # another attribute than the sAMAccountName the authentication
             # will fail!
-            bind_user = u"{0!s}\{1!s}".format(domain_name, uinfo.get("username"))
+            bind_user = u"{0!s}\\{1!s}".format(domain_name, uinfo.get("username"))
         else:
             bind_user = self._getDN(uid)
 

--- a/privacyidea/lib/resolvers/PasswdIdResolver.py
+++ b/privacyidea/lib/resolvers/PasswdIdResolver.py
@@ -171,10 +171,9 @@ class IdResolver (UserIdResolver):
                 if len(descriptions) >= 5:
                     for field in descriptions[4:]:
                         # very basic e-mail regex
-                        email_match = re.search('.+@.+\..+', field)
+                        email_match = re.search(r'.+@.+\..+', field)
                         if email_match:
                             self.emailDict[fields[ID]] = email_match.group(0)
-
 
     def checkPass(self, uid, password):
         """

--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -38,7 +38,7 @@
 #
 #
 
-__doc__="""This is the SMSClass to send SMS via HTTP Gateways
+__doc__ = """This is the SMSClass to send SMS via HTTP Gateways
 It can handle HTTP/HTTPS PUT and GET requests also with Proxy support
 
 The code is tested in tests/test_lib_smsprovider
@@ -206,9 +206,9 @@ class HttpSMSProvider(ISMSProvider):
                 log.warning("failed to send sms. Reply %s does not match "
                             "the RETURN_SUCCESS definition" % reply)
                 raise SMSError(response.status_code,
-                           "We received a none success reply from the "
-                           "SMS Gateway: {0!s} ({1!s})".format(reply,
-                                                               return_success))
+                               "We received a none success reply from the "
+                               "SMS Gateway: {0!s} ({1!s})".format(reply,
+                                                                   return_success))
 
         elif return_fail:
             if return_fail in reply:
@@ -269,17 +269,17 @@ class HttpSMSProvider(ISMSProvider):
                       "REGEXP": {
                           "description": _("Regular expression to modify the phone number "                 
                                            "to make it compatible with provider. "
-                                           "Enter something like '/[\+/]//' to remove "
+                                           "Enter something like '/[\\+/]//' to remove "
                                            "pluses and slashes.")
                       },
-                      "PROXY": {"description": _("An optional proxy string. DEPRECATED. Do not use"
-                                                 "this anymore. Rather use HTTP_PROXY for http connections and"
-                                                 "HTTPS_PROXY for https connection. The PROXY option will be"
-                                                 "removed in future.")},
+                      "PROXY": {"description": _("An optional proxy string. DEPRECATED. Do not use "
+                                                 "this anymore. Rather use HTTP_PROXY for http "
+                                                 "connections and HTTPS_PROXY for https "
+                                                 "connection. The PROXY option will be removed in "
+                                                 "future.")},
                       "HTTP_PROXY": {"description": _("Proxy setting for HTTP connections.")},
-                      "HTTPS_PROXY": {"description":_("Proxy setting for HTTPS connections.")},
+                      "HTTPS_PROXY": {"description": _("Proxy setting for HTTPS connections.")},
                       "TIMEOUT": {"description": _("The timeout in seconds.")}
                   }
                   }
         return params
-        

--- a/privacyidea/lib/tokens/certificatetoken.py
+++ b/privacyidea/lib/tokens/certificatetoken.py
@@ -279,7 +279,7 @@ class CertificateTokenClass(TokenClass):
         passphrase = self.token.get_pin()
         if passphrase == -1:
             passphrase = ""
-        pkcs12_bin = pkcs12.export(passphrase=passphrase)
+        pkcs12_bin = pkcs12.export(passphrase=passphrase.encode('utf8'))
         return pkcs12_bin
 
     def get_as_dict(self):

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -66,7 +66,7 @@ from privacyidea.lib import _
 import traceback
 import logging
 
-from passlib.utils.pbkdf2 import pbkdf2
+from passlib.crypto.digest import pbkdf2_hmac
 
 optional = True
 required = False
@@ -731,10 +731,11 @@ class HotpTokenClass(TokenClass):
         # Based on the two components, we generate a symmetric key using PBKDF2
         # We pass the hex-encoded server component as the password and the
         # client component as the salt.
-        secret = pbkdf2(server_component.lower(),
-                        decoded_client_component,
-                        rounds,
-                        keysize)
+        secret = pbkdf2_hmac(digest='sha1',
+                             secret=server_component.lower(),
+                             salt=decoded_client_component,
+                             rounds=rounds,
+                             keylen=keysize)
         return hexlify_and_unicode(secret)
 
     @staticmethod

--- a/privacyidea/lib/tokens/radiustoken.py
+++ b/privacyidea/lib/tokens/radiustoken.py
@@ -226,7 +226,7 @@ class RadiusTokenClass(RemoteTokenClass):
         if options is None:
             options = {}
         message = options.get('radius_message') or "Enter your RADIUS tokencode:"
-        state = binascii.hexlify(options.get('radius_state') or b'')
+        state = hexlify_and_unicode(options.get('radius_state') or b'')
         attributes = {'state': transactionid}
         validity = int(get_from_config('DefaultChallengeValidityTime', 120))
 

--- a/privacyidea/lib/utils/__init__.py
+++ b/privacyidea/lib/utils/__init__.py
@@ -56,7 +56,7 @@ ENCODING = "utf-8"
 
 BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
-ALLOWED_SERIAL = "^[0-9a-zA-Z\-_]+$"
+ALLOWED_SERIAL = r"^[0-9a-zA-Z\-_]+$"
 
 # character lists for the identifiers in the pin content policy
 CHARLIST_CONTENTPOLICY = {"c": string.ascii_letters, # characters
@@ -392,7 +392,7 @@ def decode_base32check(encoded_data, always_upper=True):
     return hexlify_and_unicode(payload)
 
 
-def sanity_name_check(name, name_exp="^[A-Za-z0-9_\-\.]+$"):
+def sanity_name_check(name, name_exp=r"^[A-Za-z0-9_\-\.]+$"):
     """
     This function can be used to check the sanity of a name like a resolver,
     ca connector or realm.
@@ -445,8 +445,8 @@ def get_data_from_params(params, exclude_params, config_description, module,
                 if k in config_description:
                     types[k] = config_description.get(k)
                 else:
-                    log.warn("the passed key %r is not a "
-                             "parameter for the %s %r" % (k, module, type))
+                    log.warning("the passed key '{0!s}' is not a parameter for "
+                                "the {1!s} type '{2!s}'".format(k, module, type))
 
     # Check that there is no type or desc without the data itself.
     # i.e. if there is a type.BindPW=password, then there must be a
@@ -953,7 +953,7 @@ def parse_legacy_time(ts, return_date=False):
     if not d.tzinfo:
         # we need to reparse the string
         d = parse_date_string(ts,
-                              dayfirst=re.match("^\d\d[/\.]",ts)).replace(
+                              dayfirst=re.match(r"^\d\d[/\.]", ts)).replace(
                                   tzinfo=tzlocal())
     if return_date:
         return d

--- a/privacyidea/lib/utils/compare.py
+++ b/privacyidea/lib/utils/compare.py
@@ -97,7 +97,13 @@ def _compare_matches(left, comparator, right):
     :return: True or False
     """
     try:
-        return re.match("^" + right + "$", left) is not None
+        # check for regex modes
+        m = re.match(r'^(\(\?[a-zA-Z]+\))(.+)$', right)
+        if m and len(m.groups()) == 2:
+            regex = m.group(1) + r'^' + m.group(2) + r'$'
+        else:
+            regex = r"^" + right + r"$"
+        return re.match(regex, left) is not None
     except re.error as e:
         raise CompareError(u"Error during matching: {!r}".format(e))
 

--- a/tests/ldap3mock.py
+++ b/tests/ldap3mock.py
@@ -47,16 +47,10 @@ from ldap3.utils.conv import escape_bytes
 import ldap3
 import re
 import pyparsing
-import six
 
-try:
-    from six import cStringIO as BufferIO
-except ImportError:
-    from six import StringIO as BufferIO
+from .smtpmock import get_wrapped
 
-import inspect
 from collections import namedtuple, Sequence, Sized
-from functools import update_wrapper
 from privacyidea.lib.utils import to_bytes, to_unicode
 
 DIRECTORY = "tests/testdata/tmp_directory"
@@ -74,30 +68,6 @@ def _convert_objectGUID(item):
     item = uuid.UUID("{{{0!s}}}".format(item)).bytes_le
     item = escape_bytes(item)
     return item
-
-
-def get_wrapped(func, wrapper_template, evaldict):
-    # Preserve the argspec for the wrapped function so that testing
-    # tools such as pytest can continue to use their fixture injection.
-    args, a, kw, defaults = inspect.getargspec(func)
-    values = args[-len(defaults):] if defaults else None
-
-    signature = inspect.formatargspec(args, a, kw, defaults)
-    is_bound_method = hasattr(func, '__self__')
-    if is_bound_method:
-        args = args[1:]     # Omit 'self'
-    callargs = inspect.formatargspec(args, a, kw, values,
-                                     formatvalue=lambda v: '=' + v)
-
-    ctx = {'signature': signature, 'funcargs': callargs}
-    six.exec_(wrapper_template % ctx, evaldict)
-
-    wrapper = evaldict['wrapper']
-
-    update_wrapper(wrapper, func)
-    if is_bound_method:
-        wrapper = wrapper.__get__(func.__self__, type(func.__self__))
-    return wrapper
 
 
 class CallList(Sequence, Sized):

--- a/tests/radiusmock.py
+++ b/tests/radiusmock.py
@@ -27,23 +27,12 @@ from __future__ import (
     absolute_import, print_function, division, unicode_literals
 )
 
-import six
-from pyrad.packet import AccessChallenge, AccessAccept, AccessReject
-
-if six.PY2:
-    try:
-        from six import cStringIO as BufferIO
-    except ImportError:
-        from six import StringIO as BufferIO
-else:
-    from io import BytesIO as BufferIO
-
-import inspect
 from collections import namedtuple, Sequence, Sized
-from functools import update_wrapper
 from pyrad import packet
 from pyrad.client import Timeout
-from pyrad.packet import AccessChallenge, AccessReject, AccessAccept
+from pyrad.packet import AccessReject, AccessAccept, AccessChallenge
+
+from .smtpmock import get_wrapped
 
 Call = namedtuple('Call', ['request', 'response'])
 
@@ -52,30 +41,6 @@ def wrapper%(signature)s:
     with radiusmock:
         return func%(funcargs)s
 """
-
-
-def get_wrapped(func, wrapper_template, evaldict):
-    # Preserve the argspec for the wrapped function so that testing
-    # tools such as pytest can continue to use their fixture injection.
-    args, a, kw, defaults = inspect.getargspec(func)
-    values = args[-len(defaults):] if defaults else None
-
-    signature = inspect.formatargspec(args, a, kw, defaults)
-    is_bound_method = hasattr(func, '__self__')
-    if is_bound_method:
-        args = args[1:]     # Omit 'self'
-    callargs = inspect.formatargspec(args, a, kw, values,
-                                     formatvalue=lambda v: '=' + v)
-
-    ctx = {'signature': signature, 'funcargs': callargs}
-    six.exec_(wrapper_template % ctx, evaldict)
-
-    wrapper = evaldict['wrapper']
-
-    update_wrapper(wrapper, func)
-    if is_bound_method:
-        wrapper = wrapper.__get__(func.__self__, type(func.__self__))
-    return wrapper
 
 
 class CallList(Sequence, Sized):

--- a/tests/redismock.py
+++ b/tests/redismock.py
@@ -23,17 +23,9 @@ from __future__ import (
     absolute_import, print_function, division, unicode_literals
 )
 
-import six
-
-
-try:
-    from six import cStringIO as BufferIO
-except ImportError:
-    from six import StringIO as BufferIO
-
-import inspect
 from collections import namedtuple, Sequence, Sized
-from functools import update_wrapper
+
+from .smtpmock import get_wrapped
 
 Call = namedtuple('Call', ['setex', 'get'])
 
@@ -42,30 +34,6 @@ def wrapper%(signature)s:
     with redismock:
         return func%(funcargs)s
 """
-
-
-def get_wrapped(func, wrapper_template, evaldict):
-    # Preserve the argspec for the wrapped function so that testing
-    # tools such as pytest can continue to use their fixture injection.
-    args, a, kw, defaults = inspect.getargspec(func)
-    values = args[-len(defaults):] if defaults else None
-
-    signature = inspect.formatargspec(args, a, kw, defaults)
-    is_bound_method = hasattr(func, '__self__')
-    if is_bound_method:
-        args = args[1:]     # Omit 'self'
-    callargs = inspect.formatargspec(args, a, kw, values,
-                                     formatvalue=lambda v: '=' + v)
-
-    ctx = {'signature': signature, 'funcargs': callargs}
-    six.exec_(wrapper_template % ctx, evaldict)
-
-    wrapper = evaldict['wrapper']
-
-    update_wrapper(wrapper, func)
-    if is_bound_method:
-        wrapper = wrapper.__get__(func.__self__, type(func.__self__))
-    return wrapper
 
 
 class CallList(Sequence, Sized):

--- a/tests/smppmock.py
+++ b/tests/smppmock.py
@@ -24,19 +24,10 @@ from __future__ import (
     absolute_import, print_function, division, unicode_literals
 )
 
-import six
-
-
-try:
-    from six import cStringIO as BufferIO
-except ImportError:
-    from six import StringIO as BufferIO
-
-import inspect
 from collections import namedtuple, Sequence, Sized
-from functools import update_wrapper
 from smpplib.exceptions import ConnectionError
 
+from .smtpmock import get_wrapped
 
 Call = namedtuple('Call', ['request', 'response'])
 
@@ -45,30 +36,6 @@ def wrapper%(signature)s:
     with smppmock:
         return func%(funcargs)s
 """
-
-
-def get_wrapped(func, wrapper_template, evaldict):
-    # Preserve the argspec for the wrapped function so that testing
-    # tools such as pytest can continue to use their fixture injection.
-    args, a, kw, defaults = inspect.getargspec(func)
-    values = args[-len(defaults):] if defaults else None
-
-    signature = inspect.formatargspec(args, a, kw, defaults)
-    is_bound_method = hasattr(func, '__self__')
-    if is_bound_method:
-        args = args[1:]     # Omit 'self'
-    callargs = inspect.formatargspec(args, a, kw, values,
-                                     formatvalue=lambda v: '=' + v)
-
-    ctx = {'signature': signature, 'funcargs': callargs}
-    six.exec_(wrapper_template % ctx, evaldict)
-
-    wrapper = evaldict['wrapper']
-
-    update_wrapper(wrapper, func)
-    if is_bound_method:
-        wrapper = wrapper.__get__(func.__self__, type(func.__self__))
-    return wrapper
 
 
 class CallList(Sequence, Sized):

--- a/tests/test_api_2stepinit.py
+++ b/tests/test_api_2stepinit.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import hashlib
-import json
 import binascii
 import base64
 import time
 
-from passlib.utils.pbkdf2 import pbkdf2
+from passlib.crypto.digest import pbkdf2_hmac
 
 from privacyidea.lib.utils import b32encode_and_unicode
 from privacyidea.lib.policy import set_policy, SCOPE, delete_policy
@@ -132,7 +131,8 @@ class TwoStepInitTestCase(MyApiTestCase):
             self.assertEqual(result.get("value"), True)
 
         # Check that the OTP key is what we expected it to be
-        expected_secret = pbkdf2(binascii.hexlify(server_component), client_component, 10000, 20)
+        expected_secret = pbkdf2_hmac('sha1', binascii.hexlify(server_component),
+                                      client_component, 10000, 20)
         self.assertEqual(otpkey_bin, expected_secret)
 
         with self.app.test_request_context('/token/'+ serial,
@@ -247,7 +247,8 @@ class TwoStepInitTestCase(MyApiTestCase):
         # Check serversize
         self.assertEqual(len(server_component), 33)
         # Check that the OTP key is what we expected it to be
-        expected_secret = pbkdf2(binascii.hexlify(server_component), client_component, 12345, 20)
+        expected_secret = pbkdf2_hmac('sha1', binascii.hexlify(server_component),
+                                      client_component, 12345, 20)
         self.assertEqual(otpkey_bin, expected_secret)
 
         with self.app.test_request_context('/token/'+ serial,
@@ -342,7 +343,8 @@ class TwoStepInitTestCase(MyApiTestCase):
         # Check serversize
         self.assertEqual(len(server_component), 5)
         # Check that the OTP key is what we expected it to be
-        expected_secret = pbkdf2(binascii.hexlify(server_component), client_component, 17898, 64)
+        expected_secret = pbkdf2_hmac('sha1', binascii.hexlify(server_component),
+                                      client_component, 17898, 64)
         self.assertEqual(otpkey_bin, expected_secret)
 
         with self.app.test_request_context('/token/'+ serial,
@@ -504,7 +506,8 @@ class TwoStepInitTestCase(MyApiTestCase):
             self.assertEqual(result.get("value"), True)
 
         # Check that the OTP key is what we expected it to be
-        expected_secret = pbkdf2(binascii.hexlify(server_component), client_component, 10000, 20)
+        expected_secret = pbkdf2_hmac('sha1', binascii.hexlify(server_component),
+                                      client_component, 10000, 20)
         self.assertEqual(otpkey_bin, expected_secret)
 
         with self.app.test_request_context('/token/'+ serial,
@@ -626,7 +629,8 @@ class TwoStepInitTestCase(MyApiTestCase):
         # Check serversize
         self.assertEqual(len(server_component), 33)
         # Check that the OTP key is what we expected it to be
-        expected_secret = pbkdf2(binascii.hexlify(server_component), client_component, 12345, 64)
+        expected_secret = pbkdf2_hmac('sha1', binascii.hexlify(server_component),
+                                      client_component, 12345, 64)
         self.assertEqual(otpkey_bin, expected_secret)
 
         with self.app.test_request_context('/token/'+ serial,

--- a/tests/test_api_caconnector.py
+++ b/tests/test_api_caconnector.py
@@ -120,7 +120,7 @@ class CAConnectorTestCase(MyApiTestCase):
                                            method='GET',
                                            headers={'Authorization': at_user}):
             res = self.app.full_dispatch_request()
-            self.assertEquals(res.status_code, 401)
+            self.assertEqual(res.status_code, 401)
             result = res.json.get("result")
             self.assertIn("do not have the necessary role", result["error"]["message"])
 
@@ -149,10 +149,10 @@ class CAConnectorTestCase(MyApiTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertEquals(res.status_code, 401)
+            self.assertEqual(res.status_code, 401)
             result = res.json.get("result")
             self.assertFalse(result['status'])
-            self.assertEquals(result['error']['code'], ERROR.AUTHENTICATE_MISSING_RIGHT)
+            self.assertEqual(result['error']['code'], ERROR.AUTHENTICATE_MISSING_RIGHT)
             self.assertIn("You do not have the necessary role (['admin']) to access this resource",
                           result['error']['message'])
 
@@ -163,10 +163,10 @@ class CAConnectorTestCase(MyApiTestCase):
                                            method='DELETE',
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertEquals(res.status_code, 401)
+            self.assertEqual(res.status_code, 401)
             result = res.json.get("result")
             self.assertFalse(result['status'])
-            self.assertEquals(result['error']['code'], ERROR.AUTHENTICATE_MISSING_RIGHT)
+            self.assertEqual(result['error']['code'], ERROR.AUTHENTICATE_MISSING_RIGHT)
             self.assertIn("You do not have the necessary role (['admin']) to access this resource",
                           result['error']['message'])
 

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -74,7 +74,7 @@ from privacyidea.lib.machineresolver import save_resolver
 from privacyidea.lib.machine import attach_token
 from privacyidea.lib.auth import ROLE
 import jwt
-import passlib
+from passlib.hash import pbkdf2_sha512
 from datetime import datetime, timedelta
 from dateutil.tz import tzlocal
 from privacyidea.lib.tokenclass import DATE_FORMAT
@@ -818,7 +818,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
                              {"base": default_chars,
                               "requirements": required})
 
-        policies = ["[cn]", "[1234567890]", "[[]]", "[ÄÖüß§$@³¬&()|<>€%/\]"]
+        policies = ["[cn]", "[1234567890]", "[[]]", "[ÄÖüß§$@³¬&()|<>€%/\\]"]
         for policy in policies:
             charlists_dict = generate_charlists_from_pin_policy(policy)
             self.assertEqual(charlists_dict,
@@ -1307,7 +1307,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         # and only use the last 4 characters of the username
         set_policy(name="email1",
                    scope=SCOPE.REGISTER,
-                   action="{0!s}=/.*@mydomain\..*".format(ACTION.REQUIREDEMAIL))
+                   action=r"{0!s}=/.*@mydomain\..*".format(ACTION.REQUIREDEMAIL))
         g.policy_object = PolicyClass()
         # request, that matches the policy
         req.all_data = {"email": "user@mydomain.net"}
@@ -3419,10 +3419,8 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         tokenobject = get_tokens(serial=serial)[0]
         self.assertEqual(tokenobject.token.count, 100)
         # check that we cannot authenticate with an offline value
-        self.assertTrue(passlib.hash.pbkdf2_sha512.verify("offline287082",
-                                                          response.get('1')))
-        self.assertTrue(passlib.hash.pbkdf2_sha512.verify("offline516516",
-                                                          response.get('99')))
+        self.assertTrue(pbkdf2_sha512.verify("offline287082", response.get('1')))
+        self.assertTrue(pbkdf2_sha512.verify("offline516516", response.get('99')))
         res = tokenobject.check_otp("516516") # count = 99
         self.assertEqual(res, -1)
         # check that we can authenticate online with the correct value

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -12,6 +12,7 @@ from privacyidea.lib.error import ParameterError
 import jwt
 import mock
 import datetime
+import warnings
 from privacyidea.lib.error import AuthError
 
 
@@ -75,8 +76,12 @@ class UtilsTestCase(MyApiTestCase):
                                          "resolver": "resolverX"},
                                 key=key,
                                 algorithm="RS256")
-        self.assertRaisesRegexp(AuthError, "The username hanswurst is not allowed to impersonate via JWT.",
-                                verify_auth_token, auth_token=auth_token, required_role="user")
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=DeprecationWarning)
+            self.assertRaisesRegexp(
+                AuthError,
+                "The username hanswurst is not allowed to impersonate via JWT.",
+                verify_auth_token, auth_token=auth_token, required_role="user")
 
         # A user ending with hans is not allowed
         # A user starting with hans and ending with "t" is not allowed
@@ -86,8 +91,12 @@ class UtilsTestCase(MyApiTestCase):
                                          "resolver": "resolverX"},
                                 key=key,
                                 algorithm="RS256")
-        self.assertRaisesRegexp(AuthError, "The username kleinerhans is not allowed to impersonate via JWT.",
-                                verify_auth_token, auth_token=auth_token, required_role="user")
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=DeprecationWarning)
+            self.assertRaisesRegexp(
+                AuthError,
+                "The username kleinerhans is not allowed to impersonate via JWT.",
+                verify_auth_token, auth_token=auth_token, required_role="user")
 
         # Successful authentication with dedicated user
         with mock.patch("logging.Logger.warning") as mock_log:

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -116,9 +116,9 @@ class APIMachinesTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            self.assertEquals(result["status"], True, result)
+            self.assertEqual(result["status"], True, result)
             self.assertGreaterEqual(result["value"]["added"], 1, result)
-            self.assertEquals(result['value']['deleted'], 0, result)
+            self.assertEqual(result['value']['deleted'], 0, result)
 
         # check if the options were set.
         token_obj = get_tokens(serial=serial)[0]
@@ -137,8 +137,8 @@ class APIMachinesTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            self.assertEquals(result["status"], True, result)
-            self.assertEquals(result["value"]["added"], 0, result)
+            self.assertEqual(result["status"], True, result)
+            self.assertEqual(result["value"]["added"], 0, result)
             self.assertGreaterEqual(result['value']['deleted'], 1, result)
 
         # check if the options were set.
@@ -160,9 +160,9 @@ class APIMachinesTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            self.assertEquals(result["status"], True, result)
+            self.assertEqual(result["status"], True, result)
             self.assertGreaterEqual(result["value"]["added"], 1, result)
-            self.assertEquals(result['value']['deleted'], 0, result)
+            self.assertEqual(result['value']['deleted'], 0, result)
 
         # check if the options were set.
         token_obj = get_tokens(serial=serial)[0]
@@ -193,8 +193,6 @@ class APIMachinesTestCase(MyApiTestCase):
             self.assertEqual(result["status"], True)
             self.assertEqual(len(result["value"]), 1)
             self.assertTrue(result["value"][0]["application"] == "luks")
-
-
 
     def test_99_detach_token(self):
         serial = "S1"

--- a/tests/test_api_policy.py
+++ b/tests/test_api_policy.py
@@ -12,7 +12,7 @@ class APIPolicyTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(res.json['result']['status'], res.json)
-            self.assertEquals(res.json["result"]["value"], [], res.json)
+            self.assertEqual(res.json["result"]["value"], [], res.json)
 
         # test the policy export
         # first without policies (this used to fail due to an index error)

--- a/tests/test_api_radiusserver.py
+++ b/tests/test_api_radiusserver.py
@@ -130,7 +130,7 @@ class RADIUSServerTestCase(MyApiTestCase):
                                            method='GET',
                                            headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
-            self.assertEquals(res.status_code, 401)
+            self.assertEqual(res.status_code, 401)
             result = res.json.get("result")
             self.assertIn("do not have the necessary role", result["error"]["message"])
 

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -64,7 +64,7 @@ class APIConfigTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            self.assertEquals(res.json['result']['value']['key3'], 'update',
+            self.assertEqual(res.json['result']['value']['key3'], 'update',
                               res.json)
 
     def test_03_set_and_del_default(self):
@@ -127,7 +127,7 @@ class APIConfigTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertEquals(result['value']['setPolicy pol1'], 1, res.json)
+            self.assertEqual(result['value']['setPolicy pol1'], 1, res.json)
 
         # Set a policy with a more complicated client which might interfere
         # with override client
@@ -148,7 +148,7 @@ class APIConfigTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json['result']
             self.assertTrue(result["status"], result)
-            self.assertEquals(result['value']['setPolicy pol1'], 1, result)
+            self.assertEqual(result['value']['setPolicy pol1'], 1, result)
         delete_privacyidea_config(SYSCONF.OVERRIDECLIENT)
 
         # setting policy with invalid name fails
@@ -1040,7 +1040,7 @@ class APIConfigTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertEquals(set(result["value"]), {"local", "remote"})
+            self.assertEqual(set(result["value"]), {"local", "remote"})
 
         # if an admin policy is defined and enrollRADIUS is not allowed, admins cannot access the RADIUS servers
         set_policy("admin", scope=SCOPE.ADMIN, action=ACTION.AUDIT)
@@ -1060,7 +1060,7 @@ class APIConfigTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertEquals(set(result["value"]), {"local", "remote"})
+            self.assertEqual(set(result["value"]), {"local", "remote"})
 
         self.setUp_user_realms()
         self.authenticate_selfservice_user()
@@ -1072,7 +1072,7 @@ class APIConfigTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertEquals(set(result["value"]), {"local", "remote"})
+            self.assertEqual(set(result["value"]), {"local", "remote"})
 
         # if a user policy is defined and enrollRADIUS is not allowed, users cannot access the RADIUS servers
         set_policy("user", scope=SCOPE.USER, action=ACTION.AUDIT)
@@ -1092,7 +1092,7 @@ class APIConfigTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             result = json.loads(res.data.decode('utf8')).get("result")
-            self.assertEquals(set(result["value"]), {"local", "remote"})
+            self.assertEqual(set(result["value"]), {"local", "remote"})
 
         delete_policy("user")
         delete_policy("admin")

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -644,9 +644,9 @@ class APITokenTestCase(MyApiTestCase):
                                                  'success': '0'},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            self.assertEquals(res.status_code, 200, res)
-            self.assertEquals(len(res.json['result']['value']['auditdata']), 1, res.json)
-            self.assertEquals(res.json['result']['value']['auditdata'][0]['success'], 0, res.json)
+            self.assertEqual(res.status_code, 200, res)
+            self.assertEqual(len(res.json['result']['value']['auditdata']), 1, res.json)
+            self.assertEqual(res.json['result']['value']['auditdata'][0]['success'], 0, res.json)
 
         # Successful resync with consecutive values
         with self.app.test_request_context('/token/resync',
@@ -668,9 +668,9 @@ class APITokenTestCase(MyApiTestCase):
                                                  'success': '1'},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            self.assertEquals(res.status_code, 200, res)
-            self.assertEquals(len(res.json['result']['value']['auditdata']), 1, res.json)
-            self.assertEquals(res.json['result']['value']['auditdata'][0]['success'], 1, res.json)
+            self.assertEqual(res.status_code, 200, res)
+            self.assertEqual(len(res.json['result']['value']['auditdata']), 1, res.json)
+            self.assertEqual(res.json['result']['value']['auditdata'][0]['success'], 1, res.json)
 
         # Get the OTP token and inspect the counter
         with self.app.test_request_context('/token/',
@@ -1585,7 +1585,11 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(value.get("count") == 1, result)
 
             tokeninfo = token.get("info")
-            self.assertDictContainsSubset({'key1': 'value 1', 'key2': 'value 2'}, tokeninfo)
+            test_dict = {'key1': 'value 1', 'key2': 'value 2'}
+            try:
+                self.assertTrue(test_dict.viewitems() <= tokeninfo.viewitems())
+            except AttributeError:
+                self.assertTrue(test_dict.items() <= tokeninfo.items())
 
         # Overwrite an existing tokeninfo value
         with self.app.test_request_context('/token/info/INF001/key1',
@@ -1610,7 +1614,11 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(value.get("count") == 1, result)
 
             tokeninfo = token.get("info")
-            self.assertDictContainsSubset({'key1': 'value 1 new', 'key2': 'value 2'}, tokeninfo)
+            test_dict = {'key1': 'value 1 new', 'key2': 'value 2'}
+            try:
+                self.assertTrue(test_dict.viewitems() <= tokeninfo.viewitems())
+            except AttributeError:
+                self.assertTrue(test_dict.items() <= tokeninfo.items())
 
         # Delete an existing tokeninfo value
         with self.app.test_request_context('/token/info/INF001/key1',
@@ -1653,7 +1661,10 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(value.get("count") == 1, result)
 
             tokeninfo = token.get("info")
-            self.assertDictContainsSubset({'key2': 'value 2'}, tokeninfo)
+            try:
+                self.assertTrue({'key2': 'value 2'}.viewitems() <= tokeninfo.viewitems())
+            except AttributeError:
+                self.assertTrue({'key2': 'value 2'}.items() <= tokeninfo.items())
             self.assertNotIn('key1', tokeninfo)
 
     def test_25_user_init_defaults(self):

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -45,7 +45,7 @@ class APIUsersTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(res.json['result']['status'], res.json)
-            self.assertEquals(res.json['result']['value'], 1, res.json)
+            self.assertEqual(res.json['result']['value'], 1, res.json)
         
         # create realm
         realm = u"realm1"

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1085,7 +1085,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
+            self.assertEqual(result['value']['setPolicy pol_chal_resp'], 1, result)
 
         # create the challenge by authenticating with the OTP PIN
         with self.app.test_request_context('/validate/check',
@@ -1154,7 +1154,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
+            self.assertEqual(result['value']['setPolicy pol_chal_resp'], 1, result)
 
         # create the challenge by authenticating with the OTP PIN
         with self.app.test_request_context('/validate/check',
@@ -1188,7 +1188,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
+            self.assertEqual(result['value']['setPolicy pol_chal_resp'], 1, result)
 
         chalresp_serials = ["CHALRESP1", "CHALRESP2"]
         chalresp_pins = ["chalresp1", "chalresp2"]
@@ -1381,7 +1381,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
+            self.assertEqual(result['value']['setPolicy pol_chal_resp'], 1, result)
 
         serial = "CHALRESP2"
         pin = "chalresp2"
@@ -1440,7 +1440,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result["status"] is True, result)
-            self.assertEquals(result['value']['setPolicy pol_chal_resp'], 1, result)
+            self.assertEqual(result['value']['setPolicy pol_chal_resp'], 1, result)
 
         serial = "CHALRESP3"
         pin = "chalresp3"

--- a/tests/test_lib_framework.py
+++ b/tests/test_lib_framework.py
@@ -30,7 +30,7 @@ class FrameworkTestCase(MyTestCase):
             self.assertNotIn("test_flag", g)
             g.test_flag = False
 
-        self.assertEquals(g.test_flag, True)
+        self.assertEqual(g.test_flag, True)
         g.pop("test_flag")
 
         # We get a different store if we push a context for another app

--- a/tests/test_lib_machinetokens.py
+++ b/tests/test_lib_machinetokens.py
@@ -130,7 +130,7 @@ class MachineTokenTestCase(MyTestCase):
         # fetch the auth_items for application SSH on machine gandalf
         ai = get_auth_items("gandalf", ip="192.168.0.1", application="ssh")
         sshkey_auth_items = ai.get("ssh")
-        self.assertEquals(len(sshkey_auth_items), 1)
+        self.assertEqual(len(sshkey_auth_items), 1)
         self.assertTrue(sshkey_auth_items[0].get("sshkey").startswith(
             "ssh-rsa"))
 
@@ -138,7 +138,7 @@ class MachineTokenTestCase(MyTestCase):
         ai = get_auth_items("gandalf", ip="192.168.0.1", application="ssh",
                             filter_param={"user": "testuser"})
         sshkey_auth_items = ai.get("ssh")
-        self.assertEquals(len(sshkey_auth_items), 1)
+        self.assertEqual(len(sshkey_auth_items), 1)
         self.assertTrue(sshkey_auth_items[0].get("sshkey").startswith(
             "ssh-rsa"))
 

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -468,22 +468,22 @@ class HttpSMSTestCase(MyTestCase):
         self.assertEqual("4912345678", p)
 
         # Replace + with 00
-        p = HttpSMSProvider._mangle_phone("+49 123/456-78", {"REGEXP": "/\+/00/"})
+        p = HttpSMSProvider._mangle_phone("+49 123/456-78", {"REGEXP": r"/\+/00/"})
         self.assertEqual("0049 123/456-78", p)
-        p = self.regexp_provider._mangle_phone("+49 123/456-78", {"REGEXP": "/[\+/]//"})
+        p = self.regexp_provider._mangle_phone("+49 123/456-78", {"REGEXP": r"/[\+/]//"})
         self.assertEqual("49 123456-78", p)
 
         # An invalid regexp is caught and a log error is written. The same
         # phone number is returned
-        p = HttpSMSProvider._mangle_phone("+49 123/456-78", {"REGEXP": "/+/00/"})
+        p = HttpSMSProvider._mangle_phone("+49 123/456-78", {"REGEXP": r"/+/00/"})
         self.assertEqual("+49 123/456-78", p)
 
         # Only use leading numbers and not the rest
-        p = HttpSMSProvider._mangle_phone("12345abcdef", {"REGEXP":  "/^([0-9]+).*/\\1/"})
+        p = HttpSMSProvider._mangle_phone("12345abcdef", {"REGEXP":  r"/^([0-9]+).*/\1/"})
         self.assertEqual("12345", p)
 
         # Known limitation: The slash in the replace statement does not work!
-        p = HttpSMSProvider._mangle_phone("12.34.56.78", {"REGEXP": "/\./\//"})
+        p = HttpSMSProvider._mangle_phone("12.34.56.78", {"REGEXP": r"/\./\//"})
         self.assertEqual("12.34.56.78", p)
 
     @responses.activate

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -1438,37 +1438,37 @@ class TokenTestCase(MyTestCase):
             return [token.token.id for l2 in l for token in l2]
 
         # serial72 token has invalid type. Check behavior and remove it.
-        self.assertEquals(list(get_tokens_paginated_generator(serial_wildcard="serial*")), [[]])
+        self.assertEqual(list(get_tokens_paginated_generator(serial_wildcard="serial*")), [[]])
         Token.query.filter_by(serial="serial72").delete()
 
         all_matching_tokens = get_tokens(serial_wildcard="S*")
         lists1 = list(get_tokens_paginated_generator(serial_wildcard="S*"))
-        self.assertEquals(len(lists1), 1)
-        self.assertEquals(len(lists1[0]), 6)
+        self.assertEqual(len(lists1), 1)
+        self.assertEqual(len(lists1[0]), 6)
         lists2 = list(get_tokens_paginated_generator(serial_wildcard="S*", psize=2))
-        self.assertEquals(len(lists2), 3)
-        self.assertEquals(len(lists2[0]), 2)
-        self.assertEquals(len(lists2[1]), 2)
-        self.assertEquals(len(lists2[2]), 2)
+        self.assertEqual(len(lists2), 3)
+        self.assertEqual(len(lists2[0]), 2)
+        self.assertEqual(len(lists2[1]), 2)
+        self.assertEqual(len(lists2[2]), 2)
         lists3 = list(get_tokens_paginated_generator(serial_wildcard="S*", psize=3))
-        self.assertEquals(len(lists3), 2)
-        self.assertEquals(len(lists3[0]), 3)
-        self.assertEquals(len(lists3[1]), 3)
+        self.assertEqual(len(lists3), 2)
+        self.assertEqual(len(lists3[0]), 3)
+        self.assertEqual(len(lists3[1]), 3)
         lists4 = list(get_tokens_paginated_generator(serial_wildcard="S*", psize=4))
-        self.assertEquals(len(lists4), 2)
-        self.assertEquals(len(lists4[0]), 4)
-        self.assertEquals(len(lists4[1]), 2)
+        self.assertEqual(len(lists4), 2)
+        self.assertEqual(len(lists4[0]), 4)
+        self.assertEqual(len(lists4[1]), 2)
         lists5 = list(get_tokens_paginated_generator(serial_wildcard="S*", psize=6))
-        self.assertEquals(len(lists5), 1)
-        self.assertEquals(len(lists5[0]), 6)
-        self.assertEquals(set([t.token.id for t in all_matching_tokens]), set(flatten_tokens(lists1)))
-        self.assertEquals(flatten_tokens(lists1), flatten_tokens(lists2))
-        self.assertEquals(flatten_tokens(lists2), flatten_tokens(lists3))
-        self.assertEquals(flatten_tokens(lists3), flatten_tokens(lists4))
-        self.assertEquals(flatten_tokens(lists4), flatten_tokens(lists5))
+        self.assertEqual(len(lists5), 1)
+        self.assertEqual(len(lists5[0]), 6)
+        self.assertEqual(set([t.token.id for t in all_matching_tokens]), set(flatten_tokens(lists1)))
+        self.assertEqual(flatten_tokens(lists1), flatten_tokens(lists2))
+        self.assertEqual(flatten_tokens(lists2), flatten_tokens(lists3))
+        self.assertEqual(flatten_tokens(lists3), flatten_tokens(lists4))
+        self.assertEqual(flatten_tokens(lists4), flatten_tokens(lists5))
 
         lists6 = list(get_tokens_paginated_generator(serial_wildcard="*DOESNOTEXIST*"))
-        self.assertEquals(lists6, [])
+        self.assertEqual(lists6, [])
 
     def test_56_get_tokens_paginated_generator_removal(self):
         all_serials = set(t.token.serial for t in get_tokens(serial_wildcard="S*"))
@@ -1478,7 +1478,7 @@ class TokenTestCase(MyTestCase):
         remove_token(list1[0].token.serial)
         list2 = next(gen)
         # Check that we did not miss any tokens
-        self.assertEquals(set(t.token.serial for t in list1 + list2), all_serials)
+        self.assertEqual(set(t.token.serial for t in list1 + list2), all_serials)
 
     def test_0057_check_invalid_serial(self):
         # This is an invalid serial, which will trigger an exception

--- a/tests/test_lib_tokens_daplug.py
+++ b/tests/test_lib_tokens_daplug.py
@@ -326,10 +326,10 @@ class DaplugTokenTestCase(MyTestCase):
                       "pin": "test",
                       "otplen": 6})
         # OTP does not exist
-        self.assertEquals(token.check_otp_exist(_digi2daplug("222333")), -1)
+        self.assertEqual(token.check_otp_exist(_digi2daplug("222333")), -1)
         # OTP does exist
         res = token.check_otp_exist(_digi2daplug("969429"))
-        self.assertEquals(res, 3, res)
+        self.assertEqual(res, 3, res)
 
     def test_14_split_pin_pass(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -577,7 +577,7 @@ class PushTokenTestCase(MyTestCase):
                                            data={"serial": tokenobj.token.serial,
                                                  "nonce": challenge}):
             res = self.app.full_dispatch_request()
-            self.assertEquals(res.status_code, 400)
+            self.assertEqual(res.status_code, 400)
 
         # This is what the smartphone answers.
         # create the signature:

--- a/tests/test_lib_tokens_radius.py
+++ b/tests/test_lib_tokens_radius.py
@@ -14,7 +14,7 @@ from . import radiusmock
 from privacyidea.lib.token import init_token
 from privacyidea.lib.radiusserver import add_radius
 
-DICT_FILE="tests/testdata/dictionary"
+DICT_FILE = "tests/testdata/dictionary"
 
 
 class RadiusTokenTestCase(MyTestCase):
@@ -34,26 +34,6 @@ class RadiusTokenTestCase(MyTestCase):
                "radius.dictfile": "tests/testdata/dictfile"}
     serial3 = "serial3"
     params3 = {"radius.server": "my.other.radiusserver:1812"}
-
-    success_body = {"detail": {"message": "matching 1 tokens",
-                               "serial": "PISP0000AB00",
-                               "type": "spass"},
-                    "id": 1,
-                    "jsonrpc": "2.0",
-                    "result": {"status": True,
-                               "value": True
-                    },
-                    "version": "privacyIDEA unknown"
-    }
-
-    fail_body = {"detail": {"message": "wrong otp value"},
-                    "id": 1,
-                    "jsonrpc": "2.0",
-                    "result": {"status": True,
-                               "value": False
-                    },
-                    "version": "privacyIDEA unknown"
-    }
 
     def test_01_create_token(self):
         db_token = Token(self.serial3, tokentype="radius")
@@ -242,7 +222,8 @@ class RadiusTokenTestCase(MyTestCase):
 
         # Now check, if the answer for the challenge is correct
         radiusmock.setdata(response=radiusmock.AccessAccept)
-        r = token.check_challenge_response(passw="radiuscode",options={"transaction_id": transaction_id})
+        r = token.check_challenge_response(passw="radiuscode",
+                                           options={"transaction_id": transaction_id})
         self.assertTrue(r)
 
     @radiusmock.activate
@@ -289,12 +270,14 @@ class RadiusTokenTestCase(MyTestCase):
 
         # Check what happens if the RADIUS server rejects the response
         radiusmock.setdata(timeout=False, response=radiusmock.AccessReject)
-        r = token.check_challenge_response(passw="some_response", options={"transaction_id": transaction_id})
+        r = token.check_challenge_response(passw="some_response",
+                                           options={"transaction_id": transaction_id})
         self.assertLess(r, 0)
 
         # Now checking the response to the challenge and we issue a RADIUS request
         radiusmock.setdata(timeout=False, response=radiusmock.AccessAccept)
-        r = token.check_challenge_response(passw="some_response", options={"transaction_id": transaction_id})
+        r = token.check_challenge_response(passw="some_response",
+                                           options={"transaction_id": transaction_id})
         self.assertGreaterEqual(r, 0)
 
     @radiusmock.activate
@@ -339,8 +322,8 @@ class RadiusTokenTestCase(MyTestCase):
         # Now checking the response to the challenge and we issue a RADIUS request
         # But the RADIUS server answers with a second AccessChallenge
         radiusmock.setdata(timeout=False, response=radiusmock.AccessChallenge,
-                                              response_data={"State": state2,
-                                                             "Reply_Message": ["Please provide even more information."]})
+                           response_data={"State": state2,
+                                          "Reply_Message": ["Please provide even more information."]})
         opts2 = {"transaction_id": transaction_id}
         r = token.check_challenge_response(passw="some_response", options=opts2)
         # The answer might be correct, but since the RADIUS server want to get more answers, we get a -1

--- a/tests/test_lib_tokens_u2f.py
+++ b/tests/test_lib_tokens_u2f.py
@@ -265,8 +265,8 @@ class U2FTokenTestCase(MyTestCase):
 
         # decode valid signature
         sig_bin = der_decode(sig_der_bin)
-        self.assertEquals(sig_bin[:32], r)
-        self.assertEquals(sig_bin[32:], s)
+        self.assertEqual(sig_bin[:32], r)
+        self.assertEqual(sig_bin[32:], s)
 
         # decode broken signature
         broken_sig_hex = '304502207f3e632dc9fd607aa9e04c9130f1ddff0d44cf3f2dc3' \

--- a/tests/test_lib_usercache.py
+++ b/tests/test_lib_usercache.py
@@ -12,14 +12,13 @@ from privacyidea.lib.error import UserError
 from tests import ldap3mock
 from tests.test_mock_ldap3 import LDAPDirectory
 from .base import MyTestCase
-from privacyidea.lib.resolvers.LDAPIdResolver import IdResolver as LDAPResolver
 from privacyidea.lib.resolver import (save_resolver, delete_resolver, get_resolver_object)
 from privacyidea.lib.realm import (set_realm, delete_realm)
 from privacyidea.lib.user import (User, get_username, create_user)
 from privacyidea.lib.usercache import (get_cache_time,
                                        cache_username, delete_user_cache,
                                        EXPIRATION_SECONDS, retrieve_latest_entry, is_cache_enabled)
-from privacyidea.lib.config import set_privacyidea_config, get_from_config
+from privacyidea.lib.config import set_privacyidea_config
 from datetime import timedelta
 from datetime import datetime
 from privacyidea.models import UserCache
@@ -223,7 +222,7 @@ class UserCacheTestCase(MyTestCase):
         UserCache("hans1", "hans1", "resolver1", "uid1", now).save()
 
         r = UserCache.query.filter(UserCache.username == "hans1", UserCache.resolver == "resolver1")
-        self.assertEquals(r.count(), 2)
+        self.assertEqual(r.count(), 2)
 
         u_name = get_username("uid1", "resolver1")
         self.assertEqual(u_name, "hans1")
@@ -235,7 +234,7 @@ class UserCacheTestCase(MyTestCase):
         UserCache("hans1", "hans1", "resolver1", "uid1", now - timedelta(seconds=60)).save()
 
         r = UserCache.query.filter(UserCache.user_id == "uid1", UserCache.resolver == "resolver1")
-        self.assertEquals(r.count(), 2)
+        self.assertEqual(r.count(), 2)
 
         u_name = get_username("uid1", "resolver1")
         self.assertEqual(u_name, "hans2")
@@ -246,7 +245,7 @@ class UserCacheTestCase(MyTestCase):
     def test_06_implicit_cache_population(self):
         self._create_realm()
         # testing `get_username`
-        self.assertEquals(UserCache.query.count(), 0)
+        self.assertEqual(UserCache.query.count(), 0)
         # the cache is empty, so the username is read from the resolver
         u_name = get_username(self.uid, self.resolvername1)
         self.assertEqual(self.username, u_name)
@@ -258,7 +257,7 @@ class UserCacheTestCase(MyTestCase):
         r = delete_user_cache()
 
         # testing `User()`, but this time we add an already-expired entry to the cache
-        self.assertEquals(UserCache.query.count(), 0)
+        self.assertEqual(UserCache.query.count(), 0)
         UserCache(self.username, self.username,
                   self.resolvername1, 'fake_uid', datetime.now() - timedelta(weeks=50)).save()
         # cache contains an expired entry, uid is read from the resolver (we can verify
@@ -275,13 +274,13 @@ class UserCacheTestCase(MyTestCase):
         self._delete_realm()
 
     def _populate_cache(self):
-        self.assertEquals(UserCache.query.count(), 0)
+        self.assertEqual(UserCache.query.count(), 0)
         # initially populate the cache with three entries
         timestamp = datetime.now()
         UserCache("hans1", "hans1", self.resolvername1, "uid1", timestamp).save()
         UserCache("hans2", "hans2", self.resolvername1, "uid2", timestamp - timedelta(weeks=50)).save()
         UserCache("hans3", "hans3", "resolver2", "uid2", timestamp).save()
-        self.assertEquals(UserCache.query.count(), 3)
+        self.assertEqual(UserCache.query.count(), 3)
 
     def test_07_invalidate_save_resolver(self):
         self._create_realm()
@@ -294,12 +293,12 @@ class UserCacheTestCase(MyTestCase):
              "type.fileName": "string",
              "desc.fileName": "Some change"
         })
-        self.assertEquals(UserCache.query.count(), 1)
+        self.assertEqual(UserCache.query.count(), 1)
         # Only hans3 in resolver2 should still be in the cache
         # We can use get_username to ensure it is fetched from the cache
         # because resolver2 does not actually exist
         u_name = get_username("uid2", "resolver2")
-        self.assertEquals("hans3", u_name)
+        self.assertEqual("hans3", u_name)
         delete_user_cache()
         self._delete_realm()
 
@@ -308,10 +307,10 @@ class UserCacheTestCase(MyTestCase):
         self._populate_cache()
         # call delete_resolver on resolver1, which should invalidate all of its entries
         self._delete_realm()
-        self.assertEquals(UserCache.query.count(), 1)
+        self.assertEqual(UserCache.query.count(), 1)
         # Only hans3 in resolver2 should still be in the cache
         u_name = get_username("uid2", "resolver2")
-        self.assertEquals("hans3", u_name)
+        self.assertEqual("hans3", u_name)
         delete_user_cache()
 
     def _create_sql_realm(self):
@@ -330,10 +329,10 @@ class UserCacheTestCase(MyTestCase):
         # Validate that editing users actually invalidates the cache. For that, we first need an editable resolver
         self._create_sql_realm()
         # The cache is initially empty
-        self.assertEquals(UserCache.query.count(), 0)
+        self.assertEqual(UserCache.query.count(), 0)
         # The following adds an entry to the cache
         user = User(login="wordpressuser", realm=self.sql_realm)
-        self.assertEquals(UserCache.query.count(), 1)
+        self.assertEqual(UserCache.query.count(), 1)
         uinfo = user.info
         self.assertEqual(uinfo.get("givenname", ""), "")
 
@@ -356,10 +355,10 @@ class UserCacheTestCase(MyTestCase):
         # Validate that deleting users actually invalidates the cache. For that, we first need an editable resolver
         self._create_sql_realm()
         # The cache is initially empty
-        self.assertEquals(UserCache.query.count(), 0)
+        self.assertEqual(UserCache.query.count(), 0)
         # The following adds an entry to the cache
         user = User(login="wordpressuser", realm=self.sql_realm)
-        self.assertEquals(UserCache.query.count(), 1)
+        self.assertEqual(UserCache.query.count(), 1)
         uinfo = user.info
         user.delete()
         # This should have removed the entry from the cache
@@ -553,48 +552,48 @@ class TestUserCacheMultipleLoginAttributes(MyTestCase):
         self._create_ldap_realm()
         # Populate the user cache, check its contents
         user1 = User('alice', self.ldap_realm)
-        self.assertEquals(user1.resolver, self.ldap_resolver)
-        self.assertEquals(user1.uid, "cn=alice,ou=example,o=test")
-        self.assertEquals(user1.login, "alice")
-        self.assertEquals(user1.used_login, "alice")
+        self.assertEqual(user1.resolver, self.ldap_resolver)
+        self.assertEqual(user1.uid, "cn=alice,ou=example,o=test")
+        self.assertEqual(user1.login, "alice")
+        self.assertEqual(user1.used_login, "alice")
         entry = UserCache.query.one()
-        self.assertEquals(entry.user_id, user1.uid)
-        self.assertEquals(entry.used_login, "alice")
-        self.assertEquals(entry.username, "alice")
-        self.assertEquals(entry.resolver, self.ldap_resolver)
+        self.assertEqual(entry.user_id, user1.uid)
+        self.assertEqual(entry.used_login, "alice")
+        self.assertEqual(entry.username, "alice")
+        self.assertEqual(entry.resolver, self.ldap_resolver)
         # query again, user cache does not change
         user2 = User('alice', self.ldap_realm)
-        self.assertEquals(user2.resolver, self.ldap_resolver)
-        self.assertEquals(user2.uid, "cn=alice,ou=example,o=test")
-        self.assertEquals(user2.login, "alice")
-        self.assertEquals(user2.used_login, "alice")
-        self.assertEquals(UserCache.query.count(), 1)
+        self.assertEqual(user2.resolver, self.ldap_resolver)
+        self.assertEqual(user2.uid, "cn=alice,ou=example,o=test")
+        self.assertEqual(user2.login, "alice")
+        self.assertEqual(user2.used_login, "alice")
+        self.assertEqual(UserCache.query.count(), 1)
         # use secondary login attribute, usercache has a new entry with secondary login attribute
         user3 = User('alice@test.com', self.ldap_realm)
-        self.assertEquals(user3.resolver, self.ldap_resolver)
-        self.assertEquals(user3.uid, "cn=alice,ou=example,o=test")
-        self.assertEquals(user3.login, "alice")
-        self.assertEquals(user3.used_login, "alice@test.com")
+        self.assertEqual(user3.resolver, self.ldap_resolver)
+        self.assertEqual(user3.uid, "cn=alice,ou=example,o=test")
+        self.assertEqual(user3.login, "alice")
+        self.assertEqual(user3.used_login, "alice@test.com")
         entries = UserCache.query.filter_by(user_id="cn=alice,ou=example,o=test").order_by(UserCache.id).all()
-        self.assertEquals(len(entries), 2)
+        self.assertEqual(len(entries), 2)
         entry = entries[-1]
-        self.assertEquals(entry.user_id, user1.uid)
-        self.assertEquals(entry.used_login, "alice@test.com")
-        self.assertEquals(entry.username, "alice")
-        self.assertEquals(entry.resolver, self.ldap_resolver)
+        self.assertEqual(entry.user_id, user1.uid)
+        self.assertEqual(entry.used_login, "alice@test.com")
+        self.assertEqual(entry.username, "alice")
+        self.assertEqual(entry.resolver, self.ldap_resolver)
         # use secondary login attribute again, login name is fetched correctly
         user4 = User('alice@test.com', self.ldap_realm)
-        self.assertEquals(user4.resolver, self.ldap_resolver)
-        self.assertEquals(user4.uid, "cn=alice,ou=example,o=test")
-        self.assertEquals(user4.login, "alice")
-        self.assertEquals(user4.used_login, "alice@test.com")
+        self.assertEqual(user4.resolver, self.ldap_resolver)
+        self.assertEqual(user4.uid, "cn=alice,ou=example,o=test")
+        self.assertEqual(user4.login, "alice")
+        self.assertEqual(user4.used_login, "alice@test.com")
         # still only two entries in the cache
         entries = UserCache.query.filter_by(user_id="cn=alice,ou=example,o=test").order_by(UserCache.id).all()
-        self.assertEquals(len(entries), 2)
+        self.assertEqual(len(entries), 2)
         # get the primary login name
         login_name = get_username("cn=alice,ou=example,o=test", self.ldap_resolver)
-        self.assertEquals(login_name, "alice")
+        self.assertEqual(login_name, "alice")
         # still only two entries in the cache
         entries = UserCache.query.filter_by(user_id="cn=alice,ou=example,o=test").order_by(UserCache.id).all()
-        self.assertEquals(len(entries), 2)
+        self.assertEqual(len(entries), 2)
         self._delete_ldap_realm()

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -754,40 +754,40 @@ class UtilsTestCase(MyTestCase):
     def test_25_encodings(self):
         u = u'Hello Wörld'
         b = b'Hello World'
-        self.assertEquals(to_utf8(None), None)
-        self.assertEquals(to_utf8(u), u.encode('utf8'))
-        self.assertEquals(to_utf8(b), b)
+        self.assertEqual(to_utf8(None), None)
+        self.assertEqual(to_utf8(u), u.encode('utf8'))
+        self.assertEqual(to_utf8(b), b)
 
-        self.assertEquals(to_unicode(u), u)
-        self.assertEquals(to_unicode(b), b.decode('utf8'))
-        self.assertEquals(to_unicode(None), None)
-        self.assertEquals(to_unicode(10), 10)
+        self.assertEqual(to_unicode(u), u)
+        self.assertEqual(to_unicode(b), b.decode('utf8'))
+        self.assertEqual(to_unicode(None), None)
+        self.assertEqual(to_unicode(10), 10)
 
-        self.assertEquals(to_bytes(u), u.encode('utf8'))
-        self.assertEquals(to_bytes(b), b)
-        self.assertEquals(to_bytes(10), 10)
+        self.assertEqual(to_bytes(u), u.encode('utf8'))
+        self.assertEqual(to_bytes(b), b)
+        self.assertEqual(to_bytes(10), 10)
 
-        self.assertEquals(to_byte_string(u), u.encode('utf8'))
-        self.assertEquals(to_byte_string(b), b)
-        self.assertEquals(to_byte_string(10), b'10')
+        self.assertEqual(to_byte_string(u), u.encode('utf8'))
+        self.assertEqual(to_byte_string(b), b)
+        self.assertEqual(to_byte_string(10), b'10')
 
     def test_26_conversions(self):
-        self.assertEquals(hexlify_and_unicode(u'Hallo'), u'48616c6c6f')
-        self.assertEquals(hexlify_and_unicode(b'Hallo'), u'48616c6c6f')
-        self.assertEquals(hexlify_and_unicode(b'\x00\x01\x02\xab'), u'000102ab')
+        self.assertEqual(hexlify_and_unicode(u'Hallo'), u'48616c6c6f')
+        self.assertEqual(hexlify_and_unicode(b'Hallo'), u'48616c6c6f')
+        self.assertEqual(hexlify_and_unicode(b'\x00\x01\x02\xab'), u'000102ab')
 
-        self.assertEquals(b32encode_and_unicode(u'Hallo'), u'JBQWY3DP')
-        self.assertEquals(b32encode_and_unicode(b'Hallo'), u'JBQWY3DP')
-        self.assertEquals(b32encode_and_unicode(b'\x00\x01\x02\xab'), u'AAAQFKY=')
+        self.assertEqual(b32encode_and_unicode(u'Hallo'), u'JBQWY3DP')
+        self.assertEqual(b32encode_and_unicode(b'Hallo'), u'JBQWY3DP')
+        self.assertEqual(b32encode_and_unicode(b'\x00\x01\x02\xab'), u'AAAQFKY=')
 
-        self.assertEquals(b64encode_and_unicode(u'Hallo'), u'SGFsbG8=')
-        self.assertEquals(b64encode_and_unicode(b'Hallo'), u'SGFsbG8=')
-        self.assertEquals(b64encode_and_unicode(b'\x00\x01\x02\xab'), u'AAECqw==')
+        self.assertEqual(b64encode_and_unicode(u'Hallo'), u'SGFsbG8=')
+        self.assertEqual(b64encode_and_unicode(b'Hallo'), u'SGFsbG8=')
+        self.assertEqual(b64encode_and_unicode(b'\x00\x01\x02\xab'), u'AAECqw==')
 
-        self.assertEquals(urlsafe_b64encode_and_unicode(u'Hallo'), u'SGFsbG8=')
-        self.assertEquals(urlsafe_b64encode_and_unicode(b'Hallo'), u'SGFsbG8=')
-        self.assertEquals(urlsafe_b64encode_and_unicode(b'\x00\x01\x02\xab'), u'AAECqw==')
-        self.assertEquals(urlsafe_b64encode_and_unicode(b'\xfa\xfb\xfc\xfd\xfe\xff'),
+        self.assertEqual(urlsafe_b64encode_and_unicode(u'Hallo'), u'SGFsbG8=')
+        self.assertEqual(urlsafe_b64encode_and_unicode(b'Hallo'), u'SGFsbG8=')
+        self.assertEqual(urlsafe_b64encode_and_unicode(b'\x00\x01\x02\xab'), u'AAECqw==')
+        self.assertEqual(urlsafe_b64encode_and_unicode(b'\xfa\xfb\xfc\xfd\xfe\xff'),
                           u'-vv8_f7_')
 
     def test_27_images(self):
@@ -801,28 +801,28 @@ class UtilsTestCase(MyTestCase):
                   u'kJ6u7UYKZ7fE1Z3mq5phmJ1DMLYrcPL9/J6VII7oEkKclaH1dR6CsB6wPkvWU' \
                   u'JH8LuvZI1Qw5CMgg8hmRzyOEq7nPWZCa+3uY9rWpZsi+r12O+pVjwojKTOP/a' \
                   u'51yyimn9kL9ACOsApMnN2KuAAAAAElFTkSuQmCC'
-        self.assertEquals(b64encode_and_unicode(create_png('Hallo')), png_b64)
-        self.assertEquals(create_img('Hello', raw=True),
+        self.assertEqual(b64encode_and_unicode(create_png('Hallo')), png_b64)
+        self.assertEqual(create_img('Hello', raw=True),
                           u'data:image/png;base64,SGVsbG8=')
-        self.assertEquals(create_img('Hallo'),
+        self.assertEqual(create_img('Hallo'),
                           u'data:image/png;base64,{0!s}'.format(png_b64))
 
     def test_28_yubikey_utils(self):
-        self.assertEquals(modhex_encode(b'\x47'), 'fi')
-        self.assertEquals(modhex_encode(b'\xba\xad\xf0\x0d'), 'nlltvcct')
-        self.assertEquals(modhex_encode(binascii.unhexlify('0123456789abcdef')),
+        self.assertEqual(modhex_encode(b'\x47'), 'fi')
+        self.assertEqual(modhex_encode(b'\xba\xad\xf0\x0d'), 'nlltvcct')
+        self.assertEqual(modhex_encode(binascii.unhexlify('0123456789abcdef')),
                           'cbdefghijklnrtuv')
-        self.assertEquals(modhex_encode('Hallo'), 'fjhbhrhrhv')
+        self.assertEqual(modhex_encode('Hallo'), 'fjhbhrhrhv')
         # and the other way around
-        self.assertEquals(modhex_decode('fi'), b'\x47')
-        self.assertEquals(modhex_decode('nlltvcct'), b'\xba\xad\xf0\x0d')
-        self.assertEquals(modhex_decode('cbdefghijklnrtuv'),
+        self.assertEqual(modhex_decode('fi'), b'\x47')
+        self.assertEqual(modhex_decode('nlltvcct'), b'\xba\xad\xf0\x0d')
+        self.assertEqual(modhex_decode('cbdefghijklnrtuv'),
                           binascii.unhexlify('0123456789abcdef'))
-        self.assertEquals(modhex_decode('fjhbhrhrhv'), b'Hallo')
+        self.assertEqual(modhex_decode('fjhbhrhrhv'), b'Hallo')
 
         # now test the crc function
-        self.assertEquals(checksum(b'\x01\x02\x03\x04'), 0xc66e)
-        self.assertEquals(checksum(b'\x01\x02\x03\x04\x919'), 0xf0b8)
+        self.assertEqual(checksum(b'\x01\x02\x03\x04'), 0xc66e)
+        self.assertEqual(checksum(b'\x01\x02\x03\x04\x919'), 0xf0b8)
 
     def test_29_check_ip(self):
         found, excluded = check_ip_in_policy("10.0.1.2", ["10.0.1.0/24", "1.1.1.1"])

--- a/tests/test_lib_utils_compare.py
+++ b/tests/test_lib_utils_compare.py
@@ -60,21 +60,21 @@ class UtilsCompareTestCase(MyTestCase):
                                         "uid=[^,]+,cn=admins,dc=test,dc=intranet"))
 
     def test_05_parse_comma_separated_string(self):
-        self.assertEquals(parse_comma_separated_string("hello world"), ["hello world"])
+        self.assertEqual(parse_comma_separated_string("hello world"), ["hello world"])
         # whitespace immediately following a delimiter is skipped
-        self.assertEquals(parse_comma_separated_string("realm1,     realm2,realm3"),
+        self.assertEqual(parse_comma_separated_string("realm1,     realm2,realm3"),
                           ["realm1", "realm2", "realm3"])
         # whitespace before delimiters is not skipped
-        self.assertEquals(parse_comma_separated_string("  realm1  ,realm2"),
+        self.assertEqual(parse_comma_separated_string("  realm1  ,realm2"),
                           ["realm1  ", "realm2"])
         # strings can be quoted
-        self.assertEquals(parse_comma_separated_string('realm1, "realm2", " realm3"'),
+        self.assertEqual(parse_comma_separated_string('realm1, "realm2", " realm3"'),
                           ["realm1", "realm2", " realm3"])
         # even with commas
-        self.assertEquals(parse_comma_separated_string('realm1, "realm2, with a, strange, name", other stuff'),
+        self.assertEqual(parse_comma_separated_string('realm1, "realm2, with a, strange, name", other stuff'),
                           ["realm1", "realm2, with a, strange, name", "other stuff"])
         # double quotes can be escaped
-        self.assertEquals(parse_comma_separated_string(r'realm\", realm2'),
+        self.assertEqual(parse_comma_separated_string(r'realm\", realm2'),
                           ['realm"', 'realm2'])
         # error if a string is not properly quoted
         with self.assertRaises(CompareError):
@@ -83,7 +83,7 @@ class UtilsCompareTestCase(MyTestCase):
         with self.assertRaises(CompareError):
             parse_comma_separated_string('realm1\nrealm2')
         # but we can quote newlines
-        self.assertEquals(parse_comma_separated_string('"realm1\nrealm2"'),
+        self.assertEqual(parse_comma_separated_string('"realm1\nrealm2"'),
                           ["realm1\nrealm2"])
 
     def test_06_compare_in(self):

--- a/tests/test_mod_apache.py
+++ b/tests/test_mod_apache.py
@@ -34,9 +34,7 @@ FAIL_BODY = {"detail": {"message": "wrong otp value"},
 
 class ApacheTestCase(MyTestCase):
 
-    pw_dig = passlib.hash.pbkdf2_sha512.encrypt("test100001",
-                                                rounds=ROUNDS,
-                                                salt_size=SALT_SIZE)
+    pw_dig = passlib.hash.pbkdf2_sha512.using(rounds=ROUNDS, salt_size=SALT_SIZE).hash("test100001")
 
     @redismock.activate
     @responses.activate
@@ -70,4 +68,3 @@ class ApacheTestCase(MyTestCase):
 
         r = check_password({}, "cornelius", "test100002")
         self.assertEqual(r, UNAUTHORIZED)
-

--- a/tests/test_resolver_realm.py
+++ b/tests/test_resolver_realm.py
@@ -43,7 +43,7 @@ class APIResolverTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(res.json['result']['status'], res.json)
-            self.assertEquals(res.json['result']['value'], 1, res.json)
+            self.assertEqual(res.json['result']['value'], 1, res.json)
                     
         # check if the resolver was created
         with self.app.test_request_context('/resolver/',


### PR DESCRIPTION
- passlib uses the `hash()` function to calculate the pbkdf2 password
- the pbkdf2 digest moved from `passlib.utils` to `passlib.crypto.digest`
- the `inspect.getargspec()` function is deprecated
- add 'r' specifier on regex strings
- some huey queue parameter are deprecated
- refactor: use `get_data_from_params()` in `save_resolver()`
- escape some backslashes in strings
- fix some byte encoding issues
- refactor: the `get_wrapped()` function for all mocks is moved to `smtpmock`
- `assertEquals()` is deprecated and changed to `assertEqual()`
- `assertRaisesRegexp()` is deprecated in favour of `assertRaisesRegex()`
- `assertDictContainsSubset()` is deprecated
- `sqlalchemy.testing` emits a `BytesWarning`
- remove some unused code and fix some PEP8

For functions that are not available in either Python2 or Python3 we can
- add a context manager to catch the `DeprecationWarning` or
- add a `try...except AttributeError` and have both function calls