### PR TITLE
2304/fix censor conn string

### DIFF
--- a/privacyidea/lib/utils/__init__.py
+++ b/privacyidea/lib/utils/__init__.py
@@ -1077,20 +1077,12 @@ def censor_connect_string(connect_string):
     """
     Take a SQLAlchemy connect string and return a sanitized version
     that can be written to the log without disclosing the password.
-    The password is replaced with "xxxx".
+    The password is replaced with "***".
     In case any error occurs, return "<error when censoring connect string>"
     """
     try:
-        parsed = urlparse(connect_string)
-        if parsed.password is not None:
-            # We need to censor the ``netloc`` attribute: user:pass@host
-            _, host = parsed.netloc.rsplit("@", 1)
-            new_netloc = u'{}:{}@{}'.format(parsed.username, 'xxxx', host)
-            # Convert the URL to six components. netloc is component #1.
-            splitted = list(parsed)
-            splitted[1] = new_netloc
-            return urlunparse(splitted)
-        return connect_string
+        parsed = sqlalchemy.engine.url.make_url(connect_string)
+        return repr(parsed)
     except Exception:
         return "<error when censoring connect string>"
 

--- a/privacyidea/lib/utils/__init__.py
+++ b/privacyidea/lib/utils/__init__.py
@@ -1082,7 +1082,7 @@ def censor_connect_string(connect_string):
     """
     try:
         parsed = sqlalchemy.engine.url.make_url(connect_string)
-        return repr(parsed)
+        return parsed.__repr__()
     except Exception:
         return "<error when censoring connect string>"
 

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -535,15 +535,17 @@ class UtilsTestCase(MyTestCase):
         self.assertEqual(censor_connect_string("mysql://pi@localhost/pi"),
                          "mysql://pi@localhost/pi")
         self.assertEqual(censor_connect_string("mysql://pi:kW44sqqWtGYX@localhost/pi"),
-                         "mysql://pi:xxxx@localhost/pi")
+                         "mysql://pi:***@localhost/pi")
         self.assertEqual(censor_connect_string("psql+odbc://pi@localhost/pi"),
                          "psql+odbc://pi@localhost/pi")
         self.assertEqual(censor_connect_string("psql+odbc://pi:MySecretPassword123466$@localhost/pi"),
-                         "psql+odbc://pi:xxxx@localhost/pi")
+                         "psql+odbc://pi:***@localhost/pi")
         self.assertEqual(censor_connect_string("mysql://pi:kW44s@@qqWtGYX@localhost/pi"),
-                         "mysql://pi:xxxx@localhost/pi")
+                         "mysql://pi:***@localhost/pi")
         self.assertEqual(censor_connect_string(u"mysql://knöbel:föö@localhost/pi"),
-                         u"mysql://knöbel:xxxx@localhost/pi")
+                         u"mysql://knöbel:***@localhost/pi")
+        self.assertEqual(censor_connect_string(u"oracle+cx_oracle://pi:MySecretPassword1234@localhost:1521/?service_name=my_database"),
+                         u"oracle+cx_oracle://pi:***@localhost:1521/?service_name=my_database")
 
     def test_19_truncate_comma_list(self):
         r = truncate_comma_list("123456,234567,345678", 19)


### PR DESCRIPTION
Resubmitted my proposed solution using sqlalchemy's own URL class.
This time with @plettich suggested change of __repr__ instead of repr() to support both python 2 and python 3.

Tests ok on both versions:

![image](https://user-images.githubusercontent.com/25209188/89795208-7f450700-dafe-11ea-9f35-f89df2335ace.png)

Fixes #2304 

Thank you!