### PR TITLE
Initialize the OTP PIN in the token details UI

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenDetailController.js
+++ b/privacyidea/static/components/token/controllers/tokenDetailController.js
@@ -65,6 +65,7 @@ myApp.controller("tokenDetailController", function ($scope,
     $scope.params = {page: 1};
     $scope.form = {options: {}};
     $scope.editTokenInfo = 0;
+    $scope.pin1 = $scope.pin2 = "";
     $scope.testTokenPlaceholder = gettextCatalog.getString('Enter PIN and OTP to check the' +
         ' token.');
     ConfigFactory.getSystemConfig(function(data) {


### PR DESCRIPTION
Now that the PIN is initiailized the admin can
immediately set an empty pin.

Closes #2472