### PR TITLE
3196/adjusted OTP input field

### DIFF
--- a/privacyidea/static/components/login/views/enter-response.html
+++ b/privacyidea/static/components/login/views/enter-response.html
@@ -17,9 +17,9 @@
                    ng-model="transactionid">
 
 
-            <label for="password" class="sr-only" translate>Response</label>
-            <input name="password" type="password" autocomplete="new-password"
-                   id="password" class="form-control"
+            <label for="otp" class="sr-only" translate>Response</label>
+            <input name="otp" type="password" autocomplete="one-time-code"
+                   id="otp" class="form-control"
                    ng-model="login.password" required
                    placeholder="{{ challenge_message }}"/>
 


### PR DESCRIPTION
Set `name="password"` to `"otp"` and specify `"one-time-code"` as the autofill parameter.

closes #3196.