### PR TITLE
remove highlighting due to possible html injections

### DIFF
--- a/privacyidea/static/app.js
+++ b/privacyidea/static/app.js
@@ -20,7 +20,7 @@
  */
 myApp = angular.module("privacyideaApp",
     ['ui.router', 'ui.bootstrap', 'TokenModule',
-        'ngIdle', 'ui.highlight', 'ngSanitize',
+        'ngIdle', 'ngSanitize',
         'privacyideaAuth',
         'privacyideaApp.auditStates',
         'privacyideaApp.configStates',

--- a/privacyidea/static/components/config/views/config.policies.details.html
+++ b/privacyidea/static/components/config/views/config.policies.details.html
@@ -318,8 +318,8 @@
                                                    name="{{ action.name }}"
                                                    ng-model="actionCheckBox[action.name]"
                                                    id="cb_{{ action.name }}">
-                                            <label for="cb_{{ action.name }}"
-                                                   ng-bind-html="action.name | highlight: action_filter">
+                                            <label for="cb_{{ action.name }}">
+                                                   {{ action.name }}
                                             </label>
                                         </td>
 
@@ -377,8 +377,8 @@
                                         <td>
                                             <!-- This is the description of the policy action
                                              -->
-                                            <p class="help help-block"
-                                               ng-bind-html="action.desc | highlight: action_filter">
+                                            <p class="help help-block">
+                                               {{ action.desc }}
                                             </p>
                                         </td>
                                     </tr>


### PR DESCRIPTION
rollback changes from #2578. Although highlighting is a nice feature, we should reconsider to make it more secure and prevent interpretation of the full descriptive texts (which breaks in some cases).