### PR TITLE
Update GitHub workflow for new branches

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,15 +21,28 @@ jobs:
       run_tests: ${{ steps.check.outputs.run_tests}}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+#    - name: Dump GitHub context
+#      env:
+#        GITHUB_CONTEXT: ${{ toJson(github) }}
+#      run: echo "$GITHUB_CONTEXT"
     - name: 'Get changed file list'
       id: list
       run: |
-        if [ $GITHUB_BASE_REF ]; then
-          git fetch origin $GITHUB_BASE_REF --depth=1
-          export DIFF=$( git diff --name-only --diff-filter=AM origin/$GITHUB_BASE_REF $GITHUB_SHA )
+        if [[ -n "${GITHUB_BASE_REF}" ]]; then
+          # this is a pull request. We need the base branch to compare.
+          git fetch origin ${GITHUB_BASE_REF} --depth=1
+          export DIFF=$( git diff --name-only --diff-filter=AM origin/${GITHUB_BASE_REF} ${GITHUB_SHA} )
         else
-          git fetch origin ${{ github.event.before }} --depth=1
-          export DIFF=$( git diff --name-only --diff-filter=AM ${{ github.event.before }} $GITHUB_SHA )
+          # this is a push event.
+          if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
+            # this is the first commit in a branch
+            export DIFF=$( git diff --name-only --diff-filter=AM HEAD^1 ${GITHUB_SHA} )
+          else
+            git fetch origin ${{ github.event.before }} --depth=1
+            export DIFF=$( git diff --name-only --diff-filter=AM ${{ github.event.before }} $GITHUB_SHA )
+          fi
         fi
         echo "Changed files: $DIFF"
         # Escape newlines (replace \n with %0A)


### PR DESCRIPTION
When pushing to a new branch, the workflow now compares with the HEAD^1
revision since we checkout with depth=2.
This should also work for merge commits.