### PR TITLE
Fix enroll-button staying disabled

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -471,7 +471,9 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
         $scope.form.validity_period_start = date_object_to_string($scope.form.validity_period_start);
         $scope.form.validity_period_end = date_object_to_string($scope.form.validity_period_end);
         TokenFactory.enroll($scope.newUser,
-            $scope.form, $scope.callback);
+            $scope.form, $scope.callback,
+            function (data) {$scope.enrolling=false;}
+            );
     };
 
     $scope.pollTokenInfo = function () {

--- a/privacyidea/static/components/token/factories/token.js
+++ b/privacyidea/static/components/token/factories/token.js
@@ -204,7 +204,7 @@ angular.module("TokenModule", ["privacyideaAuth"])
                     {headers: {'PI-Authorization': AuthFactory.getAuthToken()}
                     }).then(function (response) { callback(response.data) }, function(error) { AuthFactory.authError(error.data) });
             },
-            enroll: function (userObject, formdata, callback) {
+            enroll: function (userObject, formdata, callback, callback_error) {
                 var username = fixUser(userObject.user);
                 // all formdata is passed
                 var params = formdata;
@@ -219,7 +219,12 @@ angular.module("TokenModule", ["privacyideaAuth"])
                 }
                 $http.post(tokenUrl + "/init", params,
                     {headers: {'PI-Authorization': AuthFactory.getAuthToken()}}
-                ).then(function (response) { callback(response.data) }, function(error) { AuthFactory.authError(error.data) });
+                ).then(function (response) { callback(response.data) },
+                       function(error) { AuthFactory.authError(error.data);
+                            if (callback_error) {
+                                callback_error(error.data);
+                            }
+                });
             },
             delete: function (serial, callback) {
                 $http.delete(tokenUrl + "/" + serial,


### PR DESCRIPTION
In case of an error during enrollment the enroll-button
stays disabled. This happens due to the $scope.enrolling
still being "true" in the webUI. We need to set this
to "false" again. To do so, we add a callback-function
for the error-case. This way we can reset the
enrolling variable in the correct scope.

Closes #2717