### PR TITLE
setup.py: only SQLAlchemy 1.3 is supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires = ["beautifulsoup4[lxml]>=4.3.2",
                     "qrcode>=6.1",
                     "requests>=2.7.0",
                     "smpplib>=2.0",
-                    "SQLAlchemy>=1.3.0",
+                    "SQLAlchemy>=1.3.0,<1.4",
                     "sqlsoup>=0.9.0"]
 
 


### PR DESCRIPTION
The problem with 1.4 is that it doesn't several APIs anymore that were
needed by `sqlsoup` such as the `MapperExtension`[1].

In fact it might be better to entirely drop `sqlsoup` here since it
seems mostly dead, especially since the `bitbucket.org` link on PyPI[2]
is dead.

I actually tried to move the code, but unfortunately I'm not experienced
enough with SQLAlchemy to "just do it". My attempt was mostly a port of
`sqlsoup` into the SQLIdResolver but I doubt that this is the correct
approach, so I decided to only fix the version range for now.

[1] https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html#change-6daf2f59ac2438ef9c8213e9ebeac157
[2] https://pypi.org/project/sqlsoup/