### PR TITLE
2257/fix reading hash algorithm

### DIFF
--- a/doc/workflows_and_tools/import/index.rst
+++ b/doc/workflows_and_tools/import/index.rst
@@ -128,6 +128,8 @@ privacyIDEA lets you import PSKC files.
 All necessary information (OTP length, Hash algorithm, token type) are read
 from the file.
 
+.. note:: If the Hash algorithm is not specified for a token, SHA1 is used as the default.
+
 PSKC files can be encrypted - either with a password or an AES key. You can
 provide this during the upload.
 

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -537,9 +537,10 @@ def parsePSKCdata(xml_data,
             # Check if hashlib is explicitly set in file
             if parameters.suite and parameters.suite.string:
                 hash_lib = parameters.suite.string.lower()
-            token["hashlib"] = hash_lib
         except Exception as e:
             log.warning(f"No compatible suite contained, falling back to default {hash_lib}.")
+
+        token["hashlib"] = hash_lib
 
         try:
             if key.data.secret.plainvalue:

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -533,10 +533,13 @@ def parsePSKCdata(xml_data,
 
         hash_lib = "sha1"
 
-        # Check if hashlib is explicitly set in file
-        if parameters.suite and parameters.suite.string:
-            hash_lib = parameters.suite.string.lower()
-        token["hashlib"] = hash_lib
+        try:
+            # Check if hashlib is explicitly set in file
+            if parameters.suite and parameters.suite.string:
+                hash_lib = parameters.suite.string.lower()
+            token["hashlib"] = hash_lib
+        except Exception as e:
+            log.warning(f"No compatible suite contained, falling back to default {hash_lib}.")
 
         try:
             if key.data.secret.plainvalue:

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -529,10 +529,15 @@ def parsePSKCdata(xml_data,
 
         parameters = key.algorithmparameters
         token["otplen"] = parameters.responseformat["length"] or 6
-        try:
-            token["hashlib"] = parameters.suite["hashalgo"] or "sha1"
-        except Exception as exx:
-            log.warning("No compatible suite contained.")
+        # token["hashlib"] = parameters.suite or "sha1"
+
+        hash_lib = "sha1"
+
+        # Check if hashlib is explicitly set in file
+        if parameters.suite and parameters.suite.string:
+            hash_lib = parameters.suite.string.lower()
+        token["hashlib"] = hash_lib
+
         try:
             if key.data.secret.plainvalue:
                 secret = key.data.secret.plainvalue.string

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -533,12 +533,11 @@ def parsePSKCdata(xml_data,
 
         hash_lib = "sha1"
 
-        try:
-            # Check if hashlib is explicitly set in file
-            if parameters.suite and parameters.suite.string:
-                hash_lib = parameters.suite.string.lower()
-        except Exception as e:
-            log.warning(f"No compatible suite contained, falling back to default {hash_lib}.")
+        # Check if hashlib is explicitly set in file
+        if parameters.suite and parameters.suite.string:
+            hash_lib = parameters.suite.string.lower()
+        else:
+            log.warning("No hashlib defined, falling back to default {}.".format(hash_lib))
 
         token["hashlib"] = hash_lib
 

--- a/tests/test_lib_importotp.py
+++ b/tests/test_lib_importotp.py
@@ -95,6 +95,7 @@ XML_PSKC = '''<?xml version="1.0" encoding="UTF-8"?>
     </DeviceInfo>
     <Key Id="1000133508267" Algorithm="urn:ietf:params:xml:ns:keyprov:pskc:hotp">
       <AlgorithmParameters>
+        <Suite>sha256</Suite>
         <ResponseFormat Length="6" Encoding="DECIMAL"/>
       </AlgorithmParameters>
       <Data>
@@ -629,14 +630,19 @@ class ImportOTPTestCase(MyTestCase):
         tokens, _ = parsePSKCdata(XML_PSKC)
         self.assertEqual(len(tokens), 7)
         self.assertEqual(tokens["1000133508267"].get("type"), "hotp")
+        self.assertEqual(tokens["1000133508267"].get("hashlib"), "sha256")
         self.assertEqual(tokens["2600135004013"].get("type"), "totp")
+        self.assertEqual(tokens["2600135004013"].get("hashlib"), "sha1")
+
         # Check the TOTP counter...
         self.assertEqual(tokens["2600135004013"].get("counter"), "121212")
         self.assertEqual(tokens["2600135004013"].get("timeShift"), "-122")
         self.assertEqual(tokens["2600135004013"].get("timeStep"), "60")
+
         # check the PW token
         self.assertEqual(tokens["PW001"].get("type"), "pw")
         self.assertEqual(tokens["PW001"].get("otplen"), "12")
+
         # The secret (password) of the pw token is "123456789012"
         self.assertEqual(tokens["PW001"].get("otpkey"), hexlify_and_unicode("123456789012"))
 


### PR DESCRIPTION
May close #2257.
Added that SHA1 is used as the default hash algorithm for imported tokens from PSKC to the documentation:
```
..note:: If the Hash algorithm is not specified for a token, SHA1 is used as the default.
```

Changed / fixed how the hash algorithm specified in the file is read.