### PR TITLE
Avoid Push-Token to break if firebase fails

### DIFF
--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -68,6 +68,8 @@ import time
 log = logging.getLogger(__name__)
 
 DEFAULT_CHALLENGE_TEXT = _("Please confirm the authentication on your mobile device!")
+ERROR_CHALLENGE_TEXT = _("Use the polling feature of your privacyIDEA Authenticator App"
+                         " to check for a new Login request.")
 DEFAULT_MOBILE_TEXT = _("Do you want to confirm the login?")
 PRIVATE_KEY_SERVER = "private_key_server"
 PUBLIC_KEY_SERVER = "public_key_server"
@@ -866,12 +868,14 @@ class PushTokenClass(TokenClass):
             if not res:
                 log.warning(u"Failed to submit message to Firebase service for token {0!s}."
                             .format(self.token.serial))
+                message += " " + ERROR_CHALLENGE_TEXT
                 if is_true(options.get("exception")):
                     raise ValidateError("Failed to submit message to Firebase service.")
         else:
             log.warning(u"The token {0!s} has no tokeninfo {1!s}. "
                         u"The message could not be sent.".format(self.token.serial,
                                                                  PUSH_ACTION.FIREBASE_CONFIG))
+            message += " " + ERROR_CHALLENGE_TEXT
             if is_true(options.get("exception")):
                 raise ValidateError("The token has no tokeninfo. Can not send via Firebase service.")
 

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -860,19 +860,22 @@ class PushTokenClass(TokenClass):
                                          validitytime=validity)
                 db_challenge.save()
                 self.challenge_janitor()
+                transactionid = db_challenge.transaction_id
 
-            # If sending the Push message failed, we still raise an error and a warning.
+            # If sending the Push message failed, we log a warning
             if not res:
                 log.warning(u"Failed to submit message to Firebase service for token {0!s}."
                             .format(self.token.serial))
-                raise ValidateError("Failed to submit message to Firebase service.")
+                if is_true(options.get("exception")):
+                    raise ValidateError("Failed to submit message to Firebase service.")
         else:
             log.warning(u"The token {0!s} has no tokeninfo {1!s}. "
                         u"The message could not be sent.".format(self.token.serial,
                                                                  PUSH_ACTION.FIREBASE_CONFIG))
-            raise ValidateError("The token has no tokeninfo. Can not send via Firebase service.")
+            if is_true(options.get("exception")):
+                raise ValidateError("The token has no tokeninfo. Can not send via Firebase service.")
 
-        return True, message, db_challenge.transaction_id, reply_dict
+        return True, message, transactionid, reply_dict
 
     @check_token_locked
     def authenticate(self, passw, user=None, options=None):

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -268,6 +268,12 @@ class PushTokenTestCase(MyTestCase):
                     # Check that the warning was written to the log file.
                     mock_log.assert_called_with("Failed to submit message to Firebase service for token {0!s}."
                                                 .format(serial))
+                    # Check that the user was informed about the need to poll
+                    detail = res.json.get("detail")
+                    self.assertEqual("Please confirm the authentication on your mobile device! "
+                                     "Use the polling feature of your privacyIDEA Authenticator App "
+                                     "to check for a new Login request.", detail.get("message"))
+
 
             # Our ServiceAccountCredentials mock has been called once, because
             # no access token has been fetched before

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -253,18 +253,21 @@ class PushTokenTestCase(MyTestCase):
                           content_type="application/json")
 
             # Send the first authentication request to trigger the challenge
-            with self.app.test_request_context('/validate/check',
-                                               method='POST',
-                                               data={"user": "cornelius",
-                                                     "realm": self.realm1,
-                                                     "pass": "pushpin"}):
-                res = self.app.full_dispatch_request()
-                self.assertTrue(res.status_code == 400, res)
-                jsonresp = res.json
-                self.assertFalse(jsonresp.get("result").get("status"))
-                self.assertEqual(jsonresp.get("result").get("error").get("code"), 401)
-                self.assertEqual(jsonresp.get("result").get("error").get("message"),
-                                 "ERR401: Failed to submit message to Firebase service.")
+            with mock.patch("logging.Logger.warning") as mock_log:
+                with self.app.test_request_context('/validate/check',
+                                                   method='POST',
+                                                   data={"user": "cornelius",
+                                                         "realm": self.realm1,
+                                                         "pass": "pushpin"}):
+                    res = self.app.full_dispatch_request()
+                    self.assertTrue(res.status_code == 200, res)
+                    result = res.json.get("result")
+                    self.assertTrue(result.get("status"))
+                    self.assertFalse(result.get("value"))
+                    self.assertEqual("CHALLENGE", result.get("authentication"))
+                    # Check that the warning was written to the log file.
+                    mock_log.assert_called_with("Failed to submit message to Firebase service for token {0!s}."
+                                                .format(serial))
 
             # Our ServiceAccountCredentials mock has been called once, because
             # no access token has been fetched before
@@ -283,36 +286,43 @@ class PushTokenTestCase(MyTestCase):
             set_policy('push_poll', SCOPE.AUTH,
                        action='{0!s}={1!s}'.format(PUSH_ACTION.ALLOW_POLLING,
                                                    PushAllowPolling.DENY))
-            with self.app.test_request_context('/validate/check',
-                                               method='POST',
-                                               data={"user": "cornelius",
-                                                     "realm": self.realm1,
-                                                     "pass": "pushpin"}):
-                res = self.app.full_dispatch_request()
-                self.assertTrue(res.status_code == 400, res)
-                jsonresp = res.json
-                self.assertFalse(jsonresp.get("result").get("status"))
-                self.assertEqual(jsonresp.get("result").get("error").get("code"), 401)
-                self.assertEqual(jsonresp.get("result").get("error").get("message"),
-                                 "ERR401: Failed to submit message to Firebase service.")
+
+            with mock.patch("logging.Logger.warning") as mock_log:
+                with self.app.test_request_context('/validate/check',
+                                                   method='POST',
+                                                   data={"user": "cornelius",
+                                                         "realm": self.realm1,
+                                                         "pass": "pushpin"}):
+                    res = self.app.full_dispatch_request()
+                    self.assertTrue(res.status_code == 200, res)
+                    result = res.json.get("result")
+                    self.assertTrue(result.get("status"))
+                    self.assertFalse(result.get("value"))
+                    self.assertEqual("CHALLENGE", result.get("authentication"))
+                    # Check that the warning was written to the log file.
+                    mock_log.assert_called_with("Failed to submit message to Firebase service for token {0!s}."
+                                                .format(serial))
             self.assertEqual(len(get_challenges(serial=tokenobj.token.serial)), 0)
             # disallow polling the specific token through a policy
             set_policy('push_poll', SCOPE.AUTH,
                        action='{0!s}={1!s}'.format(PUSH_ACTION.ALLOW_POLLING,
                                                    PushAllowPolling.TOKEN))
             tokenobj.add_tokeninfo(POLLING_ALLOWED, False)
-            with self.app.test_request_context('/validate/check',
-                                               method='POST',
-                                               data={"user": "cornelius",
-                                                     "realm": self.realm1,
-                                                     "pass": "pushpin"}):
-                res = self.app.full_dispatch_request()
-                self.assertTrue(res.status_code == 400, res)
-                jsonresp = res.json
-                self.assertFalse(jsonresp.get("result").get("status"))
-                self.assertEqual(jsonresp.get("result").get("error").get("code"), 401)
-                self.assertEqual(jsonresp.get("result").get("error").get("message"),
-                                 "ERR401: Failed to submit message to Firebase service.")
+            with mock.patch("logging.Logger.warning") as mock_log:
+                with self.app.test_request_context('/validate/check',
+                                                   method='POST',
+                                                   data={"user": "cornelius",
+                                                         "realm": self.realm1,
+                                                         "pass": "pushpin"}):
+                    res = self.app.full_dispatch_request()
+                    self.assertTrue(res.status_code == 200, res)
+                    result = res.json.get("result")
+                    self.assertTrue(result.get("status"))
+                    self.assertFalse(result.get("value"))
+                    self.assertEqual("CHALLENGE", result.get("authentication"))
+                    # Check that the warning was written to the log file.
+                    mock_log.assert_called_with("Failed to submit message to Firebase service for token {0!s}."
+                                                .format(serial))
             self.assertEqual(len(get_challenges(serial=tokenobj.token.serial)), 0)
             # Check that the challenge is created if the request to firebase
             # succeeded even though polling is disabled


### PR DESCRIPTION
The Push Token should not raise an exception
when the challenge can not be submitted to firebase,
since polling could still work. This way we ensure,
that user can still authenticate if poll is working.

Closes #2904