### PR TITLE
catch FileNotFoundError in get_templates

### DIFF
--- a/privacyidea/lib/caconnectors/localca.py
+++ b/privacyidea/lib/caconnectors/localca.py
@@ -40,6 +40,7 @@ import logging
 import os
 from six import string_types
 from six.moves import input
+import traceback
 
 log = logging.getLogger(__name__)
 
@@ -472,9 +473,10 @@ class LocalCAConnector(BaseCAConnector):
                 with open(self.template_file, 'r') as content_file:
                     file_content = content_file.read()
                     content = yaml.safe_load(file_content)
-            except (FileNotFoundError, PermissionError):
+            except EnvironmentError:
                 log.warning("Template file {0!s} for {1!s} not found or "
                             "not permitted.".format(self.template_file, self.name))
+                log.debug('{0!s}'.format(traceback.format_exc()))
         return content
 
     def publish_cert(self):

--- a/privacyidea/lib/caconnectors/localca.py
+++ b/privacyidea/lib/caconnectors/localca.py
@@ -472,9 +472,9 @@ class LocalCAConnector(BaseCAConnector):
                 with open(self.template_file, 'r') as content_file:
                     file_content = content_file.read()
                     content = yaml.safe_load(file_content)
-            except FileNotFoundError:
-                log.warning("Template file {0!s} for {1!s} not found.".format(
-                    self.template_file, self.name))
+            except (FileNotFoundError, PermissionError):
+                log.warning("Template file {0!s} for {1!s} not found or "
+                            "not permitted.".format(self.template_file, self.name))
         return content
 
     def publish_cert(self):

--- a/privacyidea/lib/caconnectors/localca.py
+++ b/privacyidea/lib/caconnectors/localca.py
@@ -468,9 +468,13 @@ class LocalCAConnector(BaseCAConnector):
         """
         content = {}
         if self.template_file:
-            with open(self.template_file, 'r') as content_file:
-                file_content = content_file.read()
-                content = yaml.safe_load(file_content)
+            try:
+                with open(self.template_file, 'r') as content_file:
+                    file_content = content_file.read()
+                    content = yaml.safe_load(file_content)
+            except FileNotFoundError:
+                log.warning("Template file {0!s} for {1!s} not found.".format(
+                    self.template_file, self.name))
         return content
 
     def publish_cert(self):

--- a/privacyidea/lib/caconnectors/localca.py
+++ b/privacyidea/lib/caconnectors/localca.py
@@ -476,7 +476,7 @@ class LocalCAConnector(BaseCAConnector):
             except EnvironmentError:
                 log.warning("Template file {0!s} for {1!s} not found or "
                             "not permitted.".format(self.template_file, self.name))
-                log.debug('{0!s}'.format(traceback.format_exc()))
+                log.debug(u'{0!s}'.format(traceback.format_exc()))
         return content
 
     def publish_cert(self):

--- a/tests/test_lib_caconnector.py
+++ b/tests/test_lib_caconnector.py
@@ -324,6 +324,10 @@ class LocalCATestCase(MyTestCase):
         self.assertTrue(ddiff.days > 740, ddiff.days)
         self.assertTrue(ddiff.days < 760, ddiff.days)
 
+        # in case of a nonexistent template file, no exception is raised
+        # but an empty value is returned
+        cacon.template_file = "nonexistent"
+        self.assertEquals(cacon.get_templates(), {})
 
 class CreateLocalCATestCase(MyTestCase):
     """


### PR DESCRIPTION
We catch the error if the file cannot be found or privacyidea is not permitted to read it.

closes #2374