### PR TITLE
Allow to truncate longer audit columns

### DIFF
--- a/doc/audit/index.rst
+++ b/doc/audit/index.rst
@@ -136,13 +136,24 @@ This will read the configuration (only the database uri) from the config file
 Table size
 ~~~~~~~~~~
 
-Sometimes the entires to be written to the database may be longer than the
+Sometimes the entries to be written to the database may be longer than the
 column in the database. You can either enlarge the columns in the database or
 you can set
 
    PI_AUDIT_SQL_TRUNCATE = True
 
 in ``pi.cfg``. This will truncate each entry to the defined column length.
+
+If the default column length of the audit log table are to shore, you can
+make the columns longer in the database. You should then also increase this
+information for truncation with a setting in the config file ``pi.cfg`` using
+the setting:
+
+    PI_AUDIT_SQL_COLUMN_LENGTH = {"user": 100,
+                                  "policies": 1000}
+
+which will increase truncation of the user column to 100 and the policies
+column to 1000.
 
 .. _logger_audit:
 

--- a/doc/audit/index.rst
+++ b/doc/audit/index.rst
@@ -137,23 +137,25 @@ Table size
 ~~~~~~~~~~
 
 Sometimes the entries to be written to the database may be longer than the
-column in the database. You can either enlarge the columns in the database or
-you can set
+column in the database. You should set
 
    PI_AUDIT_SQL_TRUNCATE = True
 
 in ``pi.cfg``. This will truncate each entry to the defined column length.
 
-If the default column length of the audit log table are to shore, you can
-make the columns longer in the database. You should then also increase this
-information for truncation with a setting in the config file ``pi.cfg`` using
-the setting:
+However, if you sill want to fetch more information in the audit log, you can
+increase the column length directly in the database by the usual database means.
+However, privacyIDEA does not know about this, and will still truncate the entries
+to the originally defined length.
+
+To avoid this, you need to tell privacyIDEA about the changes. In :ref:cfgfile pi.cfg add the setting
+like:
 
     PI_AUDIT_SQL_COLUMN_LENGTH = {"user": 100,
                                   "policies": 1000}
 
 which will increase truncation of the user column to 100 and the policies
-column to 1000.
+column to 1000. Check the database schema for the available columns.
 
 .. _logger_audit:
 

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -306,6 +306,24 @@ class AuditTestCase(MyTestCase):
         self.assertEqual(audit_log.auditdata[0].get("token_type"), "spass")
 
 
+class AuditColumnLengthTestCase(OverrideConfigTestCase):
+    class Config(TestingConfig):
+        # this needs to exist on app creation
+        PI_AUDIT_SQL_COLUMN_LENGTH = {'user': 10}
+
+    def setUp(self):
+        self.Audit = getAudit(self.app.config)
+        self.Audit.clear()
+
+    def test_01_check_custom_column_lengths(self):
+        # Since changing the database during tests would be a hassle, we just
+        # reduce the custom length and check if it gets applied
+        self.Audit.log({"action": "test06", "tokentype": "spass",
+                        "user": "a_very_long_username@long_realm"})
+        self.Audit._truncate_data()
+        self.assertEqual(len(self.Audit.audit_data.get("user")), 10, self.Audit.audit_data)
+
+
 class AuditFileTestCase(OverrideConfigTestCase):
     class Config(TestingConfig):
         # this needs to exist on app creation


### PR DESCRIPTION
The admin can raise the length of audit log columns
in the database. To still use a valid truncation, the
admin can define in pi.cfg a setting
PI_AUDIT_SQL_COLUMN_LENGTH as a dictionary with the
length of the columns that were altered.

Closes #1756