### PR TITLE
Add username of failed auth in dashboard

### DIFF
--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -120,6 +120,10 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
         AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "0"},
             function (data) {
                 $scope.authentications.fail = data.result.value.count;
+                $scope.authentications.users = Array();
+                angular.forEach(data.result.value.auditdata, function(auditentry){
+                    $scope.authentications.users.push({"user": auditentry.user, "realm": auditentry.realm});
+                });
             });
      };
 

--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -121,8 +121,13 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
             function (data) {
                 $scope.authentications.fail = data.result.value.count;
                 $scope.authentications.users = Array();
+                $scope.authentications.serials = Array();
                 angular.forEach(data.result.value.auditdata, function(auditentry){
-                    $scope.authentications.users.push({"user": auditentry.user, "realm": auditentry.realm});
+                    if (auditentry.user) {
+                        $scope.authentications.users.push({"user": auditentry.user, "realm": auditentry.realm});
+                    } else {
+                        $scope.authentications.serials.push(auditentry.serial);
+                    }
                 });
             });
      };

--- a/privacyidea/static/components/dashboard/views/dashboard.html
+++ b/privacyidea/static/components/dashboard/views/dashboard.html
@@ -51,6 +51,16 @@
                                 <td translate>failed</td>
                                 <td>{{ authentications.fail }}</td>
                             </tr>
+                            <tr>
+                                <td translate>failed users</td>
+                                <td>
+                                    {{ authentcations.users }}
+                                    <span ng-repeat="userobj in authentications.users">
+                                        | <a ui-sref="user.details({username: userobj.user, realmname: userobj.realm})">
+                                        {{ userobj.user }}@{{ userobj.realm }}</a>
+                                    </span>
+                                </td>
+                            </tr>
                          </tbody>
                      </table>
                  </div>

--- a/privacyidea/static/components/dashboard/views/dashboard.html
+++ b/privacyidea/static/components/dashboard/views/dashboard.html
@@ -52,12 +52,15 @@
                                 <td>{{ authentications.fail }}</td>
                             </tr>
                             <tr>
-                                <td translate>failed users</td>
+                                <td translate>failed users / tokens</td>
                                 <td>
-                                    {{ authentcations.users }}
                                     <span ng-repeat="userobj in authentications.users">
                                         | <a ui-sref="user.details({username: userobj.user, realmname: userobj.realm})">
                                         {{ userobj.user }}@{{ userobj.realm }}</a>
+                                    </span>
+                                    <span ng-repeat="serial in authentications.serials">
+                                        | <a ui-sref="token.details({tokenSerial: serial})">
+                                        {{ serial }}</a>
                                     </span>
                                 </td>
                             </tr>


### PR DESCRIPTION
The authentication widget contains the list of the
last 15 failed users.

Note: If a user failed to authenticate more than once he will appear
more than once in the list. We will see, if this helps to identify often
failing users or if we should convert the array to a set (which is not
easily possible in javascript).

Closes #2475