### PR TITLE
Fix the ValidateError in case of poll-only

### DIFF
--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -821,7 +821,8 @@ class PushTokenClass(TokenClass):
 
         attributes = None
         data = None
-        res = False
+        # Initially we assume there is no error from Firebase
+        res = True
         fb_identifier = self.get_tokeninfo(PUSH_ACTION.FIREBASE_CONFIG)
         if fb_identifier:
             challenge = b32encode_and_unicode(geturandom())


### PR DESCRIPTION
The push token will raise a ValidateError if
the "res" is false, which would usually indicate,
that there is an error when submitting to firebase.

But since we do not submit to firebase there will be no
error, so we default the "res" to True.

For the polling endpoint the administrator sill needs to
set the push_poll_allow policies.

Closes #2720