### PR TITLE
Remove border around tables in lists views

### DIFF
--- a/privacyidea/static/components/config/views/config.caconnectors.list.html
+++ b/privacyidea/static/components/config/views/config.caconnectors.list.html
@@ -1,4 +1,4 @@
-<span>
+<div class="table-responsive">
     <table class="table table-bordered table-responsive table-striped">
         <thead>
         <tr>

--- a/privacyidea/static/components/config/views/config.mresolvers.list.html
+++ b/privacyidea/static/components/config/views/config.mresolvers.list.html
@@ -1,4 +1,4 @@
-<div>
+<div class="table-responsive">
     <table class="table table-bordered table-responsive table-striped">
         <thead>
         <tr>

--- a/privacyidea/static/components/config/views/config.privacyideaserver.list.html
+++ b/privacyidea/static/components/config/views/config.privacyideaserver.list.html
@@ -1,4 +1,4 @@
-<div>
+<div class="table-responsive">
     <table class="table table-bordered table-responsive table-striped">
         <thead>
         <tr>

--- a/privacyidea/static/components/config/views/config.radius.list.html
+++ b/privacyidea/static/components/config/views/config.radius.list.html
@@ -1,4 +1,4 @@
-<div>
+<div class="table-responsive">
     <table class="table table-bordered table-responsive table-striped">
         <thead>
         <tr>

--- a/privacyidea/static/components/config/views/config.realms.list.html
+++ b/privacyidea/static/components/config/views/config.realms.list.html
@@ -1,4 +1,4 @@
-<div>
+<div class="table-responsive">
     <table class="table table-bordered table-responsive table-striped">
         <thead>
         <tr>

--- a/privacyidea/static/components/config/views/config.resolvers.list.html
+++ b/privacyidea/static/components/config/views/config.resolvers.list.html
@@ -1,4 +1,4 @@
-<div>
+<div class="table-responsive">
     <table class="table table-bordered table-responsive table-striped">
         <thead>
         <tr>

--- a/privacyidea/static/components/config/views/config.smtp.list.html
+++ b/privacyidea/static/components/config/views/config.smtp.list.html
@@ -1,4 +1,4 @@
-<div>
+<div class="table-responsive">
     <table class="table table-bordered table-responsive table-striped">
         <thead>
         <tr>


### PR DESCRIPTION
By adding the `table-responsive` class to the surrounding `div`, the
borders are removed.

Fixes #2585