### PR TITLE
do not display rollover button for clientwait tokens

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenDetailController.js
+++ b/privacyidea/static/components/token/controllers/tokenDetailController.js
@@ -389,7 +389,7 @@ myApp.controller("tokenDetailController", function ($scope,
     $scope.rolloverTokenAllowed = function(token) {
         if ( typeof(token) != 'undefined' ) {
             if ($scope.checkEnroll() && (token.tokentype in $scope.token_rollover) &&
-                token.info.tokenkind === 'software') {
+                token.info.tokenkind === 'software' && token.rollout_state !== 'clientwait' ) {
                 return true;
             }
         }


### PR DESCRIPTION
working on #2741 

This PR hides the rollover button for tokens which are in the clientwait state. This will affect totp, hotp and push tokens.