### PR TITLE
Make the token-janitor more robust

### DIFF
--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -315,18 +315,18 @@ def export_token_data(token_list):
                       u"{0!s}".format(token_obj.token.tokentype)]
         try:
             user = token_obj.user
+            if user:
+                token_data.append(u"{0!s}".format(user.info.get("username", "")))
+                token_data.append(u"{0!s}".format(user.info.get("givenname", "")))
+                token_data.append(u"{0!s}".format(user.info.get("surname", "")))
+                token_data.append(u"{0!s}".format(user.uid))
+                token_data.append(u"{0!s}".format(user.resolver))
+                token_data.append(u"{0!s}".format(user.realm))
         except Exception:
             sys.stderr.write("Failed to determine user for token {0!s}.\n".format(
                 token_obj.token.serial
             ))
             token_data.append("**failed to resolve user**")
-        if user:
-            token_data.append(u"{0!s}".format(user.info.get("username", "")))
-            token_data.append(u"{0!s}".format(user.info.get("givenname", "")))
-            token_data.append(u"{0!s}".format(user.info.get("surname", "")))
-            token_data.append(u"{0!s}".format(user.uid))
-            token_data.append(u"{0!s}".format(user.resolver))
-            token_data.append(u"{0!s}".format(user.realm))
         tokens.append(token_data)
     return tokens
 


### PR DESCRIPTION
Sometimes user objects have problems in the resolvers
like non-existing or broken uuids.
To avoid a complete bail out of the user listing, we
enhance the Exception catching.

Closes #2405