### PR TITLE
token types in dashboard

### DIFF
--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -44,6 +44,23 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
             }, {"pagesize": 0});
     };
 
+    $scope.get_token_by_type = function () {
+        $scope.tokens.by_type = {};
+        var tokentypes = ['certificate', 'daplug', 'email', 'foureyes', 'hotp', 'indexedsecret',
+        'motp', 'ocra', 'paper', 'password', 'push', 'questionnaire', 'radius', 'registration',
+        'remote', 'sms', 'spass', 'sshkey', 'tan', 'tiqr', 'totp', 'u2f', 'vasco', 'webauthn',
+        'yubico', 'yubikey'];
+        tokentypes.forEach(function (tokentype, index) {
+            TokenFactory.getTokensNoCancel(function (data) {
+                    if (data) {
+                        if (data.result.value.count != 0) {
+                            $scope.tokens.by_type[tokentype] = data.result.value.count;
+                        }
+                    }
+            }, {"pagesize": 0, "type": tokentype});
+        });
+    };
+
     $scope.get_token_hardware = function () {
         TokenFactory.getTokensNoCancel(function (data) {
                 if (data) {
@@ -157,6 +174,7 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
 
     if (AuthFactory.checkRight('tokenlist')) {
         $scope.get_total_token_number();
+        $scope.get_token_by_type();
         $scope.get_token_hardware();
         $scope.get_token_software();
     };
@@ -176,6 +194,7 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
     $scope.$on("piReload", function() {
         if (AuthFactory.checkRight('tokenlist')) {
             $scope.get_total_token_number();
+            $scope.get_token_by_type();
             $scope.get_token_hardware();
             $scope.get_token_software();
         };

--- a/privacyidea/static/components/dashboard/views/dashboard.html
+++ b/privacyidea/static/components/dashboard/views/dashboard.html
@@ -15,6 +15,14 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td colspan="2">
+                                    <span ng-repeat="(type, number) in tokens.by_type">
+                                        | {{ type }}: <a ui-sref="token.list()"
+                                           ng-click="$rootScope.returnTo=dashboard;">{{ number }}</a>
+                                    </span>
+                                </td>
+                            </tr>
+                            <tr>
                                 <td translate>Hardware</td>
                                 <td>{{ tokens.hardware }}</td>
                             </tr>


### PR DESCRIPTION
working on #2457

This PR implements a token type list in the dashboard. This adds one request per token type, which may slow the dashboard loading.

Linked is simply the token list, since the token list does not accept filters as state-parameter yet