### PR TITLE
fix the names of some renamed policies

### DIFF
--- a/doc/policies/admin.rst
+++ b/doc/policies/admin.rst
@@ -269,12 +269,12 @@ is allowed to unassign tokens from a user. I.e. the
 administrator can remove the link between the token 
 and the user. The token still continues to exist in the system.
 
-import
-~~~~~~
+importtokens
+~~~~~~~~~~~~
 
 type: bool
 
-If the ``import`` action is defined, the administrator is 
+If the ``importtokens`` action is defined, the administrator is
 allowed to import token seeds from a token file, thus
 creating many new token objects in the systems database.
 
@@ -306,12 +306,12 @@ he should only work with tokens, but not see all users at once.
 .. note:: If an administrator has any right in a realm, the administrator
    is also allowed to view the token list.
 
-checkstatus
-~~~~~~~~~~~
+getchallenges
+~~~~~~~~~~~~~
 
 type: bool
 
-If the ``checkstatus`` action is defined, the administrator is 
+If the ``getchallenges`` action is defined, the administrator is
 allowed to check the status of open challenge requests.
 
 manageToken
@@ -590,7 +590,7 @@ For example a value ``sig_check log_level`` will hide these two columns.
 The list of available columns can be checked by examining the response of the
 request to the :ref:`rest_audit`.
 
-trigger_challenge
+triggerchallenge
 ~~~~~~~~~~~~~~~~~
 
 type: bool

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -514,7 +514,7 @@ The default is to ``allow`` polling
 
 .. _policy_challenge_text:
 
-challenge_text, challenge_text_header, challenge_test_footer
+challenge_text, challenge_text_header, challenge_text_footer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. index:: Challenge Text Policy

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -205,8 +205,8 @@ The date, when the PIN needs to be changed, is returned in the API response
 of */validate/check*. For more information see :ref:`change_pin_first_use`.
 To specify the contents of the PIN see :ref:`user_policies`.
 
-otp_pin_encrypt
-~~~~~~~~~~~~~~~
+encrypt_pin
+~~~~~~~~~~~
 
 type: bool
 
@@ -214,7 +214,7 @@ If set the OTP PIN of a token will be encrypted. The default
 behaviour is to hash the OTP PIN, which is safer.
 
 registration.length
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. index:: registration token
 
@@ -223,7 +223,7 @@ type: int
 This is the length of the generated registration codes.
 
 registration.contents
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 type: string
 
@@ -233,8 +233,8 @@ This defines what characters the registrationcodes should contain.
 
 This takes the same values like the admin policy :ref:`admin_policies_otp_pin_contents`.
 
-lostTokenPWLen
-~~~~~~~~~~~~~~
+losttoken_PW_length
+~~~~~~~~~~~~~~~~~~~
 
 .. index:: lost token
 
@@ -242,8 +242,8 @@ type: int
 
 This is the length of the generated password for the lost token process.
  
-lostTokenPWContents
-~~~~~~~~~~~~~~~~~~~
+losttoken_PW_contents
+~~~~~~~~~~~~~~~~~~~~~
 
 type: string
 
@@ -266,8 +266,8 @@ password like *AC#!49MK))*.
    part of the password. Also ``C`` would again add the character "I", which is
    not part of Base58.
 
-lostTokenValid
-~~~~~~~~~~~~~~
+losttoken_valid
+~~~~~~~~~~~~~~~
 
 type: int
 

--- a/doc/policies/user.rst
+++ b/doc/policies/user.rst
@@ -42,12 +42,12 @@ There are ``enroll`` actions per token type. Thus you can
 create policies that allow the user to enroll
 SMS tokens but not to enroll HMAC tokens.
 
-assgin
+assign
 ~~~~~~
 
 type: bool
 
-The user is allowed to assgin an existing token, that is
+The user is allowed to assign an existing token, that is
 located in his realm and that does not belong to any other user,
 by entering the serial number.
 


### PR DESCRIPTION
this PR fixes a number of policy names in the documentation

working on #2768 