### PR TITLE
Make entries available in audit log

### DIFF
--- a/privacyidea/lib/auditmodules/base.py
+++ b/privacyidea/lib/auditmodules/base.py
@@ -141,7 +141,8 @@ class Audit(object):  # pragma: no cover
         return ['number', 'action', 'success', 'serial', 'date', 'startdate',
                 'duration', 'token_type', 'user', 'realm', 'administrator',
                 'action_detail', 'info', 'privacyidea_server', 'client',
-                'loglevel', 'policies', 'clearance_level']
+                'log_level', 'policies', 'clearance_level', 'sig_check',
+                'missing_line', 'resolver']
 
     def get_total(self, param, AND=True, display_error=True, timelimit=None):
         """

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -402,7 +402,7 @@ class Audit(AuditBase):
                     'info': LogEntry.info,
                     'privacyidea_server': LogEntry.privacyidea_server,
                     'client': LogEntry.client,
-                    'loglevel': LogEntry.loglevel,
+                    'log_level': LogEntry.loglevel,
                     'policies': LogEntry.policies,
                     'clearance_level': LogEntry.clearance_level}
         return sortname.get(key)

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -317,6 +317,16 @@ class AuditTestCase(MyTestCase):
         # The tokentype was actually written as token_type
         self.assertEqual(audit_log.auditdata[0].get("token_type"), "spass")
 
+    def test_11_check_audit_columns(self):
+        self.Audit.log({"action": "test11"})
+        self.Audit.finalize_log()
+        audit_log = self.Audit.search({"action": "test11"})
+        self.assertEqual(audit_log.total, 1)
+        # The tokentype was actually written as token_type
+        self.assertEqual(set(audit_log.auditdata[0].keys()),
+                         set(self.Audit.available_audit_columns),
+                         audit_log.auditdata[0].keys())
+
 
 class AuditColumnLengthTestCase(OverrideConfigTestCase):
     class Config(TestingConfig):


### PR DESCRIPTION
The `missing line` and `signature` entries were missing from the audit
log. Adding them to the `available_audit_columns` property fixes this.
Also enhanced tests for audit columns which revealed some minor issues.

Fixes #2627