### PR TITLE
Allow to reset PIN during WebUI Login

### DIFF
--- a/privacyidea/lib/challengeresponsedecorators.py
+++ b/privacyidea/lib/challengeresponsedecorators.py
@@ -59,6 +59,7 @@ def _create_pin_reset_challenge(token_obj, message, challenge_data=None):
     reply_dict = {}
     reply_dict["multi_challenge"] = [{"transaction_id": db_challenge.transaction_id,
                                       "message": message,
+                                      "attributes": None,
                                       "serial": token_obj.token.serial,
                                       "type": token_obj.token.tokentype}]
     reply_dict["message"] = message


### PR DESCRIPTION
The challenge response was missing an
attribute. That resulted in an error
in loginController.js in line 248
https://github.com/privacyidea/privacyidea/blob/master/privacyidea/static/components/login/controllers/loginControllers.js#L248

Adding an empty attribute to the
challenge response fixes this issue.

Fixes #2474