### PR TITLE
Complete policy-action documentation

### DIFF
--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -290,7 +290,7 @@ yubikey_access_code
 type: string
 
 This is a 12 character long access code in hex format to be used to initialize Yubikeys.
-This access code is not actively used by the privacyIDEA server. It is ment to be read by
+This access code is not actively used by the privacyIDEA server. It is meant to be read by
 an admin client or enrollment client, so the component initializing the Yubikey can use this
 access code, without the operator knowing the code.
 

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -289,14 +289,20 @@ yubikey_access_code
 
 type: string
 
-This is a 12 character long access code in hex format to be used to initialize Yubikeys. If
-no access code is set, Yubikeys can be re-initialized by everybody. You can choose
-a company wide access code, so that Yubikeys can only be re-initialized by your own system.
+This is a 12 character long access code in hex format to be used to initialize Yubikeys.
+This access code is not actively used by the privacyIDEA server. It is ment to be read by
+an admin client or enrollment client, so the component initializing the Yubikey can use this
+access code, without the operator knowing the code.
+
+If a yubikey uses an access code, Yubikeys can only be re-initialized by persons know this code.
+You could choose a company wide access code, so that Yubikeys can only be re-initialized by your own system.
 
 You can add two access codes separated by a colon to change from one access code to the other.
 
    313233343536:414243444546
 
+.. note:: As long as the enrollment client does not read and uses this access code, this configuration
+   has no effect.
 
 papertoken_count
 ~~~~~~~~~~~~~~~~

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -294,14 +294,14 @@ This access code is not actively used by the privacyIDEA server. It is meant to 
 an admin client or enrollment client, so the component initializing the Yubikey can use this
 access code, without the operator knowing the code.
 
-If a yubikey uses an access code, Yubikeys can only be re-initialized by persons know this code.
+If a yubikey uses an access code, Yubikeys can only be re-initialized by persons who know this code.
 You could choose a company wide access code, so that Yubikeys can only be re-initialized by your own system.
 
 You can add two access codes separated by a colon to change from one access code to the other.
 
    313233343536:414243444546
 
-.. note:: As long as the enrollment client does not read and uses this access code, this configuration
+.. note:: As long as the enrollment client does not read and use this access code, this configuration
    has no effect.
 
 papertoken_count

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -142,11 +142,6 @@ class HotpTokenClass(TokenClass):
                            'desc': _("The user may only have this maximum number of active HOTP tokens assigned."),
                            'group': GROUP.TOKEN
                        },
-                       'yubikey_access_code': {
-                           'type': 'str',
-                           'desc': _("The Yubikey access code used to "
-                                     "initialize Yubikeys.")
-                       },
                        'hotp_2step_clientsize': {
                            'type': 'int',
                            'desc': _("The size of the OTP seed part contributed "

--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -175,7 +175,12 @@ class YubikeyTokenClass(TokenClass):
                            'desc': _(
                                "The user may only have this maximum number of active Yubikey tokens assigned."),
                            'group': GROUP.TOKEN
-                       }
+                       },
+                       'yubikey_access_code': {
+                           'type': 'str',
+                           'desc': _("The Yubikey access code can be read by an enrollment client to "
+                                     "initialize Yubikeys.")
+                       },
                    }
                }
         }


### PR DESCRIPTION
The yubikey_access_code is not actively used
by the server but only ment to be read by the
enrollment client.

I moved the definition from the HOTPTokenClass
to the YubikeyTokenClass, so that the policy is
not automatically prefixed with `hotp_`, which
is confusing.

Closes #2768