### PR TITLE
Add link for the PUSH-Enrollment

### DIFF
--- a/privacyidea/static/components/token/views/token.enrolled.push.html
+++ b/privacyidea/static/components/token/views/token.enrolled.push.html
@@ -8,6 +8,8 @@
     <div class="col-sm-6" ng-show="enrolledToken.rollout_state === 'clientwait'">
         <p class="help-block" translate>
             Please scan the QR code with the privacyIDEA Authenticator App
+            or click <a href="{{ enrolledToken.pushurl.value }}">this link</a> on your
+            smartphone.
         </p>
         <img width="{{ qrCodeWidth }}"
              ng-src="{{ enrolledToken.pushurl.img }}"/>


### PR DESCRIPTION
We add a link that contains the contents of
the QR Code, so that the user on a smartphon
can actually click this link to enroll the
PUSH token.

Fixes #2522