### PR TITLE
2516/add more descriptive tooltip to token when assigning to machine

### DIFF
--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -211,7 +211,11 @@ myApp.directive('assignToken', function($http, $rootScope, tokenUrl,
                 serial: "*" + $viewValue + "*"}
             }).then(function ($response) {
                 scope.newTokenObject.loadedSerials = $response.data.result.value.tokens.map(function (item) {
-                    return item.serial + " (" + item.tokentype + ")";
+                serial_string = item.serial + " [" + item.tokentype + "] "
+                if (item.description !=''){
+                    serial_string += "[" + item.description + "] "
+                }
+                    return serial_string;
                 });
                 return scope.newTokenObject.loadedSerials;
             });
@@ -245,7 +249,14 @@ myApp.directive('attachToken', function($http, tokenUrl,
                 params: {serial: "*" + $viewValue + "*"}
             }).then(function ($response) {
                 return $response.data.result.value.tokens.map(function (item) {
-                    return item.serial + " (" + item.tokentype + ")";
+                serial_string = item.serial + " [" + item.tokentype + "] "
+                if (item.username !=''){
+                    serial_string += "[" + item.username +"@"+ item.realms + "] "
+                }
+                if(item.description != '') {
+                    serial_string += "[" + item.description + "] "
+                }
+                return serial_string;
                 });
             });
             };

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -211,7 +211,7 @@ myApp.directive('assignToken', function($http, $rootScope, tokenUrl,
                 serial: "*" + $viewValue + "*"}
             }).then(function ($response) {
                 scope.newTokenObject.loadedSerials = $response.data.result.value.tokens.map(function (item) {
-                serial_string = item.serial + " [" + item.tokentype + "] "
+                serial_string = item.serial + " (" + item.tokentype + ") "
                 if (item.description !=''){
                     serial_string += "[" + item.description + "] "
                 }
@@ -249,7 +249,7 @@ myApp.directive('attachToken', function($http, tokenUrl,
                 params: {serial: "*" + $viewValue + "*"}
             }).then(function ($response) {
                 return $response.data.result.value.tokens.map(function (item) {
-                serial_string = item.serial + " [" + item.tokentype + "] "
+                serial_string = item.serial + " (" + item.tokentype + ") "
                 if (item.username !=''){
                     serial_string += "[" + item.username +"@"+ item.realms + "] "
                 }


### PR DESCRIPTION
Now also shows "user+realm" and "description" when entering data into the "serial" entry field if add token to a machine
and "description" if add a token to an existing user.

closes #2516 