### PR TITLE
Fix tokeninfo value filter with Oracle

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,7 +4,8 @@ Version 3.5.1, 2020-01-xx
   * Fix DB migration script for update from prior of 3.3. (#2582)
   * Fix the internal interface of container audit module (#2562)
   * Add missing headers to /auth request (#2599)
-  
+  * Fix tokeninfo value filter with Oracle db (#2602)
+
 
 Version 3.5, 2020-12-22
 


### PR DESCRIPTION
Oracle uses the CLOB datatype to represent a UnicodeText internally.
CLOBs don't support matching in a `where` clause so it needs to be cast
to a VARCHAR using the `to_char()` function before.

Fixes: #2602