### PR TITLE
col-lg-9 instead of col-sm-9

### DIFF
--- a/privacyidea/static/components/token/views/token.html
+++ b/privacyidea/static/components/token/views/token.html
@@ -88,7 +88,7 @@
             </div>
 
         </div>
-        <div ng-class="{'col-sm-9': !token_wizard, 'col-sm-12': token_wizard}"
+        <div ng-class="{'col-lg-9': !token_wizard, 'col-lg-12': token_wizard}"
              ui-view class="slide panel">
         </div>
     </div>


### PR DESCRIPTION
On small screens, the token list appears improperly scaled. We previously used col-lg, which was accidentally changed in #2351 2351 and is restored by this pull-request.