### PR TITLE
Removed aladdin_hashlib and default_hashlib parameters

### DIFF
--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -921,7 +921,6 @@ def loadtokens_api(filename=None):
     known_types = ['aladdin-xml', 'oathcsv', "OATH CSV", 'yubikeycsv',
                    'Yubikey CSV', 'pskc']
     file_type = getParam(request.all_data, "type", required)
-    hashlib = getParam(request.all_data, "aladdin_hashlib")
     aes_validate_mac = getParam(request.all_data, "pskcValidateMAC", default='check_fail_hard')
     aes_psk = getParam(request.all_data, "psk")
     aes_password = getParam(request.all_data, "password")
@@ -990,8 +989,7 @@ def loadtokens_api(filename=None):
 
         import_token(serial,
                      TOKENS[serial],
-                     tokenrealms=tokenrealms,
-                     default_hashlib=hashlib)
+                     tokenrealms=tokenrealms)
 
     g.audit_object.log({'info': u"{0!s}, {1!s} (imported: {2:d})".format(file_type,
                                                            token_file,

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1081,8 +1081,7 @@ def init_token(param, user=None, tokenrealms=None,
     if user is not None and user.login != "":
         tokenobject.add_user(user)
 
-    upd_params = param
-    tokenobject.update(upd_params)
+    tokenobject.update(param)
 
     try:
         # Save the token to the database

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -940,7 +940,7 @@ def gen_serial(tokentype=None, prefix=None):
 
 
 @log_with(log)
-def import_token(serial, token_dict, default_hashlib=None, tokenrealms=None):
+def import_token(serial, token_dict, tokenrealms=None):
     """
     This function is used during the import of a PSKC file.
 
@@ -959,8 +959,6 @@ def import_token(serial, token_dict, default_hashlib=None, tokenrealms=None):
             }
 
     :type token_dict: dict
-    :param default_hashlib: Set the given hashlib as default
-    :type default_hashlib: str
     :param tokenrealms: List of realms to set as realms of the token
     :type tokenrealms: list
     :return: the token object
@@ -977,9 +975,6 @@ def import_token(serial, token_dict, default_hashlib=None, tokenrealms=None):
         user_obj = User(token_dict.get("user").get("username"),
                         token_dict.get("user").get("realm"),
                         token_dict.get("user").get("resolver"))
-
-    if default_hashlib and default_hashlib != "auto":
-        init_param['hashlib'] = default_hashlib
 
     # Imported tokens are usually hardware tokens
     token = init_token(init_param, user=user_obj,


### PR DESCRIPTION
Closes #2634.

Parameter | Method | Reason for removal
-|-|-
`aladdin_hashlib` | `loadtokens_api` | Undocumented and overrides hash lib specified by the imported file
`default_hashlib` | `import_token` | Has misleading docstring and name, was used to override existing hash lib of token; default hash lib is defined elsewhere in code
