### PR TITLE
2303/user obj in auth

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -267,6 +267,7 @@ def get_auth_token():
     elif verify_db_admin(username, password):
         role = ROLE.ADMIN
         admin_auth = True
+        log.info("Local admin '{0!s}' successfully logged in.".format(username))
         # This admin is not in the default realm!
         realm = ""
         g.audit_object.log({"success": True,
@@ -289,6 +290,11 @@ def get_auth_token():
                                                     superuser_realms=
                                                     superuser_realms)
         details = details or {}
+        if db_admin_exist(loginname) and realm == get_default_realm():
+            # If there is a local admin with the same login name as the user
+            # in the default realm, we inform about this in the log file.
+            log.warning("A user '{0!s}' exists as local admin and as user in "
+                        "your default realm!".format(loginname))
         if role == ROLE.ADMIN:
             g.audit_object.log({"user": "",
                                 "administrator": user_obj.login,

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -104,6 +104,16 @@ def before_request():
                         "action_detail": "",
                         "info": ""})
 
+    username = getParam(request.all_data, "username")
+    if username:
+        # We only fill request.user, if we really have a username.
+        # On endpoints like /auth/rights, this is not available
+        loginname, realm = split_user(username)
+        # overwrite the split realm if we have a realm parameter. Default back to default_realm
+        realm = getParam(request.all_data, "realm", default=realm) or realm or get_default_realm()
+        # Prefill the requst.user. This is used by some pre-event handlers
+        request.user = User(loginname, realm)
+
 
 @jwtauth.route('', methods=['POST'])
 @prepolicy(pushtoken_disable_wait, request)

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -106,13 +106,13 @@ def before_request():
 
     username = getParam(request.all_data, "username")
     if username:
-        # We only fill request.user, if we really have a username.
+        # We only fill request.User, if we really have a username.
         # On endpoints like /auth/rights, this is not available
         loginname, realm = split_user(username)
         # overwrite the split realm if we have a realm parameter. Default back to default_realm
         realm = getParam(request.all_data, "realm", default=realm) or realm or get_default_realm()
-        # Prefill the requst.user. This is used by some pre-event handlers
-        request.user = User(loginname, realm)
+        # Prefill the request.User. This is used by some pre-event handlers
+        request.User = User(loginname, realm)
 
 
 @jwtauth.route('', methods=['POST'])

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -9,6 +9,10 @@ from privacyidea.lib.policy import (set_policy, SCOPE, ACTION, REMOTE_USER,
 from privacyidea.lib.auth import create_db_admin
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.realm import set_realm, set_default_realm
+from privacyidea.lib.event import set_event, delete_event
+from privacyidea.lib.eventhandler.base import CONDITION
+from privacyidea.lib.token import get_tokens, remove_token
+from privacyidea.lib.user import User
 
 
 PWFILE = "tests/testdata/passwd-duplicate-name"
@@ -585,3 +589,91 @@ class DuplicateUserApiTestCase(MyApiTestCase):
             # check if we have this log entry
             mock_log.assert_called_with("A user 'testadmin' exists as local admin and as user "
                                         "in your default realm!")
+
+
+class AAPreEventHandlerTest(MyApiTestCase):
+
+    def test_01_setup_eventhandlers(self):
+        # This test create an HOTP token with C/R with a pre-event handler
+        # and the user uses this HOTP token to directly login to /auth
+
+        # Setup realm
+        rid = save_resolver({"resolver": self.resolvername1,
+                             "type": "passwdresolver",
+                             "fileName": PWFILE})
+        self.assertTrue(rid > 0, rid)
+
+        (added, failed) = set_realm(self.realm1,
+                                    [self.resolvername1])
+        self.assertTrue(len(failed) == 0)
+        self.assertTrue(len(added) == 1)
+
+        set_default_realm(self.realm1)
+
+        # set a policy to authenticate against privacyIDEA
+        set_policy("piLogin", scope=SCOPE.WEBUI, action="{0!s}=privacyIDEA".format(ACTION.LOGINMODE))
+        # set a policy to for otppin=userstore
+        set_policy("otppin", scope=SCOPE.AUTH, action="{0!s}=userstore".format(ACTION.OTPPIN))
+        # Set a policy to do C/R with HOTP tokens
+        set_policy("crhotp", scope=SCOPE.AUTH, action="{0!s}=hotp".format(ACTION.CHALLENGERESPONSE))
+
+        # Create an event handler, that creates HOTP token on /auth with default OTP key
+        eid = set_event("createtoken", event=["auth"], handlermodule="Token",
+                        action="enroll", position="pre",
+                        conditions={CONDITION.USER_TOKEN_NUMBER: 0},
+                        options={"tokentype": "hotp", "user": "1",
+                                 "additional_params": {
+                                     'otpkey': self.otpkey,
+                                     # We need to set gekey=0, otherwise the Tokenhandler will
+                                     # generate a random otpkey
+                                     'genkey': 0}})
+        # cleanup tokens
+        remove_token(user=User("someuser", self.realm1))
+
+        # user tries to log in with his userstore password and gets a transaction_id
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": "someuser",
+                                                 "password": "test"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(401, res.status_code, res)
+            result = res.json.get("result")
+            self.assertFalse(result.get("status"), result)
+            detail = res.json.get("detail")
+            self.assertEqual("please enter otp: ", detail.get("message"))
+            transaction_id = detail.get("transaction_id")
+
+        # Check if the token was enrolled
+        toks = get_tokens(user=User("someuser", self.realm1))
+        self.assertEqual(len(toks), 1)
+        self.assertEqual(toks[0].token.tokentype, "hotp")
+        serial = toks[0].token.serial
+        # Check if the correct otpkey was used
+        hotptoken = toks[0]
+        r = hotptoken.check_otp(self.valid_otp_values[1])
+        self.assertTrue(r >= 0)
+
+        # Now the user logs in with the second step of C/R with OTP value of new token
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": "someuser",
+                                                 "transaction_id": transaction_id,
+                                                 "password": self.valid_otp_values[2]}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            result = res.json.get("result")
+            self.assertTrue(result.get("status"))
+            self.assertTrue(result.get("value"))
+
+        # Check that there is still only one token
+        toks = get_tokens(user=User("someuser", self.realm1))
+        self.assertEqual(len(toks), 1)
+        self.assertEqual(toks[0].token.tokentype, "hotp")
+        self.assertEqual(serial, toks[0].token.serial)
+
+        # cleanup
+        delete_policy("piLogin")
+        delete_policy("otppin")
+        delete_policy("crhotp")
+        delete_event(eid)
+        remove_token(hotptoken.token.serial)

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -567,7 +567,7 @@ class DuplicateUserApiTestCase(MyApiTestCase):
                 self.assertIn('token', result.get("value"), result)
                 # role should be 'admin'
                 self.assertEqual('admin', result['value']['role'], result)
-            mock_log.assert_called_once_with("Local admin 'testadmin' successfully logged in.")
+            mock_log.assert_called_with("Local admin 'testadmin' successfully logged in.")
 
         # If a user logs in, with the same name as the admin, this event is logged in warning
         with mock.patch("logging.Logger.warning") as mock_log:

--- a/tests/testdata/passwd-duplicate-name
+++ b/tests/testdata/passwd-duplicate-name
@@ -1,0 +1,1 @@
+testadmin:H9Y6eYntkrrKo:1004:1004:::

--- a/tests/testdata/passwd-duplicate-name
+++ b/tests/testdata/passwd-duplicate-name
@@ -1,1 +1,2 @@
 testadmin:H9Y6eYntkrrKo:1004:1004:::
+someuser:H9Y6eYntkrrKo:1005:1005:::


### PR DESCRIPTION
@laclaro, please review this pull request, since you orginally posted the issue.
I added exactly the test case of a user with now token, who gets a token enrolled by a pre-event handler when logging in against /auth.