### PR TITLE
Always create Push-Challenge if polling is enabled

### DIFF
--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -735,9 +735,9 @@ class PushTokenClass(TokenClass):
             # But only if polling is allowed.
             allow_polling = get_action_values_from_options(
                 SCOPE.AUTH, PUSH_ACTION.ALLOW_POLLING, options=options) or PushAllowPolling.ALLOW
-            if (allow_polling == PushAllowPolling.ALLOW or
-                    (allow_polling == PushAllowPolling.TOKEN and
-                     is_true(self.get_tokeninfo(POLLING_ALLOWED, default='True')))):
+            if ((allow_polling == PushAllowPolling.ALLOW or
+                 (allow_polling == PushAllowPolling.TOKEN and
+                  is_true(self.get_tokeninfo(POLLING_ALLOWED, default='True')))) or res):
                 validity = int(get_from_config('DefaultChallengeValidityTime', 120))
                 tokentype = self.get_tokentype().lower()
                 # Maybe there is a PushChallengeValidityTime...

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -729,6 +729,32 @@ class PushTokenClass(TokenClass):
                                                      challenge, fb_gateway,
                                                      pem_privkey, options)
             res = fb_gateway.submit_message(self.get_tokeninfo("firebase_token"), smartphone_data)
+
+            # Create the challenge in the challenge table regardless of a failure
+            # when sending the Push message to the Firebase API.
+            # But only if polling is allowed.
+            allow_polling = get_action_values_from_options(
+                SCOPE.AUTH, PUSH_ACTION.ALLOW_POLLING, options=options) or PushAllowPolling.ALLOW
+            if (allow_polling == PushAllowPolling.ALLOW or
+                    (allow_polling == PushAllowPolling.TOKEN and
+                     is_true(self.get_tokeninfo(POLLING_ALLOWED, default='True')))):
+                validity = int(get_from_config('DefaultChallengeValidityTime', 120))
+                tokentype = self.get_tokentype().lower()
+                # Maybe there is a PushChallengeValidityTime...
+                lookup_for = tokentype.capitalize() + 'ChallengeValidityTime'
+                validity = int(get_from_config(lookup_for, validity))
+
+                # Create the challenge in the database
+                db_challenge = Challenge(self.token.serial,
+                                         transaction_id=transactionid,
+                                         challenge=challenge,
+                                         data=data,
+                                         session=options.get("session"),
+                                         validitytime=validity)
+                db_challenge.save()
+                self.challenge_janitor()
+
+            # If sending the Push message failed, we still raise an error.
             if not res:
                 raise ValidateError("Failed to submit message to firebase service.")
         else:
@@ -737,21 +763,6 @@ class PushTokenClass(TokenClass):
                                                                  PUSH_ACTION.FIREBASE_CONFIG))
             raise ValidateError("The token has no tokeninfo. Can not send via firebase service.")
 
-        validity = int(get_from_config('DefaultChallengeValidityTime', 120))
-        tokentype = self.get_tokentype().lower()
-        # Maybe there is a PushChallengeValidityTime...
-        lookup_for = tokentype.capitalize() + 'ChallengeValidityTime'
-        validity = int(get_from_config(lookup_for, validity))
-
-        # Create the challenge in the database
-        db_challenge = Challenge(self.token.serial,
-                                 transaction_id=transactionid,
-                                 challenge=challenge,
-                                 data=data,
-                                 session=options.get("session"),
-                                 validitytime=validity)
-        db_challenge.save()
-        self.challenge_janitor()
         return True, message, db_challenge.transaction_id, attributes
 
     @check_token_locked

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -730,9 +730,9 @@ class PushTokenClass(TokenClass):
                                                      pem_privkey, options)
             res = fb_gateway.submit_message(self.get_tokeninfo("firebase_token"), smartphone_data)
 
-            # Create the challenge in the challenge table regardless of a failure
-            # when sending the Push message to the Firebase API.
-            # But only if polling is allowed.
+            # Create the challenge in the challenge table if either the message
+            # was successfully submitted to the Firebase API or if polling is
+            # allowed in general or for this specific token.
             allow_polling = get_action_values_from_options(
                 SCOPE.AUTH, PUSH_ACTION.ALLOW_POLLING, options=options) or PushAllowPolling.ALLOW
             if ((allow_polling == PushAllowPolling.ALLOW or


### PR DESCRIPTION
Even if submitting the message for the Push-notification to the firebase
service fails a challenge is created if polling is enabled (either
globally or for that token specifically).
The App is then able to poll for open challenges and answer them
correctly.

Fixes #2438