### PR TITLE
Allow to configure an alternative Web UI

### DIFF
--- a/doc/faq/customization.rst
+++ b/doc/faq/customization.rst
@@ -235,3 +235,10 @@ and
 
 The list of the token modules you want to add, must be specified in ``pi.cfg``.
 See :ref:`picfg_3rd_party_tokens`.
+
+Custom Web UI
+~~~~~~~~~~~~~
+
+You can also write your complete new WebUI.
+To do so you need to specify files and folders in ``pi.cfg``.
+Read more about this at :ref:`custom_web_ui`.

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -225,7 +225,7 @@ The Web UI is a single page application, that is initiated from the file
 ``static/templates/index.html``. This file pulls all CSS, the javascript framework
 and all the javascript business logic.
 
-You can configure privacyIDEA to use a complete different, your own Web UI.
+You can configure privacyIDEA to use a completely different, your own Web UI.
 
 You can do this using the following config values:
 

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -216,3 +216,23 @@ in ``pi.cfg`` using the parameter ``PI_TOKEN_MODULES``:
 
     PI_TOKEN_MODULES = [ "myproject.cooltoken", "myproject.lametoken" ]
 
+.. _custom_web_ui:
+
+Custom Web UI
+-------------
+
+The Web UI is a single page application, that is initiated from the file
+``static/templates/index.html``. This file pulls all CSS, the javascript framework
+and all the javascript business logic.
+
+You can configure privacyIDEA to use a complete different, your own Web UI.
+
+You can do this using the following config values:
+
+    PI_INDEX_HTML = "myindex.html"
+    PI_STATIC_FOLDER = "mystatic"
+    PI_TEMPLATE_FOLDER = "mystatic/templates"
+
+In this example the file ``mystatic/templates/myindex.html`` would be loaded
+as the initial single page application.
+

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -225,7 +225,7 @@ The Web UI is a single page application, that is initiated from the file
 ``static/templates/index.html``. This file pulls all CSS, the javascript framework
 and all the javascript business logic.
 
-You can configure privacyIDEA to use a completely different, your own Web UI.
+You can configure privacyIDEA to use your own WebUI, which is completely different and stored at another location.
 
 You can do this using the following config values:
 

--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -136,6 +136,10 @@ def create_app(config_name="development",
     # If this file does not exist, we create an error!
     app.config.from_envvar(ENV_KEY, silent=True)
 
+    # We allow to set different static folders
+    app.static_folder = app.config.get("PI_STATIC_FOLDER", "static/")
+    app.template_folder = app.config.get("PI_TEMPLATE_FOLDER", "static/templates/")
+
     app.register_blueprint(validate_blueprint, url_prefix='/validate')
     app.register_blueprint(token_blueprint, url_prefix='/token')
     app.register_blueprint(system_blueprint, url_prefix='/system')
@@ -221,5 +225,8 @@ def create_app(config_name="development",
                                                     'fr', 'it', 'es', 'en'])
 
     queue.register_app(app)
+
+    logging.debug(u"Reading application from the static folder {0!s} and "
+                  u"the template folder {1!s}".format(app.static_folder, app.template_folder))
 
     return app

--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -113,6 +113,12 @@ class TestingConfig(Config):
                        "resolver": "resolverX"}]
 
 
+class AltUIConfig(TestingConfig):
+    PI_INDEX_HTML = "testui.html"
+    PI_STATIC_FOLDER = "../tests/testdata/altstatic"
+    PI_TEMPLATE_FOLDER = "../tests/testdata/altstatic/templates"
+
+
 class ProductionConfig(Config):
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'data.sqlite')
@@ -154,5 +160,6 @@ config = {
     'testing': TestingConfig,
     'production': ProductionConfig,
     'default': DevelopmentConfig,
-    'heroku': HerokuConfig
+    'heroku': HerokuConfig,
+    'altUI': AltUIConfig
 }

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -183,4 +183,5 @@ def single_page_application():
         'page_title': page_title
     }
 
-    return send_html(render_template("index.html", **render_context))
+    index_page = current_app.config.get("PI_INDEX_HTML") or "index.html"
+    return send_html(render_template(index_page, **render_context))

--- a/tests/test_ui_login.py
+++ b/tests/test_ui_login.py
@@ -27,7 +27,7 @@ class AlternativeWebUI(MyTestCase):
         db.session.commit()
 
     def test_01_normal_login(self):
-        # We just test, if the alterrnative page is calles
+        # We just test, if the alterrnative page is called
         with self.app.test_request_context('/',
                                            method='GET'):
             res = self.app.full_dispatch_request()

--- a/tests/test_ui_login.py
+++ b/tests/test_ui_login.py
@@ -33,7 +33,7 @@ class AlternativeWebUI(MyTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             self.assertEqual(res.mimetype, 'text/html', res)
-            self.assertIn("This is an alternative UI", res.data)
+            self.assertIn(b"This is an alternative UI", res.data)
 
 
 class LoginUITestCase(MyTestCase):

--- a/tests/test_ui_login.py
+++ b/tests/test_ui_login.py
@@ -9,6 +9,31 @@ from .base import MyTestCase
 from privacyidea.lib.policy import set_policy, SCOPE, ACTION, PolicyClass, delete_all_policies
 from privacyidea.lib.utils import to_unicode
 import re
+from privacyidea.app import create_app
+from privacyidea.models import db, save_config_timestamp
+
+
+class AlternativeWebUI(MyTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = create_app('altUI', "")
+        cls.app_context = cls.app.app_context()
+        cls.app_context.push()
+        db.create_all()
+        # save the current timestamp to the database to avoid hanging cached
+        # data
+        save_config_timestamp()
+        db.session.commit()
+
+    def test_01_normal_login(self):
+        # We just test, if the alterrnative page is calles
+        with self.app.test_request_context('/',
+                                           method='GET'):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.mimetype, 'text/html', res)
+            self.assertIn("This is an alternative UI", res.data)
 
 
 class LoginUITestCase(MyTestCase):

--- a/tests/testdata/altstatic/templates/testui.html
+++ b/tests/testdata/altstatic/templates/testui.html
@@ -1,0 +1,1 @@
+<h1>This is an alternative UI!</h1>


### PR DESCRIPTION
The pi.cfg can contain alternative index.html file
and alternative static/template path to be able
to easily load an alternative web UI without the
need to mangle with the existing one.

Closes #2591