### PR TITLE
Fix disabled otpauth URI scheme

### DIFF
--- a/privacyidea/static/app.js
+++ b/privacyidea/static/app.js
@@ -154,10 +154,8 @@ myApp.config(['$httpProvider', function ($httpProvider, inform, gettext) {
 
 myApp.config(['$compileProvider',
     function ($compileProvider) {
-        // allow otpauth scheme in URLs
-        $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|tel|file|blob|otpauth):/);
-        // allow only links to our readthedocs documentation
-        $compileProvider.aHrefSanitizationTrustedUrlList(/^\s*https:\/\/privacyidea.readthedocs.io\//);
+        // allow only links to our readthedocs documentation, netknights homepage and "otpauth:" links
+        $compileProvider.aHrefSanitizationTrustedUrlList(/^\s*(https:\/\/(privacyidea.readthedocs.io|netknights.it)\/|otpauth:)/);
 }]);
 
 // A function to escape regexp queries

--- a/privacyidea/static/components/config/views/config.token.yubikey.html
+++ b/privacyidea/static/components/config/views/config.token.yubikey.html
@@ -6,9 +6,10 @@
 
 <p class="help-block" translate>
     The authentication request can be handled by the default privacyIDEA
-    <a href="http://privacyidea.readthedocs.org/en/latest/modules/api/validate.html">
+    <a href="https://privacyidea.read1thedocs.org/en/latest/modules/api/validate.html" target="_blank">
         validate API</a> but can also be handled by the
-    <a href="http://privacyidea.readthedocs.org/en/latest/modules/lib/tokentypes/yubikey.html#privacyidea.lib.tokens.yubikeytoken.YubikeyTokenClass.api_endpoint">
+    <a href="https://privacyidea.readthedocs.org/en/latest/modules/lib/tokentypes/yubikey.html#privacyidea.lib.tokens.yubikeytoken.YubikeyTokenClass.api_endpoint"
+       target="_blank">
         Yubico Validation Protocol</a>.
 </p>
 

--- a/privacyidea/static/components/config/views/config.token.yubikey.html
+++ b/privacyidea/static/components/config/views/config.token.yubikey.html
@@ -6,9 +6,9 @@
 
 <p class="help-block" translate>
     The authentication request can be handled by the default privacyIDEA
-    <a href="https://privacyidea.read1thedocs.org/en/latest/modules/api/validate.html" target="_blank">
+    <a href="https://privacyidea.readthedocs.io/en/latest/modules/api/validate.html" target="_blank">
         validate API</a> but can also be handled by the
-    <a href="https://privacyidea.readthedocs.org/en/latest/modules/lib/tokentypes/yubikey.html#privacyidea.lib.tokens.yubikeytoken.YubikeyTokenClass.api_endpoint"
+    <a href="https://privacyidea.readthedocs.io/en/latest/modules/lib/tokentypes/yubikey.html#privacyidea.lib.tokens.yubikeytoken.YubikeyTokenClass.api_endpoint"
        target="_blank">
         Yubico Validation Protocol</a>.
 </p>

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -27,7 +27,7 @@ String.prototype.mysplit = function(separator) {
 
 
 angular.module("privacyideaApp")
-    .controller("mainController", ["Idle", "$scope", "$http", "$location",
+    .controller("mainController", ["Idle", "$scope", "$sce", "$http", "$location",
                                    "authUrl", "validateUrl", "AuthFactory", "$rootScope",
                                    "$state", "ConfigFactory", "inform",
                                    "PolicyTemplateFactory", "gettextCatalog",
@@ -35,7 +35,7 @@ angular.module("privacyideaApp")
                                    "U2fFactory", "webAuthnToken", "instanceUrl",
                                    "PollingAuthFactory", "$transitions",
                                    "resourceNamePatterns",
-                                   function (Idle, $scope, $http, $location,
+                                   function (Idle, $scope, $sce, $http, $location,
                                              authUrl, validateUrl, AuthFactory, $rootScope,
                                              $state, ConfigFactory, inform,
                                              PolicyTemplateFactory, gettextCatalog,
@@ -78,7 +78,8 @@ angular.module("privacyideaApp")
     obj = angular.element(document.querySelector('#SHOW_NODE'));
     $scope.show_node = obj.val();
     obj = angular.element(document.querySelector('#GDPR_LINK'));
-    $scope.piGDPRLink = obj.val();
+    // we need to trust the GDPR URI explicitly since an admin can change this via policy.
+    $scope.piGDPRLink = $sce.trustAsUrl(obj.val());
     obj = angular.element(document.querySelector('#PI_TRANSLATION_WARNING'));
     $scope.piTranslationWarning = obj.val() !== "False";
     $scope.piTranslationPrefix = obj.val();

--- a/privacyidea/static/templates/baseline.html
+++ b/privacyidea/static/templates/baseline.html
@@ -9,7 +9,7 @@
 
         <a class="navbar-btn btn btn-success pull-right"
            ng-show="piExternalLinks !== 'False'"
-           href="{{ privacyideaSupportLink }}"
+           ng-href="{{ privacyideaSupportLink }}"
            target="_external">
             <translate>Support</translate>
         </a>
@@ -21,13 +21,13 @@
 
         <a class="navbar-text pull-right"
            ng-show="privacyideaVersionNumber"
-                href="http://privacyidea.readthedocs.org/en/v{{ privacyideaVersionNumber }}"
+                ng-href="https://privacyidea.readthedocs.io/en/v{{ privacyideaVersionNumber }}"
                 target="documentation">
             <translate>Online Documentation</translate>
         </a>
        <a class="navbar-text pull-right pull-right"
            ng-show="piGDPRLink"
-           href="{{ piGDPRLink }}"
+           ng-href="{{ piGDPRLink }}"
            target="_external">
             <translate>Privacy Statement</translate>
         </a>

--- a/privacyidea/static/templates/cert_request_form.html
+++ b/privacyidea/static/templates/cert_request_form.html
@@ -45,7 +45,7 @@
             privacyIDEA Forum</a>
         <a class="navbar-text pull-right"
            ng-show="privacyideaVersionNumber"
-                href="http://privacyidea.readthedocs.org/en/v{{ privacyideaVersionNumber }}"
+           ng-href="https://privacyidea.readthedocs.io/en/v{{ privacyideaVersionNumber }}"
                 target="documentation">
             Online Documentation
         </a>

--- a/privacyidea/static/templates/menu.html
+++ b/privacyidea/static/templates/menu.html
@@ -133,14 +133,14 @@
                             <span class="sr-only">Toggle Dropdown</span>
                         </button>
                         <ul class="dropdown-menu">
-                            <li><a href="http://privacyidea.readthedocs.org/en/v{{ privacyideaVersionNumber }}"
+                            <li><a ng-href="https://privacyidea.readthedocs.io/en/v{{ privacyideaVersionNumber }}"
 				                   target="documentation" translate>
                                 Online Documentation</a></li>
                             <li ng-show="piExternalLinks !== 'False'">
                                 <a href="https://community.privacyidea.org"
 				                   target="_external" translate>Community</a></li>
                             <li ng-show="piExternalLinks !== 'False'">
-                                <a href="{{ privacyideaSupportLink }}"
+                                <a ng-href="{{ privacyideaSupportLink }}"
 				                   target="_external" translate
 				>Support</a></li>
                             <li class="divider"></li>

--- a/privacyidea/static/templates/token_enrolled.html
+++ b/privacyidea/static/templates/token_enrolled.html
@@ -54,7 +54,7 @@ The certificate with token serial {{ serial }} for user {{ username }}
             privacyIDEA Forum</a>
         <a class="navbar-text pull-right"
            ng-show="privacyideaVersionNumber"
-                href="http://privacyidea.readthedocs.org/en/v{{ privacyideaVersionNumber }}"
+           ng-href="https://privacyidea.readthedocs.io/en/v{{ privacyideaVersionNumber }}"
                 target="documentation">
             Online Documentation
         </a>


### PR DESCRIPTION
Due to the sanitization of HTML data the otpauth URI-scheme was marked
as disabled.
Adding this together with the netknights.it URL to the trusted URL list
fixes this.
Also in case an administrator changes the GDPR link via policy, the
link-contents must be marked as untrusted to avoid disabling the link.
Fixed some https links as well.

Closes #3067