### PR TITLE
1059/add limited cache to auth cache

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -356,13 +356,20 @@ type: string
 
 The Authentication Cache caches the credentials of a successful
 authentication and allows to use the same credentials - also with an OTP
-value - for the specified amount of time.
+value - for the specified amount of time and optionally for a specified number
+of authentications.
 
-The time to cache the credentials can be specified like "4h", "5m", "2d"
-(hours, minutes days) or "4h/5m". The notation 4h/5m means, that credentials
-are cached for 4 hours, but only may be used again, if every 5 minutes the
+The time to cache the credentials can be specified like "4h", "5m", "2d", "3s"
+(hours, minutes, days, seconds). The number of allowed authentications can be
+specified as a whole number, greater than zero.
+
+The notation "4h/5m" means, that credentials
+are cached for 4 hours, but may only be used again, if every 5 minutes the
 authentication occurs. If the authentication with the same credentials would
 not occur within 5 minutes, the credentials can not be used anymore.
+
+The notation "2m/3" means, that credentials are cached for 2 minutes, but may only be used 3 times
+in this timeframe.
 
 In future implementations the caching of the credentials could also be
 dependent on the clients IP address and the user agent.

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -96,7 +96,7 @@ def cleanup(minutes):
 
 
 def verify_in_cache(username, realm, resolver, password, first_auth=None, last_auth=None,
-                    max_number_of_authentications=0):
+                    max_auths=0):
     """
     Verify if the given credentials are cached and if the time is correct.
     
@@ -108,10 +108,10 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
         cache. Only find newer entries 
     :param last_auth: The timestamp when the entry was last successfully 
         verified. Only find newer entries
-    :param max_number_of_authentications: Maximum number of times the authcache entry can be used to skip
+    :param max_auths: Maximum number of times the authcache entry can be used to skip
         authentication, as defined by ACTION.AUTH_CACHE policy. Will return False if the current number of
         authentications + 1 of the cached authentication exceeds this value.
-    :type max_number_of_authentications: int
+    :type max_auths: int
     :return: 
     """
     conditions = []
@@ -135,9 +135,9 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
             log.debug("Old authcache entry for user {0!s}@{1!s}.".format(username, realm))
             result = False
 
-        if result and max_number_of_authentications > 0:
+        if result and max_auths > 0:
             # Check if auth_count allows this authentication too
-            result = cached_auth.auth_count < max_number_of_authentications
+            result = cached_auth.auth_count < max_auths
 
         if result:
             # Update the last_auth

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -108,9 +108,9 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
         cache. Only find newer entries 
     :param last_auth: The timestamp when the entry was last successfully 
         verified. Only find newer entries
-    :param max_number_of_authentications: Maximum number of times the authcache entry can be used to skip authentication,
-        as defined by ACTION.AUTH_CACHE policy. Will return False if the current number of authentications + 1 of the
-        cached authentication exceeds this value.
+    :param max_number_of_authentications: Maximum number of times the authcache entry can be used to skip
+        authentication, as defined by ACTION.AUTH_CACHE policy. Will return False if the current number of
+        authentications + 1 of the cached authentication exceeds this value.
     :return: 
     """
     conditions = []

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -136,12 +136,12 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
             result = False
 
         if result and max_number_of_authentications > 0:
+            # Check if auth_count allows this authentication too
             result = cached_auth.auth_count < max_number_of_authentications
-            increment_auth_count(cached_auth.id)
-            break
 
         if result:
             # Update the last_auth
+            increment_auth_count(cached_auth.id)
             update_cache_last_auth(cached_auth.id)
             break
 

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -47,7 +47,7 @@ def add_to_cache(username, realm, resolver, password):
 
 def increment_auth_count(cache_id):
     db.session.query(AuthCache).filter(AuthCache.id == cache_id).update(
-        {AuthCache.current_number_of_authentications: AuthCache.current_number_of_authentications + 1})
+        {AuthCache.auth_count: AuthCache.auth_count + 1})
     db.session.commit()
 
 
@@ -135,7 +135,7 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
             result = False
 
         if result and max_number_of_authentications:
-            result = cached_auth.current_number_of_authentications < max_number_of_authentications
+            result = cached_auth.auth_count < max_number_of_authentications
             increment_auth_count(cached_auth.id)
             break
 

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -45,16 +45,11 @@ def add_to_cache(username, realm, resolver, password):
     return r
 
 
-def increment_auth_count(cache_id):
-    db.session.query(AuthCache).filter(AuthCache.id == cache_id).update(
-        {AuthCache.auth_count: AuthCache.auth_count + 1})
-    db.session.commit()
-
-
-def update_cache_last_auth(cache_id):
+def update_cache(cache_id):
     last_auth = datetime.datetime.utcnow()
-    AuthCache.query.filter(
-        AuthCache.id == cache_id).update({"last_auth": last_auth})
+    db.session.query(AuthCache).filter(
+        AuthCache.id == cache_id).update({"last_auth": last_auth,
+                                          AuthCache.auth_count: AuthCache.auth_count + 1})
     db.session.commit()
 
 
@@ -140,9 +135,8 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
             result = cached_auth.auth_count < max_auths
 
         if result:
-            # Update the last_auth
-            increment_auth_count(cached_auth.id)
-            update_cache_last_auth(cached_auth.id)
+            # Update the last_auth and the auth_count
+            update_cache(cached_auth.id)
             break
 
     if not result:

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -96,7 +96,7 @@ def cleanup(minutes):
 
 
 def verify_in_cache(username, realm, resolver, password, first_auth=None, last_auth=None,
-                    max_number_of_authentications=None):
+                    max_number_of_authentications=0):
     """
     Verify if the given credentials are cached and if the time is correct.
     
@@ -111,6 +111,7 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
     :param max_number_of_authentications: Maximum number of times the authcache entry can be used to skip
         authentication, as defined by ACTION.AUTH_CACHE policy. Will return False if the current number of
         authentications + 1 of the cached authentication exceeds this value.
+    :type max_number_of_authentications: int
     :return: 
     """
     conditions = []
@@ -134,7 +135,7 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
             log.debug("Old authcache entry for user {0!s}@{1!s}.".format(username, realm))
             result = False
 
-        if result and max_number_of_authentications:
+        if result and max_number_of_authentications > 0:
             result = cached_auth.auth_count < max_number_of_authentications
             increment_auth_count(cached_auth.id)
             break

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -44,6 +44,7 @@ policy decorators for the API (pre/post) are defined in api/lib/policy
 The functions of this module are tested in tests/test_lib_policy_decorator.py
 """
 import logging
+import re
 
 from privacyidea.lib.policy import Match
 from privacyidea.lib.error import PolicyError, privacyIDEAError
@@ -166,12 +167,11 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
             auth_times = list(auth_cache_dict)[0].split("/")
             # determine first_auth from policy!
             first_offset = parse_timedelta(auth_times[0])
+            first_auth = datetime.datetime.utcnow() - first_offset
 
-            import re
             # Use auth cache when number of allowed authentications is defined
             if len(auth_times) == 2 and re.match(r"^\d+$", auth_times[1]):
 
-                first_auth = datetime.datetime.utcnow() - first_offset
                 result = verify_in_cache(user_object.login, user_object.realm,
                                          user_object.resolver, passw,
                                          first_auth=first_auth,
@@ -184,7 +184,6 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
                     # If there is no last_auth, it is equal to first_auth
                     last_offset = first_offset
 
-                first_auth = datetime.datetime.utcnow() - first_offset
                 last_auth = datetime.datetime.utcnow() - last_offset
                 result = verify_in_cache(user_object.login, user_object.realm,
                                          user_object.resolver, passw,

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -174,6 +174,7 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
             if len(auth_times) == 2:
                 if re.match(r"^\d+$", auth_times[1]):
                     max_auths = int(auth_times[1])
+                    last_auth = None
                 else:
                     # Determine last_auth delta from policy
                     last_offset = parse_timedelta(auth_times[1])

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -162,32 +162,31 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
         auth_cache_dict = Match.user(g, scope=SCOPE.AUTH, action=ACTION.AUTH_CACHE,
                                      user_object=user_object).action_values(unique=True, write_to_audit_log=False)
         if auth_cache_dict:
-            # verify in cache and return an early success
             auth_times = list(auth_cache_dict)[0].split("/")
+
             # determine first_auth from policy!
             first_offset = parse_timedelta(auth_times[0])
             first_auth = datetime.datetime.utcnow() - first_offset
+            last_auth = first_auth  # Default if no last auth exists
+            max_auths = 0  # Default value, 0 has no effect on verification
 
             # Use auth cache when number of allowed authentications is defined
-            if len(auth_times) == 2 and re.match(r"^\d+$", auth_times[1]):
-
-                result = verify_in_cache(user_object.login, user_object.realm,
-                                         user_object.resolver, passw,
-                                         first_auth=first_auth,
-                                         max_number_of_authentications=int(auth_times[1]))
-            else:
-                if len(auth_times) == 2:
-                    # Determine last_auth from policy
-                    last_offset = parse_timedelta(auth_times[1])
+            if len(auth_times) == 2:
+                if re.match(r"^\d+$", auth_times[1]):
+                    max_auths = int(auth_times[1])
                 else:
-                    # If there is no last_auth, it is equal to first_auth
-                    last_offset = first_offset
+                    # Determine last_auth delta from policy
+                    last_offset = parse_timedelta(auth_times[1])
+                    last_auth = datetime.datetime.utcnow() - last_offset
+            else:
+                # If there is no last_auth, it is equal to first_auth
+                last_auth = datetime.datetime.utcnow() - first_offset
 
-                last_auth = datetime.datetime.utcnow() - last_offset
-                result = verify_in_cache(user_object.login, user_object.realm,
-                                         user_object.resolver, passw,
-                                         first_auth=first_auth,
-                                         last_auth=last_auth)
+            result = verify_in_cache(user_object.login, user_object.realm,
+                                     user_object.resolver, passw,
+                                     first_auth=first_auth,
+                                     last_auth=last_auth,
+                                     max_auths=max_auths)
 
             if result:
                 g.audit_object.add_policy(next(iter(auth_cache_dict.values())))

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -174,14 +174,10 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
             if len(auth_times) == 2:
                 if re.match(r"^\d+$", auth_times[1]):
                     max_auths = int(auth_times[1])
-                    last_auth = None
                 else:
                     # Determine last_auth delta from policy
                     last_offset = parse_timedelta(auth_times[1])
                     last_auth = datetime.datetime.utcnow() - last_offset
-            else:
-                # If there is no last_auth, it is equal to first_auth
-                last_auth = datetime.datetime.utcnow() - first_offset
 
             result = verify_in_cache(user_object.login, user_object.realm,
                                      user_object.resolver, passw,

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2699,16 +2699,8 @@ class AuthCache(MethodsMixin, db.Model):
         self.realm = realm
         self.resolver = resolver
         self.authentication = authentication
-
-        if first_auth:
-            self.first_auth = first_auth
-        else:
-            self.first_auth = datetime.utcnow()
-
-        if last_auth:
-            self.last_auth = last_auth
-        else:
-            self.last_auth = first_auth
+        self.first_auth = first_auth if first_auth else datetime.utcnow()
+        self.last_auth = last_auth if last_auth else self.first_auth
 
 
 ### Periodic Tasks

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2688,6 +2688,7 @@ class AuthCache(MethodsMixin, db.Model):
     realm = db.Column(db.Unicode(120), default=u'', index=True)
     client_ip = db.Column(db.Unicode(40), default=u"")
     user_agent = db.Column(db.Unicode(120), default=u"")
+    current_number_of_authentications = db.Column(db.Integer, default=0)
     # We can hash the password like this:
     # binascii.hexlify(hashlib.sha256("secret123456").digest())
     authentication = db.Column(db.Unicode(255), default=u"")

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2688,7 +2688,7 @@ class AuthCache(MethodsMixin, db.Model):
     realm = db.Column(db.Unicode(120), default=u'', index=True)
     client_ip = db.Column(db.Unicode(40), default=u"")
     user_agent = db.Column(db.Unicode(120), default=u"")
-    current_number_of_authentications = db.Column(db.Integer, default=0)
+    auth_count = db.Column(db.Integer, default=0)
     # We can hash the password like this:
     # binascii.hexlify(hashlib.sha256("secret123456").digest())
     authentication = db.Column(db.Unicode(255), default=u"")

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2699,8 +2699,16 @@ class AuthCache(MethodsMixin, db.Model):
         self.realm = realm
         self.resolver = resolver
         self.authentication = authentication
-        self.first_auth = first_auth
-        self.last_auth = last_auth
+
+        if first_auth:
+            self.first_auth = first_auth
+        else:
+            self.first_auth = datetime.utcnow()
+
+        if last_auth:
+            self.last_auth = last_auth
+        else:
+            self.last_auth = first_auth
 
 
 ### Periodic Tasks

--- a/tests/test_lib_authcache.py
+++ b/tests/test_lib_authcache.py
@@ -6,7 +6,7 @@ The lib.auth_cache.py only depends on the database model.
 from .base import MyTestCase
 
 from privacyidea.lib.authcache import (add_to_cache, delete_from_cache,
-                                       update_cache_last_auth, verify_in_cache,
+                                       update_cache, verify_in_cache,
                                        _hash_password,
                                        cleanup)
 from passlib.hash import argon2
@@ -37,7 +37,7 @@ class AuthCacheTestCase(MyTestCase):
         self.assertTrue(auth.first_auth > teststart)
         self.assertEqual(auth.last_auth, auth.first_auth)
 
-        update_cache_last_auth(r)
+        update_cache(r)
         auth = AuthCache.query.filter(AuthCache.id == r).first()
         self.assertTrue(auth.last_auth > teststart)
 
@@ -57,7 +57,6 @@ class AuthCacheTestCase(MyTestCase):
 
         # Add Entry to cache
         r = add_to_cache(self.username, self.realm, self.resolver, self.password)
-        update_cache_last_auth(r)
 
         auth = AuthCache.query.filter(AuthCache.id == r).first()
         last_auth1 = auth.last_auth

--- a/tests/test_lib_authcache.py
+++ b/tests/test_lib_authcache.py
@@ -67,7 +67,7 @@ class AuthCacheTestCase(MyTestCase):
 
         r = verify_in_cache(self.username, self.realm, self.resolver,
                             self.password, first_auth=first_auth,
-                            last_auth=last_auth)
+                            last_auth=last_auth, max_number_of_authentications=1)
         self.assertTrue(r)
         self.assertEqual(0, auth_count1)
 
@@ -77,6 +77,11 @@ class AuthCacheTestCase(MyTestCase):
         auth_count2 = auth.auth_count
         self.assertTrue(last_auth2 > last_auth1)
         self.assertEqual(1, auth_count2)
+
+        r = verify_in_cache(self.username, self.realm, self.resolver,
+                            self.password, first_auth=first_auth,
+                            last_auth=last_auth, max_number_of_authentications=1)
+        self.assertFalse(r)
 
     def test_03_delete_old_entries(self):
         # Create a VERY old authcache entry

--- a/tests/test_lib_authcache.py
+++ b/tests/test_lib_authcache.py
@@ -60,6 +60,7 @@ class AuthCacheTestCase(MyTestCase):
         update_cache_last_auth(r)
         auth = AuthCache.query.filter(AuthCache.id == r).first()
         last_auth1 = auth.last_auth
+        auth_count1 = auth.auth_count
 
         first_auth = datetime.datetime.utcnow() - datetime.timedelta(hours=4)
         last_auth = datetime.datetime.utcnow() - datetime.timedelta(minutes=5)
@@ -68,11 +69,14 @@ class AuthCacheTestCase(MyTestCase):
                             self.password, first_auth=first_auth,
                             last_auth=last_auth)
         self.assertTrue(r)
+        self.assertEqual(0, auth_count1)
 
         # The last_auth was increased!
         auth = AuthCache.query.filter(AuthCache.id == r).first()
         last_auth2 = auth.last_auth
+        auth_count2 = auth.auth_count
         self.assertTrue(last_auth2 > last_auth1)
+        self.assertEqual(1, auth_count2)
 
     def test_03_delete_old_entries(self):
         # Create a VERY old authcache entry

--- a/tests/test_lib_authcache.py
+++ b/tests/test_lib_authcache.py
@@ -58,18 +58,19 @@ class AuthCacheTestCase(MyTestCase):
         # Add Entry to cache
         r = add_to_cache(self.username, self.realm, self.resolver, self.password)
         update_cache_last_auth(r)
+
         auth = AuthCache.query.filter(AuthCache.id == r).first()
         last_auth1 = auth.last_auth
         auth_count1 = auth.auth_count
+        self.assertEqual(0, auth_count1)
 
         first_auth = datetime.datetime.utcnow() - datetime.timedelta(hours=4)
         last_auth = datetime.datetime.utcnow() - datetime.timedelta(minutes=5)
 
         r = verify_in_cache(self.username, self.realm, self.resolver,
                             self.password, first_auth=first_auth,
-                            last_auth=last_auth, max_number_of_authentications=1)
+                            last_auth=last_auth, max_auths=1)
         self.assertTrue(r)
-        self.assertEqual(0, auth_count1)
 
         # The last_auth was increased!
         auth = AuthCache.query.filter(AuthCache.id == r).first()
@@ -80,8 +81,9 @@ class AuthCacheTestCase(MyTestCase):
 
         r = verify_in_cache(self.username, self.realm, self.resolver,
                             self.password, first_auth=first_auth,
-                            last_auth=last_auth, max_number_of_authentications=1)
+                            last_auth=last_auth, max_auths=1)
         self.assertFalse(r)
+
 
     def test_03_delete_old_entries(self):
         # Create a VERY old authcache entry

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -572,8 +572,8 @@ class LibPolicyTestCase(MyTestCase):
         AuthCache(username, realm, resolver, _hash_password(password),
                   first_auth=datetime.datetime.utcnow() - timedelta(hours=3),
                   last_auth=datetime.datetime.utcnow() - timedelta(minutes=1)).save()
-        r = auth_cache(fake_check_user_pass, User(username,realm),
-                        password, options=options)
+        r = auth_cache(fake_check_user_pass, User(username, realm),
+                       password, options=options)
         self.assertTrue(r[0])
         self.assertEqual(r[1].get("message"), "Authenticated by AuthCache.")
 
@@ -619,14 +619,10 @@ class LibPolicyTestCase(MyTestCase):
                   first_auth=datetime.datetime.utcnow() - timedelta(hours=2),
                   last_auth=datetime.datetime.utcnow() - timedelta(
                       hours=1)).save()
-        r = auth_cache(fake_check_user_pass, User(username,realm),
+        r = auth_cache(fake_check_user_pass, User(username, realm),
                        password, options=options)
         self.assertTrue(r[0])
         self.assertEqual(r[1].get("message"), "Authenticated by AuthCache.")
-
-        # TODO Thus we need the additional column auth_count. That simply records, how often this auth_cache entry was used.
-        #  The setting 10s/2 will mean, check first_auth to be less than 10s ago and check auth_count to be less than 2.
-        #  (If it exceeds the auth_cache entry can be deleted again.) ~ Cornelius
 
         # Test auth_cache policy with format "<seconds>/<#allowed authentications>"
         set_policy(name="pol1",
@@ -652,6 +648,28 @@ class LibPolicyTestCase(MyTestCase):
                        password, options=options)
         self.assertTrue(r[0])
         self.assertEqual(r[1].get("message"), "Authenticated by AuthCache.")
+
+        r = auth_cache(fake_check_user_pass, User(username, realm),
+                       password, options=options)
+        self.assertTrue(r[0])
+        self.assertEqual(r[1].get("message"), "Fake Authentication")
+
+        delete_from_cache(username, realm, resolver, password)
+
+        # Authentication not read from cache because first auth was too long ago
+        set_policy(name="pol1",
+                   scope=SCOPE.AUTH,
+                   realm=realm,
+                   resolver=resolver,
+                   action="{0!s}={1!s}".format(ACTION.AUTH_CACHE, "50s/2"))
+
+        g = FakeFlaskG()
+        g.policy_object = PolicyClass()
+        g.audit_object = FakeAudit()
+        options = {"g": g}
+
+        AuthCache(username, realm, resolver, _hash_password(password),
+                  first_auth=datetime.datetime.utcnow() - timedelta(seconds=55)).save()
 
         r = auth_cache(fake_check_user_pass, User(username, realm),
                        password, options=options)


### PR DESCRIPTION
Closes #1059.

Limited number of attempts for authentication that are handled by the cache can be specified by `<timeframe>/<#attempts>`, e.g., `10s/2` allows two cached authentications.
This means, after the user authenticated themself with a password, the user can use the same password two additional times for 10s after the initial authentication.

