### PR TITLE
Avoid exception if Email token is not assigend to user

### DIFF
--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -434,8 +434,8 @@ class EmailTokenClass(HotpTokenClass):
         tags = create_tag_dict(serial=serial,
                                tokenowner=self.user,
                                tokentype=self.get_tokentype(),
-                               recipient={"givenname": self.user.info.get("givenname"),
-                                          "surname": self.user.info.get("surname")},
+                               recipient={"givenname": self.user.info.get("givenname") if self.user else "",
+                                          "surname": self.user.info.get("surname") if self.user else ""},
                                escape_html=mimetype.lower() == "html")
 
         message = message.format(otp=otp, **tags)


### PR DESCRIPTION
When creating the tag dictionary we use the same failsafe
as with the SMS token, if the token is not assigned to a user.

Fixes #2990