### PR TITLE
use autocomplete='new-password'

### DIFF
--- a/privacyidea/static/components/directives/views/directive.assigntoken.html
+++ b/privacyidea/static/components/directives/views/directive.assigntoken.html
@@ -26,10 +26,12 @@ This is the directive for assigning tokens to users.
         -->
     <label for="otppin" translate>PIN</label>
     <input name="otppin" ng-model="newTokenObject.pin"
+            autocomplete="new-password"
             type=password class="form-control"
             equals="{{pin2}}"
             placeholder="{{ 'Type a password'|translate }}">
     <input name="otppin2" ng-model="pin2"
+            autocomplete="new-password"
             type=password class="form-control"
             equals="{{newTokenObject.pin}}"
             placeholder="{{ 'Repeat password'|translate }}">

--- a/privacyidea/static/components/directives/views/directive.assignuser.html
+++ b/privacyidea/static/components/directives/views/directive.assignuser.html
@@ -13,7 +13,7 @@ This is the directive for assigning users.
 <div class="form-group">
     <label for="username" translate>Username</label>
     <input name="username" type="text" ng-model="newUserObject.user"
-           autocomplete="off"
+           autocomplete="new-password"
            placeholder="{{ 'start typing a username'|translate }}"
            ng-keypress="toggleLoadUsers($event.which==13)"
            typeahead-wait-ms="100"
@@ -35,10 +35,12 @@ This is the directive for assigning users.
         -->
     <label for="otppin" translate>PIN</label>
     <input name="otppin" ng-model="newUserObject.pin"
+            autocomplete="new-password"
             type=password class="form-control"
             equals="{{pin2}}"
             placeholder="{{ 'Type a password'|translate }}">
     <input name="otppin2" ng-model="pin2"
+            autocomplete="new-password"
             type=password class="form-control"
             equals="{{newUserObject.pin}}"
             placeholder="{{ 'Repeat password'|translate }}">

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -330,11 +330,13 @@
             <td>
                 <input type="text" ng-model="otp1"
                        class="form-control"
+                       autocomplete="new-password"
                        placeholder="{{ 'Enter first OTP value' | translate }}">
             </td>
             <td>
                 <input type="text" ng-model="otp2"
                        class="form-control"
+                       autocomplete="new-password"
                        placeholder="{{ 'Enter second OTP value' | translate }}">
             </td>
             <td>
@@ -351,12 +353,12 @@
         <tr ng-hide="token.locked || !checkRight('setpin')">
             <td>
                 <input type="password" ng-model="pin1"
-                       class="form-control" autocomplete="off"
+                       class="form-control" autocomplete="new-password"
                        placeholder="{{ 'Enter PIN for token'|translate }}">
             </td>
             <td>
                 <input type="password" ng-model="pin2"
-                       class="form-control" autocomplete="off"
+                       class="form-control" autocomplete="new-password"
                        placeholder="{{ 'Enter PIN again'|translate }}">
             </td>
             <td>
@@ -396,12 +398,13 @@
                        name="testPassword"
                        ng-show="showPassword"
                        class="form-control"
+                       autocomplete="new-password"
                        placeholder="{{ testTokenPlaceholder }}">
                 <input type="password" ng-model="testPassword"
                        ng-hide="showPassword"
                        name="testPassword"
                        class="form-control"
-                       autocomplete="off"
+                       autocomplete="new-password"
                        placeholder="{{ testTokenPlaceholder }}">
             </td>
             <td>

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -28,6 +28,7 @@
         <div class="form-group" ng-hide="loggedInUser.role == 'user' && !checkRight('setdescription')">
             <label for="description" translate>Description</label>
             <input type="text" class="form-control" id="description"
+                   autocomplete="new-password"
                    placeholder="{{ 'Some nice words...'|translate }}"
                    ng-model="form.description" />
         </div>

--- a/privacyidea/static/components/user/views/user.add.dynamic.form.fields.html
+++ b/privacyidea/static/components/user/views/user.add.dynamic.form.fields.html
@@ -12,6 +12,7 @@
 <div ng-if="field.type=='password'" class="form-group">
     <label class="control-label" for="{{ field.label }}">{{ field.label }}</label>
     <input ng-show="{{ editUser }}"
+           autocomplete="new-password"
            type="{{ field.type }}" name="{{ field.name }}"
            id="{{ field.name }}" ng-model="User[field.name]"
            class="form-control" ng-required="{{ field.required }}"/>
@@ -23,7 +24,7 @@
 <div ng-if="field.type=='email'" class="form-group">
     <label for="{{ field.label }}">{{field.label}}</label>
     <input ng-show="{{ editUser }}"
-            type="{{ field.type }}" name="{{ field.name }}"
+           type="{{ field.type }}" name="{{ field.name }}"
            id="{{ field.name }}" ng-model="User[field.name]"
            class="form-control" ng-required="{{ field.required }}"/>
     <div ng-hide="{{ editUser }}" name="{{ field.name }}">

--- a/privacyidea/static/components/user/views/user.password.html
+++ b/privacyidea/static/components/user/views/user.password.html
@@ -51,12 +51,12 @@
                 <input type="password" name="password" class="form-control"
                        equals="{{ password2 }}"
                        ng-model="User.password"
-                       autocomplete="off"
+                       autocomplete="new-password"
                        placeholder="{{ 'Type a password'|translate }}"
                         >
                 <input type="password" name="password2" class="form-control"
                        equals="{{ User.password }}"
-                       autocomplete="off"
+                       autocomplete="new-password"
                        placeholder="{{ 'Repeat password'|translate }}"
                        ng-model="password2">
             </div>


### PR DESCRIPTION
autocomplete="new-password" makes the browser not use the autocomplete feature.

This pull request replaces the old autocomplete="no" in the token details, enrollment and several other places.

closes #2292