### PR TITLE
Fix broken CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - run: mkdir -p test-results/generic
+      - run: pip install -U pip
       # We do not want any caching (always the latest packages) therefore we
       # install the packages directly (not using the python orb)
       - run: pip install pytest pytest-cov mock responses testfixtures
@@ -43,6 +44,7 @@ jobs:
       - run: git submodule update --init
       - restore_cache:
           key: v1-deps-{{ checksum "requirements.txt" }}
+      - run: pip install -U pip
       - run: pip install -r tests/requirements.txt
       - run: mkdir -p test-results/mysql
       - run:

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,7 @@
 
 import unittest
 import mock
+from sqlalchemy.orm.session import close_all_sessions
 
 from privacyidea.app import create_app
 from privacyidea.config import TestingConfig
@@ -172,8 +173,9 @@ class MyTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         call_finalizers()
-        db.session.remove()
+        close_all_sessions()
         db.drop_all()
+        db.engine.dispose()
         cls.app_context.pop()
 
     def authenticate(self):


### PR DESCRIPTION
- We need a current pip so we update it before installing PI
- try to close connections to the db on tearDown. It seems like the pool
  isn't closed properly and the still checked out connections will not
  be recycled.