### PR TITLE
fix checkRight for events in dashboard

### DIFF
--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -163,7 +163,7 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
     if (AuthFactory.checkRight('policyread')) {
         $scope.get_policies();
     };
-    if (AuthFactory.checkRight('eventhandler_read')) {
+    if (AuthFactory.checkRight('eventhandling_read')) {
         $scope.get_events();
     };
     $scope.getSubscriptions();
@@ -182,7 +182,7 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
         if (AuthFactory.checkRight('policyread')) {
             $scope.get_policies();
         };
-        if (AuthFactory.checkRight('eventhandler_read')) {
+        if (AuthFactory.checkRight('eventhandling_read')) {
             $scope.get_events();
         };
         $scope.getSubscriptions();


### PR DESCRIPTION
this PR corrects a spelling error in checkRight in the dashboard in PR #2469, issue #2456. This causes the events not being listed on the dashboard.