### PR TITLE
Display challenge_text_header and pin_change message

### DIFF
--- a/privacyidea/lib/challengeresponsedecorators.py
+++ b/privacyidea/lib/challengeresponsedecorators.py
@@ -62,7 +62,9 @@ def _create_pin_reset_challenge(token_obj, message, challenge_data=None):
                                       "serial": token_obj.token.serial,
                                       "type": token_obj.token.tokentype}]
     reply_dict["message"] = message
+    reply_dict["messages"] = [message]
     reply_dict["transaction_id"] = db_challenge.transaction_id
+    # TODO: This line is deprecated: Add the information for the old administrative triggerchallenge
     reply_dict["transaction_ids"] = [db_challenge.transaction_id]
 
     return reply_dict


### PR DESCRIPTION
In case of a challenge_text_header the pin_change message would
not have been displayed. This assures, that the pin_change
message is contained in reply_dict["messages"] (this list of
reply messages) and thus is correctly handled with the
challenge_text_header.

closes #2364