### PR TITLE
2401/change autocomplete on passwords

### DIFF
--- a/privacyidea/static/components/config/views/config.mresolvers.ldap.html
+++ b/privacyidea/static/components/config/views/config.mresolvers.ldap.html
@@ -105,7 +105,7 @@
         <div class="col-sm-3">
             <input name="bindpw" class="form-control" id="bindpw"
                    type="password"
-                   autocomplete="off"
+                   autocomplete="new-password"
                    ng-model="params.BINDPW"
                    placeholder="topsecret"/>
         </div>

--- a/privacyidea/static/components/config/views/config.privacyideaserver.edit.html
+++ b/privacyidea/static/components/config/views/config.privacyideaserver.edit.html
@@ -73,7 +73,8 @@
         <div class="col-sm-3">
             <label for="password" translate>Password</label>
             <input type="password" class="form-control" class="col"
-                   autocomplete="off" id="password"
+                   autocomplete="new-password"
+                   id="password"
                    ng-model="params.password" name="password">
         </div>
         <div class="col-sm-3">

--- a/privacyidea/static/components/config/views/config.radius.edit.html
+++ b/privacyidea/static/components/config/views/config.radius.edit.html
@@ -104,7 +104,7 @@
         <div class="col-sm-3">
             <label for="password" translate>Password</label>
             <input type="password" class="form-control" class="col"
-                   autocomplete="off"
+                   autocomplete="new-password"
                    ng-model="params.password" name="password">
         </div>
         <div class="col-sm-3">

--- a/privacyidea/static/components/config/views/config.resolvers.ldap.html
+++ b/privacyidea/static/components/config/views/config.resolvers.ldap.html
@@ -128,7 +128,7 @@
         <div class="col-sm-3">
             <input name="bindpw" class="form-control"
                    type="password"
-                   autocomplete="off"
+                   autocomplete="new-password"
                    ng-model="params.BINDPW"
                    placeholder="topsecret"/>
         </div>

--- a/privacyidea/static/components/config/views/config.resolvers.sql.html
+++ b/privacyidea/static/components/config/views/config.resolvers.sql.html
@@ -81,7 +81,7 @@
 
             <div class="col-sm-9">
                 <input name="password" class="form-control"
-                       type="password" autocomplete="off"
+                       type="password" autocomplete="new-password"
                        ng-model="params.Password"
                        placeholder="topsecret"/>
             </div>

--- a/privacyidea/static/components/config/views/config.smtp.edit.html
+++ b/privacyidea/static/components/config/views/config.smtp.edit.html
@@ -87,7 +87,7 @@
                translate>Password</label>
         <div class="col-sm-9">
             <input name="password" class="form-control"
-                   type="password" autocomplete="off"
+                   type="password" autocomplete="new-password"
                    ng-model="params.password"
                    placeholder="topsecret"/>
         </div>

--- a/privacyidea/static/components/dialogs/views/dialog.lock.html
+++ b/privacyidea/static/components/dialogs/views/dialog.lock.html
@@ -20,7 +20,6 @@
                         <label for="password" class="sr-only"
                                translate>Password</label>
                         <input name="password" type="password"
-                               autocomplete="off"
                                id="password" class="form-control"
                                ng-model="login.password" required
                                placeholder="{{ 'Password'|translate }}"/>

--- a/privacyidea/static/components/directives/views/directive.assigntoken.html
+++ b/privacyidea/static/components/directives/views/directive.assigntoken.html
@@ -4,7 +4,7 @@ This is the directive for assigning tokens to users.
 <div class="form-group">
     <label for="serial" translate>Serial</label>
     <input name="serial" type="text" ng-model="newTokenObject.serial"
-           autocomplete="off" required
+           autocomplete="new-password" required
            placeholder="{{ 'start typing a serial number of a token that is notassigned, yet.'|translate}} "
            ng-keypress="toggleLoadSerials($event.which==13)"
            typeahead-wait-ms="100"

--- a/privacyidea/static/components/directives/views/directive.attachmachine.html
+++ b/privacyidea/static/components/directives/views/directive.attachmachine.html
@@ -4,7 +4,7 @@ This is the directive for attaching machines to tokens.
 <div class="form-group">
     <label for="serial" translate>Machine</label>
     <input name="serial" type="text" ng-model="newMachine"
-           autocomplete="off"
+           autocomplete="new-password"
            placeholder="{{ 'start typing a machine.'|translate }}"
            typeahead-wait-ms="100"
            uib-typeahead="serial for serial in loadMachines($viewValue)"

--- a/privacyidea/static/components/directives/views/directive.attachtoken.html
+++ b/privacyidea/static/components/directives/views/directive.attachtoken.html
@@ -4,7 +4,7 @@ This is the directive for attach tokens to machines.
 <div class="form-group">
     <label for="serial" translate>Serial</label>
     <input name="serial" type="text" ng-model="newTokenObject.serial"
-           autocomplete="off"
+           autocomplete="new-password"
            placeholder="{{ 'start typing a serial number of a token.'|
            translate }}"
            typeahead-wait-ms="100"

--- a/privacyidea/static/components/login/views/enter-response.html
+++ b/privacyidea/static/components/login/views/enter-response.html
@@ -18,7 +18,7 @@
 
 
             <label for="password" class="sr-only" translate>Response</label>
-            <input name="password" type="password" autocomplete="off"
+            <input name="password" type="password" autocomplete="new-password"
                    id="password" class="form-control"
                    ng-model="login.password" required
                    placeholder="{{ challenge_message }}"/>

--- a/privacyidea/static/components/login/views/login.html
+++ b/privacyidea/static/components/login/views/login.html
@@ -70,7 +70,7 @@
                     <option ng-hide="piRealms[0]===''" value="" selected translate>Choose a realm...</option>
                 </select>
                 <label for="password" class="sr-only" translate>Password</label>
-                <input name="password" type="password" autocomplete="off"
+                <input name="password" type="password"
                        id="password" class="form-control round-bottom"
                        ng-model="login.password" required
                        placeholder="{{ 'Password'|translate }}"/>

--- a/privacyidea/static/components/login/views/pinchange.html
+++ b/privacyidea/static/components/login/views/pinchange.html
@@ -9,13 +9,13 @@
 
             <label for="pin1" class="sr-only" translate>New PIN</label>
             <input name="pin1" type="password" class="form-control"
-                   ng-model="newpin" autocomplete="off"
+                   ng-model="newpin" autocomplete="new-password"
                    equals="{{ newpin2 }}"
                    placeholder="{{ 'New PIN' | translate }}" />
 
             <label for="pin2" class="sr-only" translate>New PIN</label>
             <input name="pin2" type="password" class="form-control"
-                   ng-model="newpin2" autocomplete="off"
+                   ng-model="newpin2" autocomplete="new-password"
                    equals="{{ newpin }}"
                    placeholder="{{ 'Repeat new PIN' | translate }}"/>
 

--- a/privacyidea/static/components/register/views/register.html
+++ b/privacyidea/static/components/register/views/register.html
@@ -73,13 +73,13 @@
                   ng-class="{'has-error': !newUser.password }">
                 <label for="password" translate>Password</label>
                 <input name="password" type="password"
-                       autocomplete="off"
+                       autocomplete="new-password"
                        id="pw1" class="form-control round-top"
                        ng-model="newUser.password" required
                        equals="{{ password2 }}"
                        placeholder="{{ 'Password'|translate }}"/>
                 <input name="password" type="password"
-                       autocomplete="off"
+                       autocomplete="new-password"
                        id="pw2" class="form-control round-bottom"
                        ng-model="password2"
                        equals="{{ newUser.password }}"


### PR DESCRIPTION
This closes #2401. Most occurrences of `autocomplete="off"` are replaced by `autocomplete="new-password"` to prevent the browser from pre-filling them. `autocomplete="off"` was removed from server logins to prompt the browser to use saved passwords there explicitly.