### PR TITLE
filter tokeninfo condition by _policy_matches_info_condition

### DIFF
--- a/doc/policies/conditions.rst
+++ b/doc/policies/conditions.rst
@@ -31,6 +31,7 @@ Sections
 ~~~~~~~~
 
 privacyIDEA 3.1 implements only one section, which is called ``userinfo``.
+The class ``tokeninfo`` is first supported with privacyIDEA 3.5.
 
 ``userinfo``
 ^^^^^^^^^^^^
@@ -105,6 +106,16 @@ allowed to log in.
 If the userinfo of the user that is trying to log in does not contain attributes
 ``email`` or ``groups`` (due to a resolver misconfiguration, for example), privacyIDEA
 throws an error and the request is aborted.
+
+
+``tokeninfo``
+^^^^^^^^^^^^
+
+The tokeninfo condition works the same way as userinfo but matches the tokeninfo instead.
+
+.. note:: In contrast to the userinfo condition, a missing token in the request, does not cancel it.
+   Instead the condition is effectively **disabled** for the request.
+
 
 ``HTTP Request Header``
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/policies/conditions.rst
+++ b/doc/policies/conditions.rst
@@ -112,9 +112,8 @@ throws an error and the request is aborted.
 
 The tokeninfo condition works the same way as userinfo but matches the tokeninfo instead.
 
-.. note:: In contrast to the userinfo condition, a missing token in the request, does not cancel it.
-   Instead the condition is handled as being fulfilled, so it is effectively **disabled** for the request.
-   Therefore the policy may apply.
+.. note:: Similar to the userinfo condition, a policy with an active tokeninfo condition will
+   throw an exception whenever the token object cannot be determined (usually from the serial).
 
 
 ``HTTP Request Header``

--- a/doc/policies/conditions.rst
+++ b/doc/policies/conditions.rst
@@ -30,8 +30,7 @@ consists of five parts:
 Sections
 ~~~~~~~~
 
-privacyIDEA 3.1 implements only one section, which is called ``userinfo``.
-The class ``tokeninfo`` is first supported with privacyIDEA 3.5.
+privacyIDEA implements three sections ``userinfo``, ``tokeninfo`` and ``HTTP Request Headers``.
 
 ``userinfo``
 ^^^^^^^^^^^^
@@ -114,7 +113,8 @@ throws an error and the request is aborted.
 The tokeninfo condition works the same way as userinfo but matches the tokeninfo instead.
 
 .. note:: In contrast to the userinfo condition, a missing token in the request, does not cancel it.
-   Instead the condition is effectively **disabled** for the request.
+   Instead the condition is handled as being fulfilled, so it is effectively **disabled** for the request.
+   Therefore the policy may apply.
 
 
 ``HTTP Request Header``

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -842,29 +842,22 @@ class PolicyClass(object):
                 log.warning(u"Unknown {!s} key referenced in a condition of policy {!r}: {!r}".format(
                     type, policy['name'], key
                 ))
-                # If we do have a user object, but the conditions of policies reference
-                # an unknown userinfo key, we have a misconfiguration and raise an error.
-                if type == CONDITION_SECTION.USERINFO:
-                    raise PolicyError(u"Unknown key in the {!s} conditions of policy {!r}".format(
-                        type, policy['name']
-                    ))
+                # If we do have an user or token object, but the conditions of policies reference
+                # an unknown userinfo or tokeninfo key, we have a misconfiguration and raise an error.
+                raise PolicyError(u"Unknown key in the {!s} conditions of policy {!r}".format(
+                    type, policy['name']
+                ))
         else:
-            # If the policy specifies a userinfo condition, but no user object is available,
+            log.warning(u"Policy {!r} has condition on {!s} {!r}, but the according object"
+                        u" is not available.".format(policy['name'], type, key
+            ))
+            # If the policy specifies a userinfo or tokeninfo condition, but no object is available,
             # the policy is misconfigured. We have to raise a PolicyError to ensure that
             # the privacyIDEA server does not silently misbehave.
-            if type == CONDITION_SECTION.USERINFO:
-                raise PolicyError(
-                    u"Policy {!r} has condition on userinfo, but a user_object is not available".format(
-                        policy['name']
-                    ))
-            # If the policy specifies a tokeninfo but not token is available, the policy tokeninfo condition
-            # has no effect. Note: This differs from the userinfo conditions, since no exception is raised!
-            elif type == CONDITION_SECTION.TOKENINFO:
-                log.warning(u"Policy {!r} has condition on tokeninfo {!r}, but the according token object"
-                            u" is not available. Condition is dropped for this request.".format(policy['name'], key
+            raise PolicyError(
+                u"Policy {!r} has condition on {!s}, but an according object is not available".format(
+                    policy['name'], type
                 ))
-
-        return True
 
     @staticmethod
     def check_for_conflicts(policies, action):
@@ -2526,7 +2519,7 @@ class Match(object):
         return cls(g, name=None, scope=scope, realm=None, active=True,
                    resolver=None, user=None, user_object=None,
                    client=g.client_ip, action=action, adminrealm=None, time=None,
-                   sort_by_priority=True, serial=g.serial)
+                   sort_by_priority=True)
 
     @classmethod
     def realm(cls, g, scope, action, realm):

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -2526,7 +2526,7 @@ class Match(object):
         return cls(g, name=None, scope=scope, realm=None, active=True,
                    resolver=None, user=None, user_object=None,
                    client=g.client_ip, action=action, adminrealm=None, time=None,
-                   sort_by_priority=True)
+                   sort_by_priority=True, serial=g.serial)
 
     @classmethod
     def realm(cls, g, scope, action, realm):
@@ -2546,7 +2546,7 @@ class Match(object):
         return cls(g, name=None, scope=scope, realm=realm, active=True,
                    resolver=None, user=None, user_object=None,
                    client=g.client_ip, action=action, adminrealm=None, time=None,
-                   sort_by_priority=True)
+                   sort_by_priority=True, serial=g.serial)
 
     @classmethod
     def user(cls, g, scope, action, user_object):
@@ -2572,7 +2572,7 @@ class Match(object):
         return cls(g, name=None, scope=scope, realm=None, active=True,
                    resolver=None, user=None, user_object=user_object,
                    client=g.client_ip, action=action, adminrealm=None, time=None,
-                   sort_by_priority=True)
+                   sort_by_priority=True, serial=g.serial)
 
     @classmethod
     def token(cls, g, scope, action, token_obj):
@@ -2590,7 +2590,6 @@ class Match(object):
         :param token_obj: The token where the user object or the realm should match.
         :rtype: ``Match``
         """
-        # Todo: eventually consider token serial given by g.serial
         if token_obj.user:
             return cls.user(g, scope, action, token_obj.user)
         else:
@@ -2628,7 +2627,7 @@ class Match(object):
         return cls(g, name=None, scope=SCOPE.ADMIN, user_object=user_obj, active=True,
                    resolver=None, client=g.client_ip, action=action,
                    adminuser=adminuser, adminrealm=adminrealm, time=None,
-                   sort_by_priority=True)
+                   sort_by_priority=True, serial=g.serial)
 
     @classmethod
     def admin_or_user(cls, g, action, user_obj):
@@ -2661,7 +2660,7 @@ class Match(object):
         return cls(g, name=None, scope=scope, realm=userrealm, active=True,
                    resolver=None, user=username, user_object=user_obj,
                    client=g.client_ip, action=action, adminrealm=adminrealm, adminuser=adminuser,
-                   time=None, sort_by_priority=True)
+                   time=None, sort_by_priority=True, serial=g.serial)
 
     @classmethod
     def generic(cls, g, scope=None, realm=None, resolver=None, user=None, user_object=None,

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -820,7 +820,7 @@ class PolicyClass(object):
         In case of a tokeninfo, no exception is raised if ``dbtoken`` is None. The condition
         is effectively set to True.
         :param policy: a policy dictionary, the policy in question
-        :param key: a tokeninfo key
+        :param key: a tokeninfo or userinfo key
         :param comparator: a value comparator: one of "equal", "contains"
         :param value: a value against which the tokeninfo value will be compared
         :param type: the info type to match, "userinfo" or "tokeninfo"

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -755,7 +755,7 @@ class PolicyClass(object):
                     if section == CONDITION_SECTION.USERINFO:
                         if not self._policy_matches_info_condition(policy, key, comparator, value,
                                                                    CONDITION_SECTION.USERINFO,
-                                                                   userobj=user_object):
+                                                                   user_object=user_object):
                             include_policy = False
                             break
                     elif section == CONDITION_SECTION.TOKENINFO:
@@ -812,25 +812,28 @@ class PolicyClass(object):
                         u" is not available".format(policy["name"], key))
 
     @staticmethod
-    def _policy_matches_info_condition(policy, key, comparator, value, type, userobj=None, dbtoken=None):
+    def _policy_matches_info_condition(policy, key, comparator, value, type, user_object=None, dbtoken=None):
         """
         Check if the given policy matches a certain userinfo or tokeninfo condition depending
         on the specified ``type``.
-        For the userinfo, if ``userobj_or_dbtoken`` is None, a PolicyError is raised.
-        In case of a tokeninfo, no exception is raised. The condition is effectively set to True.
+        For the userinfo, if ``user_object`` is None, a PolicyError is raised.
+        In case of a tokeninfo, no exception is raised if ``dbtoken`` is None. The condition
+        is effectively set to True.
         :param policy: a policy dictionary, the policy in question
         :param key: a tokeninfo key
         :param comparator: a value comparator: one of "equal", "contains"
         :param value: a value against which the tokeninfo value will be compared
-        :param userobj_or_dbtoken: a User object, a dbtoken object or None
+        :param type: the info type to match, "userinfo" or "tokeninfo"
+        :param user_object: a User object, if any, or None
+        :param dbtoken: a dbtoken object, if any, or None
         :return: a Boolean
         """
         # Match the user object's user info, if it is not-None and non-empty
         from privacyidea.lib.tokenclass import TokenClass
 
-        if userobj or dbtoken:
+        if user_object or dbtoken:
             if type == CONDITION_SECTION.USERINFO:
-                info = userobj.info
+                info = user_object.info
             elif type == CONDITION_SECTION.TOKENINFO:
                 info = dbtoken.get_info()
             else:

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -655,9 +655,9 @@ class PolicyClass(object):
 
     @log_with(log)
     def match_policies(self, name=None, scope=None, realm=None, active=None,
-                       resolver=None, user=None, user_object=None, pinode=None, serial=None,
+                       resolver=None, user=None, user_object=None, pinode=None,
                        client=None, action=None, adminrealm=None, adminuser=None, time=None,
-                       sort_by_priority=True, audit_data=None, request_headers=None):
+                       sort_by_priority=True, audit_data=None, request_headers=None, serial=None):
         """
         Return all policies matching the given context.
         Optionally, write the matching policies to the audit log.
@@ -755,7 +755,7 @@ class PolicyClass(object):
                     if section == CONDITION_SECTION.USERINFO:
                         if not self._policy_matches_info_condition(policy, key, comparator, value,
                                                                    CONDITION_SECTION.USERINFO,
-                                                                   userobj_or_dbtoken=user_object):
+                                                                   userobj=user_object):
                             include_policy = False
                             break
                     elif section == CONDITION_SECTION.TOKENINFO:
@@ -765,7 +765,7 @@ class PolicyClass(object):
                             dbtoken = None
                         if not self._policy_matches_info_condition(policy, key, comparator, value,
                                                                    CONDITION_SECTION.TOKENINFO,
-                                                                   userobj_or_dbtoken=dbtoken):
+                                                                   dbtoken=dbtoken):
                             include_policy = False
                             break
                     elif section == CONDITION_SECTION.HTTP_REQUEST_HEADER:
@@ -812,7 +812,7 @@ class PolicyClass(object):
                         u" is not available".format(policy["name"], key))
 
     @staticmethod
-    def _policy_matches_info_condition(policy, key, comparator, value, type, userobj_or_dbtoken=None):
+    def _policy_matches_info_condition(policy, key, comparator, value, type, userobj=None, dbtoken=None):
         """
         Check if the given policy matches a certain userinfo or tokeninfo condition depending
         on the specified ``type``.
@@ -828,11 +828,11 @@ class PolicyClass(object):
         # Match the user object's user info, if it is not-None and non-empty
         from privacyidea.lib.tokenclass import TokenClass
 
-        if userobj_or_dbtoken is not None:
+        if userobj or dbtoken:
             if type == CONDITION_SECTION.USERINFO:
-                info = userobj_or_dbtoken.info
+                info = userobj.info
             elif type == CONDITION_SECTION.TOKENINFO:
-                info = userobj_or_dbtoken.get_info()
+                info = dbtoken.get_info()
             else:
                 info = {}
 
@@ -2672,8 +2672,8 @@ class Match(object):
 
     @classmethod
     def generic(cls, g, scope=None, realm=None, resolver=None, user=None, user_object=None,
-                client=None, action=None, adminrealm=None, adminuser=None, time=None, serial=None,
-                active=True, sort_by_priority=True):
+                client=None, action=None, adminrealm=None, adminuser=None, time=None,
+                active=True, sort_by_priority=True, serial=None):
         """
         Low-level legacy policy matching interface: Search for active policies and return
         them sorted by priority. All parameters that should be used for matching have to

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1365,6 +1365,7 @@ class PolicyTestCase(MyTestCase):
             resolver = 'resolver'
 
         user1 = MockUser()
+        user1.info = {"email": "foo@bar.com"}
 
         # Policy with initially inactive condition, setpin is allowed for this token
         set_policy("setpin_pol", scope=SCOPE.USER, action=ACTION.SETPIN,

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1345,6 +1345,50 @@ class PolicyTestCase(MyTestCase):
         delete_policy("delete_node2")
         delete_policy("enable")
 
+    def test_31_filter_by_conditions_tokeninfo(self):
+        def _names(policies):
+            return set(p['name'] for p in policies)
+
+        from privacyidea.lib.tokenclass import TokenClass
+        from privacyidea.models import Token
+        serial = "filter_by_conditions_token"
+        db_token = Token(serial, tokentype="spass")
+        db_token.save()
+        token = TokenClass(db_token)
+        token.set_tokeninfo({"fixedpin": "true", "otherinfo": "true"})
+
+        P = PolicyClass()
+
+        class MockUser(object):
+            login = 'login'
+            realm = 'realm'
+            resolver = 'resolver'
+
+        user1 = MockUser()
+
+        # Policy with initially inactive condition, setpin is allowed for this token
+        set_policy("setpin_pol", scope=SCOPE.USER, action=ACTION.SETPIN,
+                   conditions=[("tokeninfo", "fixedpin", "equals", "false", False)])
+
+        # policy matches, because the condition on tokeninfo is inactive
+        self.assertEqual(_names(P.match_policies(user_object=user1, serial=serial)),
+                         {"setpin_pol"})
+
+        # activate the condition
+        set_policy("setpin_pol", conditions=[("tokeninfo", "fixedpin", "equals", "false", True)])
+
+        # policy does not match anymore, because the condition on tokeninfo is active
+        # setpin action not returned for our token with tokeninfo "fixedpin" = "true"
+        self.assertEqual(_names(P.match_policies(user_object=user1, serial=serial)),
+                         set())
+
+        # A request without any serial number will match the policy.
+        # The condition is dropped in this case and a log message is written.
+        self.assertEqual(_names(P.match_policies(user_object=user1)),
+                         {"setpin_pol"})
+
+        delete_policy("setpin_pol")
+        db_token.delete()
 
 class PolicyMatchTestCase(MyTestCase):
     @classmethod

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1198,7 +1198,7 @@ class PolicyTestCase(MyTestCase):
         user3.info = {"type": "notverysecure", "groups": ["b", "c"]}
 
         # no user => policy error
-        with self.assertRaisesRegexp(PolicyError, ".* a user_object is not available.*"):
+        with self.assertRaisesRegexp(PolicyError, ".* an according object is not available.*"):
             P.match_policies(user_object=None)
 
         # empty user => policy error
@@ -1383,10 +1383,9 @@ class PolicyTestCase(MyTestCase):
         self.assertEqual(_names(P.match_policies(user_object=user1, serial=serial)),
                          set())
 
-        # A request without any serial number will match the policy.
-        # The condition is dropped in this case and a log message is written.
-        self.assertEqual(_names(P.match_policies(user_object=user1)),
-                         {"setpin_pol"})
+        # A request without any serial number will raise a Policy error, since condition
+        # on tokeninfo is there, but no dbtoken object is available.
+        self.assertRaises(PolicyError, P.match_policies, user_object=user1)
 
         delete_policy("setpin_pol")
         db_token.delete()

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -801,6 +801,7 @@ class LibPolicyTestCase(MyTestCase):
         g.policy_object = PolicyClass()
         g.audit_object = FakeAudit()
         g.client_ip = None
+        g.serial = None
         options = {"g": g}
 
         r = reset_all_user_tokens(self.fake_check_token_list,

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -1737,6 +1737,7 @@ class TokenFailCounterTestCase(MyTestCase):
         g.policy_object = PolicyClass()
         g.audit_object = FakeAudit()
         g.client_ip = None
+        g.serial = None
         options = {"g": g}
 
         check_token_list([token1, token2], pin1, user=user,


### PR DESCRIPTION
This PR implements the tokeninfo policy filtering using the token serial from the g object

To Do
- [x] Code
- [x] lib and api Tests
- [x] Documentation

closes #1947 