### PR TITLE
3198/Enrolling_ssh_pc_without_comment_element

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -151,6 +151,7 @@ class ROLLOUTSTATE(object):
     # This means the user needs to authenticate to verify that the token was successfully enrolled.
     VERIFYPENDING = 'verify'
     ENROLLED = 'enrolled'
+    BROKEN = 'broken'
 
 
 class TokenClass(object):


### PR DESCRIPTION
- [ ] bug fixed when rolling out shh token without comment
- [ ] add exception for ssh keys with less than 2 entries
- [ ] marks incorrectly rolled out tokens as broken in the rollout state
- [ ] add and customize tests