### PR TITLE
Use clientwait with U2F and WebAuthn

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -134,7 +134,7 @@ class TOKENMODE(object):
 
 class ROLLOUTSTATE(object):
     CLIENTWAIT = 'clientwait'
-    PENDING = 'pending' # TODO: to be used, if the server needs to take action
+    PENDING = 'pending'  # TODO: to be used, if the server needs to take action
 
 
 class TokenClass(object):

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -132,6 +132,11 @@ class TOKENMODE(object):
     OUTOFBAND = 'outofband'
 
 
+class ROLLOUTSTATE(object):
+    CLIENTWAIT = 'clientwait'
+    PENDING = 'pending' # TODO: to be used, if the server needs to take action
+
+
 class TokenClass(object):
 
     # Class properties
@@ -517,7 +522,7 @@ class TokenClass(object):
             otpKey = self.decode_otpkey(otpKey, otpkeyformat)
 
         if twostep_init:
-            if self.token.rollout_state == "clientwait":
+            if self.token.rollout_state == ROLLOUTSTATE.CLIENTWAIT:
                 # We do not do 2stepinit in the second step
                 raise ParameterError("2stepinit is only to be used in the "
                                      "first initialization step.")
@@ -543,7 +548,7 @@ class TokenClass(object):
             otpKey = getParam(param, "otpkey", required)
 
         if otpKey is not None:
-            if self.token.rollout_state == "clientwait":
+            if self.token.rollout_state == ROLLOUTSTATE.CLIENTWAIT:
                 # If we have otpkey and the token is in the enrollment-state
                 # generate the new key
                 server_component = to_unicode(self.token.get_otpkey().getKey())
@@ -558,7 +563,7 @@ class TokenClass(object):
 
         if twostep_init:
             # After the key is generated, we set "waiting for the client".
-            self.token.rollout_state = "clientwait"
+            self.token.rollout_state = ROLLOUTSTATE.CLIENTWAIT
 
         pin = getParam(param, "pin", optional)
         if pin is not None:

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -134,7 +134,7 @@ class TOKENMODE(object):
 
 class ROLLOUTSTATE(object):
     CLIENTWAIT = 'clientwait'
-    PENDING = 'pending'  # TODO: to be used, if the server needs to take action
+    PENDING = 'pending'
 
 
 class TokenClass(object):

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -46,7 +46,7 @@ from privacyidea.lib.policy import SCOPE, ACTION, GROUP, get_action_values_from_
 from privacyidea.lib.log import log_with
 from privacyidea.lib import _
 
-from privacyidea.lib.tokenclass import TokenClass, TOKENMODE
+from privacyidea.lib.tokenclass import TokenClass, TOKENMODE, ROLLOUTSTATE
 from privacyidea.models import Challenge, db
 from privacyidea.lib.decorators import check_token_locked
 import logging
@@ -411,7 +411,7 @@ class PushTokenClass(TokenClass):
 
         if "serial" in upd_param and "fbtoken" in upd_param and "pubkey" in upd_param:
             # We are in step 2:
-            if self.token.rollout_state != "clientwait":
+            if self.token.rollout_state != ROLLOUTSTATE.CLIENTWAIT:
                 raise ParameterError("Invalid state! The token you want to enroll is not in the state 'clientwait'.")
             enrollment_credential = getParam(upd_param, "enrollment_credential", optional=False)
             if enrollment_credential != self.get_tokeninfo("enrollment_credential"):
@@ -459,7 +459,7 @@ class PushTokenClass(TokenClass):
         imageurl = params.get("appimageurl")
         if imageurl:
             extra_data.update({"image": imageurl})
-        if self.token.rollout_state == "clientwait":
+        if self.token.rollout_state == ROLLOUTSTATE.CLIENTWAIT:
             # Get enrollment values from the policy
             registration_url = getParam(params, PUSH_ACTION.REGISTRATION_URL, optional=False)
             ttl = getParam(params, PUSH_ACTION.TTL, default="10")
@@ -551,7 +551,7 @@ class PushTokenClass(TokenClass):
             try:
                 token_obj = get_one_token(serial=serial,
                                           tokentype="push",
-                                          rollout_state="clientwait")
+                                          rollout_state=ROLLOUTSTATE.CLIENTWAIT)
                 token_obj.update(request_data)
             except ResourceNotFoundError:
                 raise ResourceNotFoundError("No token with this serial number "

--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -29,7 +29,7 @@
 #
 from privacyidea.api.lib.utils import getParam, attestation_certificate_allowed
 from privacyidea.lib.config import get_from_config
-from privacyidea.lib.tokenclass import TokenClass
+from privacyidea.lib.tokenclass import TokenClass, ROLLOUTSTATE
 from privacyidea.lib.token import get_tokens
 from privacyidea.lib.log import log_with
 import logging
@@ -312,7 +312,6 @@ class U2fTokenClass(TokenClass):
         TokenClass.__init__(self, db_token)
         self.set_type(u"u2f")
         self.hKeyRequired = False
-        self.init_step = 1
 
     def update(self, param, reset_failcount=True):
         """
@@ -326,8 +325,9 @@ class U2fTokenClass(TokenClass):
         description = "U2F initialization"
         reg_data = getParam(param, "regdata")
         verify_cert = is_true(getParam(param, "u2f.verify_cert", default=True))
-        if reg_data:
-            self.init_step = 2
+        if not reg_data:
+            self.token.rollout_state = ROLLOUTSTATE.CLIENTWAIT
+        elif reg_data and self.token.rollout_state == ROLLOUTSTATE.CLIENTWAIT:
             attestation_cert, user_pub_key, key_handle, \
                 signature, description = parse_registration_data(reg_data,
                                                                  verify_cert=verify_cert)
@@ -348,6 +348,10 @@ class U2fTokenClass(TokenClass):
             self.add_tokeninfo("attestation_issuer", issuer)
             self.add_tokeninfo("attestation_serial", serial)
             self.add_tokeninfo("attestation_subject", subject)
+            # Reset rollout state
+            self.token.rollout_state = ""
+        else:
+            raise ParameterError("regdata provided but token not in clientwait rollout_state.")
 
         # If a description is given we use the given description
         description = getParam(param, "description", default=description)
@@ -359,7 +363,8 @@ class U2fTokenClass(TokenClass):
         At the end of the initialization we ask the user to press the button
         """
         response_detail = {}
-        if self.init_step == 1:
+        # get_init_details runs after "update" method. So in the first step clientwait has already been set
+        if self.token.rollout_state == ROLLOUTSTATE.CLIENTWAIT:
             # This is the first step of the init request
             app_id = get_from_config("u2f.appId", "").strip("/")
             from privacyidea.lib.error import TokenAdminError
@@ -374,8 +379,8 @@ class U2fTokenClass(TokenClass):
             response_detail["u2fRegisterRequest"] = register_request
             self.add_tokeninfo("appId", app_id)
 
-        elif self.init_step == 2:
-            # This is the second step of the init request
+        elif self.token.rollout_state == "":
+            # This is the second step of the init request, the clientwait rollout state has been reset
             response_detail["u2fRegisterResponse"] = {"subject":
                                                           self.token.description}
 

--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -322,7 +322,6 @@ class U2fTokenClass(TokenClass):
         :return: None
         """
         TokenClass.update(self, param)
-        automatic_description = "U2F initialization"
         reg_data = getParam(param, "regdata")
         verify_cert = is_true(getParam(param, "u2f.verify_cert", default=True))
         if not reg_data:
@@ -343,7 +342,7 @@ class U2fTokenClass(TokenClass):
                                     user_pub_key, key_handle, signature)
             self.set_otpkey(key_handle)
             self.add_tokeninfo("pubKey", user_pub_key)
-            # add attestation certificat info
+            # add attestation certificate info
             issuer = x509name_to_string(attestation_cert.get_issuer())
             serial = "{!s}".format(attestation_cert.get_serial_number())
             subject = x509name_to_string(attestation_cert.get_subject())

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -2990,7 +2990,80 @@ class WebAuthn(MyApiTestCase):
         set_policy("wan2", scope=SCOPE.ENROLL,
                    action="webauthn_relying_party_name=example")
 
-    def test_01_enroll_token(self):
+    def test_01_enroll_token_cumstom_description(self):
+        client_data = "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoibmgwaUJ6MFNNbmRsVnNQUkdM" \
+                      "dk9DUWMtUHByUHhPSmYzMEtlWm1UWFk5NCIsIm9yaWdpbiI6Imh0dHBzOi8vcGkuZXhhbXBsZS5jb" \
+                      "20iLCJjcm9zc09yaWdpbiI6ZmFsc2V9"
+        regdata = """o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEgwRgIhANAt-cBR3mZglj13PZPXA3srJYxX
+↵J6v-LzxAhmxZM7AsAiEAxu4gi8AiKOfyhU68HcIBHuIwgjBWJUlt4cIETWFYdetjeDVjgVkCwDCC
+↵ArwwggGkoAMCAQICBAOt8BIwDQYJKoZIhvcNAQELBQAwLjEsMCoGA1UEAxMjWXViaWNvIFUyRiBS
+↵b290IENBIFNlcmlhbCA0NTcyMDA2MzEwIBcNMTQwODAxMDAwMDAwWhgPMjA1MDA5MDQwMDAwMDBa
+↵MG0xCzAJBgNVBAYTAlNFMRIwEAYDVQQKDAlZdWJpY28gQUIxIjAgBgNVBAsMGUF1dGhlbnRpY2F0
+↵b3IgQXR0ZXN0YXRpb24xJjAkBgNVBAMMHVl1YmljbyBVMkYgRUUgU2VyaWFsIDYxNzMwODM0MFkw
+↵EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGZ6HnBYtt9w57kpCoEYWpbMJ_soJL3a-CUj5bW6VyuTM
+↵Zc1UoFnPvcfJsxsrHWwYRHnCwGH0GKqVS1lqLBz6F6NsMGowIgYJKwYBBAGCxAoCBBUxLjMuNi4x
+↵LjQuMS40MTQ4Mi4xLjcwEwYLKwYBBAGC5RwCAQEEBAMCBDAwIQYLKwYBBAGC5RwBAQQEEgQQ-iuZ
+↵3J45QlePkkow0jxBGDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAo67Nn_tHY8OKJ
+↵68qf9tgHV8YOmuV8sXKMmxw4yru9hNkjfagxrCGUnw8t_Awxa_2xdbNuY6Iru1gOrcpSgNB5hA5a
+↵HiVyYlo7-4dgM9v7IqlpyTi4nOFxNZQAoSUtlwKpEpPVRRnpYN0izoon6wXrfnm3UMAC_tkBa3Ee
+↵ya10UBvZFMu-jtlXEoG3T0TrB3zmHssGq4WpclUmfujjmCv0PwyyGjgtI1655M5tspjEBUJQQCMr
+↵K2HhDNcMYhW8A7fpQHG3DhLRxH-WZVou-Z1M5Vp_G0sf-RTuE22eYSBHFIhkaYiARDEWZTiJuGSG
+↵2cnJ_7yThUU1abNFdEuMoLQ3aGF1dGhEYXRhWMSjeab27q-5pV43jBGANOJ1Hmgvq58tMKsT0hJV
+↵hs4ZR0EAAAD4-iuZ3J45QlePkkow0jxBGABAkNhnmLSbmlUebUHbpXxU-zMfqtnIqT5y2E3sfQgW
+↵wE1FlUGvPg_c4zNcIucBnQAN8qTHJ8clzq7v5oQnnJz7T6UBAgMmIAEhWCBARZY9ak9nT6EI-dwL
+↵uj0TB5-XjlmAvivyWLi9WSI7pCJYIEJicw0LtP_hdy8yh6ANEUXBJsWtkGDci9DcN1rDG1tE"""
+        # First enrollment step
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"user": self.username,
+                                                 "pin": self.pin,
+                                                 "serial": self.serial,
+                                                 "type": "webauthn",
+                                                 "description": "my description",
+                                                 "genkey": 1},
+                                           headers={"authorization": self.at,
+                                                    "Host": "pi.example.com",
+                                                    "Origin": "https://pi.example.com"}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            data = res.json
+            webAuthnRequest = data.get("detail").get("webAuthnRegisterRequest")
+            self.assertEqual("Please confirm with your WebAuthn token", webAuthnRequest.get("message"))
+            transaction_id = webAuthnRequest.get("transaction_id")
+
+        # We need to change the nonce in the challenge database to use our recorded WebAuthN enrollment data
+        recorded_nonce = "nh0iBz0SMndlVsPRGLvOCQc-PprPxOJf30KeZmTXY94"
+        recorded_nonce_hex = binascii.hexlify(webauthn_b64_decode(recorded_nonce))
+        # Update the nonce in the challenge database.
+        from privacyidea.lib.challenge import get_challenges
+        chal = get_challenges(serial=self.serial, transaction_id=transaction_id)[0]
+        chal.challenge = recorded_nonce_hex
+        chal.save()
+
+        # 2nd enrollment step
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"user": self.username,
+                                                 "pin": self.pin,
+                                                 "serial": self.serial,
+                                                 "type": "webauthn",
+                                                 "transaction_id": transaction_id,
+                                                 "clientdata": client_data,
+                                                 "regdata": regdata},
+                                           headers={"authorization": self.at,
+                                                    "Host": "pi.example.com",
+                                                    "Origin": "https://pi.example.com"}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            data = res.json
+            self.assertEqual('my description',
+                             data.get("detail").get("webAuthnRegisterResponse").get("subject"))
+
+        # Test, if the token received the automatic description
+        self.assertEqual(get_tokens(serial=self.serial)[0].token.description, "my description")
+        remove_token(self.serial)
+
+    def test_02_enroll_token(self):
         client_data = "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoibmgwaUJ6MFNNbmRsVnNQUkdM" \
                       "dk9DUWMtUHByUHhPSmYzMEtlWm1UWFk5NCIsIm9yaWdpbiI6Imh0dHBzOi8vcGkuZXhhbXBsZS5jb" \
                       "20iLCJjcm9zc09yaWdpbiI6ZmFsc2V9"
@@ -3057,6 +3130,9 @@ class WebAuthn(MyApiTestCase):
             data = res.json
             self.assertEqual('Yubico U2F EE Serial 61730834',
                              data.get("detail").get("webAuthnRegisterResponse").get("subject"))
+
+        # Test, if the token received the automatic description
+        self.assertEqual(get_tokens(serial=self.serial)[0].token.description, "Yubico U2F EE Serial 61730834")
 
     def test_10_validate_check(self):
         # Run challenge request agsint /validate/check


### PR DESCRIPTION
We also use the rollout_state "clientwait" for
webauthn and u2f tokens. This way the token janitor
can easily find tokens, that have not been successfully/finally
enrolled.

The logic has changed slightly, so that some testcases would
not run correctly anymore, seemingly the lib-testcases do
not reflect the real world use case in this scenario.

This is why we need to failsafe the name of the
token in the description.

Added a class ROLLOUTSTATE for future use and
to avoid typos in the state names.

Working on #2784