### PR TITLE
If only one realm is available make it the selected realm

### DIFF
--- a/privacyidea/static/components/user/controllers/userControllers.js
+++ b/privacyidea/static/components/user/controllers/userControllers.js
@@ -337,7 +337,13 @@ angular.module("privacyideaApp")
         $scope.getRealms = function () {
             ConfigFactory.getRealms(function (data) {
                 $scope.realms = data.result.value;
+                num_realms = Object.keys($scope.realms).length;
                 angular.forEach($scope.realms, function (realm, realmname) {
+                    if (num_realms === 1) {
+                        // If the admin is allowed to see only one realm, we make this the
+                        // default realm in the UI
+                        realm.default = true;
+                    }
                     if (realm.default) {
                         $scope.defaultRealm = realmname;
                         if (!$scope.selectedRealm) {


### PR DESCRIPTION
It could be that a realm admin is only allowed to see one realm,
which is not the default realm.
However, we make it the default selected realm in the WebUI,
so that the admin does not need to "select" this single realm
manually.

Closes #2908