### PR TITLE
Handle a not enrolled token correctly

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -668,6 +668,10 @@ class TokenClass(object):
     def is_active(self):
         return self.token.active
 
+    @property
+    def rollout_state(self):
+        return self.token.rollout_state
+
     def is_fit_for_challenge(self, messages, options=None):
         """
         This method is called if a cryptographically matching response to a challenge was found.
@@ -1216,6 +1220,8 @@ class TokenClass(object):
             message_list.append("Failcounter exceeded")
         elif not self.check_validity_period():
             message_list.append("Outside validity period")
+        elif self.rollout_state in [ROLLOUTSTATE.CLIENTWAIT]:
+            message_list.append("Token is not yet enrolled")
         else:
             r = True
         if not r:


### PR DESCRIPTION
A not ready enrolled token is still in the
state client_wait. If the token is somehow enabled on
purpose, it still can not be used for authentication.

We fix this by added a check for the rollout_state in
check_all().

Fixes #2852