### PR TITLE
change the default configurations

### DIFF
--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -262,6 +262,7 @@ class HttpSMSProvider(ISMSProvider):
                                            "authentication.")
                       },
                       "CHECK_SSL": {
+                          "required": True,
                           "description": _("Should the SSL certificate be "
                                            "verified."),
                           "values": ["yes", "no"]

--- a/privacyidea/static/components/config/controllers/privacyideaServerController.js
+++ b/privacyidea/static/components/config/controllers/privacyideaServerController.js
@@ -30,6 +30,11 @@ myApp.controller("privacyideaServerController", function($scope, $stateParams,
     if ($scope.identifier) {
         // We are editing an existing RADIUS Server
         $scope.getPrivacyideaServers($scope.identifier);
+        } else {
+        // This is a new privacyIDEA server
+        $scope.params = {
+            tls: true
+        }
     }
 
     // Get all servers

--- a/privacyidea/static/components/config/controllers/smtpServerController.js
+++ b/privacyidea/static/components/config/controllers/smtpServerController.js
@@ -29,6 +29,13 @@ myApp.controller("smtpServerController", function($scope, $stateParams, inform,
     if ($scope.identifier) {
         // We are editing an existing SMTP Server
         $scope.getSmtpServers($scope.identifier);
+    } else {
+        // This is a new SMTP server
+        $scope.params = {
+            tls: true,
+            port: 25,
+            timeout: 10
+        }
     }
 
     // Get all servers


### PR DESCRIPTION
change the default configurations for the SMTP server, privacyIDEA server and set "CHECK_SSL" as required to reduce the chance of accidental misconfiguration by the admins.

Closes #2408 