### PR TITLE
2334/fix date search in audit

### DIFF
--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -77,6 +77,12 @@ def fn_to_isodate(element, compiler, **kw):
     return "to_char(%s, 'IYYY-MM-DD HH24:MI:SS')" % compiler.process(element.clauses, **kw)
 
 
+@compiles(to_isodate, 'sqlite')
+def fn_to_isodate(element, compiler, **kw):
+    # sqlite does not have a DateTime type, they are already in ISO format
+    return "%s" % compiler.process(element.clauses, **kw)
+
+
 @compiles(to_isodate)
 def fn_to_isodate(element, compiler, **kw):
     # The four percent signs are necessary for two format substitutions

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -182,7 +182,7 @@ class Audit(AuditBase):
                 data = self.audit_data[column]
                 if isinstance(data, string_types):
                     if column == "policies":
-                        # The policies column is shortend per comma entry
+                        # The policies column is shortened per comma entry
                         data = truncate_comma_list(data, l)
                     else:
                         data = data[:l]
@@ -216,8 +216,9 @@ class Audit(AuditBase):
                     else:
                         # All other keys are compared as strings
                         column = getattr(LogEntry, search_key)
-                        if search_key.endswith("date"):
-                            # but we cast "date" to a string first (required on postgresql)
+                        if search_key in ["date", "startdate"]:
+                            # but we cast a column with a DateTime type to an
+                            # ISO-format string first
                             column = to_isodate(column)
                         search_value = search_value.replace('*', '%')
                         if '%' in search_value:


### PR DESCRIPTION
The DateTime objects from the database were not always converted to
ISO-strings properly. With custom dialect-based functions the formatting
is done in the SQL statement.

Working on #2334