### PR TITLE
Fix the auth count in the dashboard

### DIFF
--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -113,17 +113,14 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
 
      $scope.getAuthentication = function () {
         $scope.authentications = {"success": 0, "fail": 0};
-        AuditFactory.get({"timelimit": "1d", "action": "*validate*"},
+        AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "1"},
             function (data) {
-            var authentications = data.result.value.auditdata;
-            angular.forEach(authentications, function(authlog) {
-                if (authlog.success) {
-                    $scope.authentications.success += 1;
-                } else {
-                    $scope.authentications.fail += 1;
-                }
+                $scope.authentications.success = data.result.value.count;
             });
-        });
+        AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "0"},
+            function (data) {
+                $scope.authentications.fail = data.result.value.count;
+            });
      };
 
      $scope.getAdministration = function () {


### PR DESCRIPTION
The dashboard used a GET /audit that
was limited to the first 15-entry page of
all validate-entries.

We now issue two requests for successful and
failed requests and use the overall count.

Fixes #2473