### PR TITLE
Fix parsing timestamps without timezone

### DIFF
--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -176,7 +176,8 @@ def _try_convert_to_datetime(given_value_string):
     try:
         parsed = parser.parse(given_value_string, dayfirst=False)
         if not parsed.tzinfo:
-            parsed = parser.parse(given_value_string, dayfirst=False, tzinfos=tzlocal)
+            # If not timezone is given we assume the timestamp is given in local time
+            parsed = parsed.replace(tzinfo=tzlocal())
         return parsed
     except ValueError:
         raise InvalidCommand('Not a valid datetime format: {}'.format(given_value_string))


### PR DESCRIPTION
In case a given timestamp does not contain a timezone, the parsing
failed. We just add the local timezone in this case.

Fixes #3016