### PR TITLE
allow placeholders in eventhandler usernotification email reply-to

### DIFF
--- a/migrations/versions/ff26585932ec_.py
+++ b/migrations/versions/ff26585932ec_.py
@@ -1,0 +1,39 @@
+"""v3.7: migrate old reply_to email
+
+Revision ID: ff26585932ec
+Revises: fa07bd604a75
+Create Date: 2021-07-15 14:17:17.624748
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ff26585932ec'
+down_revision = 'fa07bd604a75'
+
+from alembic import op
+from sqlalchemy import orm
+from privacyidea.models import EventHandlerOption
+from privacyidea.lib.eventhandler.usernotification import NOTIFY_TYPE
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    try:
+        for row in session.query(EventHandlerOption).filter(EventHandlerOption.Key == 'reply_to'):
+            reply_email = row.Value
+            evh_id = row.eventhandler_id
+            row.Value = NOTIFY_TYPE.EMAIL
+            row.save()
+            EventHandlerOption(evh_id, 'reply_to email', reply_email).save()
+
+    except Exception as e:
+        session.rollback()
+        print(e)
+
+    finally:
+        session.commit()
+
+
+def downgrade():
+    pass

--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -267,13 +267,13 @@ class UserNotificationEventHandler(BaseEventHandler):
             reply_to = tokenowner.info.get("email")
 
         elif reply_to_type == NOTIFY_TYPE.INTERNAL_ADMIN:
-            username = handler_options.get("reply_to "+NOTIFY_TYPE.INTERNAL_ADMIN)
+            username = handler_options.get("reply_to " + NOTIFY_TYPE.INTERNAL_ADMIN)
             internal_admin = get_db_admin(username)
             reply_to = internal_admin.email if internal_admin else ""
 
         elif reply_to_type == NOTIFY_TYPE.ADMIN_REALM:
             # Adds all email addresses from a specific admin realm to the reply-to-header
-            admin_realm = handler_options.get("reply_to "+NOTIFY_TYPE.ADMIN_REALM)
+            admin_realm = handler_options.get("reply_to " + NOTIFY_TYPE.ADMIN_REALM)
             attr = is_attribute_at_all()
             ulist = get_user_list({"realm": admin_realm}, custom_attributes=attr)
             # create a list of all user-emails, if the user has an email
@@ -297,7 +297,7 @@ class UserNotificationEventHandler(BaseEventHandler):
                     reply_to = user_obj.info.get("email") if user_obj else ""
 
         elif reply_to_type == NOTIFY_TYPE.EMAIL:
-            email = handler_options.get("reply_to "+NOTIFY_TYPE.EMAIL, "").split(",")
+            email = handler_options.get("reply_to " + NOTIFY_TYPE.EMAIL, "").split(",")
             reply_to = email[0]
 
         else:

--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -84,7 +84,7 @@ class NOTIFY_TYPE(object):
     INTERNAL_ADMIN = "internal admin"
     ADMIN_REALM = "admin realm"
     EMAIL = "email"
-
+    NO_REPLY_TO = ""
 
 class UserNotificationEventHandler(BaseEventHandler):
     """
@@ -142,6 +142,7 @@ class UserNotificationEventHandler(BaseEventHandler):
                     "required": False,
                     "description": _("The Reply-To header in the sent email."),
                     "value": [
+                        NOTIFY_TYPE.NO_REPLY_TO,
                         NOTIFY_TYPE.TOKENOWNER,
                         NOTIFY_TYPE.LOGGED_IN_USER,
                         NOTIFY_TYPE.INTERNAL_ADMIN,
@@ -248,7 +249,7 @@ class UserNotificationEventHandler(BaseEventHandler):
         handler_def = options.get("handler_def")
         handler_options = handler_def.get("options", {})
         notify_type = handler_options.get("To", NOTIFY_TYPE.TOKENOWNER)
-        reply_to_type = handler_options.get("reply_to", NOTIFY_TYPE.TOKENOWNER)
+        reply_to_type = handler_options.get("reply_to")
         try:
             logged_in_user = g.logged_in_user
         except Exception:
@@ -263,7 +264,10 @@ class UserNotificationEventHandler(BaseEventHandler):
         recipient = None
         reply_to = None
 
-        if reply_to_type == NOTIFY_TYPE.TOKENOWNER and not tokenowner.is_empty():
+        if reply_to_type == NOTIFY_TYPE.NO_REPLY_TO:
+            reply_to = ""
+
+        elif reply_to_type == NOTIFY_TYPE.TOKENOWNER and not tokenowner.is_empty():
             reply_to = tokenowner.info.get("email")
 
         elif reply_to_type == NOTIFY_TYPE.INTERNAL_ADMIN:
@@ -301,8 +305,8 @@ class UserNotificationEventHandler(BaseEventHandler):
             reply_to = email[0]
 
         else:
-            log.warning("Was not able to determine the email for the user "
-                        "notification: {0!s}".format(handler_def))
+            log.warning("Was not able to determine the email for the reply-to "
+                        "header: {0!s}".format(handler_def))
 
         if notify_type == NOTIFY_TYPE.TOKENOWNER and not tokenowner.is_empty():
             recipient = {

--- a/tests/test_lib_eventhandler_usernotification.py
+++ b/tests/test_lib_eventhandler_usernotification.py
@@ -733,6 +733,61 @@ class UserNotificationTestCase(MyTestCase):
         self.assertTrue(res)
 
     @smtpmock.activate
+    def test_12_send_to_tokenowner(self):
+        # setup realms
+        self.setUp_user_realms()
+
+        r = add_smtpserver(identifier="myserver", server="1.2.3.4", tls=False)
+        self.assertTrue(r > 0)
+
+        smtpmock.setdata(response={"recp@example.com": (200, "OK")},
+                         support_tls=False)
+
+        g = FakeFlaskG()
+        audit_object = FakeAudit()
+        audit_object.audit_data["serial"] = "123456"
+
+        g.logged_in_user = {"username": "admin",
+                            "role": "admin",
+                            "realm": ""}
+        g.audit_object = audit_object
+
+        builder = EnvironBuilder(method='POST',
+                                 data={'serial': "OATH123456"},
+                                 headers={})
+
+        env = builder.get_environ()
+        # Set the remote address so that we can filter for it
+        env["REMOTE_ADDR"] = "10.0.0.1"
+        g.client_ip = env["REMOTE_ADDR"]
+        req = Request(env)
+        req.all_data = {"serial": "SomeSerial",
+                        "user": "cornelius"}
+        req.User = User("cornelius", self.realm1)
+        resp = Response()
+        resp.data = """{"result": {"value": true},
+        "detail": {"registrationcode": "12345678910"}
+        }
+        """
+        options = {"g": g,
+                   "request": req,
+                   "response": resp,
+                   "handler_def": {
+                       "conditions": {"serial": "123.*"},
+                       "options": {"body": "your {registrationcode}",
+                                   "emailconfig": "myserver",
+                                   "To": NOTIFY_TYPE.TOKENOWNER,
+                                   "To " + NOTIFY_TYPE.TOKENOWNER:
+                                       "recp@example.com",
+                                   "reply_to": NOTIFY_TYPE.TOKENOWNER,
+                                   "reply_to" + NOTIFY_TYPE.TOKENOWNER:
+                                       "recp@example.com"}}}
+
+        un_handler = UserNotificationEventHandler()
+        res = un_handler.do("sendmail", options=options)
+        self.assertTrue(res)
+
+    @smtpmock.activate
     def test_12_send_to_internal_admin(self):
         # setup realms
         self.setUp_user_realms()

--- a/tests/test_lib_eventhandler_usernotification.py
+++ b/tests/test_lib_eventhandler_usernotification.py
@@ -723,6 +723,9 @@ class UserNotificationTestCase(MyTestCase):
                                    "emailconfig": "myserver",
                                    "To": NOTIFY_TYPE.EMAIL,
                                    "To " + NOTIFY_TYPE.EMAIL:
+                                       "recp@example.com",
+                                   "reply_to": NOTIFY_TYPE.EMAIL,
+                                   "reply_to" + NOTIFY_TYPE.EMAIL:
                                        "recp@example.com"}}}
 
         un_handler = UserNotificationEventHandler()
@@ -777,6 +780,9 @@ class UserNotificationTestCase(MyTestCase):
                                    "emailconfig": "myserver",
                                    "To": NOTIFY_TYPE.INTERNAL_ADMIN,
                                    "To " + NOTIFY_TYPE.INTERNAL_ADMIN:
+                                       "super",
+                                   "reply_to": NOTIFY_TYPE.INTERNAL_ADMIN,
+                                   "reply_to" + NOTIFY_TYPE.INTERNAL_ADMIN:
                                        "super"}}}
 
         un_handler = UserNotificationEventHandler()
@@ -793,6 +799,9 @@ class UserNotificationTestCase(MyTestCase):
                                    "emailconfig": "myserver",
                                    "To": NOTIFY_TYPE.INTERNAL_ADMIN,
                                    "To " + NOTIFY_TYPE.INTERNAL_ADMIN:
+                                       "testadmin",
+                                   "reply_to": NOTIFY_TYPE.INTERNAL_ADMIN,
+                                   "reply_to" + NOTIFY_TYPE.INTERNAL_ADMIN:
                                        "testadmin"}}}
 
         un_handler = UserNotificationEventHandler()
@@ -845,6 +854,7 @@ class UserNotificationTestCase(MyTestCase):
                        "conditions": {"serial": "123.*"},
                        "options": {"body": "your {registrationcode}",
                                    "emailconfig": "myserver",
+                                   "reply_to": NOTIFY_TYPE.LOGGED_IN_USER,
                                    "To": NOTIFY_TYPE.LOGGED_IN_USER}}}
 
         un_handler = UserNotificationEventHandler()
@@ -862,6 +872,7 @@ class UserNotificationTestCase(MyTestCase):
                        "conditions": {"serial": "123.*"},
                        "options": {"body": "your {registrationcode}",
                                    "emailconfig": "myserver",
+                                   "reply_to": NOTIFY_TYPE.LOGGED_IN_USER,
                                    "To": NOTIFY_TYPE.LOGGED_IN_USER}}}
         un_handler = UserNotificationEventHandler()
         res = un_handler.do("sendmail", options=options)
@@ -917,6 +928,9 @@ class UserNotificationTestCase(MyTestCase):
                                    "emailconfig": "myserver",
                                    "To": NOTIFY_TYPE.ADMIN_REALM,
                                    "To " + NOTIFY_TYPE.ADMIN_REALM:
+                                       "realm1",
+                                   "reply_to": NOTIFY_TYPE.ADMIN_REALM,
+                                   "reply_to" + NOTIFY_TYPE.ADMIN_REALM:
                                        "realm1"}}}
         un_handler = UserNotificationEventHandler()
         res = un_handler.do("sendmail", options=options)


### PR DESCRIPTION
these options are now available

* tokenowner
* logged_in_user
* internal admin -> (choose names of internal admins)
* admin realm -> (choose admin realm)
* email -> (choose static email address)