### PR TITLE
Update challenge response behaviour

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1396,7 +1396,7 @@ class TokenClass(object):
         ``options`` parameter contains a key ``state`` or ``transactionid``.
 
         This method does not try to verify the response itself!
-        It only determines, if this is a response for a challenge or not.
+        It only determines, if this could be a response for a challenge or not.
         The response is verified in check_challenge_response.
 
         :param passw: password, which might be pin or pin+otp
@@ -1409,15 +1409,8 @@ class TokenClass(object):
         :rtype: bool
         """
         options = options or {}
-        challenge_response = False
         transaction_id = options.get("transaction_id") or options.get("state")
-        if transaction_id:
-            # Now we also need to check, if the transaction_id is an entry to the
-            # serial number of this token
-            chals = get_challenges(serial=self.token.serial, transaction_id=transaction_id)
-            challenge_response = bool(chals)
-
-        return challenge_response
+        return bool(transaction_id)
 
     @check_token_locked
     def check_challenge_response(self, user=None, passw=None, options=None):

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1274,9 +1274,13 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertFalse(result.get("value"))
 
         # Failcounter for the first token is increased
-        # Failcounter for the second token is unchanged
+        # Failcounter for the second token is increased, since both tokens are in the
+        # the challenge_response_tokenlist.
         self.assertEqual(tokens[0].get_failcount(), 6)
-        self.assertEqual(tokens[1].get_failcount(), 5)
+        self.assertEqual(tokens[1].get_failcount(), 6)
+        # Check that the received OTP counter is set to 1 for this token
+        challs = get_challenges(serial=chalresp_serials[0])
+        self.assertEqual(challs[0].received_count, 1)
 
         # send the correct OTP value
         with self.app.test_request_context('/validate/check',
@@ -1294,10 +1298,7 @@ class ValidateAPITestCase(MyApiTestCase):
         # Failcounter for the first token is reset
         # Failcounter for the second token is unchanged
         self.assertEqual(tokens[0].get_failcount(), 0)
-        self.assertEqual(tokens[1].get_failcount(), 5)
-
-        # Set the same failcount for both tokens
-        tokens[0].set_failcount(5)
+        self.assertEqual(tokens[1].get_failcount(), 6)
 
         # trigger a challenge for both tokens
         with self.app.test_request_context('/validate/triggerchallenge',
@@ -1324,8 +1325,8 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertFalse(result.get("value"))
 
         # Failcounter for both tokens are increased
-        self.assertEqual(tokens[0].get_failcount(), 6)
-        self.assertEqual(tokens[1].get_failcount(), 6)
+        self.assertEqual(tokens[0].get_failcount(), 1)
+        self.assertEqual(tokens[1].get_failcount(), 7)
 
         # delete the tokens
         for serial in chalresp_serials:

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -567,8 +567,9 @@ class TokenBaseTestCase(MyTestCase):
                                                 realm=self.realm1),
                                             "test123456",
                                             options={"transaction_id": transaction_id})
-        # The token has not DB entry in the challenges table
-        self.assertFalse(resp)
+        # Even if the token has no transaction_id in the database, the "transaction_id" in the
+        # request paramters defines, that it is a chal_resp.
+        self.assertTrue(resp)
 
         # Create a challenge
         C = Challenge(serial=self.serial1, transaction_id=transaction_id, challenge="12")


### PR DESCRIPTION
An authentication request is now deemed to be a response
to a challenge, simply if it contains a transaction_id.
We do not check for an existing DB-challenge entry anymore,
since this entry could have been cleaned up due to time expiry.

So in ``Tokenckass::is_challenge_response`` we do not check for a DB-challenge
anymore. This way in lib/token.py:check_token_list we get a much
longer list  of ``challenge_response_token_list``.

If a user has several challenge response tokens, this way, an
invalid challenge will now increase failcounters for
every token, not only for the one token, that created the challenge.

Closes #2491