### PR TITLE
Fix upper realm names

### DIFF
--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -718,7 +718,7 @@ class PolicyClass(object):
             # if a user_object is passed, we check, if it differs from potentially passed user, resolver, realm:
             if (user and user.lower() != user_object.login.lower()) \
                     or (resolver and resolver.lower() != user_object.resolver.lower()) \
-                    or (realm and realm != user_object.realm):
+                    or (realm and realm.lower() != user_object.realm):
                 tb_str = ''.join(traceback.format_stack())
                 log.warning("Cannot pass user_object as well as user, resolver, realm "
                             "in policy {0!s}. "

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1107,6 +1107,20 @@ class PolicyTestCase(MyTestCase):
         self.assertEqual(P.get_action_values(action=ACTION.OTPPIN, scope=SCOPE.AUTH, user_object=None),
                          {"userstore": ["act1", "act2"], "none": ["act3", "act4", "act5"]})
 
+        # if we pass user_obj ornelius, we only get 4 policies
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=cornelius)),
+                         {"act1", "act2", "act3", "act5"})
+        # Provide a user object and parameters
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=cornelius,
+                                                                 user="cornelius",
+                                                                 realm="realm1")),
+                         {"act1", "act2", "act3", "act5"})
+        # For some reason pass the same user_obj and parameters, but realm in upper case
+        self.assertEqual(set(p['name'] for p in P.match_policies(user_object=cornelius,
+                                                                 user="cornelius",
+                                                                 realm="REALM1")),
+                         {"act1", "act2", "act3", "act5"})
+
         delete_policy("act1")
         delete_policy("act2")
         delete_policy("act3")


### PR DESCRIPTION
The user object check needs to be case-in-sensitive in the
realm.

Fixes #2869