### PR TITLE
make backup create ready for tar v1.30

### DIFF
--- a/pi-manage
+++ b/pi-manage
@@ -316,7 +316,8 @@ def create(directory="/var/lib/privacyidea/backup/",
 
     if not enckey:
         # Exclude enckey from backup
-        backup_call.append("--exclude={0!s}".format(enc_file))
+        # since tar v1.30 --exclude cannot be appended
+        backup_call.insert(1, "--exclude={0!s}".format(enc_file))
 
     call(backup_call)
     os.unlink(sqlfile)


### PR DESCRIPTION
closes #2646.

This PR is against branch-3.5 since this bugfix should arrive as quick as possible.

Tested on Ubuntu 18.04 (tar 1.29) and 20.04 (tar 1.30)