### PR TITLE
Policy to force login with remote user

### DIFF
--- a/doc/policies/webui.rst
+++ b/doc/policies/webui.rst
@@ -56,11 +56,19 @@ This policy defines, if the login to the privacyIDEA using the web servers
 integrated authentication (like basic authentication or digest
 authentication) should be allowed.
 
-Possible values are "disable" and "allowed".
+Possible values are "disable", "allowed" and "force".
+
+If set to "allowed" a user can choose to use the REMOTE_USER or login with
+credentials. If set to "force", the user can not switch to login with credentials but
+can only login with the REMOTE_USER from the browser.
 
 .. note:: The policy is evaluated before the user is logged in. At this point
    in time there is no realm known, so a policy to allow remote_user must not
    select any realm.
+
+.. note:: The policy setting "force" only works on the UI level. On the API level
+   the user could still log in with credentials! If you want to avoid this, see
+   the next note.
 
 .. note:: The policy *login_mode* and *remote_user* work independent of each
    other. I.e. you can disable *login_mode* and allow *remote_user*.

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -59,7 +59,7 @@ from privacyidea.lib.audit import getAudit
 from privacyidea.lib.auth import (check_webui_user, ROLE, verify_db_admin,
                                   db_admin_exist)
 from privacyidea.lib.user import User, split_user, log_used_user
-from privacyidea.lib.policy import PolicyClass
+from privacyidea.lib.policy import PolicyClass, REMOTE_USER
 from privacyidea.lib.realm import get_default_realm, realm_is_defined
 from privacyidea.api.lib.postpolicy import (postpolicy, get_webui_settings, add_user_detail_to_response, check_tokentype, 
                                             check_tokeninfo, check_serial, no_detail_on_fail, no_detail_on_success,
@@ -254,7 +254,7 @@ def get_auth_token():
     user_obj = User()
 
     # Check if the remote user is allowed
-    if (request.remote_user == username) and is_remote_user_allowed(request):
+    if (request.remote_user == username) and is_remote_user_allowed(request) != REMOTE_USER.DISABLE:
         # Authenticated by the Web Server
         # Check if the username exists
         # 1. in local admins

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1229,7 +1229,7 @@ def is_remote_user_allowed(req, write_to_audit_log=True):
     :param req: The flask request, containing the remote user and the client IP
     :param write_to_audit_log: whether the policy name should be added to the audit log entry
     :type write_to_audit_log: bool
-    :return: 0 if disabled, 1 if allowrd, 2 if forced.
+    :return: 0 if disabled, 1 if allowed, 2 if forced.
     """
     res = 0
     if req.remote_user:

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1229,9 +1229,9 @@ def is_remote_user_allowed(req, write_to_audit_log=True):
     :param req: The flask request, containing the remote user and the client IP
     :param write_to_audit_log: whether the policy name should be added to the audit log entry
     :type write_to_audit_log: bool
-    :return: 0 if disabled, 1 if allowed, 2 if forced.
+    :return: Return a value or REMOTE_USER, can be "disable", "active" or "force".
+    :rtype: basestring
     """
-    res = 0
     if req.remote_user:
         loginname, realm = split_user(req.remote_user)
         realm = realm or get_default_realm()
@@ -1242,12 +1242,10 @@ def is_remote_user_allowed(req, write_to_audit_log=True):
                                                                 write_to_audit_log=write_to_audit_log)
         # there should be only one action value here
         if ruser_active:
-            if list(ruser_active)[0] == REMOTE_USER.ACTIVE:
-                res = 1
-            if list(ruser_active)[0] == REMOTE_USER.FORCE:
-                res = 2
+            return list(ruser_active)[0]
 
-    return res
+    # Return default "disable"
+    return REMOTE_USER.DISABLE
 
 
 def save_client_application_type(request, action):

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1229,9 +1229,9 @@ def is_remote_user_allowed(req, write_to_audit_log=True):
     :param req: The flask request, containing the remote user and the client IP
     :param write_to_audit_log: whether the policy name should be added to the audit log entry
     :type write_to_audit_log: bool
-    :return: a bool value
+    :return: 0 if disabled, 1 if allowrd, 2 if forced.
     """
-    res = False
+    res = 0
     if req.remote_user:
         loginname, realm = split_user(req.remote_user)
         realm = realm or get_default_realm()
@@ -1243,7 +1243,9 @@ def is_remote_user_allowed(req, write_to_audit_log=True):
         # there should be only one action value here
         if ruser_active:
             if list(ruser_active)[0] == REMOTE_USER.ACTIVE:
-                res = True
+                res = 1
+            if list(ruser_active)[0] == REMOTE_USER.FORCE:
+                res = 2
 
     return res
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1230,7 +1230,7 @@ def is_remote_user_allowed(req, write_to_audit_log=True):
     :param write_to_audit_log: whether the policy name should be added to the audit log entry
     :type write_to_audit_log: bool
     :return: Return a value or REMOTE_USER, can be "disable", "active" or "force".
-    :rtype: basestring
+    :rtype: str
     """
     if req.remote_user:
         loginname, realm = split_user(req.remote_user)

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -2164,7 +2164,7 @@ def get_static_policy_definitions(scope=None):
             },
             ACTION.REMOTE_USER: {
                 'type': 'str',
-                'value': [REMOTE_USER.ACTIVE, REMOTE_USER.DISABLE],
+                'value': [REMOTE_USER.ACTIVE, REMOTE_USER.DISABLE, REMOTE_USER.FORCE],
                 'desc': _('The REMOTE_USER set by the webserver can be used '
                           'to login to privacyIDEA or it will be ignored. '
                           'Defaults to "disable".')

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -394,7 +394,6 @@ class MAIN_MENU(object):
     COMPONENTS = "components"
 
 
-
 class LOGINMODE(object):
     __doc__ = """This is the list of possible values for the login mode."""
     USERSTORE = "userstore"
@@ -406,6 +405,7 @@ class REMOTE_USER(object):
     __doc__ = """The list of possible values for the remote_user policy."""
     DISABLE = "disable"
     ACTIVE = "allowed"
+    FORCE = "force"
 
 
 class ACTIONVALUE(object):

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -50,6 +50,8 @@ angular.module("privacyideaApp")
     if (!$scope.remoteUser) {
         $scope.loginWithCredentials = true;
     }
+    obj = angular.element(document.querySelector('#FORCE_REMOTE_USER'));
+    $scope.forceRemoteUser = obj.val();
     obj = angular.element(document.querySelector("#PASSWORD_RESET"));
     $scope.passwordReset = obj.val();
     obj = angular.element(document.querySelector("#HSM_READY"));

--- a/privacyidea/static/components/login/views/login.html
+++ b/privacyidea/static/components/login/views/login.html
@@ -20,7 +20,8 @@
                 <button ng-click="authenticate_remote_user()"
                         class="btn btn-primary btn-block" translate>Log In
                 </button>
-                <button ng-click="loginWithCredentials = true"
+                <button ng-hide="forceRemoteUser === 'True'"
+                        ng-click="loginWithCredentials = true"
                         class="btn btn-info btn-block" translate>
                     Login with credentials
                 </button>

--- a/privacyidea/static/templates/index.html
+++ b/privacyidea/static/templates/index.html
@@ -9,6 +9,7 @@
 </div>
 
 <input type=hidden id=REMOTE_USER value="{{ remote_user }}">
+<input type=hidden id=FORCE_REMOTE_USER value="{{ force_remote_user }}">
 <input type=hidden id=PASSWORD_RESET value="{{ password_reset }}">
 <input type=hidden id=HSM_READY value="{{ hsm_ready }}">
 <input type=hidden id=CUSTOMIZATION value="{{ customization }}">

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -114,7 +114,9 @@ def single_page_application():
             realms = ",".join(get_realms())
 
     try:
-        if is_remote_user_allowed(request, write_to_audit_log=False):
+        r = is_remote_user_allowed(request, write_to_audit_log=False)
+        force_remote_user = r == 2
+        if r:
             remote_user = request.remote_user
         password_reset = is_password_reset(g)
         hsm_ready = True
@@ -153,6 +155,7 @@ def single_page_application():
         'backendUrl': backend_url,
         'browser_lang': browser_lang,
         'remote_user': remote_user,
+        'force_remote_user': force_remote_user,
         'theme': theme,
         'translation_warning': translation_warning,
         'password_reset': password_reset,

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -37,7 +37,7 @@ from privacyidea.api.lib.prepolicy import is_remote_user_allowed
 from privacyidea.lib.passwordreset import is_password_reset
 from privacyidea.lib.error import HSMException
 from privacyidea.lib.realm import get_realms
-from privacyidea.lib.policy import PolicyClass, ACTION, SCOPE, Match
+from privacyidea.lib.policy import PolicyClass, ACTION, SCOPE, Match, REMOTE_USER
 from privacyidea.lib.subscriptions import subscription_status
 from privacyidea.lib.utils import get_client_ip
 from privacyidea.lib.config import get_from_config, SYSCONF
@@ -115,8 +115,8 @@ def single_page_application():
 
     try:
         r = is_remote_user_allowed(request, write_to_audit_log=False)
-        force_remote_user = r == 2
-        if r:
+        force_remote_user = r == REMOTE_USER.FORCE
+        if r != REMOTE_USER.DISABLE:
             remote_user = request.remote_user
         password_reset = is_password_reset(g)
         hsm_ready = True

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1285,6 +1285,13 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         req = Request(env)
         self.assertEqual(REMOTE_USER.ACTIVE, is_remote_user_allowed(req))
 
+        # Now set the remote force policy
+        set_policy(name="ruser",
+                   scope=SCOPE.WEBUI,
+                   action="{0!s}={1!s}".format(ACTION.REMOTE_USER, REMOTE_USER.FORCE),
+                   user="super")
+        self.assertEqual(REMOTE_USER.FORCE, is_remote_user_allowed(req))
+
         set_privacyidea_config(SYSCONF.SPLITATSIGN, False)
         self.assertEqual(REMOTE_USER.DISABLE, is_remote_user_allowed(req))
 

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -1260,7 +1260,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
                    action="{0!s}={1!s}".format(ACTION.REMOTE_USER, REMOTE_USER.ACTIVE))
 
         r = is_remote_user_allowed(req)
-        self.assertTrue(r)
+        self.assertEqual(REMOTE_USER.ACTIVE, r)
 
         # Login for the REMOTE_USER is not allowed.
         # Only allowed for user "super", but REMOTE_USER=admin
@@ -1270,23 +1270,23 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
                    user="super")
 
         r = is_remote_user_allowed(req)
-        self.assertFalse(r)
+        self.assertEqual(REMOTE_USER.DISABLE, r)
 
         # The remote_user "super" is allowed to login:
         env["REMOTE_USER"] = "super"
         req = Request(env)
         r = is_remote_user_allowed(req)
-        self.assertTrue(r)
+        self.assertEqual(REMOTE_USER.ACTIVE, r)
 
         # check that Splt@Sign works correctly
         create_realm(self.realm1)
         set_privacyidea_config(SYSCONF.SPLITATSIGN, True)
         env["REMOTE_USER"] = "super@realm1"
         req = Request(env)
-        self.assertTrue(is_remote_user_allowed(req))
+        self.assertEqual(REMOTE_USER.ACTIVE, is_remote_user_allowed(req))
 
         set_privacyidea_config(SYSCONF.SPLITATSIGN, False)
-        self.assertFalse(is_remote_user_allowed(req))
+        self.assertEqual(REMOTE_USER.DISABLE, is_remote_user_allowed(req))
 
         set_privacyidea_config(SYSCONF.SPLITATSIGN, True)
         delete_policy("ruser")


### PR DESCRIPTION
If a remote user exists a policy can now force
the login with this user and not provide
the login-with-credentials button.

Closes #2072

I was thinking about if this policy is necessary at all or if we could simply use remote_user=allow and disallow the webui login.
This would be the same for users, who actually authenticated with BASIC Auth. But if a user does not authenticate with basic auth this user would not be able to login (since credential login would be overall disallowed).
So this way we have a slightly bigger flexibility to have only one button (login with BASIC auth - no login with credential auth) for a user who has a remote_user.