### PR TITLE
Skip nightly tests if nothing changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,26 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
+      - run:
+          # Cancel workflow if there were no changes for one day
+          # (https://discuss.circleci.com/t/how-to-programmatically-end-or-cancel-the-workflow-build/37742)
+          command: |
+            if [[ -n $(git log --since=1.day) ]] ; then
+              circleci-agent step halt
+            fi
+          name: Check for changes
+      - restore_cache:
+          key: v1-deps-{{ checksum "requirements.txt" }}
       - run: pip install -r tests/requirements.txt
       - run: mkdir -p test-results/mysql
       - run:
           command: |
             python -b -m pytest --cov=privacyidea --junit-xml=test-results/mysql/results.xml tests/
           name: MySQL Test
+      - save_cache:
+          paths:
+            - "${PYENV_ROOT}"
+          key: v1-deps-{{ checksum "requirements.txt" }}
       - store_test_results:
           path: test-results
       - store_artifacts:


### PR DESCRIPTION
The nightly test run for checking the databases can be skipped if there
were no changes in the master branch.
Also caching is introduced for the nightly builds.

Working on #2477