### PR TITLE
token-janitor can set tokenrealms

### DIFF
--- a/doc/workflows_and_tools/tools/index.rst
+++ b/doc/workflows_and_tools/tools/index.rst
@@ -24,6 +24,8 @@ type, description or token info.
 It can unassign, delete or disable those tokens and it can set additional
 tokeninfo or descriptions.
 
+Starting with version 3.4 it can also set the tokenrealms of the found tokens.
+
 If you are unsure to directly delete orphaned tokens, because there might be
 a glimpse in the connection to your user store, you could as well in a first
 step *mark* the orphaned tokens. A day later you could run the script again

--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -56,7 +56,7 @@ import sys
 
 __version__ = "0.1"
 
-ALLOWED_ACTIONS = ["disable", "delete", "unassign", "mark", "export", "listuser"]
+ALLOWED_ACTIONS = ["disable", "delete", "unassign", "mark", "export", "listuser", "tokenrealms"]
 
 __doc__ = """
 This script can be used to clean up the token database.
@@ -398,6 +398,8 @@ def export_user_data(token_list):
                               'the output should only contain the number of tokens owned '
                               'by the user.',
                 dest='sum_tokens', action='store_true')
+@manager.option('--tokenrealms', help='A comma separated list of realms, to which the tokens '
+                                      'should be assigned.')
 @manager.option('--csv', dest='csv', action='store_true',
                 help='In case of a simple find, the output is written as CSV instead of the '
                      'formatted output.')
@@ -407,7 +409,7 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
          tokeninfo_value_greater_than, tokeninfo_value_less_than,
          tokeninfo_value_after, tokeninfo_value_before,
          orphaned, tokentype, serial, description, action, set_description,
-         set_tokeninfo_key, set_tokeninfo_value, sum_tokens, csv, chunksize):
+         set_tokeninfo_key, set_tokeninfo_value, sum_tokens, tokenrealms, csv, chunksize):
     """
     finds all tokens which match the conditions
     """
@@ -472,6 +474,10 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
         else:
             for token_obj in tlist:
                 try:
+                    if action == "tokenrealms":
+                        trealms = [r.strip() for r in tokenrealms.split(",") if r]
+                        token_obj.set_realms(trealms)
+                        print("Setting realms of token {0!s} to {1!s}.".format(token_obj.token.serial, trealms))
                     if action == "disable":
                         enable_token(serial=token_obj.token.serial, enable=False)
                         print("Disabling token {0!s}".format(token_obj.token.serial))


### PR DESCRIPTION
The token-janitor can now set the tokenrealms,
either to a list of given realms or it can completely
clean the tokenrealms of the found tokens.

Closes #2299