### PR TITLE
Cleanup of sqlaudit database connections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,3 @@
-q
 privacyIDEA
 ===========
 

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -114,7 +114,7 @@ class Audit(AuditBase):
         self.session = Session()
         # Ensure that the connection gets returned to the pool when the request has
         # been handled. This may close an already-closed session, but this is not a problem.
-        register_finalizer(self.session.close)
+        register_finalizer(self._finalize_session)
         self.session._model_changes = {}
 
     def _create_engine(self):
@@ -138,6 +138,11 @@ class Audit(AuditBase):
             engine = create_engine(connect_string)
             log.debug("Using no SQL pool_size.")
         return engine
+
+    def _finalize_session(self):
+        """ Close current session and dispose connections of db engine"""
+        self.session.close()
+        self.engine.dispose()
 
     def _truncate_data(self):
         """

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,6 +11,7 @@ from privacyidea.lib.realm import (set_realm)
 from privacyidea.lib.user import User
 from privacyidea.lib.auth import create_db_admin
 from privacyidea.lib.auditmodules.base import Audit
+from privacyidea.lib.lifecycle import call_finalizers
 
 
 PWFILE = "tests/testdata/passwords"
@@ -169,6 +170,7 @@ class MyTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        call_finalizers()
         db.session.remove()
         db.drop_all()
         cls.app_context.pop()


### PR DESCRIPTION
During testing of the audit libs, the database connection to the audit
table weren't closed properly which lead to a hanging run when using
MySQL.

Working on #2477