### PR TITLE
2441/verify enrollment

### DIFF
--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -445,7 +445,7 @@ type: string
 
 This action takes a white space separated list of tokentypes.
 These tokens then need to be verified during enrollment.
-This is supported for HOTP and TOTP tokens.
+This is supported for HOTP, TOTP, Email and SMS tokens.
 
 In this case after enrolling the token the user is queried to enter
 a valid OTP value. This way the system can verify, that the user has

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -437,6 +437,24 @@ verification during authentication, see :ref:`policy_push_ssl_verify_auth`.
 
 .. _policy_webauthn_enroll_relying_party_id:
 
+
+verify_enrollment
+~~~~~~~~~~~~~~~~~
+
+type: string
+
+This action takes a white space separated list of tokentypes.
+These tokens then need to be verified during enrollment.
+This is supported for HOTP and TOTP tokens.
+
+In this case after enrolling the token the user is queried to enter
+a valid OTP value. This way the system can verify, that the user has
+successfully enrolled the token.
+
+As long as no OTP value is provided by the user during the enrollment process, the
+token can not be used for authentication.
+
+
 webauthn_relying_party_id
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -812,6 +812,7 @@ def check_verify_enrollment(request, response):
                 content["detail"]["verify"] = tokenobj.prepare_verify_enrollment()
                 content["detail"]["rollout_state"] = ROLLOUTSTATE.VERIFYPENDING
                 tokenobj.token.rollout_state = ROLLOUTSTATE.VERIFYPENDING
+                tokenobj.token.save()
                 response.set_data(json.dumps(content))
     else:
         log.warning("No distinct token object found in enrollment response!")

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -784,6 +784,10 @@ def check_verify_enrollment(request, response):
     :return:
     """
     serial = response.json.get("detail").get("serial")
+    verify = request.all_data.get("verify")
+    if verify:
+        # In case we are in a 2nd step verification, we must early exit
+        return response
     tokenobj_list = get_tokens(serial=serial)
     if len(tokenobj_list) == 1:
         tokenobj = tokenobj_list[0]

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -64,6 +64,7 @@ from privacyidea.lib.realm import get_default_realm
 from privacyidea.lib.subscriptions import subscription_status
 from privacyidea.lib.utils import create_img
 from privacyidea.lib.config import get_privacyidea_node
+from privacyidea.lib.tokenclass import ROLLOUTSTATE
 
 log = logging.getLogger(__name__)
 
@@ -767,5 +768,48 @@ def is_authorized(request, response):
     if authorized_pol:
         if list(authorized_pol)[0] == AUTHORIZED.DENY:
             raise ValidateError("User is not authorized to authenticate under these conditions.")
+
+    return response
+
+
+def check_verify_enrollment(request, response):
+    """
+    This policy decorator is used in the ENROLL scope to
+    decorate the /token/init
+    If will check for action=verify_enrollment and ask the user
+    in a 2nd step to provide information to verify, that the token was successfully enrolled.
+
+    :param request:
+    :param response:
+    :return:
+    """
+    serial = response.json.get("detail").get("serial")
+    tokenobj_list = get_tokens(serial=serial)
+    if len(tokenobj_list) == 1:
+        tokenobj = tokenobj_list[0]
+        # check if this token type can do verify enrollment
+        if tokenobj.can_verify_enrollment:
+            # Get policies
+            verify_pol_dict = Match.user(g, scope=SCOPE.ENROLL, action=ACTION.VERIFY_ENROLLMENT,
+                                         user_object=request.User).action_values(unique=False,
+                                                                                 allow_white_space_in_action=True,
+                                                                                 write_to_audit_log=False)
+            # verify_pol_dict.keys() is a list of actions from several policies. It
+            # could look like this:
+            # ["hotp totp", "hotp email"]
+            do_verify_enrollment = False
+            for toks in verify_pol_dict:
+                if tokenobj.get_tokentype().upper() in [x.upper() for x in toks.split(" ")]:
+                    # This token is supposed to do verify enrollment
+                    do_verify_enrollment = True
+                    g.audit_object.add_policy(verify_pol_dict.get(toks))
+            if do_verify_enrollment:
+                content = response.json
+                content["detail"]["verify"] = tokenobj.prepare_verify_enrollment()
+                content["detail"]["rollout_state"] = ROLLOUTSTATE.VERIFYPENDING
+                tokenobj.token.rollout_state = ROLLOUTSTATE.VERIFYPENDING
+                response.set_data(json.dumps(content))
+    else:
+        log.warning("No distinct token object found in enrollment response!")
 
     return response

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -681,7 +681,7 @@ def verify_enrollment(request=None, action=None):
     """
     This is used to verify an already enrolled token.
     The parameter "verify" is used to do so. If successful,
-    the current rollout_state "verify_pending" of the token will be changed to "enrolled".
+    the current rollout_state "verify" of the token will be changed to "enrolled".
     :param request:
     :param action:
     :return:

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -270,7 +270,7 @@ def init():
     The first API call to /token/init returns responses in
 
         {"detail": {"verify": {"message": "Please provide a valid OTP value."},
-                    "rollout_state": "verify_pending"}}
+                    "rollout_state": "verify"}}
 
     The second API call then needs to send the serial number and a response
 
@@ -281,7 +281,7 @@ def init():
            serial=<serial from the previous response>
            verify=<e.g. the OTP value>
 
-    As long as the token is in state "verify_pending" it can not be used for
+    As long as the token is in state "verify" it can not be used for
     authentication.
     """
     response_details = {}

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -99,7 +99,7 @@ from privacyidea.api.lib.prepolicy import (prepolicy, check_base_action,
                                            indexedsecret_force_attribute,
                                            check_admin_tokenlist, webauthntoken_enroll, webauthntoken_allowed,
                                            webauthntoken_request, required_piv_attestation)
-from privacyidea.api.lib.postpolicy import (save_pin_change,
+from privacyidea.api.lib.postpolicy import (save_pin_change, check_verify_enrollment,
                                             postpolicy)
 from privacyidea.lib.event import event
 from privacyidea.api.auth import admin_required
@@ -147,6 +147,7 @@ To see how to authenticate read :ref:`rest_auth`.
 @prepolicy(webauthntoken_enroll, request)
 @prepolicy(required_piv_attestation, request)
 @postpolicy(save_pin_change, request)
+@postpolicy(check_verify_enrollment, request)
 @CheckSubscription(request)
 @event("token_init", request, g)
 @log_with(log, log_entry=False)

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -96,6 +96,7 @@ from privacyidea.api.lib.prepolicy import (prepolicy, check_base_action,
                                            twostep_enrollment_parameters,
                                            sms_identifiers, pushtoken_add_config,
                                            check_admin_tokenlist,
+                                           verify_enrollment,
                                            indexedsecret_force_attribute,
                                            check_admin_tokenlist, webauthntoken_enroll, webauthntoken_allowed,
                                            webauthntoken_request, required_piv_attestation)
@@ -146,6 +147,7 @@ To see how to authenticate read :ref:`rest_auth`.
 @prepolicy(webauthntoken_request, request)
 @prepolicy(webauthntoken_enroll, request)
 @prepolicy(required_piv_attestation, request)
+@prepolicy(verify_enrollment, request)
 @postpolicy(save_pin_change, request)
 @postpolicy(check_verify_enrollment, request)
 @CheckSubscription(request)
@@ -254,6 +256,33 @@ def init():
     Base Tokenclass contains an extremely simple way by concatenating the 
     two parts. See
     :func:`~privacyidea.lib.tokenclass.TokenClass.generate_symmetric_key`
+
+    **verify enrollment**
+
+    Some tokens can be configured via enrollment policy so that the user
+    needs to provide some verification that e.g. a QR code was scanned correctly or
+    the token works correctly in general.
+    The specific way depends on the token class.
+    The necessary token class functions are
+    :func:`~privacyidea.lib.tokenclass.TokenClass.verify_enrollment`
+    :func:`~privacyidea.lib.tokenclass.TokenClass.prepare_verify_enrollment`
+
+    The first API call to /token/init returns responses in
+
+        {"detail": {"verify": {"message": "Please provide a valid OTP value."},
+                    "rollout_state": "verify_pending"}}
+
+    The second API call then needs to send the serial number and a response
+
+       .. sourcecode:: http
+
+           POST /token/init
+
+           serial=<serial from the previous response>
+           verify=<e.g. the OTP value>
+
+    As long as the token is in state "verify_pending" it can not be used for
+    authentication.
     """
     response_details = {}
     tokenrealms = None

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -2161,7 +2161,7 @@ def get_static_policy_definitions(scope=None):
                 'group': GROUP.TOKEN},
             ACTION.VERIFY_ENROLLMENT: {
                 'type': 'str',
-                'desc': _("Specify a comma separated list of token types, "
+                'desc': _("Specify a white space separated list of token types, "
                           "that should be verified during enrollment."),
                 'group': GROUP.TOKEN}
         },

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -372,6 +372,7 @@ class ACTION(object):
     SHOW_NODE = "show_node"
     SET_USER_ATTRIBUTES = "set_custom_user_attributes"
     DELETE_USER_ATTRIBUTES = "delete_custom_user_attributes"
+    VERIFY_ENROLLMENT = "verify_enrollment"
 
 
 class TYPE(object):
@@ -399,6 +400,7 @@ class GROUP(object):
     MODIFYING_RESPONSE = "modifying response"
     CONDITIONS = "conditions"
     SETTING_ACTIONS = "setting actions"
+
 
 class MAIN_MENU(object):
     __doc__ = """These are the allowed top level menu items. These are used
@@ -2156,8 +2158,12 @@ def get_static_policy_definitions(scope=None):
                           "(c)haracters, (n)umeric, "
                           "(s)pecial. Use modifiers +/- or a list "
                           "of allowed characters [1234567890]"),
-                'group': GROUP.TOKEN
-            }
+                'group': GROUP.TOKEN},
+            ACTION.VERIFY_ENROLLMENT: {
+                'type': 'str',
+                'desc': _("Specify a comma separated list of token types, "
+                          "that should be verified during enrollment."),
+                'group': GROUP.TOKEN}
         },
         SCOPE.AUTH: {
             ACTION.OTPPIN: {

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -150,6 +150,7 @@ class ROLLOUTSTATE(object):
     PENDING = 'pending'
     # This means the user needs to authenticate to verify that the token was successfully enrolled.
     VERIFYPENDING = 'verify_pending'
+    ENROLLED = 'enrolled'
 
 
 class TokenClass(object):
@@ -543,6 +544,7 @@ class TokenClass(object):
         otpKey = getParam(param, "otpkey", optional)
         genkey = is_true(getParam(param, "genkey", optional))
         twostep_init = is_true(getParam(param, "2stepinit", optional))
+        verify = getParam(param, "verify", optional)
         otpkeyformat = getParam(param, "otpkeyformat", optional)
 
         if otpKey is not None and otpkeyformat is not None:
@@ -574,8 +576,8 @@ class TokenClass(object):
         if otpKey is None and genkey:
             otpKey = self._genOtpKey_(key_size)
 
-        # otpKey still None?? - raise the exception
-        if otpKey is None and self.hKeyRequired is True:
+        # otpKey still None?? - raise the exception, if an otpkey is required and we are not in verify state
+        if otpKey is None and self.hKeyRequired is True and not verify:
             otpKey = getParam(param, "otpkey", required)
 
         if otpKey is not None:

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -149,7 +149,7 @@ class ROLLOUTSTATE(object):
     CLIENTWAIT = 'clientwait'
     PENDING = 'pending'
     # This means the user needs to authenticate to verify that the token was successfully enrolled.
-    VERIFYPENDING = 'verify_pending'
+    VERIFYPENDING = 'verify'
     ENROLLED = 'enrolled'
 
 
@@ -1828,6 +1828,3 @@ class TokenClass(object):
         :return: True
         """
         return False
-
-    def set_verify_enrollment_state(self):
-        self.token.rollout_state = ROLLOUTSTATE.VERIFYPENDING

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -69,6 +69,7 @@ import logging
 import traceback
 import datetime
 from privacyidea.lib.tokens.smstoken import HotpTokenClass
+from privacyidea.lib.tokens.hotptoken import VERIFY_ENROLLMENT_MESSAGE
 from privacyidea.lib.config import get_from_config
 from privacyidea.api.lib.utils import getParam
 from privacyidea.lib.utils import is_true, create_tag_dict
@@ -99,6 +100,8 @@ class EmailTokenClass(HotpTokenClass):
     """
 
     EMAIL_ADDRESS_KEY = "email"
+    # The HOTP token provides means to verify the enrollment
+    can_verify_enrollment = True
 
     def __init__(self, aToken):
         HotpTokenClass.__init__(self, aToken)
@@ -213,18 +216,20 @@ class EmailTokenClass(HotpTokenClass):
         :return: nothing
 
         """
-        if getParam(param, "dynamic_email", optional=True):
-            self.add_tokeninfo("dynamic_email", True)
-        else:
-            # specific - e-mail
-            self._email_address = getParam(param,
-                                           self.EMAIL_ADDRESS_KEY,
-                                           optional=False)
+        verify = getParam(param, "verify", optional=True)
+        if not verify:
+            if getParam(param, "dynamic_email", optional=True):
+                self.add_tokeninfo("dynamic_email", True)
+            else:
+                # specific - e-mail
+                self._email_address = getParam(param,
+                                               self.EMAIL_ADDRESS_KEY,
+                                               optional=False)
 
-        # in case of the e-mail token, only the server must know the otpkey
-        # thus if none is provided, we let create one (in the TokenClass)
-        if 'genkey' not in param and 'otpkey' not in param:
-            param['genkey'] = 1
+            # in case of the e-mail token, only the server must know the otpkey
+            # thus if none is provided, we let create one (in the TokenClass)
+            if 'genkey' not in param and 'otpkey' not in param:
+                param['genkey'] = 1
 
         HotpTokenClass.update(self, param, reset_failcount)
         return
@@ -487,3 +492,16 @@ class EmailTokenClass(HotpTokenClass):
             description = TEST_SUCCESSFUL
 
         return r, description
+
+    def prepare_verify_enrollment(self):
+        """
+        This is called, if the token should be enrolled in a way, that the user
+        needs to provide a proof, that the server can verify, that the token
+        was successfully enrolled.
+        The email token needs to send an email with OTP.
+
+        The returned dictionary is added to the response in "detail" -> "verify".
+        :return: A dictionary with information that is needed to trigger the verification.
+        """
+        self.create_challenge()
+        return {"message": VERIFY_ENROLLMENT_MESSAGE}

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -792,15 +792,15 @@ class HotpTokenClass(TokenClass):
         """
         return {"message": VERIFY_ENROLLMENT_MESSAGE}
 
-    def verify_enrollment(self, response):
+    def verify_enrollment(self, verify):
         """
         This is called during the 2nd step of the verified enrollment.
         This method verifies the actual response from the user.
         Returns true, if the verification was successful.
 
-        :param response: The response given by the user
+        :param verify: The response given by the user
         :return: True
         """
-        r = self.check_otp(response)
+        r = self.check_otp(verify)
         log.debug("Enrollment verified: {0!s}".format(r))
         return r >= 0

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -60,6 +60,9 @@ class TotpTokenClass(HotpTokenClass):
     # but the last used OTP value, so we need to set this to 0.
     previous_otp_offset = 0
 
+    # The TOTP token provides means to verify the enrollment
+    can_verify_enrollment = True
+
     @log_with(log)
     def __init__(self, db_token):
         """

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -151,6 +151,9 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
 
     $scope.qrCodeWidth = 250;
 
+    // Available SMS gateways. We do this here to avoid javascript loops
+    $scope.smsGateways = $scope.getRightsValue('sms_gateways').split(' ');
+
     if ($state.includes('token.wizard') && !$scope.show_seed) {
         $scope.qrCodeWidth = 300;
     }

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -512,7 +512,9 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
     $scope.sendVerifyResponse = function () {
         var params = {
             "serial": $scope.enrolledToken.serial,
-            "verify": $scope.verifyResponse
+            "verify": $scope.verifyResponse,
+            "type": $scope.form.type
+
         };
         TokenFactory.enroll($scope.newUser, params, function (data) {
             $scope.verifyResponse = "";

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -421,7 +421,6 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
     $scope.CATemplates = {};
     $scope.radioCSR = 'csrgenerate';
 
-
     // default enrollment callback
     $scope.callback = function (data) {
         $scope.U2FToken = {};
@@ -506,6 +505,17 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
         };
         TokenFactory.enroll($scope.newUser, params, function (data) {
             $scope.clientpart = "";
+            $scope.callback(data);
+        });
+    };
+
+    $scope.sendVerifyResponse = function () {
+        var params = {
+            "serial": $scope.enrolledToken.serial,
+            "verify": $scope.verifyResponse
+        };
+        TokenFactory.enroll($scope.newUser, params, function (data) {
+            $scope.verifyResponse = "";
             $scope.callback(data);
         });
     };

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -174,11 +174,29 @@
     '/static/components/token/views/token.enrolled.' + form.type + '.html' + fileVersionSuffix">
     </ng-include>
 
+    <!-- Verify Token enrollment -->
+    <div ng-show="enrolledToken.rollout_state === 'verify'">
+        <p translate>The token was enrolled, but you still need to verify it before you can use it!</p>
+        <div class="form-group">
+            <label for="verifyResponse" translate>{{ enrolledToken.verify.message }}</label>
+            <input type="text" ng-model="verifyResponse"
+                   autofocus
+                   class="form-control"
+                   name="verifyResponse">
+        </div>
+        <div class="text-center">
+            <button type="button" ng-click="sendVerifyResponse()"
+                    class="btn btn-primary" translate>Verify Token</button>
+        </div>
+    </div>
+
+    <!-- Token Wizard -->
     <div ng-if="$state.includes('token.wizard')"
          ng-include="instanceUrl+'/'+piCustomization+
          '/views/includes/token.enroll.post.bottom.html'"></div>
 
-    <div class="text-center" ng-hide="click_wait || enrolledToken.rollout_state === 'clientwait'">
+    <div class="text-center" ng-hide="click_wait || enrolledToken.rollout_state === 'clientwait'
+        || enrolledToken.rollout_state === 'verify' ">
         <button ng-click="enrolledToken = null; enrolling = false"
                 ng-hide="$state.includes('token.wizard')"
                 class="btn btn-primary" translate>Enroll a new token

--- a/privacyidea/static/components/token/views/token.enroll.sms.html
+++ b/privacyidea/static/components/token/views/token.enroll.sms.html
@@ -32,12 +32,12 @@
     </div>
 </div>
 
-<div class="form-group" ng-show="getRightsValue('sms_gateways').split(' ')">
+<div class="form-group" ng-show="smsGateways">
     <label for="identifier" translate>A token specific SMS gateway</label>
     <select class="form-control" id="identifier"
             ng-model="form['sms.identifier']"
             name="identifier"
-            ng-options="identifier for identifier in getRightsValue('sms_gateways').split(' ')">
+            ng-options="identifier for identifier in smsGateways">
     </select>
     <p class="help" translate>If this token should not use the system wide SMS gateway but an individual SMS gateway,
         you can select the gateway here.</p>

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -4244,6 +4244,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         env["REMOTE_ADDR"] = "10.0.0.1"
         g.client_ip = env["REMOTE_ADDR"]
         req = Request(env)
+        req.all_data = {}
         self.setUp_user_realms()
         req.User = User("autoassignuser", self.realm1)
         # The response contains the token type HOTP, enrollment

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -58,7 +58,8 @@ from privacyidea.api.lib.postpolicy import (check_serial, check_tokentype,
                                             get_webui_settings,
                                             save_pin_change,
                                             add_user_detail_to_response,
-                                            mangle_challenge_response, is_authorized)
+                                            mangle_challenge_response, is_authorized,
+                                            check_verify_enrollment)
 from privacyidea.lib.token import (init_token, get_tokens, remove_token,
                                    set_realms, check_user_pass, unassign_token,
                                    enable_token)
@@ -4226,3 +4227,49 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
 
         delete_policy("auth01")
         delete_policy("auth02")
+
+    def test_20_verify_enrollment(self):
+        # Test verify enrollment policy
+        serial = "HOTP123456"
+        tok = init_token({"serial": serial,
+                          "type": "hotp",
+                          "otpkey": "31323334353637383040"})
+        builder = EnvironBuilder(method='POST',
+                                 data={'user': "cornelius",
+                                       'genkey': 1,
+                                       'type': 'hotp'},
+                                 headers={})
+        env = builder.get_environ()
+        # Set the remote address so that we can filter for it
+        env["REMOTE_ADDR"] = "10.0.0.1"
+        g.client_ip = env["REMOTE_ADDR"]
+        req = Request(env)
+        self.setUp_user_realms()
+        req.User = User("autoassignuser", self.realm1)
+        # The response contains the token type HOTP, enrollment
+        from privacyidea.lib.tokens.hotptoken import VERIFY_ENROLLMENT_MESSAGE
+        from privacyidea.lib.tokenclass import ROLLOUTSTATE
+        res = {"jsonrpc": "2.0",
+               "result": {"status": True,
+                          "value": True},
+               "version": "privacyIDEA test",
+               "id": 1,
+               "detail": {"serial": serial}}
+        resp = jsonify(res)
+        g.policy_object = PolicyClass()
+
+        # The response is unchanged
+        new_resp = check_verify_enrollment(req, resp)
+        self.assertEqual(resp, new_resp)
+
+        # Define a verify enrollment policy
+        set_policy("verify_toks", scope=SCOPE.ENROLL, action="{0!s}=hotp".format(ACTION.VERIFY_ENROLLMENT))
+        g.policy_object = PolicyClass()
+
+        new_resp = check_verify_enrollment(req, resp)
+        detail = new_resp.json.get("detail")
+        self.assertEqual(detail.get("verify").get("message"), VERIFY_ENROLLMENT_MESSAGE)
+        self.assertEqual(detail.get("rollout_state"), ROLLOUTSTATE.VERIFYPENDING)
+        # Also check the token object.
+        self.assertEqual(tok.token.rollout_state, ROLLOUTSTATE.VERIFYPENDING)
+        delete_policy("verify_toks")

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -2378,6 +2378,8 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             detail = res.json.get("detail")
             result = res.json.get("result")
+            self.assertTrue(result.get("status"))
+            self.assertTrue(result.get("value"))
             self.assertEqual(detail.get("rollout_state"), ROLLOUTSTATE.VERIFYPENDING)
             self.assertEqual(detail.get("verify").get("message"),  VERIFY_ENROLLMENT_MESSAGE)
             serial = detail.get("serial")


### PR DESCRIPTION
Add the ability to verify the enrolled token.
Unless it is verified, the token is in the rollout_state "verify".

The tokens hotp, totp, email and sms can be verified by providing a valid OTP value.