### PR TITLE
Only display subscription in dashboard

### DIFF
--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -166,7 +166,9 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
     if (AuthFactory.checkRight('eventhandling_read')) {
         $scope.get_events();
     };
-    $scope.getSubscriptions();
+    if (AuthFactory.checkRight('managesubscription')) {
+        $scope.getSubscriptions();
+    };
     if (AuthFactory.checkRight('auditlog')) {
         $scope.getAuthentication();
         $scope.getAdministration();
@@ -185,7 +187,9 @@ myApp.controller("dashboardController", function (ConfigFactory, TokenFactory,
         if (AuthFactory.checkRight('eventhandling_read')) {
             $scope.get_events();
         };
-        $scope.getSubscriptions();
+        if (AuthFactory.checkRight('managesubscription')) {
+            $scope.getSubscriptions();
+        };
         if (AuthFactory.checkRight('auditlog')) {
             $scope.getAuthentication();
             $scope.getAdministration();

--- a/privacyidea/static/components/dashboard/views/dashboard.html
+++ b/privacyidea/static/components/dashboard/views/dashboard.html
@@ -173,7 +173,7 @@
            </div>
        </div>
        <div class="col-lg-4">
-             <div class="panel panel-default">
+             <div class="panel panel-default" ng-show="checkRight('managesubscription')">
                  <div class="panel-heading" translate>Subscriptions</div>
                  <div class="panel-body">
                      <table class="table">


### PR DESCRIPTION
if the admin has the right to manage the subscription.
This way we suppress the error message.

Fix #2609