### PR TITLE
Add multi-challenge for questionnaire

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -589,8 +589,8 @@ supported by the token.
     :ref:`policy_webauthn_enroll_user_verification_requirement`.
 
 
-question_numbers
-~~~~~~~~~~~~~~~~
+question_number
+~~~~~~~~~~~~~~~
 
 type: integer
 

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -587,3 +587,17 @@ supported by the token.
 
 .. note:: If you configure this, you will likely also want to configure
     :ref:`policy_webauthn_enroll_user_verification_requirement`.
+
+
+question_numbers
+~~~~~~~~~~~~~~~~
+
+type: integer
+
+The questionnaire token can ask more than one question during one authentication process.
+It will ask the first question, verify the answer, ask the next question and verify the answer.
+This policy setting defines how many questions the user needs to answer. (default: 1)
+
+
+.. note:: It is currently not verified, that the same question is asked more than once, so it is a good
+   idea to have a lot more possible answers than questions being asked.

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -598,6 +598,5 @@ The questionnaire token can ask more than one question during one authentication
 It will ask the first question, verify the answer, ask the next question and verify the answer.
 This policy setting defines how many questions the user needs to answer. (default: 1)
 
-
-.. note:: It is currently not verified, that the same question is asked more than once, so it is a good
-   idea to have a lot more possible answers than questions being asked.
+.. note:: A question will be asked only once, unless the policy requires more questions to be asked,
+   than the token has available answers.

--- a/privacyidea/lib/tokens/questionnairetoken.py
+++ b/privacyidea/lib/tokens/questionnairetoken.py
@@ -225,6 +225,7 @@ class QuestionnaireTokenClass(TokenClass):
                 questions[tinfo.id] = tinfo.Key
         # if all questions are used up, make a new round
         if len(questions) == len(used_questions):
+            log.info(u"User has only {0!s} questions in his token. Reusing questions now.".format(len(questions)))
             used_questions = []
         # Reduce the allowed questions
         remaining_questions = {k: v for (k, v) in questions.items() if k not in used_questions}

--- a/privacyidea/lib/tokens/questionnairetoken.py
+++ b/privacyidea/lib/tokens/questionnairetoken.py
@@ -48,7 +48,7 @@ DEFAULT_NUM_ANSWERS = 5
 
 
 class QUESTACTION(object):
-    NUM_QUESTIONS = "numbers"
+    NUM_QUESTIONS = "number"
 
 
 class QuestionnaireTokenClass(TokenClass):
@@ -207,7 +207,6 @@ class QuestionnaireTokenClass(TokenClass):
         :return: tuple of (bool, message, transactionid, attributes)
         :rtype: tuple
 
-        The return tuple builds up like this:
         The return tuple builds up like this:
         ``bool`` if submit was successful;
         ``message`` which is displayed in the JSON response;

--- a/privacyidea/lib/tokens/questionnairetoken.py
+++ b/privacyidea/lib/tokens/questionnairetoken.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2020-09-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#             Add possibility of multiple questions and answers
 #  http://www.privacyidea.org
 #  2015-12-16 Initial writeup.
 #             Cornelius Kölbel <cornelius@privacyidea.org>
@@ -34,14 +36,19 @@ from privacyidea.models import Challenge
 from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib import _
 from privacyidea.lib.decorators import check_token_locked
-from privacyidea.lib.policy import SCOPE, ACTION, GROUP
+from privacyidea.lib.policy import SCOPE, ACTION, GROUP, get_action_values_from_options
 import random
 import json
+import datetime
 
 log = logging.getLogger(__name__)
 optional = True
 required = False
 DEFAULT_NUM_ANSWERS = 5
+
+
+class QUESTACTION(object):
+    NUM_QUESTIONS = "numbers"
 
 
 class QuestionnaireTokenClass(TokenClass):
@@ -95,6 +102,14 @@ class QuestionnaireTokenClass(TokenClass):
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
                'policy': {
+                   SCOPE.AUTH: {
+                       QUESTACTION.NUM_QUESTIONS: {
+                           'type': 'int',
+                           'desc': _("The user has to answer this number of questions during authentication."),
+                           'group': GROUP.TOKEN,
+                           'value': list(range(1, 31))
+                       }
+                   },
                    SCOPE.ENROLL: {
                        ACTION.MAXTOKENUSER: {
                            'type': 'int',
@@ -193,6 +208,7 @@ class QuestionnaireTokenClass(TokenClass):
         :rtype: tuple
 
         The return tuple builds up like this:
+        The return tuple builds up like this:
         ``bool`` if submit was successful;
         ``message`` which is displayed in the JSON response;
         additional ``attributes``, which are displayed in the JSON response.
@@ -209,7 +225,7 @@ class QuestionnaireTokenClass(TokenClass):
                 # the list
                 questions.append(question[:-5])
         message = random.choice(questions)
-        attributes = None
+        attributes = {}
 
         validity = int(get_from_config('DefaultChallengeValidityTime', 120))
         tokentype = self.get_tokentype().lower()
@@ -220,10 +236,13 @@ class QuestionnaireTokenClass(TokenClass):
         # Create the challenge in the database
         db_challenge = Challenge(self.token.serial,
                                  transaction_id=transactionid,
+                                 session=options.get("session"),
                                  challenge=message,
                                  validitytime=validity)
         db_challenge.save()
-        self.challenge_janitor()
+        expiry_date = datetime.datetime.now() + \
+                      datetime.timedelta(seconds=validity)
+        attributes['valid_until'] = "{0!s}".format(expiry_date)
         return True, message, db_challenge.transaction_id, attributes
 
     def check_answer(self, given_answer, challenge_object):
@@ -267,7 +286,7 @@ class QuestionnaireTokenClass(TokenClass):
         :rtype: int
         """
         options = options or {}
-        otp_counter = -1
+        r_success = -1
 
         # fetch the transaction_id
         transaction_id = options.get('transaction_id')
@@ -282,18 +301,41 @@ class QuestionnaireTokenClass(TokenClass):
             for challengeobject in challengeobject_list:
                 if challengeobject.is_valid():
                     # challenge is still valid
-                    otp_counter = self.check_answer(passw, challengeobject)
-                    if otp_counter >= 0:
-                        # We found the matching challenge, so lets return the
-                        #  successful result and delete the challenge object.
-                        challengeobject.delete()
+                    if self.check_answer(passw, challengeobject) > 0:
+                        r_success = 1
+                        # Set valid OTP to true. We must not delete the challenge now,
+                        # Since we need it for further mutlichallenges
+                        challengeobject.set_otp_status(True)
+                        log.debug("The presented answer was correct.")
                         break
                     else:
                         # increase the received_count
                         challengeobject.set_otp_status()
 
         self.challenge_janitor()
-        return otp_counter
+        return r_success
+
+    @log_with(log)
+    def has_further_challenge(self, options=None):
+        """
+        Check if there are still more questions to be asked.
+
+        :param options: Options dict
+        :return: True, if further challenge is required.
+        """
+        transaction_id = options.get('transaction_id')
+        challengeobject_list = get_challenges(serial=self.token.serial,
+                                              transaction_id=transaction_id)
+        question_number = int(get_action_values_from_options(SCOPE.AUTH,
+                                                             "{0!s}_{1!s}".format(self.get_class_type(),
+                                                                                  QUESTACTION.NUM_QUESTIONS),
+                                                             options) or 1)
+        if len(challengeobject_list) == 1:
+            session = int(challengeobject_list[0].session or "0") + 1
+            options["session"] = u"{0!s}".format(session)
+            if session < question_number:
+                return True
+        return False
 
     @staticmethod
     def get_setting_type(key):

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -4003,7 +4003,7 @@ class AChallengeResponse(MyApiTestCase):
                          user=User("cornelius", self.realm1))
 
         # We want two questions during authentication
-        set_policy(name="questpol", scope=SCOPE.AUTH, action="question_numbers=2")
+        set_policy(name="questpol", scope=SCOPE.AUTH, action="question_number=2")
 
         with self.app.test_request_context('/validate/check', method='POST',
                                            data={"user": "cornelius", "pass": "quest"}):

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -3992,6 +3992,55 @@ class AChallengeResponse(MyApiTestCase):
 
         remove_token(serial)
 
+    def test_15_questionnaire_multichallenge(self):
+        questionnaire = {"Question1": "Answer1",
+                         "Question2": "Answer2",
+                         "Question3": "Answer3",
+                         "Q4": "A4",
+                         "Q5": "A5"}
+        serial = "quest001"
+        tok = init_token({"type": "question", "questions": questionnaire, "pin": "quest", "serial": serial},
+                         user=User("cornelius", self.realm1))
+
+        # We want two questions during authentication
+        set_policy(name="questpol", scope=SCOPE.AUTH, action="question_numbers=2")
+
+        with self.app.test_request_context('/validate/check', method='POST',
+                                           data={"user": "cornelius", "pass": "quest"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            result = res.json['result']
+            self.assertFalse(result.get("value"))
+            detail = res.json.get("detail")
+            transaction_id = detail.get("transaction_id")
+            question = detail.get("message")
+
+        # First response
+        with self.app.test_request_context('/validate/check', method='POST',
+                                           data={"user": "cornelius", "pass": questionnaire.get(question),
+                                                 "transaction_id": transaction_id}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            result = res.json['result']
+            self.assertFalse(result.get("value"))
+            detail = res.json.get("detail")
+            transaction_id = detail.get("transaction_id")
+            question = detail.get("message")
+
+        # Second response
+        with self.app.test_request_context('/validate/check', method='POST',
+                                           data={"user": "cornelius", "pass": questionnaire.get(question),
+                                                 "transaction_id": transaction_id}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            result = res.json['result']
+            # Successful authentication!
+            self.assertTrue(result.get("value"))
+
+        remove_token(serial)
+        delete_policy("questpol")
+
+
 
 class TriggeredPoliciesTestCase(MyApiTestCase):
 


### PR DESCRIPTION
The questionnaire token can now ask multiple questions
with a policy defining the number of questions.

Multi-Challenge is used to do so.

Closes #2137