### PR TITLE
Fix deletion of registraion token

### DIFF
--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2215,13 +2215,9 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
                 if reply_dict["type"] != token_obj.token.tokentype:
                     reply_dict["type"] = "undetermined"
                 # reset the failcounter of valid token
-                try:
-                    token_obj.reset()
-                except Exception as _e:
-                    # In some cases (Registration Token) the token does not
-                    # exist anymore. So this would bail an exception!
-                    log.debug("registration token does not exist anymore and "
-                              "cannot be reset.")
+                token_obj.reset()
+                # Run the token post method. e.g. registration token deletes itself.
+                token_obj.post_success()
         if len(valid_token_list) == 1:
             # If only one token was found, we add the serial number,
             # the token type and the OTP length
@@ -2284,6 +2280,7 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
                         # This was the last successful challenge, so
                         # reset the fail counter of the challenge response token
                         tokenobject.reset()
+                        tokenobject.post_success()
 
                     # clean up all challenges from this and other tokens. I.e.
                     # all challenges with this very transaction_id!

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1055,6 +1055,13 @@ class TokenClass(object):
         return succcess_counter
 
     @check_token_locked
+    def post_success(self):
+        """
+        Run anything after a token was used for successful authentication
+        """
+        return
+
+    @check_token_locked
     def inc_count_auth(self):
         """
         Increase the counter, that counts authentications - successful and

--- a/privacyidea/lib/tokens/registrationtoken.py
+++ b/privacyidea/lib/tokens/registrationtoken.py
@@ -169,13 +169,11 @@ class RegistrationTokenClass(PasswordTokenClass):
 
     @log_with(log, log_entry=False)
     @check_token_locked
-    def inc_count_auth_success(self):
+    def post_success(self):
         """
-        Increase the counter, that counts successful authentications
-        In case of successful authentication the token does needs to be deleted.
+        Delete the registration token after successful authentication
         """
         self.delete_token()
-        return 1
 
     @log_with(log)
     def get_init_detail(self, params=None, user=None):

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -1527,6 +1527,22 @@ class TokenTestCase(MyTestCase):
                           {"serial": "invalid/chars",
                            "genkey": 1})
 
+    def test_57_registration_token_no_auth_counter(self):
+        # Test, that a registration token is deleted even if no_auth_counter is used.
+        from privacyidea.lib.config import set_privacyidea_config, delete_privacyidea_config
+        set_privacyidea_config("no_auth_counter", 1)
+        tok = init_token({"type": "registration"})
+        serial = tok.token.serial
+        detail = tok.get_init_detail()
+        reg_password = detail.get("registrationcode")
+        r, rdetail = check_token_list([tok], reg_password)
+        self.assertTrue(r)
+        self.assertEqual(rdetail["message"], "matching 1 tokens")
+        delete_privacyidea_config("no_auth_counter")
+        # Check that the token is deleted
+        toks = get_tokens(serial=serial)
+        self.assertEqual(len(toks), 0)
+
 
 class TokenOutOfBandTestCase(MyTestCase):
 

--- a/tests/test_lib_tokens_registration.py
+++ b/tests/test_lib_tokens_registration.py
@@ -51,8 +51,8 @@ class RegistrationTokenTestCase(MyTestCase):
         db_token = Token.query.filter(Token.serial == self.serial1).first()
         self.assertNotEqual(db_token, None)
 
-        # check if the token is deleted after inc_success
-        token.inc_count_auth_success()
+        # check if the token is deleted after post_success
+        token.post_success()
         db_token = Token.query.filter(Token.serial == self.serial1).first()
         self.assertEqual(db_token, None)
 


### PR DESCRIPTION
If the no_auth_counter is set, we now correctly delete
the registration token by adding a new token method
"post_success".

Fixes #2356