### PR TITLE
3204/add_anchors_for_policy_descriptions_with_multiple_actions

### DIFF
--- a/doc/policies/admin.rst
+++ b/doc/policies/admin.rst
@@ -323,6 +323,8 @@ spass_otp_pin_contents
 
 type: str
 
+.. _spass-otp-pin-minlength:
+.. _spass-otp-pin-maxlength:
 
 
 spass_otp_pin_minlength and spass_otp_pin_maxlength
@@ -571,6 +573,9 @@ type: bool
 
 Allow the administrator to read the :ref:`privacyideaserver_config` definitions.
 
+.. _policywrite:
+.. _policyread:
+.. _policydelete:
 
 policywrite, policyread, policydelete
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -583,6 +588,10 @@ Allow the administrator to write, read or delete policies.
    or realms. Having the right to read policies, will allow the
    administrator to see all policies.
 
+.. _resolverwrite:
+.. _resolverread:
+.. _resolverdelete:
+
 resolverwrite, resolverread, resolverdelete
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -594,6 +603,10 @@ Allow the administrator to write, read or delete user resolvers and realms.
    or realms. Having the right to read resolvers, will allow the
    administrator to see all resolvers and realms.
 
+.. _mresolverwrite:
+.. _mresolverread:
+.. _mresolverdelete:
+
 mresolverwrite, mresolverread, mresolverdelete
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -601,6 +614,9 @@ type: bool
 
 Allow the administrator to write, read or delete machine resolvers.
 
+.. _configwrite:
+.. _configread:
+.. _configdelete:
 
 configwrite, configread, configdelete
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -609,6 +625,9 @@ type: bool
 
 Allow the administrator to write, read or delete system configuration.
 
+.. _caconnectorwrite:
+.. _caconnectorread:
+.. _caconnectordelete:
 
 caconnectorwrite, caconnectorread, caconnectordelete
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -695,6 +714,8 @@ and is only used for triggering challenges.
 New in version 2.17.
 
 .. _admin_policy_2step:
+.. _hotp-2step:
+.. _totp-2step:
 
 hotp_2step and totp_2step
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -712,6 +733,9 @@ Such a policy can also be set for the user. See :ref:`user_policy_2step`.
 .. note:: This does not work in combination with the enrollment policy :ref:`verify_enrollment`, since
    the usage of 2step already ensures, that the user has successfully scanned the QR code.
 
+.. _hotp-hashlib:
+.. _totp-totp-hashlib:
+
 hotp_hashlib and totp_hashlib
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -722,6 +746,9 @@ The corresponding input selector will be disabled in the web UI.
 Possible values are *sha1*, *sha256* and *sha512*, default is *sha1*.
 
 New in 3.2
+
+.. _hotp-otplen:
+.. _totp-otplen:
 
 hotp_otplen and totp_otplen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -540,6 +540,9 @@ the authentication with push tokens. By default, the verification is enabled. To
 verification during enrollment, see :ref:`policy_push_ssl_verify_enrollment`.
 
 .. _policy_challenge_text:
+.. _challenge-text:
+.. _challenge-text-footer:
+.. _challenge-text-header:
 
 challenge_text, challenge_text_header, challenge_text_footer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -592,6 +595,10 @@ his WebAuthn token during authentication. This might be different from the
 challenge text received during enrollment
 (see :ref:`policy_webauthn_challenge_text_enrollment`).
 
+
+.. _email-challenge-text:
+.. _sms-challenge-text:
+.. _u2f-challenge-text:
 
 email_challenge_text, sms_challenge_text, u2f_challenge_text
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -372,6 +372,12 @@ If you do not want to verify the validity period, you can check this action.
 
 
 .. _2step_parameters:
+.. _hotp-2step-clientsize:
+.. _totp-2step-clientsize:
+.. _hotp-2step-serversize:
+.. _totp-2step-serversize:
+.. _hotp-2step-difficulty:
+.. _totp-2step-difficulty:
 
 {type}_2step_clientsize, {type}_2step_serversize, {type}_2step_difficulty
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -390,6 +396,8 @@ specifies the number of rounds.
 This is new in version 2.21.
 
 .. _force_app_pin:
+.. _hotp-force-app-pin:
+.. _totp-force-app-pin:
 
 hotp_force_app_pin, totp_force_app_pin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/policies/user.rst
+++ b/doc/policies/user.rst
@@ -267,6 +267,8 @@ email with a link to reset the password is sent to the user.
 
 
 .. _user_policy_2step:
+.. _hotp-2step:
+.. _totp-2step:
 
 hotp_2step and totp_2step
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -295,6 +297,9 @@ It allows the user to define an individual SMS gateway during token enrollment.
 
 New in version 3.0.
 
+.. _hotp-hashlib:
+.. _totp-hashlib:
+
 hotp_hashlib and totp_hashlib
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -304,6 +309,9 @@ Force the user to enroll HOTP/TOTP Tokens with the specified hashlib.
 The corresponding input selector will be disabled/hidden in the web UI.
 Possible values are *sha1*, *sha256* and *sha512*, default is *sha1*.
 
+.. _hotp-otplen:
+.. _totp-otplen:
+
 hotp_otplen and totp_otplen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -312,6 +320,9 @@ type: int
 Force the user to enroll HOTP/TOTP Tokens with the specified otp length.
 The corresponding input selector will be disabled/hidden in the web UI.
 Possible values are *6* or *8*, default is *6*.
+
+.. _hotp-force-server-generate:
+.. _totp-force-server-generate:
 
 hotp_force_server_generate and totp_force_server_generate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The documentation has sometimes one description for several actions.
I added some anchors to make all auto generated links work.

**Admin:**
- [x] spass_otp_pin_minlength and spass_otp_pin_maxlength
- [x] policywrite, policyread, policydelete
- [x] resolverwrite, resolverread, resolverdelete
- [x] mresolverwrite, mresolverread, mresolverdelete
- [x] configwrite, configread, configdelete
- [x] caconnectorwrite, caconnectorread, caconnectordelete
- [x] hotp_2step and totp_2step
- [x] hotp_hashlib and totp_hashlib
- [x] hotp_otplen and totp_otplen

**User:**
- [x] hotp_2step and totp_2step
- [x] hotp_hashlib and totp_hashlib
- [x] hotp_otplen and totp_otplen
- [x] hotp_force_server_generate and totp_force_server_generate

**Authentication:**
- [x] challenge_text, challenge_text_header, challenge_text_footer
- [x] email_challenge_text, sms_challenge_text, u2f_challenge_text

**Enrollment:**
- [x] {type}_2step_clientsize, {type}_2step_serversize, {type}_2step_difficulty
- [x] hotp_force_app_pin, totp_force_app_pin

closes #3204. 