### PR TITLE
fix doc and add webUI hint for custom user attributes

### DIFF
--- a/doc/policies/admin.rst
+++ b/doc/policies/admin.rst
@@ -724,7 +724,7 @@ For allowing all values, the asterisk ("*") is used.
 Each key is enclosed in colons and followed by a list of values separated by whitespaces,
 thus values are not allowed to contain whitespaces.
 
-Example:
+Example::
 
     :department: sales finance :city: * :*: 1 2
 

--- a/privacyidea/static/components/user/views/user.details.html
+++ b/privacyidea/static/components/user/views/user.details.html
@@ -104,9 +104,12 @@
                     ng-options = "attribute_key as attribute_key for (attribute_key, attribute_values) in allowed_custom_attributes['set']"
                 >
                 </select>
+                <label class="sr-only" for="new_custom_attribute_key" translate="Custom attribute name"></label>
                 <input class="form-control"
                        ng-show="selected_attr_key==='*'"
-                       ng-model="new_custom_attribute_key">
+                       ng-model="new_custom_attribute_key"
+                       id="new_custom_attribute_key"
+                       placeholder="Custom attribute name">
             </td>
             <td class="col-sm-4">
                 <select class="form-control"


### PR DESCRIPTION
small change which adds a descriptive hint to the custom user attributes field.

In the documentation the typesetting of the example for the custom user attributes policy is fixed.