### PR TITLE
Fix broken token view

### DIFF
--- a/privacyidea/static/components/token/views/token.html
+++ b/privacyidea/static/components/token/views/token.html
@@ -88,14 +88,9 @@
             </div>
 
         </div>
-
-        <div ui-view class="col-sm-9 slide panel" ng-hide="token_wizard">
+        <div ng-class="{'col-sm-9': !token_wizard, 'col-sm-12': token_wizard}"
+             ui-view class="slide panel">
         </div>
-        <div ui-view class="col-sm-12 slide panel" ng-show="token_wizard">
-        </div>
-
     </div>
-
-
 </div>
 


### PR DESCRIPTION
Only one `ui-view` element should be present in order for the
angular-routing to work.

Fixes #2370