### PR TITLE
demote "missing HTTP headers" to warning in policy handling

### DIFF
--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+#  2020-11-15 Jens-U. Mozdzen <jmozdzen@nde.ag>
+#             missing http headers now are only reported as warnings
 #  2020-06-05 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add privacyIDEA nodes
 #  2019-09-26 Friedrich Weber <friedrich.weber@netknights.it>
@@ -788,10 +790,10 @@ class PolicyClass(object):
                 raise PolicyError(u"Unknown HTTP header key referenced in condition of policy "
                                   u"{!r}: {!r}".format(policy["name"], key))
         else:  # pragma: no cover
-            log.error(u"Policy {!r} has conditions on headers {!r}, but http header"
+            log.warning(u"Policy {!r} has conditions on headers {!r}, but http header"
                       u" is not available. This should not happen.".format(policy["name"], key))
-            raise PolicyError(u"Policy {!r} has conditions on headers {!r}, but http header"
-                        u" is not available".format(policy["name"], key))
+            # a missing header is treated as a no-match condition
+            return False
 
     @staticmethod
     def _policy_matches_userinfo_condition(policy, key, comparator, value, user_object):


### PR DESCRIPTION
After creating policies that use custom HTTP headers, for me, authentication via push tokens started to fail. I chased this down to reported exceptions within policy handling:

- a policy ("policyX") is defined, relying on a custom header (active condition comparing a header against a given value). Sample purpose of policyX is to inititate a push token request for a specific PAM scenario

- the client sends the "/validate/check" POST request including the header, traverses the policy chain and policyX works as expected

- i.e. the push token reply is coming in ("/ttype/push" GET request) and traverses the policy chain, but does not have the custom header

- when checking "policyX" against that "/ttype/push" request, the missing HTTP header is reported as an error, an exception is thrown and further processing seems to stop

This PR changes the behavior of _policy_matches_request_header_condition() to only log a warning and to return as if the comparison on the header failed.

The comparator parameter of _policy_matches_request_header_condition() was not (yet) included in the decision. Returning "true" for "inverse matches" (!in, !contains,...) would possibly create a different semantic, but of course this can be subject of discussion.