### PR TITLE
Fix removing of tokenowner when registration token is deleted

### DIFF
--- a/privacyidea/api/register.py
+++ b/privacyidea/api/register.py
@@ -168,7 +168,7 @@ def register_post():
     if not email_sent:
         log.warning("Failed to send registration email to {0!r}".format(email))
         # delete registration token
-        token.delete()
+        token.delete_token()
         # delete user
         user.delete()
         raise RegistrationError("Failed to send email!")

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -1130,24 +1130,7 @@ def remove_token(serial=None, user=None):
 
     # Delete challenges of such a token
     for tokenobject in tokenobject_list:
-        # delete the challenge
-        Challenge.query.filter(Challenge.serial == tokenobject.get_serial(
-
-        )).delete()
-
-        # due to legacy SQLAlchemy it could happen that the
-        # foreign key relation could not be deleted
-        # so we do this manualy
-
-        # delete references to client machines
-        MachineToken.query.filter(MachineToken.token_id ==
-                                  tokenobject.token.id).delete()
-        TokenRealm.query.filter(TokenRealm.token_id ==
-                                tokenobject.token.id).delete()
-        TokenOwner.query.filter(TokenOwner.token_id ==
-                                tokenobject.token.id).delete()
-
-        tokenobject.token.delete()
+        tokenobject.delete_token()
 
     return token_count
 

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -260,6 +260,15 @@ class Token(MethodsMixin, db.Model):
         db.session.query(TokenRealm)\
                   .filter(TokenRealm.token_id == self.id)\
                   .delete()
+        db.session.query(TokenOwner)\
+                  .filter(TokenOwner.token_id == self.id)\
+                  .delete()
+        db.session.query(MachineToken)\
+                  .filter(MachineToken.token_id == self.id)\
+                  .delete()
+        db.session.query(Challenge)\
+                  .filter(Challenge.serial == self.serial)\
+                  .delete()
         db.session.query(TokenInfo)\
                   .filter(TokenInfo.token_id == self.id)\
                   .delete()


### PR DESCRIPTION
The token delete mechanism is cleaned up, so that all information
is deleted on the database model level.
If a token is deleted we take care to delete all relevant information
like tokenowner, tokenrealm...

Add test for checking if the tokenowner entry is removed after the
registration token is used and implicitly deleted.

Closes #2907