### PR TITLE
Fix number input type in policies

### DIFF
--- a/privacyidea/static/components/config/views/config.policies.details.html
+++ b/privacyidea/static/components/config/views/config.policies.details.html
@@ -386,7 +386,7 @@
                                                    ng-model="actionValuesNum[action.name]"
                                                    ng-show="action.type=='int' && !action.allowedValues"
                                                    ng-disabled="!actionCheckBox[action.name]"
-                                                   ng-required="actionCheckBox[action.name] && action.type=='num'"
+                                                   ng-required="actionCheckBox[action.name] && action.type=='int'"
                                                    class="form-control"/>
                                             <label for="action_{{ action.name }}_text"></label>
                                             <textarea id="action_{{ action.name }}_text"


### PR DESCRIPTION
In the case of a number input type for a policy action, the input wasn't
correctly validated. Enforcing validation also fixes server errors when
the field was left empty.

Fixes #3203