### PR TITLE
Allow to set email address for Email Tokens

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -63,7 +63,7 @@ from ..lib.token import (init_token, get_tokens_paginate, assign_token,
                          revoke_token,
                          reset_token, resync_token, set_pin_so, set_pin_user,
                          set_pin, set_description, set_count_window,
-                         set_sync_window, set_count_auth,
+                         set_email, set_sync_window, set_count_auth,
                          set_hashlib, set_max_failcount, set_realms,
                          copy_token_user, copy_token_pin, lost_token,
                          get_serial_by_otp, get_tokens,
@@ -794,6 +794,7 @@ def set_api(serial=None):
     count_auth_success_max = getParam(request.all_data, "count_auth_success_max")
     validity_period_start = getParam(request.all_data, "validity_period_start")
     validity_period_end = getParam(request.all_data, "validity_period_end")
+    email = getParam(request.all_data, "email")
 
     res = 0
 
@@ -845,6 +846,11 @@ def set_api(serial=None):
                                        "validity_period_start={0!r}, ".format(
                                        validity_period_start)})
         res += set_validity_period_start(serial, user, validity_period_start)
+
+    if email is not None:
+        g.audit_object.add_to_log({'action_detail': "email=%r, "
+                                                    "" % email})
+        res += set_email(serial, email, user=user)
 
     g.audit_object.log({"success": True})
     return send_result(res)

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1687,6 +1687,30 @@ def set_description(serial, description, user=None):
 
 @log_with(log)
 @check_user_or_serial
+def set_email(serial, email, user=None):
+    """
+    Set the email address of a token
+
+    :param serial: The serial number of the token (exact)
+    :type serial: basestring
+    :param email: The email address for the token
+    :type description: str
+    :param user: The owner of the tokens, which should be modified
+    :type user: User object
+    :return: number of modified tokens
+    :rtype: int
+    """
+    tokenobject_list = get_tokens_from_serial_or_user(serial=serial, user=user)
+
+    for tokenobject in tokenobject_list:
+        tokenobject.set_email(email)
+        tokenobject.save()
+
+    return len(tokenobject_list)
+
+
+@log_with(log)
+@check_user_or_serial
 def set_failcounter(serial, counter, user=None):
     """
     Set the fail counter of a  token.

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -124,6 +124,9 @@ class EmailTokenClass(HotpTokenClass):
     def _email_address(self, value):
         self.add_tokeninfo(self.EMAIL_ADDRESS_KEY, value)
 
+    def set_email(self, value):
+        self._email_address = value
+
     @staticmethod
     def get_class_type():
         """


### PR DESCRIPTION
It's currently not possible to set the email address of an Email Token through the /token/set/(serial) endpoint.

Fixes #2305 