### PR TITLE
2555/Enhance_diagnostic_report_tool

### DIFF
--- a/tools/privacyidea-diag
+++ b/tools/privacyidea-diag
@@ -155,7 +155,7 @@ system_status() {
 	log
 	log "SECTION: System Status"
 	log "======================"
-	log "CPU cores: $(grep -c ^processor /proc/cpuinfo | wc -l)"
+	log "CPU cores: $(grep -c ^processor /proc/cpuinfo)"
 	log "========================"
 	top -b -n 1 >> "$tempfile"
 	log
@@ -186,7 +186,7 @@ apache_log() {
 		log
 		log "SECTION: apache configuration"
 		log "============================="
-		tail -n +1 /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/privacyidea.conf/* >>  "$tempfile"
+		tail -n +1 /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/privacyidea.conf >>  "$tempfile"
 	else
 		log
 		log "SECTION: apache2 error_log"

--- a/tools/privacyidea-diag
+++ b/tools/privacyidea-diag
@@ -178,7 +178,7 @@ apache_log() {
 		log
 		log "SECTION: httpd SSL_error_log"
 		log "============================"
-		tail -50 /var/log/httpd/ssl_error_log  >> "$tempfile"
+		tail -100 /var/log/httpd/ssl_error_log  >> "$tempfile"
 		log
 		log "SECTION: httpd Access_log"
 		log "========================="
@@ -191,11 +191,11 @@ apache_log() {
 		log
 		log "SECTION: apache2 error_log"
 		log "=========================="
-		tail -50 /var/log/apache2/error.log >> "$tempfile"
+		tail -100 /var/log/apache2/error.log >> "$tempfile"
 		log
 		log "SECTION: apache2 SSL_access_log"
 		log "==============================="
-		tail -50 /var/log/apache2/ssl_access.log >> "$tempfile"
+		tail -100 /var/log/apache2/ssl_access.log >> "$tempfile"
 		log
 		log "SECTION: apache configuration"
 		log "============================="

--- a/tools/privacyidea-diag
+++ b/tools/privacyidea-diag
@@ -41,7 +41,12 @@ else
 fi
 
 OS=$(grep "^ID=" /etc/os-release | sed -e 's/^ID=//g' | tr -d '"')
-tempfile=$(mktemp --suff=.diag)
+
+diag_info=$(mktemp -d -t pi_diag_XXXXXXXXXX)
+tempfile="${diag_info}/privacyidea.config"
+timestamp=$(date +"%y-%m-%d")
+location="/tmp/${timestamp}_$(basename "$diag_info").tar.gz"
+
 
 log() {
 	echo "$1" >> "$tempfile"
@@ -49,6 +54,12 @@ log() {
 
 call_pi_manage() {
 	PRIVACYIDEA_CONFIGFILE=$PICFG pi-manage "$@"
+}
+
+upload_info() {
+	echo
+	echo "Please upload the diagnostics file and $location to your support team."
+	echo
 }
 
 get_os() {
@@ -71,14 +82,8 @@ get_pi_cfg() {
 current_db_revision() {
 	log
 	log "SECTION: current_db_revision"
-	log "============================="
+	log "============================"
 	call_pi_manage db current -d /opt/privacyidea/lib/privacyidea/migrations/ >> "$tempfile"
-}
-
-upload_info() {
-	echo
-	echo "Please upload the diagnostics file $tempfile to your support team."
-	echo
 }
 
 pi_versions() {
@@ -124,52 +129,6 @@ pi_config() {
 	call_pi_manage policy p_export >> "$tempfile"
 }
 
-pi_logfile() {
-	log
-	log "SECTION: privacyIDEA Logfile"
-	log "============================"
-	R=$( grep "^PI_LOGFILE" "$PICFG" | cut -d "=" -f2 | tr -d "\'\"" )
-	[ -f ${R} ] && cat ${R} >> $tempfile || echo "Could not read logfile ${R}" >> "$tempfile"
-}
-
-pi_auditlog() {
-	log
-	log "SECTION: privacyIDEA Auditlog"
-	log "============================="
-	call_pi_manage audit dump -f - -t 2d >> "$tempfile"
-}
-
-centos_auditlog() {
-	if [[ "$(getenforce)" == "Enforcing" ]]; then
-		log
-		log "SECTION: centOS Auditlog"
-		log "========================"
-		grep "denied" /var/log/audit/audit.log  >> "$tempfile"
-	fi
-}
-
-apache_log() {
-	if [[ "${OS}" == "centos" ]]; then
-		log
-		log "SECTION: httpd SSL_error_log"
-		log "============================"
-		tail -50 /var/log/httpd/ssl_error_log  >> "$tempfile"
-		log
-		log "SECTION: httpd Access_log"
-		log "============================"
-		tail -50 /var/log/httpd/ssl_access_log  >> "$tempfile"
-	else
-		log
-		log "SECTION: apache2 error_log"
-		log "============================"
-		tail -50 /var/log/apache2/error.log >> "$tempfile"
-		log
-		log "SECTION: apache2 SSL_access_log"
-		log "============================"
-		tail -50 /var/log/apache2/ssl_access.log >> "$tempfile"
-	fi
-}
-
 FreeRADIUS_config() {
 	log
 	log "SECTION: FreeRADIUS Configurations"
@@ -191,16 +150,81 @@ else
 fi
 }
 
+system_status() {
+	log
+	log "SECTION: System Status"
+	log "======================"
+	log "CPU cores: $(grep ^processor /proc/cpuinfo | wc -l)"
+	log "========================"
+	top -b -n 1 >> "$tempfile"
+	log "========================"
+	log "HD"
+	log "========================"
+	df -h >> "$tempfile"
+}
+
+centos_auditlog() {
+	if [[ "$(getenforce)" == "Enforcing" ]]; then
+		log
+		log "SECTION: centOS Auditlog"
+		log "========================"
+		grep "denied" /var/log/audit/audit.log  >> "$tempfile"
+	fi
+}
+
+apache_log() {
+	if [[ "${OS}" == "centos" ]]; then
+		log
+		log "SECTION: httpd SSL_error_log"
+		log "============================"
+		tail -50 /var/log/httpd/ssl_error_log  >> "$tempfile"
+		log
+		log "SECTION: httpd Access_log"
+		log "========================="
+		tail -50 /var/log/httpd/ssl_access_log  >> "$tempfile"
+		log
+		log "SECTION: apache configuration"
+		log "============================="
+		cat /etc/httpd/conf/httpd.conf  >>  "$tempfile"
+	else
+		log
+		log "SECTION: apache2 error_log"
+		log "=========================="
+		tail -50 /var/log/apache2/error.log >> "$tempfile"
+		log
+		log "SECTION: apache2 SSL_access_log"
+		log "==============================="
+		tail -50 /var/log/apache2/ssl_access.log >> "$tempfile"
+		log
+		log "SECTION: apache configuration"
+		log "============================="
+		cat /etc/apache2/apache2.conf  >>  "$tempfile"
+	fi
+}
+
+pi_logfile() {
+	R=$( grep "^PI_LOGFILE" "$PICFG" | cut -d "=" -f2 | tr -d "\'\"" )
+	[ -f ${R} ] && cp ${R} "${diag_info}/privacyidea.logfile" || echo "Could not read logfile ${R}" >> "$tempfile"
+}
+
+pi_auditlog() {
+	call_pi_manage audit dump -f - -t 2d >> "${diag_info}/privacyidea.auditlog"
+}
+
+
 get_os
 get_pi_cfg
 current_db_revision
 pi_versions
 pi_config
-pi_logfile
-pi_auditlog
-upload_info
+FreeRADIUS_config
+system_status
 if [[ "${OS}" == "centos" ]]; then
 	centos_auditlog
 fi
 apache_log
-FreeRADIUS_config
+pi_logfile
+pi_auditlog
+upload_info
+
+tar -zcf "/tmp/${timestamp}_$(basename "$diag_info").tar.gz" -C /tmp "$(basename "$diag_info")"

--- a/tools/privacyidea-diag
+++ b/tools/privacyidea-diag
@@ -31,21 +31,22 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-if [ "$1" == "" ]; then
-	echo
-	echo "Please specify the pi.cfg file!"
-	echo
-	exit 1
-else
+PICFG="/etc/privacyidea/pi.cfg"
+
+if [ "$#" -gt 0 ]; then
 	PICFG=$1
 fi
 
-OS=$(grep "^ID=" /etc/os-release | sed -e 's/^ID=//g' | tr -d '"')
+if [[ ! -r $PICFG ]];then
+	echo "Could not read $PICFG! Please specify the pi.cfg file!"
+	exit 1
+fi
 
+OS=$(grep "^ID=" /etc/os-release | sed -e 's/^ID=//g' | tr -d '"')
 diag_info=$(mktemp -d -t pi_diag_XXXXXXXXXX)
 tempfile="${diag_info}/privacyidea.config"
 timestamp=$(date +"%y-%m-%d")
-location="/tmp/${timestamp}_$(basename "$diag_info").tar.gz"
+diag_file="/tmp/${timestamp}_$(basename "$diag_info").tar.gz"
 
 
 log() {
@@ -58,7 +59,7 @@ call_pi_manage() {
 
 upload_info() {
 	echo
-	echo "Please upload the diagnostics file and $location to your support team."
+	echo "Please upload the diagnostics file $diag_file to your support team."
 	echo
 }
 
@@ -133,31 +134,31 @@ FreeRADIUS_config() {
 	log
 	log "SECTION: FreeRADIUS Configurations"
 	log "=================================="
-if [[ "${OS}" == "centos" ]]; then
-	if (rpm -qa | grep freeradius > /dev/null); then
-		ls -R /etc/raddb  >> "$tempfile";
+	if [[ "${OS}" == "centos" ]]; then
+		if (rpm -qa | grep freeradius > /dev/null); then
+			ls -R /etc/raddb  >> "$tempfile";
+		else
+			log
+			log "FreeRADIUS is not installed"
+		fi
 	else
-		log
-		log "FreeRADIUS is not installed"
+		if (dpkg -l | grep freeradius > /dev/null); then
+			ls -R /etc//freeradius/3.0 >> "$tempfile";
+		else
+			log
+			log "FreeRADIUS is not installed"
+		fi
 	fi
-else
-	if (dpkg -l | grep freeradius > /dev/null); then
-		ls -R /etc//freeradius/3.0 >> "$tempfile";
-	else
-		log
-		log "FreeRADIUS is not installed"
-	fi
-fi
 }
 
 system_status() {
 	log
 	log "SECTION: System Status"
 	log "======================"
-	log "CPU cores: $(grep ^processor /proc/cpuinfo | wc -l)"
+	log "CPU cores: $(grep -c ^processor /proc/cpuinfo | wc -l)"
 	log "========================"
 	top -b -n 1 >> "$tempfile"
-	log "========================"
+	log
 	log "HD"
 	log "========================"
 	df -h >> "$tempfile"
@@ -181,11 +182,11 @@ apache_log() {
 		log
 		log "SECTION: httpd Access_log"
 		log "========================="
-		tail -50 /var/log/httpd/ssl_access_log  >> "$tempfile"
+		tail -100 /var/log/httpd/ssl_access_log  >> "$tempfile"
 		log
 		log "SECTION: apache configuration"
 		log "============================="
-		cat /etc/httpd/conf/httpd.conf  >>  "$tempfile"
+		tail -n +1 /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/privacyidea.conf/* >>  "$tempfile"
 	else
 		log
 		log "SECTION: apache2 error_log"
@@ -198,7 +199,7 @@ apache_log() {
 		log
 		log "SECTION: apache configuration"
 		log "============================="
-		cat /etc/apache2/apache2.conf  >>  "$tempfile"
+		tail -n +1 /etc/apache2/apache2.conf /etc/apache2/sites-enabled/* >> "$tempfile"
 	fi
 }
 
@@ -225,6 +226,7 @@ fi
 apache_log
 pi_logfile
 pi_auditlog
-upload_info
 
-tar -zcf "/tmp/${timestamp}_$(basename "$diag_info").tar.gz" -C /tmp "$(basename "$diag_info")"
+tar -zcf "$diag_file" -C /tmp "$(basename "$diag_info")"
+
+upload_info


### PR DESCRIPTION
- [x] add apache configuration
- [x] add system status (CPUs, RAM, HD)

I added the apache configurations to the apache_log and expanded the diag-tool with information about the cpu, hd and ram.

One file with all the information has now become three.

**1. privacyidea.config**
- with informations about the OS
- pi_cfg
- current_db_revision
- pi_versions
- pi_config
- FreeRADIUS_configurations
- system_status
- centos_auditlog and the apache logs including the apache config

**2. privacyidea.logfile**
- pi_logfile (It happens sometimes that customers have huge pi_log files. The log is now stored in a seperated file that gives us a better overview.

**3. privacyidea.auditlog**
- pi_auditlog (also stored in a seperated file)

The files are compressed and the customer sends us the tar.gz file at the end.

