### PR TITLE
Do not delete client, when policy is disabled

### DIFF
--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1344,11 +1344,11 @@ def set_policy(name=None, scope=None, action=None, realm=None, resolver=None,
         resolver = ", ".join(resolver)
     if type(client) == list:
         client = ", ".join(client)
-    try:
-        client = client or ""
-        check_ip_in_policy("127.0.0.1", [c.strip() for c in client.split(",")])
-    except AddrFormatError:
-        raise privacyIDEAError(_("Invalid client definition!"), id=302)
+    if client is not None:
+        try:
+            check_ip_in_policy("127.0.0.1", [c.strip() for c in client.split(",")])
+        except AddrFormatError:
+            raise privacyIDEAError(_("Invalid client definition!"), id=302)
     if type(pinode) == list:
         pinode = ", ".join(pinode)
     # validate conditions parameter

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1513,6 +1513,29 @@ class PolicyTestCase(MyTestCase):
         self.assertEqual(sorted(d.get("set").get("hello")), ["one", "three", "two"])
         self.assertEqual(sorted(d.get("set").get("hello2")), ["*"])
 
+    def test_40_disable_policy_client_remains(self):
+        pname = "client_must_not_vanish"
+        test_ip = "1.2.3.4"
+        set_policy(pname, scope=SCOPE.AUTH,
+                   action="otppin=none", client=test_ip)
+        p = PolicyClass()
+        plist = p.list_policies(name=pname)
+        self.assertIn(test_ip, plist[0].get("client"))
+        # Now disable the policy
+        enable_policy(pname, enable=False)
+        # client is still there
+        p = PolicyClass()
+        plist = p.list_policies(name=pname)
+        self.assertIn(test_ip, plist[0].get("client"))
+        # enable policy again
+        enable_policy(pname, enable=True)
+        # client is still there
+        p = PolicyClass()
+        plist = p.list_policies(name=pname)
+        self.assertIn(test_ip, plist[0].get("client"))
+        # clean up
+        delete_policy(pname)
+
 
 class PolicyMatchTestCase(MyTestCase):
     @classmethod


### PR DESCRIPTION
A client logic check led to the problem, that the client
was deleted from a policy, when the policy was disabled or enabled.

The client information must not deleted from the policy.

Fix #3243