### PR TITLE
3149/modify_realm_button

### DIFF
--- a/privacyidea/static/components/user/views/user.html
+++ b/privacyidea/static/components/user/views/user.html
@@ -41,8 +41,8 @@
                                 translate>Add user
                         </a>
                     </li>
-                    <li translate>Quick links</li>
-                    <li>
+                    <li ng-show="checkRight('resolverwrite')"
+                        translate>Quick links
                         <a ui-sref="config.realms.list"
                                 translate>Edit realms</a>
                     </li>


### PR DESCRIPTION
The "modify realm" button is now only displayed with "resolverwrite" rights.

closes #3149 