### PR TITLE
Token rollover

### DIFF
--- a/doc/policies/webui.rst
+++ b/doc/policies/webui.rst
@@ -306,7 +306,7 @@ token_rollover
 type: str
 
 This is a whitespace separated list of tokentypes, for which a rollover button is
-displayed in the token details and in the token list. This button will generate a
+displayed in the token details. This button will generate a
 new token secret for the displayed token.
 
 This e.g. enables a user to transfer a softtoken to a new device while keeping the

--- a/doc/policies/webui.rst
+++ b/doc/policies/webui.rst
@@ -300,6 +300,20 @@ being disabled.
 
 (Since privacyIDEA 3.0)
 
+token_rollover
+~~~~~~~~~~~~~~
+
+type: str
+
+This is a whitespace separated list of tokentypes, for which a rollover button is
+displayed in the token details and in the token list. This button will generate a
+new token secret for the displayed token.
+
+This e.g. enables a user to transfer a softtoken to a new device while keeping the
+token number restricted to 1.
+
+(Since privacyIDEA 3.6)
+
 login_text
 ~~~~~~~~~~
 

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -502,7 +502,9 @@ def get_webui_settings(request, response):
                                                   user=loginname, realm=realm).policies())
         admin_dashboard = (role == ROLE.ADMIN
                            and Match.generic(g, scope=SCOPE.WEBUI, action=ACTION.ADMIN_DASHBOARD,
-                                         user=loginname, realm=realm).any())
+                                             user=loginname, realm=realm).any())
+        token_rollover = Match.generic(g, scope=SCOPE.WEBUI, action=ACTION.TOKENROLLOVER,
+                                       user=loginname, realm=realm).action_values(unique=False)
         token_wizard = False
         dialog_no_token = False
         if role == ROLE.USER:
@@ -586,6 +588,7 @@ def get_webui_settings(request, response):
         content["result"]["value"]["dialog_no_token"] = dialog_no_token
         content["result"]["value"]["search_on_enter"] = len(search_on_enter) > 0
         content["result"]["value"]["timeout_action"] = timeout_action
+        content["result"]["value"]["token_rollover"] = token_rollover
         content["result"]["value"]["hide_welcome"] = hide_welcome
         content["result"]["value"]["hide_buttons"] = hide_buttons
         content["result"]["value"]["show_seed"] = show_seed

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -2386,7 +2386,7 @@ def get_static_policy_definitions(scope=None):
                 'type': 'str',
                 'desc': _('This is a whitespace separated list of tokentypes, '
                           'for which a rollover button is displayed in the token '
-                          'details and in the token list.'),
+                          'details.'),
                 'group': GROUP.TOKEN
             },
             ACTION.DIALOG_NO_TOKEN: {

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -316,6 +316,7 @@ class ACTION(object):
     TOKENINFO = "tokeninfo"
     TOKENWIZARD = "tokenwizard"
     TOKENWIZARD2ND = "tokenwizard_2nd_token"
+    TOKENROLLOVER = "token_rollover"
     TRIGGERCHALLENGE = "triggerchallenge"
     UNASSIGN = "unassign"
     USERLIST = "userlist"
@@ -2380,6 +2381,13 @@ def get_static_policy_definitions(scope=None):
                 'type': 'bool',
                 'desc': _("The tokenwizard will be displayed in the token "
                           "menu, even if the user already has a token.")
+            },
+            ACTION.TOKENROLLOVER: {
+                'type': 'str',
+                'desc': _('This is a whitespace separated list of tokentypes, '
+                          'for which a rollover button is displayed in the token '
+                          'details and in the token list.'),
+                'group': GROUP.TOKEN
             },
             ACTION.DIALOG_NO_TOKEN: {
                 'type': 'bool',

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -424,6 +424,7 @@ angular.module("privacyideaApp")
             $scope.hide_buttons = data.result.value.hide_buttons;
             $scope.show_seed = data.result.value.show_seed;
             $scope.show_node = data.result.value.show_node;
+            $scope.token_rollover = data.result.value.token_rollover;
             $scope.subscription_state = data.result.value.subscription_status;
             $rootScope.search_on_enter = data.result.value.search_on_enter;
             // Token specific settings

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -176,6 +176,10 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
         hashlib: "sha1",
         'radius.system_settings': true
     };
+    if ($state.includes('token.rollover')) {
+        $scope.form.serial = $stateParams.tokenSerial;
+        $scope.form.type = $stateParams.tokenType;
+    }
     $scope.vasco = {
         // Note: A primitive does not work in the ng-model of the checkbox!
         useIt: false

--- a/privacyidea/static/components/token/controllers/tokenDetailController.js
+++ b/privacyidea/static/components/token/controllers/tokenDetailController.js
@@ -386,5 +386,15 @@ myApp.controller("tokenDetailController", function ($scope,
     // listen to the reload broadcast
     $scope.$on("piReload", $scope.get);
 
+    $scope.rolloverTokenAllowed = function(token) {
+        if ( typeof(token) != 'undefined' ) {
+            if ($scope.checkEnroll() && (token.tokentype in $scope.token_rollover) &&
+                token.info.tokenkind === 'software') {
+                return true;
+            }
+        }
+        return false;
+    };
+
 
 });

--- a/privacyidea/static/components/token/states/states.js
+++ b/privacyidea/static/components/token/states/states.js
@@ -68,6 +68,11 @@ angular.module('privacyideaApp.tokenStates', ['ui.router', 'privacyideaApp.versi
                     controller: "tokenEnrollController",
                     params: { realmname: null, username: null },
                 })
+                .state('token.rollover', {
+                    url: "/rollover/:tokenType/:tokenSerial",
+                    templateUrl: tokenpath + "token.enroll.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "tokenEnrollController"
+                })
                 .state('token.wizard', {
                     url: "/wizard",
                     templateUrl: tokenpath + "token.enroll.html" + versioningSuffixProviderProvider.$get().$get(),

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -17,6 +17,13 @@
                     <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span>
                 </button>
+                <button class="btn btn-danger"
+                        ng-show="!rolloverTokenAllowed(token)"
+                        ui-sref="token.rollover({tokenSerial:token.serial, tokenType:token.tokentype})"
+                        id="rolloverButton">
+                    <span class="glyphicon glyphicon-refresh"></span>
+                    <span translate>Rollover</span>
+                </button>
             </td>
         </tr>
         <tr>

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -18,7 +18,7 @@
                     <span translate>Delete</span>
                 </button>
                 <button class="btn btn-danger"
-                        ng-show="!rolloverTokenAllowed(token)"
+                        ng-show="rolloverTokenAllowed(token)"
                         ui-sref="token.rollover({tokenSerial:token.serial, tokenType:token.tokentype})"
                         id="rolloverButton">
                     <span class="glyphicon glyphicon-refresh"></span>

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -1,4 +1,5 @@
-<h3 translate>Enroll a new token</h3>
+<h3 ng-if="$state.includes('token.enroll')" translate>Enroll a new token</h3>
+<h3 ng-if="$state.includes('token.rollover')" translate>Rollover token {{ form.serial }}</h3>
 
 <!-- hide the form, after the token was enrolled -->
 <div ng-hide="enrolledToken">
@@ -8,7 +9,8 @@
          '/views/includes/token.enroll.pre.top.html'"></div>
 
     <form name="formEnrollToken" role="form" validate>
-        <div class="form-group">
+        <!-- Do not display Type dropdown in case of rollover -->
+        <div ng-if="$state.includes('token.rollover') == false" class="form-group">
             <select class="form-control"
                     ng-hide="$state.includes('token.wizard')"
                     id="tokentype"
@@ -34,7 +36,7 @@
         </div>
 
         <!-- User Assignment -->
-        <div ng-if="loggedInUser.role == 'admin'">
+        <div ng-if="loggedInUser.role == 'admin' && $state.includes('token.rollover') == false">
             <h4 translate>Assign token to user</h4>
 
             <div assign-user new-user-object="newUser" realms="realms"
@@ -120,7 +122,9 @@
         <div class="text-center">
             <button type="button" ng-click="enrollToken()"
                     ng-disabled="!checkEnroll() || formEnrollToken.$invalid || enrolling"
-                    class="btn btn-primary" translate>Enroll Token
+                    class="btn btn-primary" translate>
+                <span ng-if="$state.includes('token.rollover') == false">Enroll Token</span>
+                <span ng-if="$state.includes('token.rollover')">Rollover Token</span>
             </button>
         </div>
     </form>

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -1,5 +1,9 @@
 <h3 ng-if="$state.includes('token.enroll')" translate>Enroll a new token</h3>
-<h3 ng-if="$state.includes('token.rollover')" translate>Rollover token {{ form.serial }}</h3>
+<div ng-if="$state.includes('token.rollover')">
+    <div class="alert alert-danger" role="alert">You are about to rollover your token! This will invalidate your existing token
+        and create a new token with a new secret key!</div>
+    <h3 translate>Rollover token {{ form.serial }}</h3>
+</div>
 
 <!-- hide the form, after the token was enrolled -->
 <div ng-hide="enrolledToken">


### PR DESCRIPTION
This is an alternative implementation of the token rollover.
It uses the normal insite token enrollment and also
allows to change data (key length, otp length) if the administrator
allows so.

Still missing the webui policy.

Working on #2613