### PR TITLE
#2895/Remove error code from the return_message of the sms and email token

### DIFF
--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -308,7 +308,8 @@ class EmailTokenClass(HotpTokenClass):
                         "EMail could not be sent: %r" % e)
                 log.warning(info)
                 log.debug(u"{0!s}".format(traceback.format_exc()))
-                return_message = info
+                return_message = info = ("The PIN was correct, but the "
+                        "EMail could not be sent")
                 if is_true(options.get("exception")):
                     raise Exception(info)
 

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -252,7 +252,7 @@ class EmailTokenClass(HotpTokenClass):
         :param transactionid: the id of this challenge
         :param options: the request context parameters / data
             You can pass ``exception=1`` to raise an exception, if
-            the SMS could not be sent. Otherwise the message is contained in the response.
+            the SMS could not be sent.
         :return: tuple
             of (success, message, transactionid, attributes)
 
@@ -304,12 +304,11 @@ class EmailTokenClass(HotpTokenClass):
                     mimetype=mimetype)
 
             except Exception as e:
-                info = ("The PIN was correct, but the "
-                        "EMail could not be sent: %r" % e)
-                log.warning(info)
+                info = _("The PIN was correct, but the "
+                         "EMail could not be sent")
+                log.warning(info + "({0!s})".format(e))
                 log.debug(u"{0!s}".format(traceback.format_exc()))
-                return_message = ("The PIN was correct, but the "
-                        "EMail could not be sent")
+                return_message = info
                 if is_true(options.get("exception")):
                     raise Exception(info)
 

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -308,7 +308,7 @@ class EmailTokenClass(HotpTokenClass):
                         "EMail could not be sent: %r" % e)
                 log.warning(info)
                 log.debug(u"{0!s}".format(traceback.format_exc()))
-                return_message = info = ("The PIN was correct, but the "
+                return_message = ("The PIN was correct, but the "
                         "EMail could not be sent")
                 if is_true(options.get("exception")):
                     raise Exception(info)

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -252,7 +252,7 @@ class EmailTokenClass(HotpTokenClass):
         :param transactionid: the id of this challenge
         :param options: the request context parameters / data
             You can pass ``exception=1`` to raise an exception, if
-            the SMS could not be sent.
+            the Email could not be sent.
         :return: tuple
             of (success, message, transactionid, attributes)
 
@@ -305,8 +305,8 @@ class EmailTokenClass(HotpTokenClass):
 
             except Exception as e:
                 info = _("The PIN was correct, but the "
-                         "EMail could not be sent")
-                log.warning(info + "({0!s})".format(e))
+                         "EMail could not be sent!")
+                log.warning(info + " ({0!s})".format(e))
                 log.debug(u"{0!s}".format(traceback.format_exc()))
                 return_message = info
                 if is_true(options.get("exception")):

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -350,9 +350,9 @@ class SmsTokenClass(HotpTokenClass):
                 transactionid = transactionid or db_challenge.transaction_id
             except Exception as e:
                 info = _("The PIN was correct, but the "
-                         "SMS could not be sent.")
+                         "SMS could not be sent!")
                 log.warning(info + " ({0!s})".format(e))
-                log.debug(u"{0!s}".format(traceback.format_exc()))
+                log.debug("{0!s}".format(traceback.format_exc()))
                 return_message = info
                 if is_true(options.get("exception")):
                     raise Exception(info)

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -353,7 +353,8 @@ class SmsTokenClass(HotpTokenClass):
                         "SMS could not be sent: %r" % e)
                 log.warning(info)
                 log.debug("{0!s}".format(traceback.format_exc()))
-                return_message = info
+                return_message = ("The PIN was correct, but the "
+                        "SMS could not be sent")
                 if is_true(options.get("exception")):
                     raise Exception(info)
 

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -306,7 +306,7 @@ class SmsTokenClass(HotpTokenClass):
         :param transactionid: the id of this challenge
         :param options: the request context parameters / data
                 You can pass exception=1 to raise an exception, if
-                the SMS could not be sent. Otherwise the message is contained in the response.
+                the SMS could not be sent.
         :return: tuple of (bool, message and data)
                  bool, if submit was successful
                  message is submitted to the user
@@ -349,12 +349,11 @@ class SmsTokenClass(HotpTokenClass):
                 db_challenge.save()
                 transactionid = transactionid or db_challenge.transaction_id
             except Exception as e:
-                info = ("The PIN was correct, but the "
-                        "SMS could not be sent: %r" % e)
-                log.warning(info)
-                log.debug("{0!s}".format(traceback.format_exc()))
-                return_message = ("The PIN was correct, but the "
-                        "SMS could not be sent")
+                info = _("The PIN was correct, but the "
+                         "SMS could not be sent.")
+                log.warning(info + " ({0!s})".format(e))
+                log.debug(u"{0!s}".format(traceback.format_exc()))
+                return_message = info
                 if is_true(options.get("exception")):
                     raise Exception(info)
 

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -489,7 +489,7 @@ class SMSTokenTestCase(MyTestCase):
         self.assertTrue(c[1].startswith("The PIN was correct, but"), c[1])
         capture.check_present(
             ('privacyidea.lib.tokens.smstoken', 'WARNING',
-             'The PIN was correct, but the SMS could not be sent. '
+             'The PIN was correct, but the SMS could not be sent! '
              '(privacyidea.lib.smsprovider.HttpSMSProvider has no '
              'attribute HttpSMSProviderWRONG)')
         )
@@ -503,7 +503,7 @@ class SMSTokenTestCase(MyTestCase):
         self.assertTrue(c[1].startswith("The PIN was correct, but"), c[1])
         capture.check_present(
             ('privacyidea.lib.tokens.smstoken', 'WARNING',
-             'The PIN was correct, but the SMS could not be sent. '
+             'The PIN was correct, but the SMS could not be sent! '
              '(Failed to load sms.providerConfig: JSONDecodeError(\''
              'Expecting value: line 1 column 1 (char 0)\'))')
         )

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -490,7 +490,6 @@ class SMSTokenTestCase(MyTestCase):
                                "HttpSMSProvider.HttpSMSProvider")
         c = token.create_challenge(transactionid)
         self.assertFalse(c[0], c)
-        self.assertTrue("Failed to load sms.providerConfig" in c[1], c[1])
 
         # test with the parameter exception=1
         self.assertRaises(Exception, token.create_challenge, transactionid, {"exception": "1"})

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -1,14 +1,14 @@
 """
 This test file tests the lib.tokens.smstoken
 """
-PWFILE = "tests/testdata/passwords"
+import logging
 
 from .base import MyTestCase, FakeFlaskG, FakeAudit
 from privacyidea.lib.resolver import (save_resolver)
 from privacyidea.lib.realm import (set_realm)
 from privacyidea.lib.user import (User)
 from privacyidea.lib.utils import is_true
-from privacyidea.lib.tokenclass import DATE_FORMAT
+from privacyidea.lib.token import init_token, remove_token
 from privacyidea.lib.tokens.smstoken import SmsTokenClass, SMSACTION
 from privacyidea.models import (Token, Config, Challenge)
 from privacyidea.lib.config import (set_privacyidea_config, set_prepend_pin)
@@ -17,6 +17,9 @@ from privacyidea.lib import _
 import datetime
 import mock
 import responses
+from testfixtures import log_capture
+
+PWFILE = "tests/testdata/passwords"
 
 
 class SMSTokenTestCase(MyTestCase):
@@ -472,25 +475,40 @@ class SMSTokenTestCase(MyTestCase):
         r = token.check_otp(self.valid_otp_values[5 + len(smstext_tests)], options=options)
         self.assertTrue(r > 0, r)
 
-    def test_21_failed_loading(self):
+    @ log_capture(level=logging.WARN)
+    def test_21_failed_loading(self, capture):
+        token = init_token({'type': 'sms', 'phone': self.phone1})
         transactionid = "123456098712"
         set_privacyidea_config("sms.providerConfig", "noJSON")
         set_privacyidea_config("sms.provider",
                                "privacyidea.lib.smsprovider."
                                "HttpSMSProvider.HttpSMSProviderWRONG")
-        db_token = Token.query.filter_by(serial=self.serial1).first()
-        token = SmsTokenClass(db_token)
 
         c = token.create_challenge(transactionid)
         self.assertFalse(c[0], c)
-        self.assertTrue("The PIN was correct, but" in c[1], c[1])
+        self.assertTrue(c[1].startswith("The PIN was correct, but"), c[1])
+        capture.check_present(
+            ('privacyidea.lib.tokens.smstoken', 'WARNING',
+             'The PIN was correct, but the SMS could not be sent. '
+             '(privacyidea.lib.smsprovider.HttpSMSProvider has no '
+             'attribute HttpSMSProviderWRONG)')
+        )
+        capture.clear()
 
         set_privacyidea_config("sms.provider",
                                "privacyidea.lib.smsprovider."
                                "HttpSMSProvider.HttpSMSProvider")
         c = token.create_challenge(transactionid)
         self.assertFalse(c[0], c)
+        self.assertTrue(c[1].startswith("The PIN was correct, but"), c[1])
+        capture.check_present(
+            ('privacyidea.lib.tokens.smstoken', 'WARNING',
+             'The PIN was correct, but the SMS could not be sent. '
+             '(Failed to load sms.providerConfig: JSONDecodeError(\''
+             'Expecting value: line 1 column 1 (char 0)\'))')
+        )
 
         # test with the parameter exception=1
         self.assertRaises(Exception, token.create_challenge, transactionid, {"exception": "1"})
 
+        remove_token(token.get_serial())

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -494,9 +494,10 @@ class SMSTokenTestCase(MyTestCase):
                            "(u'privacyidea.lib.smsprovider.HttpSMSProvider has no attribute HttpSMSProviderWRONG',)"
             else:
                 expected = "Failed to load SMSProvider: ImportError" \
-                           "('privacyidea.lib.smsprovider.HttpSMSProvider has no attribute HttpSMSProviderWRONG')"
+                           "('privacyidea.lib.smsprovider.HttpSMSProvider has no attribute HttpSMSProviderWRONG'"
             mock_log.mock_called()
-            mock_log.assert_called_once_with(expected)
+            mocked_str = mock_log
+            self.assertTrue(mocked_str.startswith(expected), mocked_str)
         capture.clear()
 
         with mock.patch("logging.Logger.error") as mock_log:
@@ -509,10 +510,11 @@ class SMSTokenTestCase(MyTestCase):
             if six.PY2:
                 expected = "Failed to load sms.providerConfig: ValueError('No JSON object could be decoded',)"
             else:
-                expected = "Failed to load SMSProvider: ImportError" \
-                           "('privacyidea.lib.smsprovider.HttpSMSProvider has no attribute HttpSMSProviderWRONG')"
+                expected = "Failed to load sms.providerConfig: " \
+                           "JSONDecodeError('Expecting value: line 1 column 1 (char 0)')"
             mock_log.mock_called()
-            mock_log.assert_called_once_with(expected)
+            mocked_str = mock_log
+            self.assertTrue(mocked_str.startswith(expected), mocked_str)
         capture.clear()
 
         #test with the parameter exception=1


### PR DESCRIPTION
Remove error code from the return_message of the sms and email token

Closes #2895 