### PR TITLE
fix missing numbers by removing :numbered: in any sub-toctree (nested)

### DIFF
--- a/doc/configuration/index.rst
+++ b/doc/configuration/index.rst
@@ -13,7 +13,6 @@ It also contains a shortcut to the policy tab (see :ref:`policies`).
 .. toctree::
    :maxdepth: 1
    :glob:
-   :numbered:
 
    useridresolvers.rst
    realms.rst

--- a/doc/tokens/index.rst
+++ b/doc/tokens/index.rst
@@ -12,7 +12,6 @@ with privacyIDEA.
 .. toctree::
    :maxdepth: 1
    :glob:
-   :numbered:
 
    authentication_modes.rst
    supported_tokens.rst


### PR DESCRIPTION
The number in the primary documentation chapter index was sometimes missing. This PR fixes this behavior by removing any `:numbered:` options in sub-indeces (->"nested numbered toctree").

working on #2342