### PR TITLE
Add PyKCS11 to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,8 @@ setup(
                  "pytest-cov>=2.5.1",
                  "responses>=0.9.0",
                  "testfixtures>=6.14.2"],
-        'postgres': ['psycopg2>=2.8.3']
+        'postgres': ['psycopg2>=2.8.3'],
+        'hsm': ['PyKCS11>=1.5.10']
     },
     install_requires=install_requires,
     include_package_data=True,


### PR DESCRIPTION
We add an extras_require "hsm" to also install PyKCS11.
This way we can build packages, that contain PyKCS11 so that
these will immediately run with HSMs as security module.

Closes #2951