### PR TITLE
Avoid double click enrollment

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -213,6 +213,7 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
         // Note: A primitive does not work in the ng-model of the checkbox!
         useIt: false
     };
+    $scope.enrolling = false;
 
     $scope.formInit = {
         tokenTypes: {"hotp": gettextCatalog.getString("HOTP: event based One Time Passwords"),
@@ -490,6 +491,7 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
     };
 
     $scope.enrollToken = function () {
+        $scope.enrolling = true;
         //debug: console.log($scope.newUser.user);
         //debug: console.log($scope.newUser.realm);
         //debug: console.log($scope.newUser.pin);

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -119,7 +119,7 @@
 
         <div class="text-center">
             <button type="button" ng-click="enrollToken()"
-                    ng-disabled="!checkEnroll() || formEnrollToken.$invalid"
+                    ng-disabled="!checkEnroll() || formEnrollToken.$invalid || enrolling"
                     class="btn btn-primary" translate>Enroll Token
             </button>
         </div>


### PR DESCRIPTION
If the user double clicks on the enroll button, two tokens might
be enrolled.
We can avoid this by disabling the button at the beginning of
the enrollment.

Fixes #2487