### PR TITLE
Escape '%' in sqlalchemy URI

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -3,6 +3,7 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.engine.url import make_url
 from logging.config import fileConfig
+from six.moves.urllib.parse import quote
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -28,6 +29,8 @@ def set_database_url(config):
         if url.startswith("mysql"):
             parsed_url = make_url(url)
             parsed_url.query.setdefault("charset", "utf8")
+            # We need to quote the password in case it contains special chars
+            parsed_url.password = quote(parsed_url.password)
             url = str(parsed_url)
     except Exception as exx:
         print(u"Attempted to set charset=utf8 on connection, but failed: {}".format(exx))
@@ -99,10 +102,10 @@ def run_migrations_online():
     finally:
         connection.close()
 
+
 if context.is_offline_mode():
     print("Running offline")
     run_migrations_offline()
 else:
     print("Running online")
     run_migrations_online()
-

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -31,7 +31,8 @@ def set_database_url(config):
             url = str(parsed_url)
     except Exception as exx:
         print(u"Attempted to set charset=utf8 on connection, but failed: {}".format(exx))
-    config.set_main_option('sqlalchemy.url', url)
+    # set_main_option() requires escaped "%" signs in the string
+    config.set_main_option('sqlalchemy.url', url.replace('%', '%%'))
 
 
 set_database_url(config)


### PR DESCRIPTION
When passing the SQLALCHEMY database URI to the alembic configuration
possible '%' signs need to be escaped.

Fixes #2661