### PR TITLE
When deleting auth cache entries also delete expired entries of that user

### DIFF
--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -65,7 +65,6 @@ def delete_from_cache(username, realm, resolver, password, last_valid_cache_time
     :param last_valid_cache_time: Oldest valid time for a cache entry to be still valid. I.e., if the first
     authentication of the entry is before this time point, it is not valid anymore.
     :param max_auths: Maximum number of allowed authentications.
-    
     """
     cached_auths = db.session.query(AuthCache).filter(AuthCache.username == username,
                                                       AuthCache.realm == realm,

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -74,10 +74,10 @@ def delete_from_cache(username, realm, resolver, password, last_valid_cache_time
         delete_entry = False
         # if the password matches or the entry is otherwise invalid, we deleted it.
         try:
-            if max_auths > 0:
-                delete_entry = cached_auth.auth_count >= max_auths
-            elif last_valid_cache_time is not None:
-                delete_entry = cached_auth.first_auth > last_valid_cache_time
+            if max_auths > 0 and cached_auth.auth_count >= max_auths:
+                delete_entry = True
+            elif last_valid_cache_time and cached_auth.first_auth < last_valid_cache_time:
+                delete_entry = True
             elif argon2.verify(password, cached_auth.authentication):
                 delete_entry = True
 

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -65,7 +65,7 @@ def delete_from_cache(username, realm, resolver, password):
             if argon2.verify(password, cached_auth.authentication):
                 delete_entry = True
         except ValueError:
-            log.debug("Old authcache entry for user {0!s}@{1!s}.".format(username, realm))
+            log.debug("Old (non-argon2) authcache entry for user {0!s}@{1!s}.".format(username, realm))
             # Also delete old entries
             delete_entry = True
         if delete_entry:
@@ -127,7 +127,7 @@ def verify_in_cache(username, realm, resolver, password, first_auth=None, last_a
         try:
             result = argon2.verify(password, cached_auth.authentication)
         except ValueError:
-            log.debug("Old authcache entry for user {0!s}@{1!s}.".format(username, realm))
+            log.debug("Old (non-argon2) authcache entry for user {0!s}@{1!s}.".format(username, realm))
             result = False
 
         if result and max_auths > 0:

--- a/privacyidea/lib/authcache.py
+++ b/privacyidea/lib/authcache.py
@@ -72,14 +72,14 @@ def delete_from_cache(username, realm, resolver, password, last_valid_cache_time
     r = 0
     for cached_auth in cached_auths:
         delete_entry = False
-        # if the password does match, we deleted it.
+        # if the password matches or the entry is otherwise invalid, we deleted it.
         try:
-            if argon2.verify(password, cached_auth.authentication):
-                delete_entry = True
-            elif max_auths > 0:
+            if max_auths > 0:
                 delete_entry = cached_auth.auth_count >= max_auths
             elif last_valid_cache_time is not None:
                 delete_entry = cached_auth.first_auth > last_valid_cache_time
+            elif argon2.verify(password, cached_auth.authentication):
+                delete_entry = True
 
         except ValueError:
             log.debug("Old (non-argon2) authcache entry for user {0!s}@{1!s}.".format(username, realm))

--- a/tests/test_lib_authcache.py
+++ b/tests/test_lib_authcache.py
@@ -139,20 +139,32 @@ class AuthCacheTestCase(MyTestCase):
 
     def test_06_delete_other_invalid_entries(self):
         # Test deletion of expired entries
-        r1 = add_to_cache(self.username, self.realm, self.resolver, self.password)
-        r2 = add_to_cache(self.username, self.realm, self.resolver, u"somethingDifferent")
+        r1 = add_to_cache(self.username, self.realm, self.resolver, u"somethingDifferent")
+        r2 = add_to_cache(self.username, self.realm, self.resolver, self.password)
 
         auth1 = AuthCache.query.filter(AuthCache.id == r1).first()
         auth2 = AuthCache.query.filter(AuthCache.id == r2).first()
         last_valid_cache_time = auth1.first_auth
+        new_valid_cache_time = auth2.first_auth
 
         self.assertFalse(auth1.first_auth == auth2.first_auth)
 
+        # delete entries where password matches or first_auth is older than last_valid_cache_time
         delete_from_cache(self.username, self.realm, self.resolver, self.password,
                           last_valid_cache_time=last_valid_cache_time)
 
         auth = AuthCache.query.filter(AuthCache.username == self.username).first()
-        self.assertEqual(auth, None)
+        # r2 should have been deleted since the password matches,
+        # r1 is still there since it's first_auth is equal to last_valid_cache_time
+        self.assertEqual(auth.id, r1)
+
+        # by setting the last_valid_cache_time to the first_auth of r2, the
+        # entry r1 should be deleted as well
+        delete_from_cache(self.username, self.realm, self.resolver, 'unknown_pw',
+                          last_valid_cache_time=new_valid_cache_time)
+
+        auth = AuthCache.query.filter(AuthCache.username == self.username).first()
+        self.assertEqual(None, auth)
 
         # Test deletion if max_auths is reached
         r1 = add_to_cache(self.username, self.realm, self.resolver, self.password)
@@ -164,7 +176,7 @@ class AuthCacheTestCase(MyTestCase):
         auth2 = AuthCache.query.filter(AuthCache.id == r2).first()
 
         self.assertEqual(2, auth2.auth_count)
-
+        # this deletes the entries matching the password and max_auth
         delete_from_cache(self.username, self.realm, self.resolver, self.password, max_auths=2)
 
         auth = AuthCache.query.filter(AuthCache.username == self.username).first()

--- a/tests/test_lib_authcache.py
+++ b/tests/test_lib_authcache.py
@@ -151,8 +151,7 @@ class AuthCacheTestCase(MyTestCase):
         delete_from_cache(self.username, self.realm, self.resolver, self.password,
                           last_valid_cache_time=last_valid_cache_time)
 
-        auth = AuthCache.query.filter(AuthCache.username ==
-                                      self.username).first()
+        auth = AuthCache.query.filter(AuthCache.username == self.username).first()
         self.assertEqual(auth, None)
 
         # Test deletion if max_auths is reached
@@ -168,6 +167,5 @@ class AuthCacheTestCase(MyTestCase):
 
         delete_from_cache(self.username, self.realm, self.resolver, self.password, max_auths=2)
 
-        auth = AuthCache.query.filter(AuthCache.username ==
-                                      self.username).first()
+        auth = AuthCache.query.filter(AuthCache.username == self.username).first()
         self.assertEqual(auth, None)

--- a/tests/test_lib_authcache.py
+++ b/tests/test_lib_authcache.py
@@ -83,7 +83,6 @@ class AuthCacheTestCase(MyTestCase):
                             last_auth=last_auth, max_auths=1)
         self.assertFalse(r)
 
-
     def test_03_delete_old_entries(self):
         # Create a VERY old authcache entry
         AuthCache("grandpa", self.realm, self.resolver, _hash_password(self.password),
@@ -137,3 +136,38 @@ class AuthCacheTestCase(MyTestCase):
 
         r = verify_in_cache("grandpa", self.realm, self.resolver, "old password")
         self.assertFalse(r)
+
+    def test_06_delete_other_invalid_entries(self):
+        # Test deletion of expired entries
+        r1 = add_to_cache(self.username, self.realm, self.resolver, self.password)
+        r2 = add_to_cache(self.username, self.realm, self.resolver, u"somethingDifferent")
+
+        auth1 = AuthCache.query.filter(AuthCache.id == r1).first()
+        auth2 = AuthCache.query.filter(AuthCache.id == r2).first()
+        last_valid_cache_time = auth1.first_auth
+
+        self.assertFalse(auth1.first_auth == auth2.first_auth)
+
+        delete_from_cache(self.username, self.realm, self.resolver, self.password,
+                          last_valid_cache_time=last_valid_cache_time)
+
+        auth = AuthCache.query.filter(AuthCache.username ==
+                                      self.username).first()
+        self.assertEqual(auth, None)
+
+        # Test deletion if max_auths is reached
+        r1 = add_to_cache(self.username, self.realm, self.resolver, self.password)
+        r2 = add_to_cache(self.username, self.realm, self.resolver, u"somethingDifferent")
+
+        update_cache(r2)
+        update_cache(r2)
+
+        auth2 = AuthCache.query.filter(AuthCache.id == r2).first()
+
+        self.assertEqual(2, auth2.auth_count)
+
+        delete_from_cache(self.username, self.realm, self.resolver, self.password, max_auths=2)
+
+        auth = AuthCache.query.filter(AuthCache.username ==
+                                      self.username).first()
+        self.assertEqual(auth, None)


### PR DESCRIPTION
Additionally to deleting entries with a specific password, entries that reached the maximum number of allowed authentications and entries that are expired are also deleted.

Closes #2481