### PR TITLE
Fix url for forum

### DIFF
--- a/privacyidea/static/templates/cert_request_form.html
+++ b/privacyidea/static/templates/cert_request_form.html
@@ -40,9 +40,9 @@
             Support
         </a>
         <a class="navbar-text pull-right"
-                href="https://groups.google.com/forum/#!forum/privacyidea"
+                href="https://community.privacyidea.org/"
                 target="_external">
-            privacyIDEA google group</a>
+            privacyIDEA Forum</a>
         <a class="navbar-text pull-right"
            ng-show="privacyideaVersionNumber"
                 href="http://privacyidea.readthedocs.org/en/v{{ privacyideaVersionNumber }}"

--- a/privacyidea/static/templates/token_enrolled.html
+++ b/privacyidea/static/templates/token_enrolled.html
@@ -49,9 +49,9 @@ The certificate with token serial {{ serial }} for user {{ username }}
             Support
         </a>
         <a class="navbar-text pull-right"
-                href="https://groups.google.com/forum/#!forum/privacyidea"
+                href="https://community.privacyidea.org/"
                 target="_external">
-            privacyIDEA google group</a>
+            privacyIDEA Forum</a>
         <a class="navbar-text pull-right"
            ng-show="privacyideaVersionNumber"
                 href="http://privacyidea.readthedocs.org/en/v{{ privacyideaVersionNumber }}"


### PR DESCRIPTION
In two templates are old forum url's,

privacyidea/static/templates/cert_request_form.html: href="https://groups.google.com/forum/#!forum/privacyidea"
privacyidea/static/templates/token_enrolled.html: href="https://groups.google.com/forum/#!forum/privacyidea"

to:
privacyidea/static/templates/cert_request_form.html: href="https://community.privacyidea.org/"
privacyidea/static/templates/token_enrolled.html: href="https://community.privacyidea.org/"