### PR TITLE
Add a simple package-management for the webUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,17 @@ pypi:
 	gpg --detach-sign -a --default-key ${SIGNING_KEY} dist/*.tar.gz
 	twine upload dist/*.tar.gz dist/*.tar.gz.asc
 
-
-depdoc:
-	#sfood privacyidea | sfood-graph | dot -Tpng -o graph.png	
-	dot -Tpng dependencies.dot -o dependencies.png
-
 doc-man:
 	(cd doc; make man)
 
 doc-html:
 	(cd doc; make html)
 
+NPM_VERSION := $(shell npm --version 2>/dev/null)
+
+update-contrib:
+ifdef NPM_VERSION
+	(cd privacyidea/static && npm install && ./update_contrib.sh)
+else
+	@echo "Command 'npm' not found! It is needed to install the JS contrib libraries."
+endif

--- a/privacyidea/static/update_contrib.sh
+++ b/privacyidea/static/update_contrib.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+# JavaScript files
+declare -a JS
+JS=(
+    "jquery/dist/jquery.js"
+    "angular/angular.js"
+    "angular-hotkeys/build/hotkeys.js"
+    "angular-inform/dist/angular-inform.js"
+    "angular-inform/dist/angular-inform.js.map"
+    "bootstrap/dist/js/bootstrap.js"
+    "angular-ui-bootstrap/dist/ui-bootstrap-tpls.js"
+)
+
+# AngularJS modules
+declare -a JS_NGMODULES
+JS_NGMODULES=(
+    "angular-gettext/dist/angular-gettext.js"
+    "ng-idle/angular-idle.js"
+    "angular-ui-router/release/angular-ui-router.js"
+    "angular-ui-router/release/angular-ui-router.js.map"
+    "ng-file-upload/dist/ng-file-upload.js"
+    "isteven-angular-multiselect/isteven-multi-select.js"
+    "angular-ui-utils/modules/highlight/highlight.js"
+)
+
+# CSS files
+declare -a CSS
+CSS=(
+    "angular-inform/dist/angular-inform.css"
+    "angular-inform/dist/angular-inform.css.map"
+    "bootstrap/dist/css/bootstrap.css"
+    "bootstrap/dist/css/bootstrap.css.map"
+    "bootstrap/dist/css/bootstrap-theme.css"
+    "bootstrap/dist/css/bootstrap-theme.css.map"
+    "angular-hotkeys/build/hotkeys.css"
+    "isteven-angular-multiselect/isteven-multi-select.css"
+)
+
+# Font files
+declare -a FONTS
+FONTS=("bootstrap/fonts/glyphicons-halflings-regular.eot"
+    "bootstrap/fonts/glyphicons-halflings-regular.svg"
+    "bootstrap/fonts/glyphicons-halflings-regular.ttf"
+    "bootstrap/fonts/glyphicons-halflings-regular.woff"
+    "bootstrap/fonts/glyphicons-halflings-regular.woff2")
+
+
+for f in ${JS[@]}; do
+    cp "node_modules/$f" "contrib/js/"
+done
+
+for f in ${JS_NGMODULES[@]}; do
+    cp "node_modules/$f" "contrib/js/ngmodules/"
+done
+
+for f in ${CSS[@]}; do
+    cp "node_modules/$f" "contrib/css/"
+done
+
+for f in ${FONTS[@]}; do
+    cp "node_modules/$f" "contrib/fonts/"
+done
+


### PR DESCRIPTION
In order to ease the management of contrib JS packages for the webUI,
a simple make target `update-contrib` is added to install the required
packages via npm. A helper script then copies the necessary files into
the privacyIDEA source tree.

closes #1886