### PR TITLE
Differentiate in C/R between tokens with/out DB-challenge

### DIFF
--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2138,8 +2138,13 @@ def check_token_list(tokenobject_list, passw, user=None, options=None, allow_res
                       tokenobject.user, tokenobject.get_serial()))
 
         if tokenobject.is_challenge_response(passw, user=user, options=options):
-            # This is a challenge response
-            challenge_response_token_list.append(tokenobject)
+            # This is a challenge response and it still has a challenge DB entry
+            if tokenobject.has_db_challenge_response(passw, user=user, options=options):
+                challenge_response_token_list.append(tokenobject)
+            else:
+                # This is a transaction_id, that either never existed or has expired.
+                # We add this to the invalid_token_list
+                invalid_token_list.append(tokenobject)
         elif tokenobject.is_challenge_request(passw, user=user,
                                               options=options):
             # This is a challenge request

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -453,7 +453,6 @@ class TokenClass(object):
 
         return pin_match, otp_counter, reply
 
-
     @staticmethod
     def decode_otpkey(otpkey, otpkeyformat):
         """
@@ -1387,7 +1386,7 @@ class TokenClass(object):
 
     def is_challenge_response(self, passw, user=None, options=None):
         """
-        This method checks, if this is a request  that is supposed to be
+        This method checks, if this is a request that is supposed to be
         the answer to a previous challenge.
 
         The default behaviour to check if this is the response to a

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1387,8 +1387,8 @@ class TokenClass(object):
 
     def is_challenge_response(self, passw, user=None, options=None):
         """
-        This method checks, if this is a request, that is the response to
-        a previously sent challenge.
+        This method checks, if this is a request  that is supposed to be
+        the answer to a previous challenge.
 
         The default behaviour to check if this is the response to a
         previous challenge is simply by checking if the request contains
@@ -1397,6 +1397,7 @@ class TokenClass(object):
 
         This method does not try to verify the response itself!
         It only determines, if this is a response for a challenge or not.
+        If the challenge still exists, is checked in has_db_challenge_response.
         The response is verified in check_challenge_response.
 
         :param passw: password, which might be pin or pin+otp
@@ -1409,11 +1410,27 @@ class TokenClass(object):
         :rtype: bool
         """
         options = options or {}
+        transaction_id = options.get("transaction_id") or options.get("state")
+        return bool(transaction_id)
+
+    def has_db_challenge_response(self, passw, user=None, options=None):
+        """
+        This method checks, if the given transaction_id is actually the response to
+        a real challenge. To do so, it verifies, if there is a DB entry for the
+        given serial number and transaction_id.
+        This is to avoid side effects by passing non-existent transaction_ids.
+
+        This method checks, if the token still has a challenge
+        :param passw:
+        :param user:
+        :param options:
+        :return:
+        """
+        options = options or {}
         challenge_response = False
         transaction_id = options.get("transaction_id") or options.get("state")
         if transaction_id:
-            # Now we also need to check, if the transaction_id is an entry to the
-            # serial number of this token
+            # Now we also need to check, if there is a corresponding DB entry
             chals = get_challenges(serial=self.token.serial, transaction_id=transaction_id)
             challenge_response = bool(chals)
 

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -563,11 +563,19 @@ class TokenBaseTestCase(MyTestCase):
                                                 realm=self.realm1),
                                             "test123456")
         self.assertFalse(resp, resp)
+
+        # A the token has not DB entry in the challenges table, basically
+        # "is_cahllenge_response"
         resp = token.is_challenge_response(User(login="cornelius",
                                                 realm=self.realm1),
                                             "test123456",
                                             options={"transaction_id": transaction_id})
-        # The token has not DB entry in the challenges table
+        self.assertTrue(resp)
+        # ... but is does not "has_db_challenge_response"
+        resp = token.has_db_challenge_response(User(login="cornelius",
+                                                realm=self.realm1),
+                                               "test123456",
+                                               options={"transaction_id": transaction_id})
         self.assertFalse(resp)
 
         # Create a challenge


### PR DESCRIPTION
A response to a challenge can arrive so late, that the
original challenge does not exist anymore in the database.
It still would be a response to a challenge, so we need to
differentiate between being a legit or non-legit response at all
(it has a "transaction_id")
and a response, for which still a challenge-DB-object exists.

When merging this PR, it will also rendet this PR useless:
Closes #2493

After all it...
Closes #2491