### PR TITLE
Make the db transaction commit configurable

### DIFF
--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -103,6 +103,13 @@ class ScriptEventHandler(BaseEventHandler):
                     "visibleValue": SCRIPT_WAIT,
                     "description": _("On script error raise exception in HTTP request.")
                 },
+                "sync_to_database": {
+                    "type": "bool",
+                    "description": _("Finish current transaction before running "
+                                     "the script. This is useful if changes to "
+                                     "the database should be made available to "
+                                     "the script or the running request.")
+                },
                 "serial": {
                     "type": "bool",
                     "description": _("Add '--serial <serial number>' as script "
@@ -190,7 +197,10 @@ class ScriptEventHandler(BaseEventHandler):
         rcode = 0
         try:
             log.info("Starting script {script!r}.".format(script=script_name))
-            db.session.commit()
+            if is_true(handler_options.get('sync_to_database', False)):
+                log.debug('Committing current transaction for script '
+                          '{0!s}'.format(script_name))
+                db.session.commit()
             p = subprocess.Popen(proc_args, cwd=self.script_directory, universal_newlines=True)
             if handler_options.get("background") == SCRIPT_WAIT:
                 rcode = p.wait()

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -9,7 +9,7 @@ lib/event.py (the decorator)
 
 import responses
 import os
-from unittest import mock
+import mock
 
 from privacyidea.lib.eventhandler.usernotification import UserNotificationEventHandler
 from .base import MyTestCase, FakeFlaskG, FakeAudit
@@ -813,7 +813,7 @@ class ScriptEventTestCase(MyTestCase):
         options['handler_def']['options']['sync_to_database'] = "1"
         with mock.patch('privacyidea.lib.eventhandler.scripthandler.db') as mdb:
             res = t_handler.do(script_name, options=options)
-            mdb.session.commit.assert_called()
+            mdb.session.commit.assert_called_with()
         self.assertTrue(res)
         # and now with the parameter explicitly disabled
         options['handler_def']['options']['sync_to_database'] = "0"


### PR DESCRIPTION
In the `ScriptEventHandler` we commit the current transaction before
running the script (See #2294).
In order to save possibly unnecessary database communication, this is
disabled by default and can be configured via the `sync_to_database`
option.

Fixes #2302