### PR TITLE
Add options to `check_realm_pass()`

### DIFF
--- a/privacyidea/lib/tokens/foureyestoken.py
+++ b/privacyidea/lib/tokens/foureyestoken.py
@@ -260,7 +260,8 @@ class FourEyesTokenClass(TokenClass):
         for realm in required_realms.keys():
             found_serials[realm] = []
             for otp in passwords:
-                res, reply = check_realm_pass(realm, otp)
+                res, reply = check_realm_pass(realm, otp,
+                                              options={'exclude_types': [self.get_tokentype()]})
                 if res:
                     serial = reply.get("serial")
                     found_serials[realm].append(serial)

--- a/privacyidea/lib/tokens/foureyestoken.py
+++ b/privacyidea/lib/tokens/foureyestoken.py
@@ -261,7 +261,7 @@ class FourEyesTokenClass(TokenClass):
             found_serials[realm] = []
             for otp in passwords:
                 res, reply = check_realm_pass(realm, otp,
-                                              options={'exclude_types': [self.get_tokentype()]})
+                                              exclude_types=[self.get_tokentype()])
                 if res:
                     serial = reply.get("serial")
                     found_serials[realm].append(serial)

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -1087,28 +1087,27 @@ class TokenTestCase(MyTestCase):
 
         # check for optional parameter exclude/include type
         r = check_realm_pass(self.realm1, 'assigned' + self.valid_otp_values[2],
-                             options={'exclude_types': 'hotp'})
+                             exclude_types='hotp')
         self.assertFalse(r[0])
         self.assertEqual(r[1].get("message"), "There is no active and assigned "
-                                              "token in this realm, options: "
-                                              "{'exclude_types': 'hotp'}")
+                                              "token in this realm, included types: None, "
+                                              "excluded types: hotp")
 
         r = check_realm_pass(self.realm1, 'assigned' + self.valid_otp_values[2],
-                             options={'include_types': 'totp'})
+                             include_types='totp')
         self.assertFalse(r[0])
         self.assertEqual(r[1].get("message"), "There is no active and assigned "
-                                              "token in this realm, options: "
-                                              "{'include_types': 'totp'}")
+                                              "token in this realm, included types: totp, "
+                                              "excluded types: None")
 
         r = check_realm_pass(self.realm1, 'assigned' + self.valid_otp_values[2],
-                             options={'exclude_types': 'totp'})
+                             exclude_types='totp')
         self.assertTrue(r[0])
         self.assertEqual(r[1].get("message"), "matching 1 tokens")
 
         # check that include_types precedes exclude_types
         r = check_realm_pass(self.realm1, 'assigned' + self.valid_otp_values[3],
-                             options={'include_types': 'hotp',
-                                      'exclude_types': 'hotp'})
+                             include_types='hotp', exclude_types='hotp')
         self.assertTrue(r[0])
         self.assertEqual(r[1].get("message"), "matching 1 tokens")
 

--- a/tests/test_lib_tokens_foureyes.py
+++ b/tests/test_lib_tokens_foureyes.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 This test file tests the lib.tokens.4eyestoken
 This depends on lib.tokenclass
@@ -5,7 +7,7 @@ This depends on lib.tokenclass
 
 from .base import MyTestCase
 from privacyidea.lib.tokens.foureyestoken import FourEyesTokenClass
-from privacyidea.lib.token import init_token, check_serial_pass
+from privacyidea.lib.token import init_token, check_serial_pass, remove_token
 from privacyidea.lib.user import User
 
 
@@ -36,25 +38,29 @@ class FourEyesTokenTestCase(MyTestCase):
         self.assertEqual(r._get_separator(), "|")
 
     def test_03_authenticate(self):
+        self.setUp_user_realms()
         init_token({"type": "pw",
                     "otpkey": "password1",
-                    "pin": "pin1"},
+                    "pin": "pin1",
+                    "serial": "pwserial1"},
                    user=User("cornelius", self.realm1))
 
         init_token({"type": "pw",
                     "otpkey": "password2",
-                    "pin": "pin2"},
+                    "pin": "pin2",
+                    "serial": "pwserial2"},
                    user=User("cornelius", self.realm1))
 
         init_token({"type": "pw",
                     "otpkey": "password3",
-                    "pin": "pin3"},
+                    "pin": "pin3",
+                    "serial": "pwserial3"},
                    user=User("cornelius", self.realm1))
 
-        init_token({"serial": "eye1",
-                    "type": "4eyes",
-                    "4eyes": "{0!s}:2".format(self.realm1),
-                    "separator": " "})
+        tok = init_token({"serial": "eye1",
+                          "type": "4eyes",
+                          "4eyes": "{0!s}:2".format(self.realm1),
+                          "separator": " "})
 
         r = check_serial_pass("eye1", "pin1password1 pin2password2")
         self.assertEqual(r[0], True)
@@ -63,3 +69,21 @@ class FourEyesTokenTestCase(MyTestCase):
         self.assertEqual(r[0], False)
         self.assertEqual(r[1].get("foureyes"), "Only found 1 tokens in realm "
                                                "realm1")
+
+        # check false separator
+        r = check_serial_pass("eye1", "pin1password1:pin2password2")
+        self.assertFalse(r[0])
+        self.assertEqual(r[1].get("foureyes"), "Only found 0 tokens in realm "
+                                               "realm1")
+
+        # check authentication also works if the 4eyes-token is in the same realm
+        tok.add_user(User('cornelius', self.realm1))
+        r = check_serial_pass("eye1", "pin3password3 pin2password2")
+        self.assertTrue(r[0])
+        self.assertEqual(r[1].get('message'), 'matching 1 tokens')
+
+        # cleanup
+        remove_token(serial='pwserial1')
+        remove_token(serial='pwserial2')
+        remove_token(serial='pwserial3')
+        remove_token(serial='eye1')


### PR DESCRIPTION
In order to avoid a stack overflow due to multiple authentications using a
4eyes token, an option is introduced to `check_realm_pass()` to
exclude/include certain token types.

Fixes #1892