### PR TITLE
Fix the DB migration branch

### DIFF
--- a/migrations/versions/449903fb6e35_.py
+++ b/migrations/versions/449903fb6e35_.py
@@ -1,5 +1,4 @@
-"""Add table 'radiusserver' to configure the settings of
-remote RADIUS servers.
+"""Add table 'radiusserver' to configure the settings of remote RADIUS servers.
 
 Revision ID: 449903fb6e35
 Revises: 4023571658f8

--- a/migrations/versions/888b56ed5dcb_.py
+++ b/migrations/versions/888b56ed5dcb_.py
@@ -1,14 +1,14 @@
 """v3.6: Add table for custom user attributes
 
 Revision ID: 888b56ed5dcb
-Revises: d5870fd2f2a4
+Revises: d415d490eb05
 Create Date: 2021-02-10 12:17:40.880224
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '888b56ed5dcb'
-down_revision = 'd5870fd2f2a4'
+down_revision = 'd415d490eb05'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
We ended up with two heads. Instead of adding an
additional mergepoint this commit reorders the
DB migration scripts, since they are independent on each other.

Also remove a line break in an older migration script, which looks
a bit awkward in

   pi-manage db history

Fixes #2702