### PR TITLE
avoid extended condition check in certain cases

### DIFF
--- a/doc/policies/conditions.rst
+++ b/doc/policies/conditions.rst
@@ -119,7 +119,7 @@ The tokeninfo condition works the same way as userinfo but matches the tokeninfo
 ^^^^^^^^^
 
 The token condition works on the database columns of the token. This would be
-``description``, ``otplen``, ``count``, ``serial`` but most importantly
+``description``, ``otplen``, ``count``, ``serial``, ``active`` but most importantly
 also ``failcount`` and ``tokentype``.
 
 .. note:: A policy with an active tokeninfo condition will
@@ -130,6 +130,9 @@ also ``failcount`` and ``tokentype``.
 .. note:: The matching is case sensitive. Note, that e.g. token types are
    stored in lower case in the database.
 
+**Example**: The administrator could define a dedicated policy in the scope *user* with the
+action ``delete`` and the token condition ``active``, ``<``, ``0`` (0 or false depending on the database).
+This would allow the user to delete only inactive tokens, but not still active tokens.
 
 ``HTTP Request Header``
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/policies/conditions.rst
+++ b/doc/policies/conditions.rst
@@ -131,7 +131,8 @@ also ``failcount`` and ``tokentype``.
    stored in lower case in the database.
 
 **Example**: The administrator could define a dedicated policy in the scope *user* with the
-action ``delete`` and the token condition ``active``, ``<``, ``0`` (0 or false depending on the database).
+action ``delete`` and the token condition ``active``, ``<``, ``1``. For an inactive token the attribute ``active``
+would evaluate to ``0`` and thus be smaller than ``1``. An ``active`` token would evaluate to ``1``.
 This would allow the user to delete only inactive tokens, but not still active tokens.
 
 ``HTTP Request Header``

--- a/privacyidea/api/realm.py
+++ b/privacyidea/api/realm.py
@@ -58,6 +58,7 @@ from ..api.lib.prepolicy import prepolicy, check_base_action
 from ..lib.utils import reduce_realms
 from flask import g
 from privacyidea.lib.auth import ROLE
+from privacyidea.lib.policy import CONDITION_CHECK
 from flask_babel import gettext as _
 import logging
 
@@ -199,7 +200,8 @@ def get_realms_api():
     policies = Match.generic(g, scope=luser.get("role", ROLE.ADMIN),
                              adminrealm=luser.get("realm"),
                              adminuser=luser.get("username"),
-                             active=True).policies()
+                             active=True,
+                             extended_condition_check=CONDITION_CHECK.DO_NOT_CHECK_AT_ALL).policies()
     realms = reduce_realms(all_realms, policies)
 
     return send_result(realms)


### PR DESCRIPTION
The check of the extended conditions will fail, if
an admin (role=SCOPE.ADMIN) logs into the webui.
This is reflected in the policy methods ui_*

So we check in these cases if an admin logs in a
stop checking the extended conditions.

Working on #2676