### PR TITLE
Fix NEW routes of most config objects

### DIFF
--- a/privacyidea/static/components/config/controllers/privacyideaServerController.js
+++ b/privacyidea/static/components/config/controllers/privacyideaServerController.js
@@ -51,7 +51,7 @@ myApp.controller("privacyideaServerController", ["$scope", "$stateParams", "info
 
     $scope.identifier = $stateParams.identifier;
     if ($scope.identifier) {
-        // We are editing an existing RADIUS Server
+        // We are editing an existing privacyIDEA Server
         $scope.getPrivacyideaServers($scope.identifier);
         } else {
         // This is a new privacyIDEA server

--- a/privacyidea/static/components/config/controllers/privacyideaServerController.js
+++ b/privacyidea/static/components/config/controllers/privacyideaServerController.js
@@ -25,19 +25,9 @@ myApp.controller("privacyideaServerController", ["$scope", "$stateParams", "info
                                                           inform, gettextCatalog,
                                                           $state, $location,
                                                           ConfigFactory) {
+    // Set the default route
     if ($location.path() === "/config/privacyideaserver") {
         $location.path("/config/privacyideaserver/list");
-    }
-
-    $scope.identifier = $stateParams.identifier;
-    if ($scope.identifier) {
-        // We are editing an existing RADIUS Server
-        $scope.getPrivacyideaServers($scope.identifier);
-        } else {
-        // This is a new privacyIDEA server
-        $scope.params = {
-            tls: true
-        }
     }
 
     // Get all servers
@@ -54,6 +44,22 @@ myApp.controller("privacyideaServerController", ["$scope", "$stateParams", "info
         });
     };
 
+    if ($location.path() === "/config/privacyideaserver/list") {
+    // in case of list we fetch all servers
+        $scope.getPrivacyideaServers();
+    }
+
+    $scope.identifier = $stateParams.identifier;
+    if ($scope.identifier) {
+        // We are editing an existing RADIUS Server
+        $scope.getPrivacyideaServers($scope.identifier);
+        } else {
+        // This is a new privacyIDEA server
+        $scope.params = {
+            tls: true
+        }
+    }
+
     $scope.delPrivacyideaServer = function (identifier) {
         ConfigFactory.delPrivacyidea(identifier, function(data) {
             $scope.getPrivacyideaServers();
@@ -65,8 +71,6 @@ myApp.controller("privacyideaServerController", ["$scope", "$stateParams", "info
             $scope.getPrivacyideaServers();
         });
     };
-
-    $scope.getPrivacyideaServers();
 
     $scope.testPrivacyideaServer = function() {
         ConfigFactory.testPrivacyidea($scope.params, function(data) {

--- a/privacyidea/static/components/config/controllers/radiusServerController.js
+++ b/privacyidea/static/components/config/controllers/radiusServerController.js
@@ -33,6 +33,9 @@ myApp.controller("radiusServerController", ["$scope", "$stateParams", "inform",
     if ($scope.identifier) {
         // We are editing an existing RADIUS Server
         $scope.getRadiusServers($scope.identifier);
+    } else {
+        // This is a new RADIUS Server
+        $scope.params = { };
     }
 
     // Get all servers

--- a/privacyidea/static/components/config/controllers/radiusServerController.js
+++ b/privacyidea/static/components/config/controllers/radiusServerController.js
@@ -25,17 +25,9 @@ myApp.controller("radiusServerController", ["$scope", "$stateParams", "inform",
                                                      inform, gettextCatalog,
                                                      $state, $location,
                                                      ConfigFactory) {
+    // Set the default route
     if ($location.path() === "/config/radius") {
         $location.path("/config/radius/list");
-    }
-
-    $scope.identifier = $stateParams.identifier;
-    if ($scope.identifier) {
-        // We are editing an existing RADIUS Server
-        $scope.getRadiusServers($scope.identifier);
-    } else {
-        // This is a new RADIUS Server
-        $scope.params = { };
     }
 
     // Get all servers
@@ -52,6 +44,20 @@ myApp.controller("radiusServerController", ["$scope", "$stateParams", "inform",
         });
     };
 
+    if ($location.path() === "/config/radius/list") {
+        // In the case of list, we fetch all radius servers
+        $scope.getRadiusServers();
+    }
+
+    $scope.identifier = $stateParams.identifier;
+    if ($scope.identifier) {
+        // We are editing an existing RADIUS Server
+        $scope.getRadiusServers($scope.identifier);
+    } else {
+        // This is a new RADIUS Server or the list
+        $scope.params = { };
+    }
+
     $scope.delRadiusServer = function (identifier) {
         ConfigFactory.delRadius(identifier, function(data) {
             $scope.getRadiusServers();
@@ -63,8 +69,6 @@ myApp.controller("radiusServerController", ["$scope", "$stateParams", "inform",
             $scope.getRadiusServers();
         });
     };
-
-    $scope.getRadiusServers();
 
     $scope.testRadiusRequest = function() {
         ConfigFactory.testRadius($scope.params, function(data) {
@@ -89,6 +93,6 @@ myApp.controller("radiusServerController", ["$scope", "$stateParams", "inform",
         });
     };
 
-        // listen to the reload broadcast
+    // listen to the reload broadcast
     $scope.$on("piReload", $scope.getRadiusServers);
 }]);

--- a/privacyidea/static/components/config/controllers/smtpServerController.js
+++ b/privacyidea/static/components/config/controllers/smtpServerController.js
@@ -24,21 +24,9 @@ myApp.controller("smtpServerController", ["$scope", "$stateParams", "inform",
                                           function($scope, $stateParams, inform,
                                                    gettextCatalog, $state,
                                                    $location, ConfigFactory) {
+    // set the default route
     if ($location.path() === "/config/smtp") {
         $location.path("/config/smtp/list");
-    }
-
-    $scope.identifier = $stateParams.identifier;
-    if ($scope.identifier) {
-        // We are editing an existing SMTP Server
-        $scope.getSmtpServers($scope.identifier);
-    } else {
-        // This is a new SMTP server
-        $scope.params = {
-            tls: true,
-            port: 25,
-            timeout: 10
-        }
     }
 
     // Get all servers
@@ -55,6 +43,24 @@ myApp.controller("smtpServerController", ["$scope", "$stateParams", "inform",
         });
     };
 
+    if ($location.path() == "/config/smtp/list") {
+        // in case of list we fetch all smtp servers
+        $scope.getSmtpServers();
+    }
+
+    $scope.identifier = $stateParams.identifier;
+    if ($scope.identifier) {
+        // We are editing an existing SMTP Server
+        $scope.getSmtpServers($scope.identifier);
+    } else {
+        // This is a new SMTP server
+        $scope.params = {
+            tls: true,
+            port: 25,
+            timeout: 10
+        }
+    }
+
     $scope.delSmtpServer = function (identifier) {
         ConfigFactory.delSmtp(identifier, function(data) {
             $scope.getSmtpServers();
@@ -66,8 +72,6 @@ myApp.controller("smtpServerController", ["$scope", "$stateParams", "inform",
             $scope.getSmtpServers();
         });
     };
-
-    $scope.getSmtpServers();
 
     $scope.sendTestEmail = function() {
         ConfigFactory.testSmtp($scope.params, function(data) {

--- a/privacyidea/static/components/config/states/states.js
+++ b/privacyidea/static/components/config/states/states.js
@@ -153,6 +153,11 @@ angular.module('privacyideaApp.configStates', ['ui.router', 'privacyideaApp.vers
                     controller: "policyDetailsController",
                     params: { policyname: null },
                 })
+                .state('config.policies.add', {
+                    url: "/details/",
+                    templateUrl: configpath + "config.policies.details.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "policyDetailsController"
+                })
                 .state('config.tokens', {
                     url: "/tokens/:tokentype",
                     templateUrl: configpath + "config.tokens.html" + versioningSuffixProviderProvider.$get().$get(),
@@ -184,8 +189,12 @@ angular.module('privacyideaApp.configStates', ['ui.router', 'privacyideaApp.vers
                 .state('config.smtp.edit', {
                     url: "/edit/:identifier",
                     templateUrl: configpath + "config.smtp.edit.html" + versioningSuffixProviderProvider.$get().$get(),
-                    controller: "smtpServerController",
-                    params: { identifier: null },
+                    controller: "smtpServerController"
+                })
+                .state('config.smtp.add', {
+                    url: "/edit/",
+                    templateUrl: configpath + "config.smtp.edit.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "smtpServerController"
                 })
                 .state('config.smsgateway', {
                     url: "/smsgateway",
@@ -200,8 +209,12 @@ angular.module('privacyideaApp.configStates', ['ui.router', 'privacyideaApp.vers
                 .state('config.smsgateway.edit', {
                     url: "/edit/:gateway_id",
                     templateUrl: configpath + "config.smsgateway.edit.html" + versioningSuffixProviderProvider.$get().$get(),
-                    controller: "smsgatewayController",
-                    params: { gateway_id: null },
+                    controller: "smsgatewayController"
+                })
+                .state('config.smsgateway.add', {
+                    url: "/edit/",
+                    templateUrl: configpath + "config.smsgateway.edit.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "smsgatewayController"
                 })
                 .state('config.radius', {
                     url: "/radius",
@@ -216,8 +229,12 @@ angular.module('privacyideaApp.configStates', ['ui.router', 'privacyideaApp.vers
                 .state('config.radius.edit', {
                     url: "/edit/:identifier",
                     templateUrl: configpath + "config.radius.edit.html" + versioningSuffixProviderProvider.$get().$get(),
-                    controller: "radiusServerController",
-                    params: { identifier: null },
+                    controller: "radiusServerController"
+                })
+                .state('config.radius.add', {
+                    url: "/edit/",
+                    templateUrl: configpath + "config.radius.edit.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "radiusServerController"
                 })
                 .state('config.privacyideaserver', {
                     url: "/privacyideaserver",
@@ -232,8 +249,12 @@ angular.module('privacyideaApp.configStates', ['ui.router', 'privacyideaApp.vers
                 .state('config.privacyideaserver.edit', {
                     url: "/edit/:identifier",
                     templateUrl: configpath + "config.privacyideaserver.edit.html" + versioningSuffixProviderProvider.$get().$get(),
-                    controller: "privacyideaServerController",
-                    params: { identifier: null },
+                    controller: "privacyideaServerController"
+                })
+                .state('config.privacyideaserver.add', {
+                    url: "/edit/",
+                    templateUrl: configpath + "config.privacyideaserver.edit.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "privacyideaServerController"
                 })
                 .state('config.events', {
                     url: "/events",
@@ -243,8 +264,12 @@ angular.module('privacyideaApp.configStates', ['ui.router', 'privacyideaApp.vers
                 .state('config.events.details', {
                     url: "/details/:eventid",
                     templateUrl: configpath + "config.events.details.html" + versioningSuffixProviderProvider.$get().$get(),
-                    controller: "eventDetailController",
-                    params: { eventid: null },
+                    controller: "eventDetailController"
+                })
+                .state('config.events.add', {
+                    url: "/details/",
+                    templateUrl: configpath + "config.events.details.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "eventDetailController"
                 })
                 .state('config.events.list', {
                     url: "/list",
@@ -264,8 +289,12 @@ angular.module('privacyideaApp.configStates', ['ui.router', 'privacyideaApp.vers
                 .state('config.periodictasks.details', {
                     url: "/details/:ptaskid",
                     templateUrl: configpath + "config.periodictasks.details.html" + versioningSuffixProviderProvider.$get().$get(),
-                    controller: "periodicTaskDetailController",
-                    params: { ptaskid: null },
+                    controller: "periodicTaskDetailController"
+                })
+                .state('config.periodictasks.add', {
+                    url: "/details/",
+                    templateUrl: configpath + "config.periodictasks.details.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "periodicTaskDetailController"
                 })
             ;
         }]);

--- a/privacyidea/static/components/config/views/config.events.html
+++ b/privacyidea/static/components/config/views/config.events.html
@@ -9,8 +9,8 @@
                         All Event Handlers</a></li>
                 <li role="presentation"
                     ng-show="checkRight('eventhandling_write')"
-                    ng-class="{ active: $state.includes('config.events.details')}">
-                    <a ui-sref="config.events.details"
+                    ng-class="{ active: $state.includes('config.events.add')}">
+                    <a ui-sref="config.events.add"
                        translate>Create new Event Handler</a></li>
             </ul>
         </div>

--- a/privacyidea/static/components/config/views/config.periodictasks.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.html
@@ -9,8 +9,8 @@
                         All Periodic Tasks</a></li>
                 <li role="presentation"
                     ng-show="checkRight('periodictask_write')"
-                    ng-class="{ active: $state.includes('config.periodictasks.details')}">
-                    <a ui-sref="config.periodictasks.details"
+                    ng-class="{ active: $state.includes('config.periodictasks.add')}">
+                    <a ui-sref="config.periodictasks.add"
                        translate>Create new Periodic Task</a></li>
             </ul>
         </div>

--- a/privacyidea/static/components/config/views/config.policies.html
+++ b/privacyidea/static/components/config/views/config.policies.html
@@ -9,8 +9,8 @@
                         All Policies</a></li>
                 <li role="presentation"
                     ng-show="checkRight('policywrite')"
-                    ng-class="{ active: $state.includes('config.policies.details')}">
-                    <a ui-sref="config.policies.details"
+                    ng-class="{ active: $state.includes('config.policies.add')}">
+                    <a ui-sref="config.policies.add"
                        translate>Create new Policy</a></li>
             </ul>
         </div>

--- a/privacyidea/static/components/config/views/config.privacyideaserver.html
+++ b/privacyidea/static/components/config/views/config.privacyideaserver.html
@@ -9,11 +9,10 @@
                         definitions</a></li>
                 <li role="presentation"
                     ng-show="checkRight('privacyideaserver_write')"
-                    >
-                    <a ui-sref="config.privacyideaserver.edit" translate>
+                    ng-class="{ active: $state.includes('config.privacyideaserver.add')}">
+                    <a ui-sref="config.privacyideaserver.add" translate>
                         New privacyIDEA server
                     </a>
-
                 </li>
             </ul>
         </div>

--- a/privacyidea/static/components/config/views/config.radius.html
+++ b/privacyidea/static/components/config/views/config.radius.html
@@ -7,12 +7,11 @@
                     <a ui-sref="config.radius.list"
                             translate>List RADIUS server definitions</a></li>
                 <li role="presentation"
-                    ng-show="checkRight('radiusserver_write')"
-                    >
-                    <a ui-sref="config.radius.edit" translate>
+                    ng-class="{ active: $state.includes('config.radius.add')}"
+                    ng-show="checkRight('radiusserver_write')">
+                    <a ui-sref="config.radius.add" translate>
                         New RADIUS server
                     </a>
-
                 </li>
             </ul>
         </div>

--- a/privacyidea/static/components/config/views/config.smsgateway.html
+++ b/privacyidea/static/components/config/views/config.smsgateway.html
@@ -8,9 +8,10 @@
                         All SMS Gateways</a></li>
                 <li role="presentation"
                     ng-show="checkRight('smsgateway_write')"
-                    ng-class="{ active: $state.includes('config.smsgateway.edit')}">
-                    <a ui-sref="config.smsgateway.edit"
-                       translate>Create new SMS Gateway definition</a></li>
+                    ng-class="{ active: $state.includes('config.smsgateway.add')}">
+                    <a ui-sref="config.smsgateway.add" translate>
+                        Create new SMS Gateway definition
+                    </a></li>
             </ul>
         </div>
 

--- a/privacyidea/static/components/config/views/config.smtp.html
+++ b/privacyidea/static/components/config/views/config.smtp.html
@@ -7,12 +7,11 @@
                     <a ui-sref="config.smtp.list"
                             translate>List SMTP server definitions</a></li>
                 <li role="presentation"
-                    >
-                    <a ui-sref="config.smtp.edit" translate
-                       ng-show="checkRight('smtpserver_write')">
+                    ng-class="{ active: $state.includes('config.smtp.add')}"
+                    ng-show="checkRight('smtpserver_write')">
+                    <a ui-sref="config.smtp.add" translate>
                         New SMTP server
                     </a>
-
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
The route/state of creating an object
was broken. Previouly it was the edit-state
without a given object parameter.
This some either broke or never worked correctly.

I added an additional state like
  config.radius.add
to explicitly reference, when a new configuration
would be created.
This fixed the problem with the link and the
problem with the highlighting.

Closes #2546