### PR TITLE
Add "active" query param to GET /token

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -358,6 +358,7 @@ def list_api():
     :query sortdir: asc/desc
     :query page: request a certain page
     :query assigned: Only return assigned (True) or not assigned (False) tokens
+    :query active: Only return active (True) or inactive (False) tokens
     :query pagesize: limit the number of returned tokens
     :query user_fields: additional user fields from the userid resolver of
         the owner (user)
@@ -384,6 +385,7 @@ def list_api():
     ufields = getParam(param, "user_fields", optional)
     output_format = getParam(param, "outform", optional)
     assigned = getParam(param, "assigned", optional)
+    active = getParam(param, "active", optional)
     tokeninfokey = getParam(param, "infokey", optional)
     tokeninfovalue = getParam(param, "infovalue", optional)
     tokeninfo = None
@@ -391,6 +393,8 @@ def list_api():
         tokeninfo = {tokeninfokey: tokeninfovalue}
     if assigned:
         assigned = assigned.lower() == "true"
+    if active:
+        active = active.lower() == "true"
     
     user_fields = []
     if ufields:
@@ -404,7 +408,7 @@ def list_api():
     # get list of tokens as a dictionary
     tokens = get_tokens_paginate(serial=serial, realm=realm, page=page,
                                  user=user, assigned=assigned, psize=psize,
-                                 sortby=sort, sortdir=sdir,
+                                 active=active, sortby=sort, sortdir=sdir,
                                  tokentype=tokentype,
                                  resolver=resolver,
                                  description=description,

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -440,7 +440,7 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
     :param user: The user, whose token should be displayed
     :type user: User object
     :param serial: a pattern for matching the serial
-    :param active:
+    :param active: Returns active (True) or inactive (False) tokens
     :param resolver: A resolver name, which may contain "*" for filtering.
     :type resolver: basestring
     :param userid: A userid, which may contain "*" for filtering.


### PR DESCRIPTION
Add docstring
Add tests
(Fixes #2424)

Added que "active" query param to GET /token. Also added some tests to test with and without the parameter.