### PR TITLE
Update PyJWT error handling

### DIFF
--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -344,7 +344,7 @@ def verify_auth_token(auth_token, required_role=None):
         except jwt.DecodeError as err:
             raise AuthError(_("Authentication failure. Error during decoding your token: {0!s}").format(err),
                             id=ERROR.AUTHENTICATE_DECODING_ERROR)
-        except jwt.ExpiredSignature as err:
+        except jwt.ExpiredSignatureError as err:
             raise AuthError(_("Authentication failure. Your token has expired: {0!s}").format(err),
                             id=ERROR.AUTHENTICATE_TOKEN_EXPIRED)
     if wrong_username:


### PR DESCRIPTION
Change `jwt.ExpiredSignature` to `jwt.ExpiredSignatureError` to avoid an
internal server error when the jwt is expired.