### PR TITLE
Reworking previous OTP check

### DIFF
--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -56,6 +56,10 @@ log = logging.getLogger(__name__)
 
 class TotpTokenClass(HotpTokenClass):
 
+    # In contrast to the HOTP the counter does not contain the next OTP value,
+    # but the last used OTP value, so we need to set this to 0.
+    previous_otp_offset = 0
+
     @log_with(log)
     def __init__(self, db_token):
         """

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -760,6 +760,9 @@ class ValidateAPITestCase(MyApiTestCase):
             result = res.json.get("result")
             self.assertTrue(result.get("status") is True, result)
             self.assertTrue(result.get("value") is False, result)
+            # This is the same OTP value, so we get the "previous otp value" message
+            detail = res.json.get("detail")
+            self.assertIn("previous otp used again", detail.get("message"))
 
     def test_03a_check_user_get(self):
         # Reset the counter!
@@ -3011,6 +3014,43 @@ class ValidateAPITestCase(MyApiTestCase):
         delete_policy("allow_hardware_tokens")
         remove_token("softwareToken")
         remove_token("hardwareToken")
+
+    def test_03b_check_previous_otp_with_totp(self):
+        token = init_token({"type": "totp",
+                            "serial": "totp_previous",
+                            "otpkey": self.otpkey},
+                           user=User("cornelius", self.realm1))
+        # get the OTP
+        counter = token._time2counter(time.time(), timeStepping=30)
+        otp_now = token._calc_otp(counter)
+
+        # test successful authentication
+        with self.app.test_request_context('/validate/check',
+                                           method='GET',
+                                           query_string=urlencode(
+                                                    {"user": "cornelius",
+                                                     "pass": otp_now})):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertTrue(result.get("status"))
+            self.assertTrue(result.get("value"))
+
+        # check the same OTP value again
+        with self.app.test_request_context('/validate/check',
+                                           method='GET',
+                                           query_string=urlencode(
+                                                    {"user": "cornelius",
+                                                     "pass": otp_now})):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertTrue(result.get("status"))
+            self.assertFalse(result.get("value"))
+            detail = res.json.get("detail")
+            self.assertIn("previous otp used again", detail.get("message"))
+        # clean up
+        remove_token("totp_previous")
 
 
 class RegistrationValidity(MyApiTestCase):

--- a/tests/test_lib_tokens_hotp.py
+++ b/tests/test_lib_tokens_hotp.py
@@ -341,6 +341,9 @@ class HOTPTokenTestCase(MyTestCase):
         # OTP does exist
         res = token.check_otp_exist("969429")
         self.assertTrue(res == 3, res)
+        # check is_previous_otp
+        r = token.is_previous_otp("969429")
+        self.assertTrue(r)
 
     def test_14_split_pin_pass(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()
@@ -652,7 +655,7 @@ class HOTPTokenTestCase(MyTestCase):
         token.check_otp("67062674")
 
     def test_26_is_previous_otp(self):
-        # check if the OTP was used prebiously
+        # check if the OTP was used previously
         serial = "previous"
         db_token = Token(serial, tokentype="hotp")
         db_token.save()
@@ -677,8 +680,13 @@ class HOTPTokenTestCase(MyTestCase):
         """
         r = token.check_otp("969429")
         self.assertEqual(r, 3)
+        # Too old
         r = token.is_previous_otp("755224")
+        self.assertEqual(r, False)
+        # The very previous OTP, that was just used in check_otp
+        r = token.is_previous_otp("969429")
         self.assertEqual(r, True)
+        # Future value
         r = token.is_previous_otp("254676")
         self.assertEqual(r, False)
         r = token.check_otp("254676")

--- a/tests/test_lib_tokens_totp.py
+++ b/tests/test_lib_tokens_totp.py
@@ -746,7 +746,7 @@ class TOTPTokenTestCase(MyTestCase):
         ts0 = float(token.get_tokeninfo("timeShift"))
         self.assertTrue(-31 < ts0 < 31)
         # Too old
-        r = token.is_previous_otp(token._calc_otp(counter-3))
+        r = token.is_previous_otp(token._calc_otp(counter - 3))
         self.assertEqual(r, False)
         ts = float(token.get_tokeninfo("timeShift"))
         self.assertEqual(ts, ts0)
@@ -756,7 +756,7 @@ class TOTPTokenTestCase(MyTestCase):
         ts = float(token.get_tokeninfo("timeShift"))
         self.assertEqual(ts, ts0)
         # Future value
-        r = token.is_previous_otp(token._calc_otp(counter+8))
+        r = token.is_previous_otp(token._calc_otp(counter + 8))
         self.assertEqual(r, False)
         ts = float(token.get_tokeninfo("timeShift"))
         self.assertEqual(ts, ts0)

--- a/tests/test_lib_tokens_totp.py
+++ b/tests/test_lib_tokens_totp.py
@@ -744,7 +744,7 @@ class TOTPTokenTestCase(MyTestCase):
         self.assertEqual(r, counter)
         # Now we try several is_previous_otp and the timeShift must stay the same!
         ts0 = float(token.get_tokeninfo("timeShift"))
-        self.assertTrue(-31 < ts0 < 31)
+        self.assertTrue(-181 < ts0 < 181)
         # Too old
         r = token.is_previous_otp(token._calc_otp(counter - 3))
         self.assertEqual(r, False)


### PR DESCRIPTION
We now only check if the last HOTP value was used or
if for TOTP tokens the last OTP value that was used for
authentication was used again.

This gets logged to the log file.

Closes #2916