### PR TITLE
2792/Add_support_for_multiple_ssh_types

### DIFF
--- a/privacyidea/lib/tokens/sshkeytoken.py
+++ b/privacyidea/lib/tokens/sshkeytoken.py
@@ -28,6 +28,7 @@ The code is tested in tests/test_lib_tokens_ssh
 import logging
 from privacyidea.lib import _
 from privacyidea.api.lib.utils import getParam
+from privacyidea.lib.error import TokenAdminError
 from privacyidea.lib.log import log_with
 from privacyidea.lib.tokenclass import TokenClass, ROLLOUTSTATE
 from privacyidea.lib.policy import SCOPE, ACTION, GROUP
@@ -121,17 +122,18 @@ class SSHkeyTokenClass(TokenClass):
         self.token.save()
 
         getParam(param, "sshkey", required)
-            
+
         key_elem = param.get("sshkey").split(" ", 2)
-        if key_elem[0] not in ["ssh-rsa", "ssh-ed25519", "ecdsa-sha2-nistp256"]:
+        if key_elem[0] not in ["ssh-rsa", "ssh-ed25519", "ecdsa-sha2-nistp256",
+                               "sk-ecdsa-sha2-nistp256@openssh.com", "sk-ssh-ed25519@openssh.com"]:
             self.token.rollout_state = ROLLOUTSTATE.BROKEN
             self.token.save()
-            raise Exception("The keytype you specified is not supported.")
+            raise TokenAdminError("The keytype you specified is not supported.")
 
         if len(key_elem) < 2:
             self.token.rollout_state = ROLLOUTSTATE.BROKEN
             self.token.save()
-            raise Exception("Missing key.")
+            raise TokenAdminError("Missing key.")
 
         key_type = key_elem[0]
         key = key_elem[1]
@@ -161,4 +163,7 @@ class SSHkeyTokenClass(TokenClass):
         key_comment = ti.get("ssh_comment")
         # get the ssh key directly, otherwise it will not be decrypted
         sshkey = self.get_tokeninfo("ssh_key")
-        return u"{0!s} {1!s} {2!s}".format(key_type, sshkey, key_comment)
+        r = u"{0!s} {1!s}".format(key_type, sshkey)
+        if key_comment:
+            r += " " + key_comment
+        return r

--- a/tests/test_lib_tokens_ssh.py
+++ b/tests/test_lib_tokens_ssh.py
@@ -3,7 +3,7 @@
 This test file tests the lib.tokens.sshkeytoken
 This depends on lib.tokenclass
 """
-
+from privacyidea.lib.error import TokenAdminError
 from .base import MyTestCase
 from privacyidea.lib.tokenclass import ROLLOUTSTATE
 from privacyidea.lib.tokens.sshkeytoken import SSHkeyTokenClass
@@ -17,6 +17,7 @@ class SSHTokenTestCase(MyTestCase):
     serial1 = "ser1"
     serial2 = "ser2"
     serial3 = "ser3"
+    serial4 = "ser4"
     sshkey = u"ssh-rsa " \
              u"AAAAB3NzaC1yc2EAAAADAQABAAACAQDJy0rLoxqc8SsY8DVAFijMsQyCv" \
              u"hBu4K40hdZOacXK4O6OgnacnSKN56MP6pzz2+4svzvDzwvkFsvf34pbsgD" \
@@ -37,10 +38,14 @@ class SSHTokenTestCase(MyTestCase):
                    u"zurWTqxSMx203rY77t6xnHLZBMPPpv8rk0= cornelius@puck"
     sshkey_ed25519 = u"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC38dIb3tM6nPrT" \
                      u"3j1UfsQxOCBbf3JogwsKeVPM893Pi cornelius@puck"
+    ecdsa_sk = u"sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlz" \
+               u"dHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBOStamg+GO4TSgtoWjc82p" \
+               u"OKZIDuOeAt/8PU/jbzEmth6VuNhghRTCPqPMFtR6mB3Pb12yMDRiLH/t1VwkvWWYIA" \
+               u"AAAEc3NoOg=="
     wrong_sshkey = """---- BEGIN SSH2 PUBLIC KEY ----
-AAAAB3NzaC1kc3MAAACBAKrFC6uDvuxl9vnYL/Fu/Vq+12KJF4
-RyMSQe4mn8oHJma2VzepBRBpLt7Q==
----- END SSH2 PUBLIC KEY ----"""
+    AAAAB3NzaC1kc3MAAACBAKrFC6uDvuxl9vnYL/Fu/Vq+12KJF4
+    RyMSQe4mn8oHJma2VzepBRBpLt7Q==
+    ---- END SSH2 PUBLIC KEY ----"""
     INVALID_SSH = "ssh-rsa"
 
     def test_01_create_token(self):
@@ -49,19 +54,19 @@ RyMSQe4mn8oHJma2VzepBRBpLt7Q==
         token = SSHkeyTokenClass(db_token)
 
         # An invalid key, raises an exception
-        self.assertRaises(Exception, token.update, {"sshkey": "InvalidKey"})
+        self.assertRaises(TokenAdminError, token.update, {"sshkey": "InvalidKey"})
         self.assertEqual(token.rollout_state, ROLLOUTSTATE.BROKEN)
 
         # An invalid key, raises an exception
-        self.assertRaises(Exception, token.update, {"sshkey": self.INVALID_SSH})
+        self.assertRaises(TokenAdminError, token.update, {"sshkey": self.INVALID_SSH})
         self.assertEqual(token.rollout_state, ROLLOUTSTATE.BROKEN)
 
         # An invalid key, raises an exception
-        self.assertRaises(Exception, token.update, {"sshkey": self.wrong_sshkey})
+        self.assertRaises(TokenAdminError, token.update, {"sshkey": self.wrong_sshkey})
         self.assertEqual(token.rollout_state, ROLLOUTSTATE.BROKEN)
 
         # An unsupported keytype
-        self.assertRaises(Exception, token.update, {"sshkey": self.unsupported_keytype})
+        self.assertRaises(TokenAdminError, token.update, {"sshkey": self.unsupported_keytype})
         self.assertEqual(token.rollout_state, ROLLOUTSTATE.BROKEN)
 
         # Set valid key
@@ -85,6 +90,12 @@ RyMSQe4mn8oHJma2VzepBRBpLt7Q==
         db_token.save()
         token = SSHkeyTokenClass(db_token)
         token.update({"sshkey": self.sshkey_ed25519})
+
+        # ecdsa_sk
+        db_token = Token(self.serial4, tokentype="sshkey")
+        db_token.save()
+        token = SSHkeyTokenClass(db_token)
+        token.update({"sshkey": self.ecdsa_sk})
 
     def test_02_class_methods(self):
         db_token = Token.query.filter(Token.serial == self.serial1).first()
@@ -114,4 +125,10 @@ RyMSQe4mn8oHJma2VzepBRBpLt7Q==
         token = SSHkeyTokenClass(db_token)
         sshkey = token.get_sshkey()
         self.assertTrue(sshkey == self.sshkey_ed25519, sshkey)
+        self.assertIsInstance(sshkey, six.text_type)
+
+        db_token = Token.query.filter(Token.serial == self.serial4).first()
+        token = SSHkeyTokenClass(db_token)
+        sshkey = token.get_sshkey()
+        self.assertEqual(self.ecdsa_sk, sshkey)
         self.assertIsInstance(sshkey, six.text_type)


### PR DESCRIPTION
- add `sk-ecdsa-sha2-nistp256@openssh.com`, `sk-ssh-ed25519@openssh.com` in accepted ssh types
- adjust tests

closes #2792 