### PR TITLE
Removed `getOtp` entry in documentation

### DIFF
--- a/doc/webui/token_details.rst
+++ b/doc/webui/token_details.rst
@@ -148,17 +148,6 @@ He will not see tokens, that are not in his realm.
 So you can assign a token to realm A and realm B, thus the administrator A
 and the administrator B will be able to see the token.
 
-Get OTP
---------
-
-If the corresponding getOTP policy (see :ref:`policies`) is set, the administrator
-can get the OTP values of a token from the server without having the token
-with him.
-
-.. warning:: Of course this is a potential backdoor, since the administrator
-   could login as the user/owner of this very token.
-
-
 .. _enroll_token:
 
 Enroll Token

--- a/privacyidea/lib/tokens/sshkeytoken.py
+++ b/privacyidea/lib/tokens/sshkeytoken.py
@@ -19,8 +19,7 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 __doc__="""The SSHKeyTokenClass provides a TokenClass that stores the public
-SSH key and can give the public SSH key via the getotp function.
-This can be used to manage SSH keys and retrieve the public ssh key
+SSH key. This can be used to manage SSH keys and retrieve the public ssh key
 to import it to authorized keys files.
 
 The code is tested in tests/test_lib_tokens_ssh
@@ -48,8 +47,7 @@ required = False
 class SSHkeyTokenClass(TokenClass):
     """
     The SSHKeyTokenClass provides a TokenClass that stores the public
-    SSH key and can give the public SSH key via the getotp function.
-    This can be used to manage SSH keys and retrieve the public ssh key
+    SSH key. This can be used to manage SSH keys and retrieve the public ssh key
     to import it to authorized keys files.
     """
     mode = ['authenticate']


### PR DESCRIPTION
Closes #2636. Checked if method exists. Removed entry from documentation and removed only reference in docstring.