### PR TITLE
Fix missing blank in log messages

### DIFF
--- a/privacyidea/lib/applications/luks.py
+++ b/privacyidea/lib/applications/luks.py
@@ -57,27 +57,27 @@ class MachineApplication(MachineApplicationBase):
         ret = {}
         options = options or {}
         if token_type.lower() == "totp" and serial.startswith("UBOM"):
-                # create a challenge of 32 byte
-                # Although the yubikey is capable of doing 64byte challenges
-                # the hmac module calculates different responses for 64 bytes.
-                if challenge is None:
-                    challenge = geturandom(32)
-                    challenge_hex = hexlify_and_unicode(challenge)
-                else:
-                    challenge_hex = challenge
-                ret["challenge"] = challenge_hex
-                # create the response. We need to get
-                # the HMAC key and calculate a HMAC response for
-                # the challenge
-                toks = get_tokens(serial=serial, active=True)
-                if len(toks) == 1:
-                    # tokenclass is a TimeHmacTokenClass
-                    (_r, _p, otp, _c) = toks[0].get_otp(challenge=challenge_hex,
+            # create a challenge of 32 byte
+            # Although the yubikey is capable of doing 64byte challenges
+            # the hmac module calculates different responses for 64 bytes.
+            if challenge is None:
+                challenge = geturandom(32)
+                challenge_hex = hexlify_and_unicode(challenge)
+            else:
+                challenge_hex = challenge
+            ret["challenge"] = challenge_hex
+            # create the response. We need to get
+            # the HMAC key and calculate a HMAC response for
+            # the challenge
+            toks = get_tokens(serial=serial, active=True)
+            if len(toks) == 1:
+                # tokenclass is a TimeHmacTokenClass
+                (_r, _p, otp, _c) = toks[0].get_otp(challenge=challenge_hex,
                                                         do_truncation=False)
-                    ret["response"] = otp
+                ret["response"] = otp
         else:
-                log.info("Token %r, type %r is not supported by "
-                         "LUKS application module" % (serial, token_type))
+            log.info("Token %r, type %r is not supported by "
+                     "LUKS application module" % (serial, token_type))
 
         return ret
 

--- a/privacyidea/lib/applications/luks.py
+++ b/privacyidea/lib/applications/luks.py
@@ -76,7 +76,7 @@ class MachineApplication(MachineApplicationBase):
                                                         do_truncation=False)
                     ret["response"] = otp
         else:
-                log.info("Token %r, type %r is not supported by"
+                log.info("Token %r, type %r is not supported by "
                          "LUKS application module" % (serial, token_type))
 
         return ret

--- a/privacyidea/lib/applications/ssh.py
+++ b/privacyidea/lib/applications/ssh.py
@@ -85,7 +85,7 @@ class MachineApplication(MachineApplicationBase):
                              "option (%s) of the SSH application." % (
                         user_filter, options.get("user")))
         else:
-            log.info("Token %r, type %r is not supported by"
+            log.info("Token %r, type %r is not supported by "
                      "SSH application module" % (serial, token_type))
 
         return ret


### PR DESCRIPTION
Messages for the "applications" LUKS and SSH missed a blank, separating msg stem and parameter:

[INFO][privacyidea.lib.applications.ssh:89] Token 'PIPU00XXXX', type 'push' is not supported bySSH application module