### PR TITLE
Fix WebUI login with challenge response

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+
+build:
+  os: ubuntu-20.04
+  tools: 
+    python: 3.8
+
 # Build html documentation in the doc/ directory with Sphinx
 sphinx:
   builder: html
@@ -17,7 +23,7 @@ formats: all
 # documentation building process.  Also allow access to python packages that are globally installed by default, even if
 # they are not explicitly listed.
 python:
-  version: 3.6
+  version: 3.8
   install:
     - requirements: doc/requirements.txt
     - method: pip

--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -1,5 +1,14 @@
 # Update Notes
 
+## Update from 3.6 to 3.7
+
+* The database schema in table "machinetoken" was changed to support a new way of 
+  handling offline tokens.
+* The notification handler can contain more complex reply_to emails.
+  The handler optiones were adapted in the database.
+
+Be sure to run the schema update script!
+
 ## Update from 3.5 to 3.6
 
 * Up to version 3.5 TLS autonegotiation was used for LDAP resolvers, if no specific

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -240,7 +240,7 @@ angular.module("privacyideaApp")
                     "Authentication. You" +
                     " are not completely authenticated, yet."),
                     {type: "warning", ttl:5000});
-                $scope.hideResponseInput = true;
+                $scope.hideResponseInput = false;
                 $scope.u2fSignRequests = Array();
                 $scope.webAuthnSignRequests = [];
                 $scope.transactionid = error.detail["transaction_id"];
@@ -260,8 +260,8 @@ angular.module("privacyideaApp")
                     }
                     let challenge = multi_challenge[i];
                     let attributes = challenge.attributes ? challenge.attributes : null;
-                    if (challenge === null || (attributes && attributes.hideResponseInput !== true)) {
-                        $scope.hideResponseInput = false;
+                    if (attributes && attributes.hideResponseInput) {
+                        $scope.hideResponseInput = attributes.hideResponseInput;
                     }
                     if (challenge !== null) {
                         if (attributes && attributes.u2fSignRequest) {

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -240,7 +240,7 @@ angular.module("privacyideaApp")
                     "Authentication. You" +
                     " are not completely authenticated, yet."),
                     {type: "warning", ttl:5000});
-                $scope.hideResponseInput = false;
+                $scope.hideResponseInput = true;
                 $scope.u2fSignRequests = Array();
                 $scope.webAuthnSignRequests = [];
                 $scope.transactionid = error.detail["transaction_id"];
@@ -259,13 +259,14 @@ angular.module("privacyideaApp")
                         $scope.challenge_message = $scope.challenge_message + ' ' + multi_challenge[i].serial;
                     }
                     let challenge = multi_challenge[i];
-                    let attributes = challenge.attributes ? challenge.attributes : null;
-                    if (attributes && attributes.hideResponseInput) {
-                        $scope.hideResponseInput = attributes.hideResponseInput;
-                    }
                     if (challenge !== null) {
+                        if (challenge.client_mode === 'interactive') {
+                            // if we have at least one interactive token, we need to shoe the input field
+                            $scope.hideResponseInput = false;
+                        }
+                        let attributes = challenge.attributes ? challenge.attributes : null;
                         if (attributes && attributes.u2fSignRequest) {
-                           $scope.u2fSignRequests.push(attributes.u2fSignRequest);
+                            $scope.u2fSignRequests.push(attributes.u2fSignRequest);
                         }
                         if (attributes && attributes.webAuthnSignRequest) {
                             $scope.webAuthnSignRequests.push(attributes.webAuthnSignRequest);

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -261,7 +261,7 @@ angular.module("privacyideaApp")
                     let challenge = multi_challenge[i];
                     if (challenge !== null) {
                         if (challenge.client_mode === 'interactive') {
-                            // if we have at least one interactive token, we need to shoe the input field
+                            // if we have at least one interactive token, we need to show the input field
                             $scope.hideResponseInput = false;
                         }
                         let attributes = challenge.attributes ? challenge.attributes : null;


### PR DESCRIPTION
In case of HOTP/TOTP challenge-response token the WebUI wouldn't show
the input field in the second step.
Now we show the input field unless the hideResponseInput attribute is
given and set to false.