### PR TITLE
2594/fix import of yubicos pskc

### DIFF
--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -508,7 +508,8 @@ def parsePSKCdata(xml_data,
 
         # Special treatment for pskc files exported from Yubico
         if algo in ("http://www.yubico.com/#yubikey-aes",
-                    "urn:ietf:params:xml:ns:keyprov:pskc:hotp"):
+                    "urn:ietf:params:xml:ns:keyprov:pskc:hotp") \
+                and re.match(r"\d+:\d+", serial):  # check if the serial fits the pattern "<SerialNo>:<Slot>
             t_type = "yubikey"
             serial_split = serial.split(":")
             serial_no = serial_split[0]

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -502,13 +502,27 @@ def parsePSKCdata(xml_data,
             token["description"] = key_package.deviceinfo.manufacturer.string
         except Exception as exx:
             log.debug("Can not get manufacturer string {0!s}".format(exx))
-        serial = key["id"]
-        try:
-            serial = key_package.deviceinfo.serialno.string.strip()
-        except Exception as exx:
-            log.debug("Can not get serial string from device info {0!s}".format(exx))
+
         algo = key["algorithm"]
-        token["type"] = algo.split(":")[-1].lower()
+        serial = key["id"]
+
+        # Special treatment for pskc files exported from Yubico
+        if algo in ("http://www.yubico.com/#yubikey-aes",
+                    "urn:ietf:params:xml:ns:keyprov:pskc:hotp"):
+            t_type = "yubikey"
+            serial_split = serial.split(":")
+            serial_no = serial_split[0]
+            slot = serial_split[1]
+            serial = "UBAM{0!s}_{1!s}".format(serial_no, slot)
+        else:
+            try:
+                serial = key_package.deviceinfo.serialno.string.strip()
+            except Exception as exx:
+                log.debug("Can not get serial string from device info {0!s}".format(exx))
+            t_type = algo.split(":")[-1].lower()
+
+        token["type"] = t_type
+
         parameters = key.algorithmparameters
         token["otplen"] = parameters.responseformat["length"] or 6
         try:

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -620,8 +620,8 @@ class ImportOTPTestCase(MyTestCase):
 
         tokens, _ = parsePSKCdata(YUBIKEY_PSKC_HOTP)
         self.assertTrue(len(tokens) == 1, len(tokens))
-        self.assertTrue("UBAM10944003_1" in tokens, tokens)
-        self.assertEqual(tokens["UBAM10944003_1"]["type"], "yubikey")
+        self.assertTrue("UBOM10944003_1" in tokens, tokens)
+        self.assertEqual(tokens["UBOM10944003_1"]["type"], "hotp")
 
     def test_03_import_pskc(self):
         self.assertRaises(ImportException, parsePSKCdata, 'not xml')


### PR DESCRIPTION
Closes #2594. Supports importing keys, where the algorithm matches `http://www.yubico.com/#yubikey-aes` or `urn:ietf:params:xml:ns:keyprov:pskc:hotp`.

The second identifier is the same for non yubikey tokens, therefor we check if the tokens key matches the pattern `<SerialNo>:<Slot>`also.