### PR TITLE
add commands to set and clear default realm to pi-manage

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -979,7 +979,7 @@ def set_default(realm):
 @realm_manager.command
 def clear_default():
     """
-    Set the given realm to default
+    Unset the default realm
     """
     from privacyidea.lib.realm import set_default_realm
     set_default_realm(None)

--- a/pi-manage
+++ b/pi-manage
@@ -106,7 +106,8 @@ manager = Manager(app)
 admin_manager = Manager(usage='Create new administrators or modify existing '
                               'ones.')
 backup_manager = Manager(usage='Create database backup and restore')
-realm_manager = Manager(usage='Create new realms, set the default realm')
+realm_manager = Manager(usage='Create new realms, delete existing realms '
+                              'or set the default realm')
 resolver_manager = Manager(usage='Create new resolver')
 policy_manager = Manager(usage='Manage policies')
 event_manager = Manager(usage='Manage events')
@@ -955,16 +956,25 @@ realm_manager.add_command('list', Command(list_realms))
 
 
 @realm_manager.command
-def create(name, resolver):
+def create(name, resolvers):
     """
     Create a new realm.
-    This will create a new realm with the given resolver.
-    *restriction*: The new realm will only contain one resolver!
-
-    :return:
+    This will create a new realm with the given resolver
+    or a comma-separated list of resolvers. An existing realm
+    with the same name will be replaced.
     """
     from privacyidea.lib.realm import set_realm
-    set_realm(name, [resolver])
+    resolvers = resolvers.split(",")
+    set_realm(name, resolvers)
+
+
+@realm_manager.command
+def delete(realm):
+    """
+    Delete the given realm
+    """
+    from privacyidea.lib.realm import delete_realm
+    delete_realm(realm)
 
 
 @realm_manager.command

--- a/pi-manage
+++ b/pi-manage
@@ -106,7 +106,7 @@ manager = Manager(app)
 admin_manager = Manager(usage='Create new administrators or modify existing '
                               'ones.')
 backup_manager = Manager(usage='Create database backup and restore')
-realm_manager = Manager(usage='Create new realms')
+realm_manager = Manager(usage='Create new realms, set the default realm')
 resolver_manager = Manager(usage='Create new resolver')
 policy_manager = Manager(usage='Manage policies')
 event_manager = Manager(usage='Manage events')
@@ -965,6 +965,25 @@ def create(name, resolver):
     """
     from privacyidea.lib.realm import set_realm
     set_realm(name, [resolver])
+
+
+@realm_manager.command
+def set_default(realm):
+    """
+    Set the given realm to default
+    """
+    from privacyidea.lib.realm import set_default_realm
+    set_default_realm(realm)
+
+
+@realm_manager.command
+def clear_default():
+    """
+    Set the given realm to default
+    """
+    from privacyidea.lib.realm import set_default_realm
+    set_default_realm(None)
+
 
 # Event interface
 


### PR DESCRIPTION
Extends the realm command section of pi-manage.
- create supports multiple resolvers
- set_default
- clear_default
- delete