### PR TITLE
Cast bool event handler options to bool

### DIFF
--- a/privacyidea/lib/eventhandler/counterhandler.py
+++ b/privacyidea/lib/eventhandler/counterhandler.py
@@ -31,6 +31,7 @@ from privacyidea.lib.eventhandler.base import BaseEventHandler
 from privacyidea.lib import _
 from privacyidea.lib.counter import increase, decrease, reset
 import logging
+from privacyidea.lib.utils import is_true
 import traceback
 
 log = logging.getLogger(__name__)
@@ -102,7 +103,7 @@ class CounterEventHandler(BaseEventHandler):
             increase(counter_name)
             log.debug(u"Increased the counter {0!s}.".format(counter_name))
         elif action == "decrease_counter":
-            allow_negative = handler_options.get("allow_negative_values")
+            allow_negative = is_true(handler_options.get("allow_negative_values", False))
             decrease(counter_name, allow_negative)
             log.debug(u"Decreased the counter {0!s}.".format(counter_name))
         elif action == "reset_counter":

--- a/privacyidea/lib/eventhandler/federationhandler.py
+++ b/privacyidea/lib/eventhandler/federationhandler.py
@@ -27,6 +27,7 @@ from privacyidea.lib.eventhandler.base import BaseEventHandler
 from privacyidea.lib.privacyideaserver import (get_privacyideaservers,
                                                get_privacyideaserver)
 from privacyidea.lib import _
+from privacyidea.lib.utils import is_true
 import json
 import logging
 import requests
@@ -131,7 +132,7 @@ class FederationEventHandler(BaseEventHandler):
             tls = pi_server.config.tls
             # We also transfer the original payload
             data = request.all_data
-            if handler_options.get("forward_client_ip"):
+            if is_true(handler_options.get("forward_client_ip", False)):
                 data["client"] = g.client_ip
             if handler_options.get("realm"):
                 data["realm"] = handler_options.get("realm")
@@ -144,7 +145,7 @@ class FederationEventHandler(BaseEventHandler):
             headers = {}
 
             # We need to pass an authorization header if we forward administrative requests
-            if handler_options.get("forward_authorization_token"):
+            if is_true(handler_options.get("forward_authorization_token", False)):
                 auth_token = request.headers.get('PI-Authorization')
                 if not auth_token:
                     auth_token = request.headers.get('Authorization')

--- a/privacyidea/lib/eventhandler/scripthandler.py
+++ b/privacyidea/lib/eventhandler/scripthandler.py
@@ -173,24 +173,24 @@ class ScriptEventHandler(BaseEventHandler):
                  content.get("detail", {}).get("serial") or \
                  g.audit_object.audit_data.get("serial")
 
-        if handler_options.get("serial"):
+        if is_true(handler_options.get("serial")):
             proc_args.append("--serial")
             proc_args.append(serial or "none")
 
-        if handler_options.get("user"):
+        if is_true(handler_options.get("user")):
             proc_args.append("--user")
             proc_args.append(request.User.login or "none")
 
-        if handler_options.get("realm"):
+        if is_true(handler_options.get("realm")):
             proc_args.append("--realm")
             proc_args.append(request.User.realm or "none")
 
-        if handler_options.get("logged_in_user"):
+        if is_true(handler_options.get("logged_in_user")):
             proc_args.append("--logged_in_user")
             proc_args.append("{username}@{realm}".format(
                 **logged_in_user))
 
-        if handler_options.get("logged_in_role"):
+        if is_true(handler_options.get("logged_in_role")):
             proc_args.append("--logged_in_role")
             proc_args.append(logged_in_user.get("role", "none"))
 

--- a/privacyidea/lib/eventhandler/tokenhandler.py
+++ b/privacyidea/lib/eventhandler/tokenhandler.py
@@ -448,7 +448,7 @@ class TokenEventHandler(BaseEventHandler):
                         init_param.update(add_params)
 
                 if tokentype == "sms":
-                    if handler_options.get("dynamic_phone"):
+                    if is_true(handler_options.get("dynamic_phone")):
                         init_param["dynamic_phone"] = 1
                     else:
                         init_param['phone'] = user.get_user_phone(
@@ -459,7 +459,7 @@ class TokenEventHandler(BaseEventHandler):
                     if handler_options.get("sms_identifier"):
                         init_param["sms.identifier"] = handler_options.get("sms_identifier")
                 elif tokentype == "email":
-                    if handler_options.get("dynamic_email"):
+                    if is_true(handler_options.get("dynamic_email")):
                         init_param["dynamic_email"] = 1
                     else:
                         init_param['email'] = user.info.get("email", "")

--- a/privacyidea/lib/eventhandler/usernotification.py
+++ b/privacyidea/lib/eventhandler/usernotification.py
@@ -48,7 +48,7 @@ from privacyidea.lib.token import get_tokens
 from privacyidea.lib.smtpserver import get_smtpservers
 from privacyidea.lib.smsprovider.SMSProvider import get_smsgateway
 from privacyidea.lib.user import User, get_user_list, is_attribute_at_all
-from privacyidea.lib.utils import create_tag_dict, to_unicode
+from privacyidea.lib.utils import create_tag_dict, to_unicode, is_true
 from privacyidea.lib.crypto import get_alphanum_str
 from privacyidea.lib import _
 from email.mime.multipart import MIMEMultipart
@@ -421,7 +421,7 @@ class UserNotificationEventHandler(BaseEventHandler):
                 emailconfig = handler_options.get("emailconfig")
                 mimetype = handler_options.get("mimetype", "plain")
                 useremail = recipient.get("email")
-                attach_qrcode = handler_options.get("attach_qrcode", False)
+                attach_qrcode = is_true(handler_options.get("attach_qrcode"))
 
                 if attach_qrcode and googleurl_img:
                     # get the image part of the googleurl


### PR DESCRIPTION
In certain cases a boolean event handler option
can be stored as string "False" in the database.
We cast this to boolean.

Fix #2310