### PR TITLE
Add subscription checking for push tokens and plugins

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -594,6 +594,8 @@ def get_webui_settings(request, response):
         content["result"]["value"]["show_seed"] = show_seed
         content["result"]["value"]["show_node"] = get_privacyidea_node() if show_node else ""
         content["result"]["value"]["subscription_status"] = subscription_status()
+        content["result"]["value"]["subscription_status_push"] = subscription_status("privacyidea authenticator",
+                                                                                     tokentype="push")
         content["result"]["value"]["qr_image_android"] = qr_image_android
         content["result"]["value"]["qr_image_ios"] = qr_image_ios
         content["result"]["value"]["qr_image_custom"] = qr_image_custom

--- a/privacyidea/lib/subscriptions.py
+++ b/privacyidea/lib/subscriptions.py
@@ -71,6 +71,10 @@ APPLICATIONS = {"demo_application": 0,
                 "privacyidea-ldap-proxy": 50,
                 "privacyidea-cp": 50,
                 "privacyidea-adfs": 50,
+                "privacyidea-keycloak": 10000,
+                "simplesamlphp": 10000,
+                "privacyidea-simplesamlphp": 10000,
+                "privacyidea authenticator": 10,
                 "privacyidea": 50}
 
 log = logging.getLogger(__name__)
@@ -89,7 +93,7 @@ def get_users_with_active_tokens():
     return sql_query.count()
 
 
-def subscription_status():
+def subscription_status(component="privacyidea", tokentype=None):
     """
     Return the status of the subscription
 
@@ -100,16 +104,16 @@ def subscription_status():
 
     :return: subscription state
     """
-    token_count = get_tokens(assigned=True, active=True, count=True)
-    if token_count <= APPLICATIONS.get("privacyidea", 50):
+    token_count = get_tokens(assigned=True, active=True, count=True, tokentype=tokentype)
+    if token_count <= APPLICATIONS.get(component, 50):
         return 0
 
-    subscriptions = get_subscription("privacyidea")
+    subscriptions = get_subscription(component)
     if len(subscriptions) == 0:
         return 1
 
     try:
-        check_subscription("privacyidea")
+        check_subscription(component)
     except SubscriptionError as exx:
         log.warning(u"{0}".format(exx))
         return 2
@@ -262,7 +266,7 @@ def check_subscription(application, max_free_subscriptions=None):
                     raise SubscriptionError(description="Too many users "
                                                         "with assigned tokens. "
                                                         "Subscription exceeded.",
-                                            application="privacyIDEA")
+                                            application=application)
 
     return True
 

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -426,6 +426,7 @@ angular.module("privacyideaApp")
             $scope.show_node = data.result.value.show_node;
             $scope.token_rollover = data.result.value.token_rollover;
             $scope.subscription_state = data.result.value.subscription_status;
+            $scope.subscription_state_push = data.result.value.subscription_status_push;
             $rootScope.search_on_enter = data.result.value.search_on_enter;
             // Token specific settings
             $scope.tokensettings = {indexedsecret:
@@ -474,6 +475,20 @@ angular.module("privacyideaApp")
                 }
                 var $random_number = Math.floor(Math.random() * (9999 + 1000 + 1)) + 1000;
                 $scope.class_subscription_expired = "subscriptionExpired" + $random_number;
+                // Show info about privacyIDEA Authenticator App and push
+                if ($scope.subscription_state_push === 1 && !$scope.hide_welcome) {
+                    // no subscription at all
+                     inform.add(gettextCatalog.getString("You are using a certain amount of Push tokens. " +
+                         "Note, that you need a valid subscription, to use Push tokens in push mode. Otherwise" +
+                         " Push tokens will only work in poll only mode. "),
+                            {type: "danger", ttl: 30000});
+                }
+                if ($scope.subscription_state_push === 2) {
+                    // Subscription expired
+                    inform.add(gettextCatalog.getString("Your subscription for the privacyIDEA Authenticator" +
+                        " has expired."),
+                        {type: "danger", ttl: 20000});
+                }
             }
             if ( $scope.unlocking ) {
                 $('#dialogLock').modal('hide');


### PR DESCRIPTION
Display a warning if there are push tokens used
without a subscription.
Display a warning if the subscription for push tokens
is exceeded/expired.

Closes #2801