### PR TITLE
Use passlibs CryptContext for password hashes

### DIFF
--- a/privacyidea/lib/challengeresponsedecorators.py
+++ b/privacyidea/lib/challengeresponsedecorators.py
@@ -31,7 +31,7 @@ import logging
 from privacyidea.lib.policy import Match
 from privacyidea.lib.policy import ACTION, SCOPE, check_pin, SCOPE
 from privacyidea.lib.config import get_from_config
-from privacyidea.lib.crypto import hash2, verify_hash2, get_rand_digit_str
+from privacyidea.lib.crypto import pass_hash, verify_pass_hash, get_rand_digit_str
 from privacyidea.models import Challenge
 from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib import _
@@ -106,7 +106,7 @@ def generic_challenge_response_reset_pin(wrapped_function, *args, **kwds):
                 # PIN from the 1st response is stored in challenge.data
                 if challenge.data:
                     # Verify the password
-                    if verify_hash2(args[1], challenge.data):
+                    if verify_pass_hash(args[1], challenge.data):
                         g = options.get("g")
                         challenge.set_otp_status(True)
                         token_obj.challenge_janitor()
@@ -143,7 +143,7 @@ def generic_challenge_response_reset_pin(wrapped_function, *args, **kwds):
                     challenge.set_otp_status(True)
                     seed = get_rand_digit_str(SEED_LENGTH)
                     reply_dict = _create_pin_reset_challenge(token_obj, _("Please enter the new PIN again"),
-                                                             hash2(args[1]))
+                                                             pass_hash(args[1]))
                     return False, reply_dict
 
     success, reply_dict = wrapped_function(*args, **kwds)

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -78,11 +78,14 @@ from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
 if not PY2:
     long = int
 
+# Number of hash rounds for the argon2 algorithm
+ROUNDS = 9
+
 # The CryptContext makes it easier to work with multiple password hash algorithms:
 # The first algorithm in the list is the default algorithm used for hashing.
 # When verifying a password hash, all algorithms in the context are checked
 # until one succeeds (or all fail).
-pass_ctx = CryptContext(['argon2', 'pbkdf2_sha512'], argon2__rounds=9)
+pass_ctx = CryptContext(['argon2', 'pbkdf2_sha512'], argon2__rounds=ROUNDS)
 
 FAILED_TO_DECRYPT_PASSWORD = "FAILED TO DECRYPT PASSWORD!"
 

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -860,7 +860,7 @@ class TokenClass(object):
         :param default: the default value, if the key does not exist
         :type default: string
         :return: the value for the key
-        :rtype: int or string
+        :rtype: int or str or dict
         """
         tokeninfo = self.token.get_info()
         if key:

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -417,17 +417,16 @@ class Token(MethodsMixin, db.Model):
             else:
                 log.debug("we got a hashed PIN!")
                 if self.pin_hash:
-                    # New PIN verification
-                    if verify_pass_hash(pin, self.pin_hash):
-                        return True
-                    else:
+                    try:
+                        # New PIN verification
+                        return verify_pass_hash(pin, self.pin_hash)
+                    except ValueError as _e:
                         # old PIN verification
                         mypHash = self.get_hashed_pin(pin)
                 else:
                     mypHash = pin
                 if mypHash == (self.pin_hash or u""):
                     res = True
-    
         return res
 
 #    def split_pin_pass(self, passwd, prepend=True):

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -55,7 +55,7 @@ from sqlalchemy.schema import Sequence
 from .lib.log import log_with
 from privacyidea.lib.utils import (is_true, convert_column_to_unicode,
                                    hexlify_and_unicode)
-from privacyidea.lib.crypto import hash2, verify_hash2
+from privacyidea.lib.crypto import pass_hash, verify_pass_hash
 
 
 log = logging.getLogger(__name__)
@@ -360,8 +360,7 @@ class Token(MethodsMixin, db.Model):
         :return: the hashed pin
         :rtype: str
         """
-        self.pin_hash = ""
-        self.pin_hash = hash2(pin)
+        self.pin_hash = pass_hash(pin)
         return self.pin_hash
 
     def get_hashed_pin(self, pin):
@@ -418,9 +417,9 @@ class Token(MethodsMixin, db.Model):
             else:
                 log.debug("we got a hashed PIN!")
                 if self.pin_hash:
-                    if self.pin_hash.startswith("$argon2"):
-                        # New PIN verification
-                        return verify_hash2(pin, self.pin_hash)
+                    # New PIN verification
+                    if verify_pass_hash(pin, self.pin_hash):
+                        return True
                     else:
                         # old PIN verification
                         mypHash = self.get_hashed_pin(pin)

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -20,7 +20,7 @@ from privacyidea.lib.tokens.totptoken import TotpTokenClass
 from privacyidea.models import (Token, Challenge, TokenRealm)
 from privacyidea.lib.config import (set_privacyidea_config, get_token_types, delete_privacyidea_config, SYSCONF)
 from privacyidea.lib.policy import set_policy, SCOPE, ACTION, delete_policy, PolicyClass, delete_policy
-from privacyidea.lib.utils import b32encode_and_unicode
+from privacyidea.lib.utils import b32encode_and_unicode, hexlify_and_unicode
 from privacyidea.lib.error import PolicyError
 import datetime
 from dateutil import parser
@@ -1550,7 +1550,7 @@ class TokenTestCase(MyTestCase):
         # now set the old pin
         from privacyidea.lib.crypto import hash
         tokenobject.token.pin_hash = hash("1234", b"1234567890")
-        tokenobject.token.pin_seed = binascii.hexlify(b"1234567890")
+        tokenobject.token.pin_seed = hexlify_and_unicode(b"1234567890")
         tokenobject.token.save()
         r = tokenobject.token.check_pin("1234")
         self.assertTrue(r)


### PR DESCRIPTION
The
[`passlib.context.CryptContext`](https://passlib.readthedocs.io/en/stable/lib/passlib.context.html#the-cryptcontext-class) provides an easy way to handle several password hash algorithms.
Since changing from pbkdf2 to argon2 we still need to validate hashes with
the former method.
Unfortunately passlib does not support plain SHA256 hashes so we still need to check them separately.

Working on #2413