### PR TITLE
Fix reload of policy list

### DIFF
--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -61,9 +61,10 @@ myApp.controller("policyListController", ["$scope", "$stateParams", "$location",
         });
     };
 
-
-
     $scope.getPolicies();
+
+    // listen to the reload broadcast
+    $scope.$on("piReload", $scope.getPolicies);
 }]);
 
 myApp.controller("policyDetailsController", ["$scope", "$stateParams",


### PR DESCRIPTION
The policyListController does not register on the reload
function, so the getPolicies() is not called.
We register "getPolicies", so policies will be reloaded.

Closes #2967