### PR TITLE
Push cbor2 version to 5.2.0 to avoid segfault

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Babel==2.8.0
 backports.functools-lru-cache==1.6.1; python_version < '3.0'
 bcrypt==3.1.7
 beautifulsoup4==4.9.0
-cbor2==5.1.0
+cbor2==5.2.0
 certifi==2020.4.5.1
 cffi==1.14.0
 chardet==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def get_file_list(file_path):
 
 
 install_requires = ["beautifulsoup4[lxml]>=4.3.2",
-                    "cbor2>=5.0.1",
+                    "cbor2>=5.2.0",
                     "configobj>=5.0.6",
                     "croniter>=0.3.8",
                     "cryptography>=2.4.2",


### PR DESCRIPTION
Python 3.8 (ubuntu 20.04) segfaults at exit (double free) when using the
cbor2 package with some compiled libs (< 5.2.0).
Pushing the required version to 5.2.0 fixes this.

Fixes #2463