### PR TITLE
Add notification key to allow better background notification handling

### DIFF
--- a/privacyidea/lib/smsprovider/FirebaseProvider.py
+++ b/privacyidea/lib/smsprovider/FirebaseProvider.py
@@ -124,6 +124,10 @@ class FirebaseProvider(ISMSProvider):
             "message": {
                         "data": data,
                         "token": firebase_token,
+                        "notification": {
+                            "title": data.get("title"),
+                            "body": data.get("question")
+                        },
                         "android": {
                                     "priority": "HIGH",
                                     "ttl": "120s",


### PR DESCRIPTION
In order to allow a better background notification handling, one should add the `"notification"` key to the firebase message.

We had the problem that the message came to the device but it was not sent to the app in background mode. This is because all the information is sent in the `data` key. This doesn't trigger a proper notification on the device.

In order to have both, data and a proper notification in the background. We should add the given key.

See the specification:
https://firebase.google.com/docs/cloud-messaging/concept-options
e.g. using:
```json
{
  "message":{
    "notification":{
      "title":"Token",
      "body":"Token"
    },
    "data" : {...}
  }
}
```
> When in the background, apps receive the notification payload in the notification tray, and only handle the data payload when the user taps on the notification.

Closes #3117