### PR TITLE
More settings in admin console (WebUI)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,8 +9,6 @@ Version 3.7.1, 2022-05-11
   * Add documentation for the CustomUserAttributeHandler (#3075)
   * Send Push message as notification and data to FireBase (#3117)
   * Fix translation issue in PSKC-import (#3126)
-
-  Enhancements:
   * Add App-PIN policy for Push token (#3116)
 
 Version 3.7, 2022-03-31

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import stat
 import sys
 
 #VERSION = "2.1dev4"
-VERSION = "3.7.1dev2"
+VERSION = "3.7.1"
 
 # Taken from kennethreitz/requests/setup.py
 package_directory = os.path.realpath(os.path.dirname(__file__))


### PR DESCRIPTION
Actually when we access to the Web console in admin, we didn't set any thing about the admin user environment himself, like:

- Timeout delay before auto logoff
- Force default language (don't want to use the web browser determine the language)
- Contact information (email) to inform if newer version is available
- Update alert
- Etc.