### PR TITLE
Eventhandler condition for detail-message

### DIFF
--- a/privacyidea/lib/eventhandler/base.py
+++ b/privacyidea/lib/eventhandler/base.py
@@ -451,14 +451,14 @@ class BaseEventHandler(object):
                 return False
 
         if CONDITION.DETAIL_ERROR_MESSAGE in conditions:
-            message = content.get("detail", {}).get("error", {}).get("message")
+            message = content.get("detail", {}).get("error", {}).get("message", "")
             search_exp = conditions.get(CONDITION.DETAIL_ERROR_MESSAGE)
             m = re.search(search_exp, message)
             if not bool(m):
                 return False
 
         if CONDITION.DETAIL_MESSAGE in conditions:
-            message = content.get("detail", {}).get("message")
+            message = content.get("detail", {}).get("message", "")
             search_exp = conditions.get(CONDITION.DETAIL_MESSAGE)
             m = re.search(search_exp, message)
             if not bool(m):

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -440,6 +440,23 @@ class BaseEventHandlerTestCase(MyTestCase):
         )
         self.assertEqual(r, False)
 
+        # Check DETAIL_MESSAGE to evaluate to False if it does not exist
+        resp = Response()
+        resp.data = """{"result": {"value": true, "status": true},
+                "detail": {"options": "Nothing"}
+                }
+                """
+
+        r = uhandler.check_condition(
+            {"g": {},
+             "handler_def": {"conditions": {CONDITION.DETAIL_MESSAGE:
+                                                "special"}},
+             "request": req,
+             "response": resp
+             }
+        )
+        self.assertEqual(r, False)
+
         # Check DETAIL_ERROR_MESSAGE
         resp = Response()
         resp.data = """{"result": {"value": false, "status": false},


### PR DESCRIPTION
If the detail-message does not exist, the eventhandler
condition for detail-message and detail-error-message
evaluates to False, instead of raising an exception.

Fixes #2247