### PR TITLE
Cosmetic Error with pi-manage backup #2454

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -334,6 +334,7 @@ def _write_mysql_defaults(filename, username, password):
     """
     with open(filename, "w") as f:
         f.write("""[client]
+no-tablespaces=True
 user={0!s}
 password={1!s}""".format(username, password))
 


### PR DESCRIPTION
add parameter --no-tablespaces in the pi-manage script/ mysql-defaults
to avoid the error: 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces.

The change has been tested and works

Fixes #2454 