### PR TITLE
Allow changing POOLING_LOOP_TIMEOUT of ldap3

### DIFF
--- a/doc/configuration/useridresolvers.rst
+++ b/doc/configuration/useridresolvers.rst
@@ -186,7 +186,7 @@ from the pool and will be re-inserted after the number of seconds specified in t
 If the pool is empty after a round, a timeout is added before the next round is started.
 The ldap3 module defaults system wide to 10 seconds before starting the next round.
 This timeout can be changed by setting ``PI_LDAP_POOLING_LOOP_TIMEOUT`` to an integer in seconds in ``pi.cfg``.
-If no reachable server has could been found after the number of rounds specified in the *retry rounds*,
+If no reachable server could be found after the number of rounds specified in the *retry rounds*,
 the request fails.
 
 By default, knowledge about unavailable pool servers is not persisted between requests.

--- a/doc/configuration/useridresolvers.rst
+++ b/doc/configuration/useridresolvers.rst
@@ -183,8 +183,10 @@ The *Server pool retry rounds* and *Server pool skip timeout* settings configure
 the LDAP server pool. When establishing a LDAP connection, the resolver uses a round-robin
 strategy to select a LDAP server from the pool. If the current server is not reachable, it is removed
 from the pool and will be re-inserted after the number of seconds specified in the *skip timeout*.
-If no server from the pool is reachable, the servers are queried again from the beginning. If
-a reachable server has not been found after the number of rounds specified in the *retry rounds*,
+If the pool is empty after a round, a timeout is added before the next round is started.
+The ldap3 module defaults system wide to 10 seconds before starting the next round.
+This timeout can be changed by setting ``PI_LDAP_POOLING_LOOP_TIMEOUT`` to an integer in seconds in ``pi.cfg``.
+If no reachable server has could been found after the number of rounds specified in the *retry rounds*,
 the request fails.
 
 By default, knowledge about unavailable pool servers is not persisted between requests.

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -78,7 +78,7 @@ from passlib.hash import ldap_salted_sha1
 import hashlib
 import binascii
 from privacyidea.lib.utils import is_true
-from privacyidea.lib.framework import get_app_local_store
+from privacyidea.lib.framework import get_app_local_store, get_app_config_value
 import datetime
 
 from privacyidea.lib import _
@@ -97,6 +97,12 @@ ENCODING = "utf-8"
 SERVERPOOL_ROUNDS = 2
 # The number of seconds a non-responding server is removed from the server pool
 SERVERPOOL_SKIP = 30
+# The number of seconds that ldap3 waits if no server is left in the pool, before
+# starting the next round
+pooling_loop_timeout = get_app_config_value("PI_LDAP_POOLING_LOOP_TIMEOUT", 10)
+log.info("Setting system wide POOLING_LOOP_TIMEOUT to {0!s}.".format(pooling_loop_timeout))
+ldap3.set_config_parameter("POOLING_LOOP_TIMEOUT", pooling_loop_timeout)
+
 # 1 sec == 10^9 nano secs == 10^7 * (100 nano secs)
 MS_AD_MULTIPLYER = 10 ** 7
 MS_AD_START = datetime.datetime(1601, 1, 1)


### PR DESCRIPTION
The ldap3 config setting POOLING_LOOP_TIMEOUT is a system wide
setting, so it does not make sense to set this per LDAP resolver.
Thus we add PI_LDAP_POOLING_LOOP_TIMEOUT to pi.cfg, which is
the first LDAP resolver config in pi.cfg.

This commit does not change the default setting of currently
10 seconds of timeout between rounds. However, since the timeout
is also added if only one round is done, it might make sense
to set this to "0" in pi.cfg for performance reasons.

Closes #2662