### PR TITLE
2312/verify value mac

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -911,6 +911,8 @@ def loadtokens_api(filename=None):
                    'Yubikey CSV', 'pskc']
     file_type = getParam(request.all_data, "type", required)
     hashlib = getParam(request.all_data, "aladdin_hashlib")
+    # TODO Get parameter psck_validateMac with default to <?>
+    # TODO Add parameter to description
     aes_psk = getParam(request.all_data, "psk")
     aes_password = getParam(request.all_data, "password")
     if aes_psk and len(aes_psk) != 32:

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -925,7 +925,7 @@ def loadtokens_api(filename=None):
     if trealms:
         tokenrealms = trealms.split(",")
 
-    not_imported_names = []
+    not_imported_serials = []
     TOKENS = {}
     token_file = request.files['file']
     file_contents = ""

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -992,7 +992,7 @@ def loadtokens_api(filename=None):
                         'success': True})
     # logTokenNum()
 
-    return send_result({'n_imported': len(TOKENS), 'n_not_imported': len(not_imported_names)})
+    return send_result({'n_imported': len(TOKENS), 'n_not_imported': len(not_imported_serials)})
 
 
 @token_blueprint.route('/copypin', methods=['POST'])

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -969,7 +969,7 @@ def loadtokens_api(filename=None):
     elif file_type in ["yubikeycsv", "Yubikey CSV"]:
         TOKENS = parseYubicoCSV(file_contents)
     elif file_type in ["pskc"]:
-        TOKENS, not_imported_names = parsePSKCdata(file_contents, preshared_key_hex=aes_psk,
+        TOKENS, not_imported_serials = parsePSKCdata(file_contents, preshared_key_hex=aes_psk,
                                                    password=aes_password, validate_mac=aes_validate_mac)
 
     # Now import the Tokens from the dictionary

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -904,7 +904,8 @@ def loadtokens_api(filename=None):
         "oathcsv" or "yubikeycsv".
     :jsonparam tokenrealms: comma separated list of realms.
     :jsonparam psk: Pre Shared Key, when importing PSKC
-    :jsonparam pskcValidateMAC: Determines how invalid MACs should be handled when importing PSKC
+    :jsonparam pskcValidateMAC: Determines how invalid MACs should be handled when importing PSKC.
+               Allowed values are 'no_check', 'check_fail_soft' and 'check_fail_hard'.
     :return: The number of the imported tokens
     :rtype: int
     """

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -902,6 +902,7 @@ def loadtokens_api(filename=None):
         "oathcsv" or "yubikeycsv".
     :jsonparam tokenrealms: comma separated list of realms.
     :jsonparam psk: Pre Shared Key, when importing PSKC
+    :jsonparam pskcValidateMAC: Determines how invalid MACs should be handled when importing PSKC
     :return: The number of the imported tokens
     :rtype: int
     """
@@ -911,8 +912,7 @@ def loadtokens_api(filename=None):
                    'Yubikey CSV', 'pskc']
     file_type = getParam(request.all_data, "type", required)
     hashlib = getParam(request.all_data, "aladdin_hashlib")
-    # TODO Get parameter psck_validateMac with default to <?>
-    # TODO Add parameter to description
+    aes_validate_mac = getParam(request.all_data, "pskcValidateMAC", default='check_fail_hard')
     aes_psk = getParam(request.all_data, "psk")
     aes_password = getParam(request.all_data, "password")
     if aes_psk and len(aes_psk) != 32:
@@ -967,7 +967,7 @@ def loadtokens_api(filename=None):
         TOKENS = parseYubicoCSV(file_contents)
     elif file_type in ["pskc"]:
         TOKENS = parsePSKCdata(file_contents, preshared_key_hex=aes_psk,
-                               password=aes_password)
+                               password=aes_password, validate_mac=aes_validate_mac)
 
     # Now import the Tokens from the dictionary
     ret = ""

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -3,6 +3,8 @@
 # http://www.privacyidea.org
 # (c) cornelius kölbel, privacyidea.org
 #
+# 2020-11-11 Timo Sturm <timo.sturm@netknights.it>
+#            Select how to validate PSKC imports
 # 2020-01-28 Jean-Pierre Höhmann <jean-pierre.hoehmann@netknights.it>
 #            Add WebAuthn token
 # 2018-06-07 Cornelius Kölbel <cornelius.koelbel@netknights.it>

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -923,6 +923,7 @@ def loadtokens_api(filename=None):
     if trealms:
         tokenrealms = trealms.split(",")
 
+    not_imported_names = []
     TOKENS = {}
     token_file = request.files['file']
     file_contents = ""
@@ -966,8 +967,8 @@ def loadtokens_api(filename=None):
     elif file_type in ["yubikeycsv", "Yubikey CSV"]:
         TOKENS = parseYubicoCSV(file_contents)
     elif file_type in ["pskc"]:
-        TOKENS = parsePSKCdata(file_contents, preshared_key_hex=aes_psk,
-                               password=aes_password, validate_mac=aes_validate_mac)
+        TOKENS, not_imported_names = parsePSKCdata(file_contents, preshared_key_hex=aes_psk,
+                                                   password=aes_password, validate_mac=aes_validate_mac)
 
     # Now import the Tokens from the dictionary
     ret = ""
@@ -989,7 +990,7 @@ def loadtokens_api(filename=None):
                         'success': True})
     # logTokenNum()
 
-    return send_result(len(TOKENS))
+    return send_result({'n_imported': len(TOKENS), 'n_not_imported': len(not_imported_names)})
 
 
 @token_blueprint.route('/copypin', methods=['POST'])

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -469,7 +469,7 @@ def parsePSKCdata(xml_data,
     :param do_checkserial: Check if the serial numbers conform to the OATH
         specification (not yet implemented)
     :param validate_mac: Operation mode of hmac validation. Possible values:
-        - 'check_fail_hard' : If an invalid hmac is encountered an exception is thrown and no token gets parsed.
+        - 'check_fail_hard' : If an invalid hmac is encountered no token gets parsed.
         - 'check_fail_soft' : Skip tokens with invalid MAC.
         - 'no_check' : Hmac of tokens are not checked, every token is parsed.
 

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -479,7 +479,7 @@ def parsePSKCdata(xml_data,
 
     abort = False
 
-    not_imported_tokens_names = []
+    not_imported_serials = []
     tokens = {}
     xml = strip_prefix_from_soup(BeautifulSoup(xml_data, "lxml"))
 
@@ -553,7 +553,7 @@ def parsePSKCdata(xml_data,
                     if is_invalid and validate_mac == 'check_fail_hard':
                         abort = True
                     elif is_invalid and validate_mac == 'check_fail_soft':
-                        not_imported_tokens_names.append(serial)
+                        not_imported_serials.append(serial)
                         continue
 
         except Exception as exx:
@@ -573,11 +573,10 @@ def parsePSKCdata(xml_data,
         tokens[serial] = token
 
     if abort:
-        # Add descriptions to list and reset tokens.
-        not_imported_tokens_names = [t['description'] for t in tokens]
-        tokens = {}
+        not_imported_serials = [serial for serial in tokens]
+        tokens = {}  # reset tokens
 
-    return tokens, not_imported_tokens_names
+    return tokens, not_imported_serials
 
 
 class GPGImport(object):

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -545,10 +545,6 @@ def parsePSKCdata(xml_data,
 
                 print('\nParse token {}\nPwd: {}'.format(serial, preshared_key))
 
-                # 3132333435363738393031323334353637383930
-                # 12345678901234567890123456789012
-                # 1122334455667788990011223344556677889900
-
                 print('\nParse token {}\nPwd: {}'.format(serial, binascii.hexlify(preshared_key)))
                 print('Mac-Key: {}\nSecret: {}'.format(mac_key, secret))
                 print('XML Mac-Val: {}\nCalc Mac-Val: {}'.format(mac_value_xml, mac_value_calculated))

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -468,9 +468,9 @@ def parsePSKCdata(xml_data,
     :param password: The password that encrypted the keys
     :param do_checkserial: Check if the serial numbers conform to the OATH
         specification (not yet implemented)
-    :param validate_mac: Operation mode of hmac validation. Possible values: # TODO Use const instead
+    :param validate_mac: Operation mode of hmac validation. Possible values: # TODO Use const instead (?)
         - 'check_fail_hard' : If an invalid hmac is encountered an exception is thrown and no token gets parsed.
-        - 'check_fail_soft' : Tokens with invalid hmac are ignored on parsing.
+        - 'check_fail_soft' : Skip tokens with invalid MAC.
         - 'no_check' : Hmac of tokens are not checked, every token is parsed.
 
     :return: a dictionary of token dictionaries

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -575,7 +575,7 @@ def parsePSKCdata(xml_data,
         tokens[serial] = token
 
     if abort:
-        not_imported_serials = [serial for serial in tokens]
+        not_imported_serials = tokens.keys()
         tokens = {}  # reset tokens
 
     return tokens, not_imported_serials

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -475,7 +475,7 @@ def parsePSKCdata(xml_data,
         - 'check_fail_soft' : Skip tokens with invalid MAC.
         - 'no_check' : Hmac of tokens are not checked, every token is parsed.
 
-    :return: a dictionary of token dictionaries and a list of serial of not imported tokens
+    :return: tuple of a dictionary of token dictionaries and a list of serial of not imported tokens
         { serial : { otpkey , counter, .... }}, [serial, serial, ...]
     """
 

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -540,13 +540,14 @@ def parsePSKCdata(xml_data,
 
                 # TODO Skip this confirmation step if some policy is set
                 if mac_value_xml != mac_value_calculated:
-                    raise ImportException('XML could not be validated, mismatch of MAC.')
+                    raise ImportException('XML could not be validated, MAC-Value does not match encoded data.')
 
         except Exception as exx:
             log.error("Failed to import tokendata: {0!s}".format(exx))
             log.debug(traceback.format_exc())
             raise ImportException("Failed to import tokendata. Wrong "
                                   "encryption key? %s" % exx)
+
         if token["type"] in ["hotp", "totp"] and key.data.counter:
             token["counter"] = key.data.counter.text.strip()
         if token["type"] == "totp":

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -690,7 +690,8 @@ def export_pskc(tokenobj_list, psk=None):
                 encrypted_otpkey = aes_encrypt_b64(psk, otpkey)
             else:
                 encrypted_otpkey = aes_encrypt_b64(psk, otpkey)
-            hm = hmac.new(key=mackey, msg=otpkey, digestmod=hashlib.sha1)
+
+            hm = hmac.new(key=mackey, msg=base64.b64decode(encrypted_otpkey), digestmod=hashlib.sha1)
             mac_value = b64encode_and_unicode(hm.digest())
         except TypeError:
             # Some keys might be odd string length

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -520,17 +520,18 @@ def parsePSKCdata(xml_data,
                 enc_data = key.data.secret.encryptedvalue.ciphervalue.text
                 enc_data = enc_data.strip()
 
-                key = binascii.unhexlify(preshared_key_hex)
+                preshared_key = binascii.unhexlify(preshared_key_hex)
 
                 # TODO Check mac
                 #  calculate MAC
-                #       - mac key
-                #       - secret
                 #  check if own mac fits mac from xml
                 #  IF true THEN pass ELSE throw Exception
-                mac_key = xml.keycontainer # TODO Get macvalue
+                encrypted_mac_key = xml.keycontainer.find(
+                    "mackey").text.strip()  # TODO Is it save to assume that this exists?
+                mac_key = aes_decrypt_b64(preshared_key, encrypted_mac_key)
+                mac_value = key.data.secret.valuemac.text.strip()
 
-                secret = aes_decrypt_b64(key, enc_data)
+                secret = aes_decrypt_b64(preshared_key, enc_data)
                 if token["type"].lower() in ["hotp", "totp"]:
                     token["otpkey"] = hexlify_and_unicode(secret)
                 elif token["type"].lower() in ["pw"]:

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -477,6 +477,8 @@ def parsePSKCdata(xml_data,
         { serial : { otpkey , counter, .... }}, [serial, serial, ...]
     """
 
+    abort = False
+
     not_imported_tokens_names = []
     tokens = {}
     xml = strip_prefix_from_soup(BeautifulSoup(xml_data, "lxml"))
@@ -549,9 +551,7 @@ def parsePSKCdata(xml_data,
                     is_invalid = not hmac.compare_digest(mac_value_xml, mac_value_calculated)
 
                     if is_invalid and validate_mac == 'check_fail_hard':
-                        not_imported_tokens_names = ['error' for _ in key_packages]
-                        tokens = {}  # Reset imported tokens
-                        break
+                        abort = True
                     elif is_invalid and validate_mac == 'check_fail_soft':
                         not_imported_tokens_names.append(serial)
                         continue
@@ -571,6 +571,12 @@ def parsePSKCdata(xml_data,
                 token["timeShift"] = key.data.timedrift.text.strip()
 
         tokens[serial] = token
+
+    if abort:
+        # Add descriptions to list and reset tokens.
+        not_imported_tokens_names = [t['description'] for t in tokens]
+        tokens = {}
+
     return tokens, not_imported_tokens_names
 
 

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2020-11-11 Timo Sturm <timo.sturm@netknights.it>
+#             Select how to validate PSKC imports
 #  2018-05-10 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add fileversion to OATH CSV
 #  2017-11-24 Cornelius Kölbel <cornelius.koelbel@netknights.it>

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -544,6 +544,12 @@ def parsePSKCdata(xml_data,
                 mac_value_xml = key.data.find('valuemac').text.strip()
 
                 print('\nParse token {}\nPwd: {}'.format(serial, preshared_key))
+
+                # 3132333435363738393031323334353637383930
+                # 12345678901234567890123456789012
+                # 1122334455667788990011223344556677889900
+
+                print('\nParse token {}\nPwd: {}'.format(serial, binascii.hexlify(preshared_key)))
                 print('Mac-Key: {}\nSecret: {}'.format(mac_key, secret))
                 print('XML Mac-Val: {}\nCalc Mac-Val: {}'.format(mac_value_xml, mac_value_calculated))
                 print('Are they equal? {}'.format(mac_value_xml == mac_value_calculated))

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -538,6 +538,7 @@ def parsePSKCdata(xml_data,
 
                 mac_value_xml = key.data.find('valuemac').text.strip()
 
+                # TODO Skip this confirmation step if some policy is set
                 if mac_value_xml != mac_value_calculated:
                     raise ImportException('XML could not be validated, mismatch of MAC.')
 

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -719,8 +719,8 @@ def export_pskc(tokenobj_list, psk=None):
                                  <xenc:CipherValue>{encrypted_otpkey}</xenc:CipherValue>
                              </xenc:CipherData>
                          </EncryptedValue>
+                         <ValueMAC>{value_mac}</ValueMAC>
                      </Secret>
-                     <ValueMAC>{value_mac}</ValueMAC>
                     <Time>
                         <PlainValue>0</PlainValue>
                     </Time>

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -531,19 +531,22 @@ def parsePSKCdata(xml_data,
                 else:
                     token["otpkey"] = to_unicode(secret)
 
-                encrypted_mac_key = xml.keycontainer.find(
-                    "mackey").text  # TODO Is it save to assume that this exists?
+                encrypted_mac_key = xml.keycontainer.find("mackey").text
                 mac_key = aes_decrypt_b64(preshared_key, encrypted_mac_key)
 
                 if token["type"].lower() in ["hotp", "totp"]:
                     secret = binascii.hexlify(secret)
 
+                # FIXME Decoding the MAC_KEY like this results in the same valus as in RFC 6030, but:
+                #   1. the mac-value doesnt fit
+                #   2. this is not compatible with export_pskc
+                # mac_key = b'1122334455667788990011223344556677889900' # The mac-key from RFC 6030
+                mac_key = binascii.hexlify(mac_key)
+
                 hm = hmac.new(key=mac_key, msg=secret, digestmod=hashlib.sha1)
                 mac_value_calculated = b64encode_and_unicode(hm.digest())
 
                 mac_value_xml = key.data.find('valuemac').text.strip()
-
-                print('\nParse token {}\nPwd: {}'.format(serial, preshared_key))
 
                 print('\nParse token {}\nPwd: {}'.format(serial, binascii.hexlify(preshared_key)))
                 print('Mac-Key: {}\nSecret: {}'.format(mac_key, secret))

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -519,7 +519,18 @@ def parsePSKCdata(xml_data,
                                           "AES128-CBC.")
                 enc_data = key.data.secret.encryptedvalue.ciphervalue.text
                 enc_data = enc_data.strip()
-                secret = aes_decrypt_b64(binascii.unhexlify(preshared_key_hex), enc_data)
+
+                key = binascii.unhexlify(preshared_key_hex)
+
+                # TODO Check mac
+                #  calculate MAC
+                #       - mac key
+                #       - secret
+                #  check if own mac fits mac from xml
+                #  IF true THEN pass ELSE throw Exception
+                mac_key = xml.keycontainer # TODO Get macvalue
+
+                secret = aes_decrypt_b64(key, enc_data)
                 if token["type"].lower() in ["hotp", "totp"]:
                     token["otpkey"] = hexlify_and_unicode(secret)
                 elif token["type"].lower() in ["pw"]:

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -698,6 +698,7 @@ myApp.controller("tokenImportController", function ($scope, Upload,
                 data: {file: file,
                     type: $scope.form.type,
                     psk: $scope.form.psk,
+                    // TODO $scope.form.validateMAC
                     password: $scope.form.password,
                     tokenrealms: $scope.form.realm},
             }).then(function (resp) {

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -698,7 +698,7 @@ myApp.controller("tokenImportController", function ($scope, Upload,
                 data: {file: file,
                     type: $scope.form.type,
                     psk: $scope.form.psk,
-                    // TODO $scope.form.validateMAC
+                    pskcValidateMAC: $scope.form.validateMAC,
                     password: $scope.form.password,
                     tokenrealms: $scope.form.realm},
             }).then(function (resp) {

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -703,7 +703,8 @@ myApp.controller("tokenImportController", function ($scope, Upload,
                     tokenrealms: $scope.form.realm},
             }).then(function (resp) {
                 $scope.uploadedFile = resp.config.data.file.name;
-                $scope.uploadedTokens = resp.data.result.value;
+                $scope.uploadedTokens = resp.data.result.value.n_imported;
+                $scope.notImportedTokens = resp.data.result.value.n_not_imported;
             }, function (error) {
                 if (error.data.result.error.code === -401) {
                     $state.go('login');

--- a/privacyidea/static/components/token/views/token.import.html
+++ b/privacyidea/static/components/token/views/token.import.html
@@ -78,8 +78,7 @@
         <div></div>
         <div class="mt-5px">
             <p class="help help-block" translate>
-                You can choose how to verify the authenticity of the stored tokens.
-                <!--                TODO make a (better) description -->
+                You can choose how the authenticity the stored tokens should be verified.
             </p>
             <select class="form-control"
                     ng-model="form.validateMAC">

--- a/privacyidea/static/components/token/views/token.import.html
+++ b/privacyidea/static/components/token/views/token.import.html
@@ -82,11 +82,9 @@
             </p>
             <select class="form-control"
                     ng-model="form.validateMAC">
-                <!--                TODO Set default value for this!-->
-                <!--                FIXME How to make these strings translatable?-->
-                <option ng-repeat="(key, desc) in {no_check: 'Do not verify the authenticity',
-                 check_fail_hard : 'Abort operation on unverifiable token',
-                  check_fail_soft : 'Skip tokens that can not be verified'}"
+                <option ng-repeat="(key, desc) in {no_check: 'Do not verify the authenticity' | translate,
+                  check_fail_soft : 'Skip tokens that can not be verified' | translate,
+                  check_fail_hard : 'Abort operation on unverifiable token' | translate}"
                         value="{{ key }}">
                     {{ desc }}
                 </option>

--- a/privacyidea/static/components/token/views/token.import.html
+++ b/privacyidea/static/components/token/views/token.import.html
@@ -69,12 +69,28 @@
         </p>
         <input class="form-control"
                placeholder="{{ 'Pre Shared Key' | translate }}"
-               ng-keypress="form.password =''"
+               ng-keypress="form.password = ''"
                ng-model="form.psk" minlength="0" maxlength="32">
         <input class="form-control"
                placeholder="{{ 'Password' | translate }}"
                ng-keypress="form.psk = ''"
                ng-model="form.password">
+        <div></div>
+        <div class="mt-5px">
+            <p class="help help-block" translate>
+                You can choose how to verify the authenticity of the stored tokens.
+                <!--                TODO make a (better) description -->
+            </p>
+            <select class="form-control"
+                    ng-model="form.validateMAC">
+<!--                FIXME How to make these strings translatable?-->
+                <option ng-repeat="(key, desc) in {no_check: 'Do not verify the authenticity',
+                 check_fail_hard : 'Abort operation on unverifiable token',
+                  check_fail_soft : 'Skip tokens that can not be verified'}"
+                    value="{{ key }}">{{ desc }}
+                </option>
+            </select>
+        </div>
     </div>
 
     <div class="mt-5px">

--- a/privacyidea/static/components/token/views/token.import.html
+++ b/privacyidea/static/components/token/views/token.import.html
@@ -82,11 +82,13 @@
             </p>
             <select class="form-control"
                     ng-model="form.validateMAC">
-<!--                FIXME How to make these strings translatable?-->
+                <!--                TODO Set default value for this!-->
+                <!--                FIXME How to make these strings translatable?-->
                 <option ng-repeat="(key, desc) in {no_check: 'Do not verify the authenticity',
                  check_fail_hard : 'Abort operation on unverifiable token',
                   check_fail_soft : 'Skip tokens that can not be verified'}"
-                    value="{{ key }}">{{ desc }}
+                        value="{{ key }}">
+                    {{ desc }}
                 </option>
             </select>
         </div>
@@ -140,7 +142,7 @@
         Uploaded Tokens: {{ uploadedTokens }}
     </div>
     <div>
-<!--        How to translate this?-->
+        <!--        How to translate this?-->
         Skipped Tokens: {{ notImportedTokens }}
     </div>
 </div>

--- a/privacyidea/static/components/token/views/token.import.html
+++ b/privacyidea/static/components/token/views/token.import.html
@@ -78,7 +78,7 @@
         <div></div>
         <div class="mt-5px">
             <p class="help help-block" translate>
-                You can choose how the authenticity the stored tokens should be verified.
+                You can choose how the authenticity of the tokens to be imported should be verified.
             </p>
             <select class="form-control"
                     ng-model="form.validateMAC">
@@ -140,7 +140,7 @@
         Uploaded Tokens: {{ uploadedTokens }}
     </div>
     <div>
-        <!--        How to translate this?-->
-        Skipped Tokens: {{ notImportedTokens }}
+        <translate>Skippted Tokens
+            <translate>: {{ notImportedTokens }}
     </div>
 </div>

--- a/privacyidea/static/components/token/views/token.import.html
+++ b/privacyidea/static/components/token/views/token.import.html
@@ -139,4 +139,8 @@
     <div translate>
         Uploaded Tokens: {{ uploadedTokens }}
     </div>
+    <div>
+<!--        How to translate this?-->
+        Skipped Tokens: {{ notImportedTokens }}
+    </div>
 </div>

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -892,7 +892,7 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            value = result.get("value")
+            value = result.get("value")['n_imported']
             self.assertTrue(value == 3, result)
         # check for a successful audit entry
         entry = self.find_most_recent_audit_entry(action='*/token/load/*')
@@ -910,7 +910,7 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            value = result.get("value")
+            value = result.get("value")['n_imported']
             self.assertTrue(value == 3, result)
 
         # Load yubico.csv
@@ -924,7 +924,7 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            value = result.get("value")
+            value = result.get("value")['n_imported']
             self.assertTrue(value == 3, result)
 
         # check if the token was put into self.realm1
@@ -967,7 +967,7 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            value = result.get("value")
+            value = result.get("value")['n_imported']
             self.assertTrue(value == 1, result)
 
         # Load PSKC file, encrypted Password
@@ -981,7 +981,7 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            value = result.get("value")
+            value = result.get("value")['n_imported']
             self.assertTrue(value == 1, result)
 
     def test_11_load_tokens_only_to_specific_realm(self):
@@ -1002,7 +1002,7 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            value = result.get("value")
+            value = result.get("value")['n_imported']
             self.assertTrue(value == 3, result)
         # Now check, if the tokens are in the realm
         from privacyidea.lib.token import get_realms_of_token
@@ -1023,7 +1023,7 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            value = result.get("value")
+            value = result.get("value")['n_imported']
             self.assertTrue(value == 3, result)
         # Now check, if the tokens are in the realm
         r = get_realms_of_token("token01")

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -359,7 +359,7 @@ class DisplayTANTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            value = result.get("value")
+            value = result.get("value")['n_imported']
             self.assertTrue(value == 1, result)
 
         from privacyidea.lib.token import set_pin

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -587,6 +587,29 @@ class ImportOTPTestCase(MyTestCase):
                          "3132333435363738393031323334353637383930")
         self.assertEqual(tokens["987654321"].get("description"), "Manufacturer")
 
+        # Test 'check_fail_hard' no token parsed and import exception
+        xml_wrong_mac = XML_PSKC_AES.replace("Su+NvtQfmvfJzF6bmQiJqoLRExc=", "Su+NvtQfmvfJzF6XYZiJqoLRExc=")
+        with pytest.raises(ImportException):
+            parsePSKCdata(xml_wrong_mac,
+                          preshared_key_hex=encryption_key_hex)
+
+        # Test 'no_check' all tokens parsed and no exception
+        xml_wrong_mac = XML_PSKC_AES.replace("Su+NvtQfmvfJzF6bmQiJqoLRExc=", "Su+NvtQfmvfJzF6XYZiJqoLRExc=")
+        tokens = parsePSKCdata(xml_wrong_mac,
+                               preshared_key_hex=encryption_key_hex, validate_mac='no_check')
+        self.assertEqual(len(tokens), 1)
+        self.assertEqual(tokens["987654321"].get("type"), "hotp")
+        self.assertEqual(tokens["987654321"].get("otplen"), "8")
+        self.assertEqual(tokens["987654321"].get("otpkey"),
+                         "3132333435363738393031323334353637383930")
+        self.assertEqual(tokens["987654321"].get("description"), "Manufacturer")
+
+        # Test 'check_fail_soft' no token parsed and no exception
+        xml_wrong_mac = XML_PSKC_AES.replace("Su+NvtQfmvfJzF6bmQiJqoLRExc=", "Su+NvtQfmvfJzF6XYZiJqoLRExc=")
+        tokens = parsePSKCdata(xml_wrong_mac,
+                               preshared_key_hex=encryption_key_hex, validate_mac='check_fail_soft')
+        self.assertEqual(len(tokens), 0)
+
     def test_05_import_pskc_password(self):
         password = "qwerty"
 
@@ -635,14 +658,6 @@ class ImportOTPTestCase(MyTestCase):
         self.assertEqual(tokens.get("t2").get("description"), "something <with> xml!")
         # password token
         self.assertEqual(tokens.get("t4").get("otpkey"), u"lässig")
-
-    def test_07_import_pskc_aes_fail(self):
-        encryption_key_hex = "12345678901234567890123456789012"
-
-        xml_wrong_mac = XML_PSKC_AES.replace("Su+NvtQfmvfJzF6bmQiJqoLRExc=", "Su+NvtQfmvfJzF6XYZiJqoLRExc=")
-        with pytest.raises(ImportException):
-            parsePSKCdata(xml_wrong_mac,
-                          preshared_key_hex=encryption_key_hex)
 
 
 class GPGTestCase(MyTestCase):

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -12,8 +12,7 @@ from privacyidea.lib.importotp import (parseOATHcsv, parseYubicoCSV,
 from privacyidea.lib.token import remove_token
 from privacyidea.lib.token import init_token
 from privacyidea.lib.importotp import export_pskc
-from privacyidea.lib.utils import hexlify_and_unicode, to_unicode
-import binascii
+from privacyidea.lib.utils import hexlify_and_unicode
 
 
 XML_PSKC_PASSWORD_PREFIX = """<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -577,6 +577,7 @@ class ImportOTPTestCase(MyTestCase):
         self.assertEqual(tokens["PW001"].get("otpkey"), hexlify_and_unicode("123456789012"))
 
     def test_04_import_pskc_aes(self):
+        # Test default and all tokens are valid
         encryption_key_hex = "12345678901234567890123456789012"
         tokens = parsePSKCdata(XML_PSKC_AES,
                                preshared_key_hex=encryption_key_hex)

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -615,7 +615,7 @@ class ImportOTPTestCase(MyTestCase):
         tlist = [t1, t2, t3, t4]
         # export the tokens
         psk, token_num, soup = export_pskc(tlist)
-        # Only 2 tokens exported, the spass token does not get exported!
+        # Only 3 tokens exported, the spass token does not get exported!
         self.assertEqual(token_num, 3)
         self.assertEqual(len(psk), 32)
         export = "{0!s}".format(soup)

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -3,7 +3,7 @@
 This test file tests the lib.importotp
 
 """
-
+import pytest
 
 from .base import MyTestCase
 from privacyidea.lib.importotp import (parseOATHcsv, parseYubicoCSV,
@@ -338,8 +338,7 @@ sccTokenType: eToken-PASS-TS
 sccTokenData: sccKey=535CC2CB9DEA0B55B0A2D585EAB648EBCE73AC8B;sccMode=T;sccPwLen=6;sccVer=6.20;sccTick=30;sccPrTime=2013/03/12 00:00:00
 sccSignature: MC4CFQDju23MCRqmkWC7Z9sVDB0y0TeEOwIVAOIibmqMFxhPiY7mLlkt5qmRT/xn        '''
 
-
-YUBIKEYCSV= '''
+YUBIKEYCSV = '''
         Static Password: Scan Code,17.04.12 12:25,1,051212172c092728,,,,,0,0,0,0,0,0,0,0,0,0
         Static Password: Scan Code,17.04.12 12:27,1,282828051212172c092728,,,,,0,0,0,0,0,0,0,0,0,0
         LOGGING START,17.04.12 12:29
@@ -637,6 +636,14 @@ class ImportOTPTestCase(MyTestCase):
         self.assertEqual(tokens.get("t2").get("description"), "something <with> xml!")
         # password token
         self.assertEqual(tokens.get("t4").get("otpkey"), u"lässig")
+
+    def test_07_import_pskc_aes_fail(self):
+        encryption_key_hex = "12345678901234567890123456789012"
+
+        xml_wrong_mac = XML_PSKC_AES.replace("Su+NvtQfmvfJzF6bmQiJqoLRExc=", "Su+NvtQfmvfJzF6XYZiJqoLRExc=")
+        with pytest.raises(ImportException):
+            parsePSKCdata(xml_wrong_mac,
+                          preshared_key_hex=encryption_key_hex)
 
 
 class GPGTestCase(MyTestCase):

--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
+# 2020-11-11 Timo Sturm <timo.sturm@netknights.it>
+#            Select how to validate PSKC imports
 # 2018-02-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #            Allow to import PSKC file
 # 2017-11-21 Cornelius Kölbel <corenlius.koelbel@netknights.it>

--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -509,16 +509,18 @@ def find(last_auth, assigned, active, tokeninfo_key, tokeninfo_value,
                 help='Import this PSKC file.')
 @manager.option('--preshared_key_hex', dest='preshared_key_hex',
                 help='The AES encryption key.')
-def loadtokens(pskc, preshared_key_hex):
+@manager.option('--validate_mac', dest='validate_mac',
+                help="How the file should be validated.\n"
+                     "'no_check' : Every token is parsed, ignoring HMAC\n"
+                     "'check_fail_soft' : Skip tokens with invalid HMAC\n"
+                     "'check_fail_hard' : Only import tokens if all HMAC are valid.")
+def loadtokens(pskc, preshared_key_hex, validate_mac):
     from privacyidea.lib.importotp import parsePSKCdata
 
     with open(pskc, 'r') as pskcfile:
         file_contents = pskcfile.read()
 
-    # TODO Should the tokens that were not imported by the janitor be appended to failed_tokens?
-    # TODO Should this method allow to change how tokens are validated, how would that be done?
-
-    tokens, _ = parsePSKCdata(file_contents, preshared_key_hex)
+    tokens, _ = parsePSKCdata(file_contents, preshared_key_hex, validate_mac)
     success = 0
     failed = 0
     failed_tokens = []

--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -515,7 +515,10 @@ def loadtokens(pskc, preshared_key_hex):
     with open(pskc, 'r') as pskcfile:
         file_contents = pskcfile.read()
 
-    tokens = parsePSKCdata(file_contents, preshared_key_hex)
+    # TODO Should the tokens that were not imported by the janitor be appended to failed_tokens?
+    # TODO Should this method allow to change how tokens are validated, how would that be done?
+
+    tokens, _ = parsePSKCdata(file_contents, preshared_key_hex)
     success = 0
     failed = 0
     failed_tokens = []

--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -522,7 +522,7 @@ def loadtokens(pskc, preshared_key_hex, validate_mac):
     with open(pskc, 'r') as pskcfile:
         file_contents = pskcfile.read()
 
-    tokens, _ = parsePSKCdata(file_contents, preshared_key_hex, validate_mac)
+    tokens, not_parsed_tokens = parsePSKCdata(file_contents, preshared_key_hex, validate_mac)
     success = 0
     failed = 0
     failed_tokens = []
@@ -535,6 +535,10 @@ def loadtokens(pskc, preshared_key_hex, validate_mac):
             failed = failed + 1
             failed_tokens.append(serial)
             print("--- Failed to import token. {0!s}".format(e))
+
+    if not_parsed_tokens:
+        print("The following tokens were not read from the PSKC file"
+              " because they could not be validated: {0!s}".format(not_parsed_tokens))
     print("Successfully imported {0!s} tokens.".format(success))
     print("Failed to import {0!s} tokens: {1!s}".format(failed, failed_tokens))
 


### PR DESCRIPTION
When importing tokens from PSKC-Files the method of validating the MAC can now be selected. There are three options:
- 'no_check' : MAC values are not validated
- 'check_fail_soft' : Tokens with invalid MAC are skipped, valid tokens are imported
- 'check_fail_hard' : If an invalid MAC is encountered, no token is imported (not even the valid ones)

'check_fail_hard' is the default option.

The user can select one of the aforementioned options in the user interface, additionally more feedback is given: The UI now shows the number of not imported tokens next to the number of imported tokens.

The `privacyidea_token_manager' too supports selecting a validation method.

Both the code and the user interface should be checked when reviewing this pull request. Closes #2312 