### PR TITLE
Fix the interface of the container audit module

### DIFF
--- a/privacyidea/lib/auditmodules/containeraudit.py
+++ b/privacyidea/lib/auditmodules/containeraudit.py
@@ -46,14 +46,14 @@ class Audit(AuditBase):
     to a list of audit modules.
     """
 
-    def __init__(self, config=None):
-        super(Audit, self).__init__(config)
+    def __init__(self, config=None, startdate=None):
+        super(Audit, self).__init__(config, startdate)
         self.name = "containeraudit"
         write_conf = self.config.get('PI_AUDIT_CONTAINER_WRITE')
         read_conf = self.config.get('PI_AUDIT_CONTAINER_READ')
         # Initialize all modules
-        self.write_modules = [get_module_class(audit_module, "Audit", "log")(config) for audit_module in write_conf]
-        self.read_module = get_module_class(read_conf, "Audit", "log")(config)
+        self.write_modules = [get_module_class(audit_module, "Audit", "log")(config, startdate) for audit_module in write_conf]
+        self.read_module = get_module_class(read_conf, "Audit", "log")(config, startdate)
         if not self.read_module.is_readable:
             log.warning(u"The specified PI_AUDIT_CONTAINER_READ {0!s} is not readable.".format(self.read_module))
 

--- a/privacyidea/lib/auditmodules/containeraudit.py
+++ b/privacyidea/lib/auditmodules/containeraudit.py
@@ -52,7 +52,8 @@ class Audit(AuditBase):
         write_conf = self.config.get('PI_AUDIT_CONTAINER_WRITE')
         read_conf = self.config.get('PI_AUDIT_CONTAINER_READ')
         # Initialize all modules
-        self.write_modules = [get_module_class(audit_module, "Audit", "log")(config, startdate) for audit_module in write_conf]
+        self.write_modules = [get_module_class(audit_module, "Audit", "log")(config, startdate)
+                              for audit_module in write_conf]
         self.read_module = get_module_class(read_conf, "Audit", "log")(config, startdate)
         if not self.read_module.is_readable:
             log.warning(u"The specified PI_AUDIT_CONTAINER_READ {0!s} is not readable.".format(self.read_module))

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -413,7 +413,8 @@ class ContainerAuditTestCase(OverrideConfigTestCase):
                                                          "privacyidea.lib.auditmodules.sqlaudit"],
                             "PI_AUDIT_CONTAINER_READ": "privacyidea.lib.auditmodules.sqlaudit",
                             "PI_AUDIT_NO_SIGN": True,
-                            "PI_AUDIT_SQL_URI": 'sqlite:///' + os.path.join(basedir, 'data-test.sqlite')})
+                            "PI_AUDIT_SQL_URI": 'sqlite:///' + os.path.join(basedir, 'data-test.sqlite')},
+                           startdate=None)
         self.assertFalse(a.has_data)
         a.log({"action": "something_test_30"})
         self.assertTrue(a.has_data)


### PR DESCRIPTION
The container audit module is missing a parameter,
which leads to an exception when called from the
upper layer.

Fixes #2562