### PR TITLE
Allow to choose hashing algo for passwords and PINs.

### DIFF
--- a/doc/faq/crypto-considerations.rst
+++ b/doc/faq/crypto-considerations.rst
@@ -29,6 +29,8 @@ Token Hash Algorithms
 OTP values according to HOTP and TOTP can be calculated using SHA1, SHA2-256
 and SHA2-512.
 
+.. _faq_crypto_pin_hashing:
+
 PIN Hashing
 ~~~~~~~~~~~
 

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -82,7 +82,8 @@ slower but more robust and can be necessary in large redundant setups.
    row is otherwise not present". In this case setting ``PI_DB_SAFE_STORE``  to *True*
    might help.
 
-The first entry in ``PI_HASH_ALGO_LIST`` is used for hashing.
+``PI_HASH_ALGO_LIST`` is a user-defined list of hash algorithms wich i used to decrypt
+passwords and pins. The first entry in ``PI_HASH_ALGO_LIST`` is used for hashing.
 If ``PI_HASH_ALGO_LIST`` is not defined, ``['argon2', 'pbkdf2_sha512']`` is the default.
 
 .. note:: If you change the hash algorithm, take care that the previously used one is still

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -83,7 +83,7 @@ slower but more robust and can be necessary in large redundant setups.
    might help.
 
 ``PI_HASH_ALGO_LIST`` is a user-defined list of hash algorithms which are used
-to decrypt passwords and pins. The first entry in ``PI_HASH_ALGO_LIST`` is used
+to verify passwords and pins. The first entry in ``PI_HASH_ALGO_LIST`` is used
 for hashing a new password/pin.
 If ``PI_HASH_ALGO_LIST`` is not defined, ``['argon2', 'pbkdf2_sha512']`` is the default.
 Further information can be found in the FAQ (:ref:`faq_crypto_pin_hashing`).

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -45,8 +45,6 @@ The file should contain the following contents::
    # PI_INIT_CHECK_HOOK = 'your.module.function'
    # PI_CSS = '/location/of/theme.css'
    # PI_UI_DEACTIVATED = True
-   # This is used to create a custom list of hash algorithms.
-   # PI_HASH_ALGO_LIST = ['pbkdf2_sha1', 'pbkdf2_sha512', 'argon2']
 
 .. note:: The config file is parsed as python code, so you can use variables to
    set the path and you need to take care for indentations.
@@ -84,8 +82,7 @@ slower but more robust and can be necessary in large redundant setups.
    row is otherwise not present". In this case setting ``PI_DB_SAFE_STORE``  to *True*
    might help.
 
-``PI_HASH_ALGO_LIST`` is a user-defined list of hash algorithms can be defined in the ``pi.cfg``.
-The context object will use the first algorithm listed in ``PI_HASH_ALGO_LIST`` when creating new hashes.
+The first entry in ``PI_HASH_ALGO_LIST`` is used for hashing.
 If ``PI_HASH_ALGO_LIST`` is not defined, ``['argon2', 'pbkdf2_sha512']`` is the default.
 
 .. note:: If you change the hash algorithm, take care that the previously used one is still

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -82,7 +82,7 @@ slower but more robust and can be necessary in large redundant setups.
    row is otherwise not present". In this case setting ``PI_DB_SAFE_STORE``  to *True*
    might help.
 
-``PI_HASH_ALGO_LIST`` is a user-defined list of hash algorithms wich i used to decrypt
+``PI_HASH_ALGO_LIST`` is a user-defined list of hash algorithms which i used to decrypt
 passwords and pins. The first entry in ``PI_HASH_ALGO_LIST`` is used for hashing.
 If ``PI_HASH_ALGO_LIST`` is not defined, ``['argon2', 'pbkdf2_sha512']`` is the default.
 

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -92,11 +92,13 @@ Further information can be found in the FAQ (:ref:`faq_crypto_pin_hashing`).
    included in the ``PI_HASH_ALGO_LIST`` so already generated hashes can still be verified.
 
 
-``PI_HASH_ALGO_PARAMS`` is a is a user-defined dictionary where various parameters for the hash algorithm can be set, for example::
+``PI_HASH_ALGO_PARAMS`` is a user-defined dictionary where various parameters for the hash algorithm
+can be set, for example::
 
    PI_HASH_ALGO_PARAMS = {'argon2__rounds': 5, 'argon2__memory_cost': 768'}
 
-Further information can be found in the `PassLib documentation <https://passlib.readthedocs.io/en/stable/index.html>`_.
+Further information on possible parameters can be found in the
+`PassLib documentation <https://passlib.readthedocs.io/en/stable/lib/passlib.hash.html>`_.
 
 Logging
 -------

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -45,7 +45,8 @@ The file should contain the following contents::
    # PI_INIT_CHECK_HOOK = 'your.module.function'
    # PI_CSS = '/location/of/theme.css'
    # PI_UI_DEACTIVATED = True
-
+   # This is used to create a custom list of hash algorithms.
+   # PI_HASH_ALGO_LIST = ['pbkdf2_sha1', 'pbkdf2_sha512', 'argon2']
 
 .. note:: The config file is parsed as python code, so you can use variables to
    set the path and you need to take care for indentations.
@@ -82,6 +83,13 @@ slower but more robust and can be necessary in large redundant setups.
    The database might respond with an error like "object has been deleted or its
    row is otherwise not present". In this case setting ``PI_DB_SAFE_STORE``  to *True*
    might help.
+
+``PI_HASH_ALGO_LIST`` is a user-defined list of hash algorithms can be defined in the ``pi.cfg``.
+The context object will use the first algorithm listed in ``PI_HASH_ALGO_LIST`` when creating new hashes.
+If ``PI_HASH_ALGO_LIST`` is not defined, ``['argon2', 'pbkdf2_sha512']`` is the default.
+
+.. note:: If you change the hash algorithm, take care that the previously used one is still
+   included in the ``PI_HASH_ALGO_LIST`` so already generated hashes can still be verified.
 
 Logging
 -------

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -82,9 +82,11 @@ slower but more robust and can be necessary in large redundant setups.
    row is otherwise not present". In this case setting ``PI_DB_SAFE_STORE``  to *True*
    might help.
 
-``PI_HASH_ALGO_LIST`` is a user-defined list of hash algorithms which i used to decrypt
-passwords and pins. The first entry in ``PI_HASH_ALGO_LIST`` is used for hashing.
+``PI_HASH_ALGO_LIST`` is a user-defined list of hash algorithms which are used
+to decrypt passwords and pins. The first entry in ``PI_HASH_ALGO_LIST`` is used
+for hashing a new password/pin.
 If ``PI_HASH_ALGO_LIST`` is not defined, ``['argon2', 'pbkdf2_sha512']`` is the default.
+Further information can be found in the FAQ (:ref:`faq_crypto_pin_hashing`).
 
 .. note:: If you change the hash algorithm, take care that the previously used one is still
    included in the ``PI_HASH_ALGO_LIST`` so already generated hashes can still be verified.

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -91,6 +91,13 @@ Further information can be found in the FAQ (:ref:`faq_crypto_pin_hashing`).
 .. note:: If you change the hash algorithm, take care that the previously used one is still
    included in the ``PI_HASH_ALGO_LIST`` so already generated hashes can still be verified.
 
+
+``PI_HASH_ALGO_PARAMS`` is a is a user-defined dictionary where various parameters for the hash algorithm can be set, for example::
+
+   PI_HASH_ALGO_PARAMS = {'argon2__rounds': 5, 'argon2__memory_cost': 768'}
+
+Further information can be found in the `PassLib documentation <https://passlib.readthedocs.io/en/stable/index.html>`_.
+
 Logging
 -------
 

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -90,6 +90,8 @@ def safe_compare(a, b):
 if not PY2:
     long = int
 
+ROUNDS = 9
+
 # The CryptContext makes it easier to work with multiple password hash algorithms:
 # The first algorithm in the list is the default algorithm used for hashing.
 # When verifying a password hash, all algorithms in the context are checked
@@ -189,7 +191,8 @@ def pass_hash(password):
     :return: The hash string of the password
     """
     pass_ctx = CryptContext(get_app_config_value("PI_HASH_ALGO_LIST",
-                                                 default=DEFAULT_HASH_ALGO_LIST))
+                                                 default=DEFAULT_HASH_ALGO_LIST),
+                            argon2__rounds=ROUNDS)
     pw_dig = pass_ctx.hash(password)
     return pw_dig
 
@@ -206,7 +209,8 @@ def verify_pass_hash(password, hvalue):
     :rtype: bool
     """
     pass_ctx = CryptContext(get_app_config_value("PI_HASH_ALGO_LIST",
-                                                 default=DEFAULT_HASH_ALGO_LIST))
+                                                 default=DEFAULT_HASH_ALGO_LIST),
+                            argon2__rounds=ROUNDS)
     return pass_ctx.verify(password, hvalue)
 
 

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -58,7 +58,6 @@ import base64
 import traceback
 from six import PY2
 from passlib.context import CryptContext
-
 from privacyidea.lib.log import log_with
 from privacyidea.lib.error import HSMException
 from privacyidea.lib.framework import (get_app_local_store, get_app_config_value,
@@ -91,13 +90,12 @@ def safe_compare(a, b):
 if not PY2:
     long = int
 
-ROUNDS = 9
-
 # The CryptContext makes it easier to work with multiple password hash algorithms:
 # The first algorithm in the list is the default algorithm used for hashing.
 # When verifying a password hash, all algorithms in the context are checked
 # until one succeeds (or all fail).
-pass_ctx = CryptContext(['argon2', 'pbkdf2_sha512'], argon2__rounds=ROUNDS)
+
+DEFAULT_HASH_ALGO_LIST = ['argon2', 'pbkdf2_sha512']
 
 FAILED_TO_DECRYPT_PASSWORD = "FAILED TO DECRYPT PASSWORD!"
 
@@ -190,6 +188,8 @@ def pass_hash(password):
     :type password: str
     :return: The hash string of the password
     """
+    pass_ctx = CryptContext(get_app_config_value("PI_HASH_ALGO_LIST",
+                                                 default=DEFAULT_HASH_ALGO_LIST))
     pw_dig = pass_ctx.hash(password)
     return pw_dig
 
@@ -205,6 +205,8 @@ def verify_pass_hash(password, hvalue):
     :return: True if the password matches
     :rtype: bool
     """
+    pass_ctx = CryptContext(get_app_config_value("PI_HASH_ALGO_LIST",
+                                                 default=DEFAULT_HASH_ALGO_LIST))
     return pass_ctx.verify(password, hvalue)
 
 

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -98,6 +98,7 @@ ROUNDS = 9
 # until one succeeds (or all fail).
 
 DEFAULT_HASH_ALGO_LIST = ['argon2', 'pbkdf2_sha512']
+DEFAULT_HASH_ALGO_PARAMS = {'argon2__rounds': ROUNDS}
 
 FAILED_TO_DECRYPT_PASSWORD = "FAILED TO DECRYPT PASSWORD!"
 
@@ -190,9 +191,11 @@ def pass_hash(password):
     :type password: str
     :return: The hash string of the password
     """
+    DEFAULT_HASH_ALGO_PARAMS.update(get_app_config_value("PI_HASH_ALGO_PARAMS",
+                                                         default={}))
     pass_ctx = CryptContext(get_app_config_value("PI_HASH_ALGO_LIST",
                                                  default=DEFAULT_HASH_ALGO_LIST),
-                            argon2__rounds=ROUNDS)
+                            **DEFAULT_HASH_ALGO_PARAMS)
     pw_dig = pass_ctx.hash(password)
     return pw_dig
 
@@ -209,8 +212,7 @@ def verify_pass_hash(password, hvalue):
     :rtype: bool
     """
     pass_ctx = CryptContext(get_app_config_value("PI_HASH_ALGO_LIST",
-                                                 default=DEFAULT_HASH_ALGO_LIST),
-                            argon2__rounds=ROUNDS)
+                                                 default=DEFAULT_HASH_ALGO_LIST))
     return pass_ctx.verify(password, hvalue)
 
 

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -699,9 +699,9 @@ class CheckCustomAlgoList(OverrideConfigTestCase):
         pbkdf2_sha512_hash = '$pbkdf2-sha512$25000$XEvJOcf437tXam1Nydm79w$6eDPlPjRgnJGGK0j8a3to' \
                              'SZoSUvwZzcvEj96t7Hg.X/SC822EFaO2iWoHFTUc1NMsX6sgQyQqbjWxGXgRWNzkw'
 
-        argon2_hash = '$argon2id$v=19$m=102400,t=2,p=8$oXRO6Z3zXsv5n1PqfQ9BqA$v87efWeG6BuP4W/3xgd2QQ'
+        argon2_hash = '$argon2id$v=19$m=102400,t=9,p=8$vZeyFqI0xhiDEIKw1przfg$8FX07S7VpaYae51Oe9Cj8g'
 
-        argon2_fail_hash = '$argon2id$v=19$m=102400,t=2,p=8$oXRO6Z3zXsv5nqfQ9BqA$v87efWeG6BuP4W/3xgd2QQ'
+        argon2_fail_hash = '$argon2id$v=19$m=102400,t=9,p=8$vZeyFqI0xhiDEIKw1przfg$8FX07S7VpaYae51Oe9Cj7g'
 
         # Checks if the first entry is taken from "PI_HASH_ALGO_LIST".
         self.assertEqual(pass_hash(password)[0:7], '$pbkdf2')
@@ -724,7 +724,7 @@ class CheckDefaultAlgoList(MyTestCase):
         pbkdf2_sha512_hash = '$pbkdf2-sha512$25000$XEvJOcf437tXam1Nydm79w$6eDPlPjRgnJGGK0j8a3to' \
                              'SZoSUvwZzcvEj96t7Hg.X/SC822EFaO2iWoHFTUc1NMsX6sgQyQqbjWxGXgRWNzkw'
 
-        argon2_fail_hash = '$argon2id$v=19$m=102400,t=2,p=8$oXRO6Z3zXsv5nqfQ9BqA$v87efWeG6BuP4W/3xgd2QQ'
+        argon2_fail_hash = '$argon2id$v=19$m=102400,t=9,p=8$vZeyFqI0xhiDEIKw1przfg$8FX07S7VpaYae51Oe9Cj7g'
 
         # Checks if the first entry is taken from "DEFAULT_HASH_ALGO_LIST"
         self.assertEqual(pass_hash(password)[0:6], '$argon')

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -60,7 +60,7 @@ class SecurityModuleTestCase(MyTestCase):
     def test_04_random(self):
         config = current_app.config
         hsm = DefaultSecurityModule({"file": config.get("PI_ENCFILE"),
-            "crypted": True})
+                                     "crypted": True})
         r = hsm.random(20)
         self.assertTrue(len(r) == 20, r)
         self.assertFalse(hsm.is_ready)
@@ -108,7 +108,7 @@ class SecurityModuleTestCase(MyTestCase):
     def test_07_encrypted_key_file(self):
         config = current_app.config
         hsm = DefaultSecurityModule({"file": config.get("PI_ENCFILE_ENC"),
-            "crypted": True})
+                                     "crypted": True})
         # The HSM is not ready, since the file is crypted and we did not
         # provide the password, yet
         self.assertFalse(hsm.is_ready)


### PR DESCRIPTION
Hash algorithms can now be configured in the pi.cfg.

fixes #2981 