### PR TITLE
2402/increment failcounter

### DIFF
--- a/doc/eventhandler/tokenhandler.rst
+++ b/doc/eventhandler/tokenhandler.rst
@@ -165,9 +165,10 @@ and ``{ua_string}`` for information on the user agent and ``{username}`` and
 set failcounter
 ...............
 
-Using the action ``set failcounter`` you can reset the fail counter by
-setting it to 0 or also "block" the token by setting the fail counter to what
-ever value the "max_fail" is, e.g. 10. Only integer values are allowed.
+Using the action ``set failcounter`` you can set, increase or decrease the fail counter
+of the token by setting the action to ``n``, ``+n`` or ``-n`` respectively.
+You may use this to reset the failcounter by setting it to 0 or to "block" the token by setting
+the fail counter to the value of "max_fail" or greater.
 
 set random pin
 ..............

--- a/doc/eventhandler/tokenhandler.rst
+++ b/doc/eventhandler/tokenhandler.rst
@@ -168,7 +168,7 @@ set failcounter
 Using the action ``set failcounter`` you can set, increase or decrease the fail counter
 of the token by setting the action to ``n``, ``+n`` or ``-n`` respectively.
 You may use this to reset the fail counter by setting it to 0 or to "block" the token by setting
-the fail counter to the value of "max_fail" or greater.
+the fail counter to the value of "max_fail".
 
 set random pin
 ..............

--- a/doc/eventhandler/tokenhandler.rst
+++ b/doc/eventhandler/tokenhandler.rst
@@ -167,7 +167,7 @@ set failcounter
 
 Using the action ``set failcounter`` you can set, increase or decrease the fail counter
 of the token by setting the action to ``n``, ``+n`` or ``-n`` respectively.
-You may use this to reset the failcounter by setting it to 0 or to "block" the token by setting
+You may use this to reset the fail counter by setting it to 0 or to "block" the token by setting
 the fail counter to the value of "max_fail" or greater.
 
 set random pin

--- a/privacyidea/lib/eventhandler/counterhandler.py
+++ b/privacyidea/lib/eventhandler/counterhandler.py
@@ -44,7 +44,7 @@ class CounterEventHandler(BaseEventHandler):
     """
 
     identifier = "Counter"
-    description = "This event handler increases arbitrary counters in the database."
+    description = "This event handler increases, decreases or resets arbitrary counters in the database."
 
     @property
     def allowed_positions(cls):

--- a/privacyidea/lib/eventhandler/tokenhandler.py
+++ b/privacyidea/lib/eventhandler/tokenhandler.py
@@ -236,9 +236,8 @@ class TokenEventHandler(BaseEventHandler):
                                {
                                    "type": "str",
                                    "required": True,
-                                   "description": _("Set the failcounter of "
-                                                    "the token. Any value or increment n, "
-                                                    "given by +n or -n is accepted.")
+                                   "description": _("Increase, decrease or set the fail counter of the token. "
+                                                    "Values of +n, -n or n with n being an integer are accepted.")
                                }
                        },
                    ACTION_TYPE.SET_TOKENINFO:
@@ -375,14 +374,15 @@ class TokenEventHandler(BaseEventHandler):
                 elif action.lower() == ACTION_TYPE.SET_FAILCOUNTER:
                     try:
                         handler_option = handler_options.get("fail counter")
+                        token_obj = get_one_token(serial=serial)
                         if handler_option.startswith("+"):
-                            token_failcount = get_one_token(serial=serial).token.failcount
-                            set_failcounter(serial, token_failcount + int(handler_option[1:]))
+                            token_obj.set_failcount(token_obj.token.failcount
+                                                    + int(handler_option[1:]))
                         elif handler_option.startswith("-"):
-                            token_failcount = get_one_token(serial=serial).token.failcount
-                            set_failcounter(serial, token_failcount - int(handler_option[1:]))
+                            token_obj.set_failcount(token_obj.token.failcount
+                                                    - int(handler_option[1:]))
                         else:
-                            set_failcounter(serial, int(handler_option))
+                            token_obj.set_failcount(int(handler_option))
                     except Exception as exx:
                         log.warning("Misconfiguration: Failed to set fail "
                                     "counter!")

--- a/privacyidea/lib/eventhandler/tokenhandler.py
+++ b/privacyidea/lib/eventhandler/tokenhandler.py
@@ -46,7 +46,8 @@ from privacyidea.lib.realm import get_realms
 from privacyidea.lib.token import (set_realms, remove_token, enable_token,
                                    unassign_token, init_token, set_description,
                                    set_count_window, add_tokeninfo,
-                                   set_failcounter, delete_tokeninfo)
+                                   set_failcounter, delete_tokeninfo,
+                                   get_one_token)
 from privacyidea.lib.utils import (parse_date, is_true,
                                    parse_time_offset_from_now)
 from privacyidea.lib.tokenclass import DATE_FORMAT, AUTH_DATE_FORMAT
@@ -236,7 +237,8 @@ class TokenEventHandler(BaseEventHandler):
                                    "type": "str",
                                    "required": True,
                                    "description": _("Set the failcounter of "
-                                                    "the token.")
+                                                    "the token. Any value or increment n, "
+                                                    "given by +n or -n is accepted.")
                                }
                        },
                    ACTION_TYPE.SET_TOKENINFO:
@@ -372,8 +374,15 @@ class TokenEventHandler(BaseEventHandler):
                                                 d.strftime(DATE_FORMAT))
                 elif action.lower() == ACTION_TYPE.SET_FAILCOUNTER:
                     try:
-                        set_failcounter(serial,
-                                        int(handler_options.get("fail counter")))
+                        handler_option = handler_options.get("fail counter")
+                        if handler_option.startswith("+"):
+                            token_failcount = get_one_token(serial=serial).token.failcount
+                            set_failcounter(serial, token_failcount + int(handler_option[1:]))
+                        elif handler_option.startswith("-"):
+                            token_failcount = get_one_token(serial=serial).token.failcount
+                            set_failcounter(serial, token_failcount - int(handler_option[1:]))
+                        else:
+                            set_failcounter(serial, int(handler_option))
                     except Exception as exx:
                         log.warning("Misconfiguration: Failed to set fail "
                                     "counter!")

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1693,7 +1693,7 @@ def set_failcounter(serial, counter, user=None):
     Set the fail counter of a  token.
     
     :param serial: The serial number of the token (exact)
-    :param counter: THe counter to which the fail counter should be set
+    :param counter: The counter to which the fail counter should be set
     :param user: An optional user
     :return: Number of tokens, where the fail counter was set.
     """


### PR DESCRIPTION
closes #2402

This enables the token event handler to increment failcounters by specifying +n or -n.