### PR TITLE
Add a compatible setuptools version for Python 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ requests==2.24.0
 rsa==4.5; python_version < '3.0'
 rsa==4.6; python_version > '3.0'
 scandir==1.10.0; python_version < '3.0'
+setuptools==50.3.2; python_version <= '3.5'
 singledispatch==3.4.0.3; python_version < '3.0'
 six==1.15.0
 smpplib==2.1.0


### PR DESCRIPTION
On Ubuntu 16.04 there is Python version 3.5, which will
create a virtualenv including setuptools 51.3.x.

However, this setuptools is to new and dropped support
for Python 3.5.
Thus installing privacyIDEA in this virtualenv will fail.

privacyIDEA version 3.5 was built with setuptools
version 51.1.0.post20201221 which is not available anymore for
Python 3.5.
Thus we force to use the latest version of setuptools,
which is available for Python 3.5.