### PR TITLE
Fix log message for userinfo policy

### DIFF
--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -816,14 +816,14 @@ class PolicyClass(object):
                     policy['name']
                 ))
         else:
-            log.warning(u"Policy {!r} has condition on userinfo {!r}, but userinfo is not available".format(
+            log.warning(u"Policy {!r} has condition on userinfo {!r}, but a user_object is not available".format(
                 policy['name'], key
             ))
             # If the policy specifies a userinfo condition, but no user object is available,
             # the policy is misconfigured. We have to raise a PolicyError to ensure that
             # the privacyIDEA server does not silently misbehave.
             raise PolicyError(
-                u"Policy {!r} has condition on userinfo, but userinfo is not available".format(
+                u"Policy {!r} has condition on userinfo, but a user_object is not available".format(
                     policy['name']
                 ))
 

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1198,7 +1198,7 @@ class PolicyTestCase(MyTestCase):
         user3.info = {"type": "notverysecure", "groups": ["b", "c"]}
 
         # no user => policy error
-        with self.assertRaisesRegexp(PolicyError, ".*userinfo is not available.*"):
+        with self.assertRaisesRegexp(PolicyError, ".* a user_object is not available.*"):
             P.match_policies(user_object=None)
 
         # empty user => policy error


### PR DESCRIPTION
If a user_object does not exist in the
request a wrong log message is written.
This fixes the log message, so that it
states correctly, that no user_object is
available.
