### PR TITLE
Fix the fixing of username string and token serial string

### DIFF
--- a/privacyidea/static/components/token/factories/token.js
+++ b/privacyidea/static/components/token/factories/token.js
@@ -23,7 +23,7 @@
 function fixUser(user) {
     //debug: console.log("User In: " + user);
     if (user) {
-        var stripUser = user.match(/^\[.*\] (.*) \(.*\)$/);
+        var stripUser = user.match(/^\[.*\] (.*) \(.*\).*$/);
         if (stripUser != undefined) {
             user = stripUser[1];
         }
@@ -37,7 +37,7 @@ function fixUser(user) {
 function fixSerial(serial) {
     //debug: console.log("Serial In: " + serial);
     if (serial) {
-        var stripSerial = serial.match(/^(.*) \(.*\)$/);
+        var stripSerial = serial.match(/^(.*) \(.*\).*$/);
         if (stripSerial != undefined) {
             serial = stripSerial[1];
         }


### PR DESCRIPTION
Since the display name of users and token serials have been extended
from
~~~~
   <serial> (type)
~~~~
to
~~~~
   <serial> (type) [description]
~~~~
it can now happen, that the javascript stripping/fixing mechanism,
that extracted the serial does not work anymore.

The adapted regular expression fixes this issue.

Working on #2516