### PR TITLE
add privacy statement link to baseline

### DIFF
--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -351,6 +351,7 @@ class ACTION(object):
     SHOW_SEED = "show_seed"
     CUSTOM_MENU = "custom_menu"
     CUSTOM_BASELINE = "custom_baseline"
+    GDPR_LINK = "privacy_statement_link"
     STATISTICSREAD = "statistics_read"
     STATISTICSDELETE = "statistics_delete"
     LOGIN_TEXT = "login_text"
@@ -2180,6 +2181,10 @@ def get_static_policy_definitions(scope=None):
             ACTION.CUSTOM_BASELINE: {
                 'type': 'str',
                 'desc': _("Use your own html template for the web UI baseline/footer.")
+            },
+            ACTION.GDPR_LINK: {
+                'type': 'str',
+                'desc': _("Link your privacy statement to be displayed in the baseline/footer.")
             },
             ACTION.USERDETAILS: {
                 'type': 'bool',

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -67,6 +67,8 @@ angular.module("privacyideaApp")
     $scope.hasJobQueue = obj.val() == "True";
     obj = angular.element(document.querySelector('#LOGIN_TEXT'));
     $scope.piLoginText = obj.val();
+    obj = angular.element(document.querySelector('#GDPR_LINK'));
+    $scope.piGDPRLink = obj.val();
     obj = angular.element(document.querySelector('#PI_TRANSLATION_WARNING'));
     $scope.piTranslationWarning = obj.val() !== "False";
     $scope.piTranslationPrefix = obj.val();

--- a/privacyidea/static/templates/baseline.html
+++ b/privacyidea/static/templates/baseline.html
@@ -25,5 +25,11 @@
                 target="documentation">
             <translate>Online Documentation</translate>
         </a>
+       <a class="navbar-text pull-right pull-right"
+           ng-show="piGDPRLink"
+           href="{{ piGDPRLink }}"
+           target="_external">
+            <translate>Privacy Statement</translate>
+        </a>
     </div>
 </div>

--- a/privacyidea/static/templates/index.html
+++ b/privacyidea/static/templates/index.html
@@ -17,6 +17,7 @@
 <input type=hidden id="EXTERNAL_LINKS" value="{{ external_links }}">
 <input type=hidden id="HAS_JOB_QUEUE" value="{{ has_job_queue }}">
 <input type=hidden id="LOGIN_TEXT" value="{{ login_text }}">
+<input type=hidden id="GDPR_LINK" value="{{ gdpr_link }}">
 <input type=hidden id="PRIVACYIDEA_VERSION_NUMBER" value="{{ privacyideaVersionNumber }}">
 <input type=hidden id=PI_TRANSLATION_WARNING value="{{ translation_warning }}">
 

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -148,6 +148,13 @@ def single_page_application():
     else:
         login_text = ""
 
+    gdpr_link = Match.action_only(g, action=ACTION.GDPR_LINK, scope=SCOPE.WEBUI) \
+        .action_values(unique=True, allow_white_space_in_action=True, write_to_audit_log=False)
+    if len(gdpr_link) and list(gdpr_link)[0] and sub_state not in [1, 2]:
+        gdpr_link = list(gdpr_link)[0]
+    else:
+        gdpr_link = ""
+
     render_context = {
         'instance': instance,
         'backendUrl': backend_url,
@@ -165,6 +172,7 @@ def single_page_application():
         'realms': realms,
         'external_links': external_links,
         'login_text': login_text,
+        'gdpr_link': gdpr_link,
         'logo': logo,
         'page_title': page_title
     }

--- a/tests/test_ui_login.py
+++ b/tests/test_ui_login.py
@@ -84,3 +84,12 @@ class LoginUITestCase(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertTrue(b"<input type=hidden id=REMOTE_USER value=\"foo\">" in res.data)
+
+    def test_07_privacy_statement_link(self):
+        set_policy("gdpr_link", scope=SCOPE.WEBUI,
+                   action="{0!s}=https://privacyidea.org/".format(ACTION.GDPR_LINK))
+        with self.app.test_request_context('/',
+                                           method='GET'):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            self.assertTrue(b"https://privacyidea.org/" in res.data)


### PR DESCRIPTION
This PR adds a policy to add a custom link to the a privacy statement in the baseline.

closes #2325