### PR TITLE
Removed the versioned setting of CSS customization

### DIFF
--- a/privacyidea/static/templates/header.html
+++ b/privacyidea/static/templates/header.html
@@ -19,7 +19,7 @@
     <link href="{{ instance }}/{{ "static/css/baseline.css" | versioned }}" rel="stylesheet">
     <link href="{{ instance }}/{{ "static/css/highlight.css" | versioned }}" rel="stylesheet">
     {% if theme %}<link href="{{ instance }}/{{ theme | versioned }}" rel="stylesheet"/>{%  endif %}
-    {% if custom_css %}<link href="{{ instance }}/{{ custom_css | versioned }}" rel="stylesheet"/>{% endif %}
+    {% if custom_css %}<link href="{{ instance }}/{{ custom_css }}" rel="stylesheet"/>{% endif %}
 
     <script type="application/javascript">
         // Pass the browser Language to our Javascript code


### PR DESCRIPTION
Removed the 'versioned' setting as it introduced an error of "No such file" if the CSS customization is enabled in pi.cfg