### PR TITLE
Add test for resolver policy condition

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -41,6 +41,9 @@ class MyTestCase(unittest.TestCase):
     realm1 = "realm1"
     realm2 = "realm2"
     realm3 = "realm3"
+    testadmin = 'testadmin'
+    testadminpw = 'testpw'
+    testadminmail = "admin@test.tld"
     serials = ["SE1", "SE2", "SE3"]
     otpkey = "3132333435363738393031323334353637383930"
     valid_otp_values = ["755224",
@@ -66,7 +69,7 @@ class MyTestCase(unittest.TestCase):
         save_config_timestamp()
         db.session.commit()
         # Create an admin for tests.
-        create_db_admin(cls.app, "testadmin", "admin@test.tld", "testpw")
+        create_db_admin(cls.app, cls.testadmin, cls.testadminmail, cls.testadminpw)
 
     def setUp_user_realms(self):
         # create user realm
@@ -180,8 +183,8 @@ class MyTestCase(unittest.TestCase):
 
     def authenticate(self):
         with self.app.test_request_context('/auth',
-                                           data={"username": "testadmin",
-                                                 "password": "testpw"},
+                                           data={"username": self.testadmin,
+                                                 "password": self.testadminpw},
                                            method='POST'):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
@@ -245,8 +248,8 @@ class OverrideConfigTestCase(MyTestCase):
 class MyApiTestCase(MyTestCase):
     @classmethod
     def cls_auth(cls, app):
-        with app.test_request_context('/auth', data={"username": "testadmin",
-                                                     "password": "testpw"},
+        with app.test_request_context('/auth', data={"username": cls.testadmin,
+                                                     "password": cls.testadminpw},
                                       method='POST'):
             res = app.full_dispatch_request()
             assert res.status_code == 200

--- a/tests/base.py
+++ b/tests/base.py
@@ -222,6 +222,7 @@ class MyTestCase(unittest.TestCase):
                                            data=sorted_filter,
                                            headers={"Authorization": self.at}):
             res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res.data)
             self.assertTrue(res.is_json, res)
             result = res.json['result']
             self.assertIn('auditdata', result['value'])

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-
-from .base import MyApiTestCase
+from .base import MyApiTestCase, PWFILE2
 import json
 import os
 import datetime
@@ -9,8 +8,11 @@ from mock import mock
 from privacyidea.lib.policy import (set_policy, delete_policy, SCOPE, ACTION,
                                     enable_policy,
                                     PolicyClass)
-from privacyidea.lib.token import (get_tokens, init_token, remove_token, get_tokens_from_serial_or_user, enable_token,
+from privacyidea.lib.token import (get_tokens, init_token, remove_token,
+                                   get_tokens_from_serial_or_user, enable_token,
                                    check_serial_pass, get_realms_of_token, assign_token)
+from privacyidea.lib.resolver import save_resolver
+from privacyidea.lib.realm import set_realm
 from privacyidea.lib.user import User
 from privacyidea.lib.event import set_event, delete_event, EventConfiguration
 from privacyidea.lib.caconnector import save_caconnector
@@ -56,8 +58,7 @@ class API000TokenAdminRealmList(MyApiTestCase):
 
     def test_000_setup_realms(self):
         self.setUp_user_realms()
-
-        self.setUp_user_realms()
+        self.setUp_user_realm2()
 
         # create tokens
         t = init_token({"otpkey": self.otpkey},
@@ -79,12 +80,12 @@ class API000TokenAdminRealmList(MyApiTestCase):
         # admin is allowed to see realm1
         set_policy(name="pol-realm1",
                    scope=SCOPE.ADMIN,
-                   action="tokenlist", user="testadmin", realm=self.realm1)
+                   action=ACTION.TOKENLIST, user=self.testadmin, realm=self.realm1)
 
         # admin is allowed to list all realms
         set_policy(name="pol-all-realms",
                    scope=SCOPE.ADMIN,
-                   action="tokenlist", user="testadmin")
+                   action=ACTION.TOKENLIST, user=self.testadmin)
 
         # admin is allowed to only init, not list
         set_policy(name="pol-only-init",
@@ -126,6 +127,88 @@ class API000TokenAdminRealmList(MyApiTestCase):
             # we have two tokens
             self.assertEqual(0, result.get("value").get("count"))
 
+    def test_02_two_resolver_in_realm_policy_condition(self):
+        self.setUp_user_realms()
+        # add a second resolver to the realm
+        save_resolver({"resolver": self.resolvername2,
+                       "type": "passwdresolver",
+                       "fileName": PWFILE2})
+        added, failed = set_realm(self.realm1,
+                                  [self.resolvername2])
+        self.assertEquals(len(failed), 0)
+        self.assertEquals(len(added), 1)
+
+        # create token delete policy for "testadmin" on resolver1
+        set_policy(name="pol-reso1",
+                   scope=SCOPE.ADMIN,
+                   action=','.join([ACTION.DELETE, ACTION.ASSIGN, ACTION.UNASSIGN,
+                                    ACTION.DISABLE, ACTION.ENABLE]),
+                   user=self.testadmin,
+                   realm=self.realm1,
+                   resolver=self.resolvername1)
+
+        # create tokens for users in resolver 1 and 2
+        t1 = init_token({'type': 'spass'}, user=User(login='franzi',
+                                                     resolver=self.resolvername2,
+                                                     realm=self.realm1))
+        t2 = init_token({'type': 'spass'})
+
+        # assigning a token to a user from resolver2 should fail
+        with self.app.test_request_context('/token/assign',
+                                           method='POST',
+                                           data={"serial": t2.token.serial,
+                                                 "user": "franzi",
+                                                 "realm": self.realm1},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 403, res)
+            result = res.json.get("result")
+            self.assertEqual(result.get('error').get('code'), 303, result)
+
+        # unassign a token from a user in resolver2 should fail
+        with self.app.test_request_context('/token/unassign',
+                                           method='POST',
+                                           data={"serial": t1.token.serial},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 403, res)
+            result = res.json.get("result")
+            self.assertEqual(result.get('error').get('code'), 303, result)
+
+        # disable an active token from a user from resolver2 should fail
+        with self.app.test_request_context('/token/disable/{0!s}'.format(t1.token.serial),
+                                           method='POST',
+                                           data={},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 403, res)
+            result = res.json.get("result")
+            self.assertEqual(result.get('error').get('code'), 303, result)
+
+        # enable an inactive token from a user from resolver2 shoud fail
+        t1.token.active = False
+        with self.app.test_request_context('/token/enable/{0!s}'.format(t1.token.serial),
+                                           method='POST',
+                                           data={},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 403, res)
+            result = res.json.get("result")
+            self.assertEqual(result.get('error').get('code'), 303, result)
+
+        # token delete should fail for a token assigned to a user from resolver 2
+        with self.app.test_request_context('/token/{0!s}'.format(t1.token.serial),
+                                           method='DELETE',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 403, res)
+            result = res.json.get("result")
+            self.assertEqual(result.get('error').get('code'), 303, result)
+
+        # cleanup
+        remove_token(t1.token.serial)
+        remove_token(t2.token.serial)
+        delete_policy("pol-reso1")
 
 class APIAttestationTestCase(MyApiTestCase):
 
@@ -2205,7 +2288,7 @@ class API00TokenPerformance(MyApiTestCase):
     token_count = 21
 
     def test_00_create_some_tokens(self):
-        for i in range(0,self.token_count):
+        for i in range(0, self.token_count):
             init_token({"genkey": 1, "serial": "perf{0!s:0>3}".format(i)})
         toks = get_tokens(serial_wildcard="perf*")
         self.assertEqual(len(toks), self.token_count)


### PR DESCRIPTION
Check that an administrator for a different resolver in the same realm
is not allowed to perform actions on tokens assigned to users from the
other resolver.

Closes #2778