### PR TITLE
Enable WebUI-login with Push-Token

### DIFF
--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -821,7 +821,6 @@ class PushTokenClass(TokenClass):
                                                  ACTION.CHALLENGETEXT,
                                                  options) or DEFAULT_CHALLENGE_TEXT
 
-        reply_dict = {}
         data = None
         # Initially we assume there is no error from Firebase
         res = True
@@ -879,6 +878,7 @@ class PushTokenClass(TokenClass):
             if is_true(options.get("exception")):
                 raise ValidateError("The token has no tokeninfo. Can not send via Firebase service.")
 
+        reply_dict = {"attributes": {"hideResponseInput": self.client_mode != CLIENTMODE.INTERACTIVE}}
         return True, message, transactionid, reply_dict
 
     @check_token_locked


### PR DESCRIPTION
Due to changes in the return value of `create_challenge()` the
Push-Token (and also Webauthn/U2f-token) didn't work when logging in to
the WebUI (policy `login_mode`).
The loginController now checks the correct attributes in each challenge.
The Push-Token now returns the `hideResponseInput` attribute.

TODO:
- When using TOTP/HOTP with challenge-response, the input field is
  not shown (missing `hideResponseInput` attribute in response).
- The polling from the WebUI is not aborted when the login state is
  left.
- The Webauthn/U2F flow is not aborted when logged in with a different
  token.

Closes #2893