### PR TITLE
Catch error in last_auth_newer

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1659,9 +1659,10 @@ class TokenClass(object):
         than the specified time delta which is passed as 10h, 7d or 1y.
 
         It returns True, if the last authentication with this token is
-        **newer*** than the specified delta.
+        **newer** than the specified delta or by any chance exactly the same.
 
-        It returns False, if the data in the token can not be parsed
+        It returns False, if the last authentication is older or
+        if the data in the token can not be parsed.
 
         :param last_auth: 10h, 7d or 1y
         :type last_auth: basestring

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -798,6 +798,13 @@ class TokenBaseTestCase(MyTestCase):
         r = token_obj.check_last_auth_newer("10h")
         self.assertFalse(r)
         r = token_obj.check_last_auth_newer("2d")
+        self.assertTrue(r)
+
+        # Test a fault last_auth entry does not computer to True
+        token_obj.add_tokeninfo(ACTION.LASTAUTH, "faulty format")
+        r = token_obj.check_last_auth_newer("10h")
+        self.assertFalse(r)
+
         token_obj.delete_token()
 
     def test_39_generate_sym_key(self):


### PR DESCRIPTION
If the tokeninfo "last_auth" contains faulty datestring,
an exception is raised.
This is bad for the token-janitor and also for automatic tasks.

So we catch this exception and return False.

Closes #2780