### PR TITLE
Removed the option "user" from offline tokens

### DIFF
--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -171,7 +171,7 @@ class MachineApplication(MachineApplicationBase):
                 if user_object:
                     uInfo = user_object.info
                     if "username" in uInfo:
-                        ret["username"] = uInfo.get("username")
+                        ret["user"] = ret["username"] = uInfo.get("username")
 
         else:
             log.info("Token %r, type %r is not supported by "
@@ -185,4 +185,4 @@ class MachineApplication(MachineApplicationBase):
         returns a dictionary with a list of required and optional options
         """
         return {'required': [],
-                'optional': ['user', 'count', 'rounds']}
+                'optional': ['count', 'rounds']}

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -447,8 +447,7 @@ class APIMachinesTestCase(MyApiTestCase):
 
         # Attach the token to the machine "gandalf" with the application offline
         r = attach_token(hostname="gandalf", serial=self.serial4,
-                         application="offline", options={"user": "cornelius",
-                                                         "count": 17})
+                         application="offline", options={"count": 17})
 
         self.assertEqual(r.machine_id, "192.168.0.1")
 

--- a/tests/test_lib_applications.py
+++ b/tests/test_lib_applications.py
@@ -105,7 +105,7 @@ class OfflineApplicationTestCase(MyTestCase):
         # Can run as class
         options = OfflineApplication.get_options()
         self.assertEqual(options["required"], [])
-        self.assertEqual(options["optional"], ['user', 'count', 'rounds'])
+        self.assertEqual(options["optional"], ['count', 'rounds'])
 
     def test_02_get_auth_item(self):
         serial = "OATH1"


### PR DESCRIPTION
The option "user" in offline tokens was of no use.
It was a redundant information, the admin always had to add
the username of the user, to whom the token was assigned anyways.

Thus we simply set the required return value to the username
of the tokenowner.

Closes #3077