### PR TITLE
Properly verify webauthn trust anchors

### DIFF
--- a/privacyidea/lib/tokens/webauthn.py
+++ b/privacyidea/lib/tokens/webauthn.py
@@ -59,6 +59,7 @@ import os
 import struct
 
 import cbor2
+import cryptography.x509
 import six
 from OpenSSL import crypto
 from cryptography import x509
@@ -140,6 +141,7 @@ class ATTESTATION_FORMAT(object):
 
 
 # Only supporting 'fido-u2f', 'packed', and 'none' attestation formats for now.
+# TODO: implement android, apple and TPM authentication formats
 SUPPORTED_ATTESTATION_FORMATS = (
     ATTESTATION_FORMAT.FIDO_U2F,
     ATTESTATION_FORMAT.PACKED,
@@ -952,25 +954,27 @@ class WebAuthnRegistrationResponse(object):
             #
             # Verify the sig using verificationData and certificate public
             # key per [SEC1].
-            if client_data_hash:
-                try:
-                    _verify_signature(certificate_public_key, alg, verification_data, signature)
-                except InvalidSignature:
-                    raise RegistrationRejectedException('Invalid signature received.')
-                except NotImplementedError:
-                    # We do not support this. Treat as none attestation, if acceptable.
-                    if none_attestation_permitted:
-                        attestation_type = ATTESTATION_TYPE.NONE
-                        trust_path = []
-                        return (
-                            attestation_type,
-                            trust_path,
-                            credential_pub_key,
-                            cred_id,
-                            aaguid
-                        )
+            if not client_data_hash:
+                raise RegistrationRejectedException('Client data hash not available')
 
-                    raise RegistrationRejectedException('Unsupported algorithm.')
+            try:
+                _verify_signature(certificate_public_key, alg, verification_data, signature)
+            except InvalidSignature:
+                raise RegistrationRejectedException('Invalid signature received.')
+            except NotImplementedError:
+                # We do not support this. Treat as none attestation, if acceptable.
+                if none_attestation_permitted:
+                    attestation_type = ATTESTATION_TYPE.NONE
+                    trust_path = []
+                    return (
+                        attestation_type,
+                        trust_path,
+                        credential_pub_key,
+                        cred_id,
+                        aaguid
+                    )
+
+                raise RegistrationRejectedException('Unsupported algorithm.')
 
             # Step 7.
             #
@@ -1024,6 +1028,7 @@ class WebAuthnRegistrationResponse(object):
             # If x5c is present, this indicates that the attestation
             # type is not ECDAA.
             if 'x5c' in att_stmt:
+                # TODO: this could be a certificate chain, we should treat it as such
                 att_cert = att_stmt['x5c'][0]
                 x509_att_cert = load_der_x509_certificate(att_cert, default_backend())
                 certificate_public_key = x509_att_cert.public_key()
@@ -1136,7 +1141,7 @@ class WebAuthnRegistrationResponse(object):
                     aaguid
                 )
             elif 'ecdaaKeyId' in att_stmt:
-                # We do not support this. If attestation is optional, have it go through anyways.
+                # We do not support this. If attestation is optional, have it go through anyway.
                 if none_attestation_permitted:
                     attestation_type = ATTESTATION_TYPE.ECDAA
                     trust_path = []
@@ -1309,7 +1314,7 @@ class WebAuthnRegistrationResponse(object):
             # supported WebAuthn Attestation Statement Format Identifier
             # values. The up-to-date list of registered WebAuthn
             # Attestation Statement Format Identifier values is maintained
-            # in the in the IANA registry of the same name.
+            # in the IANA registry of the same name.
             if not _verify_attestation_statement_format(fmt):
                 raise RegistrationRejectedException('Unable to verify attestation statement format.')
 
@@ -1365,11 +1370,10 @@ class WebAuthnRegistrationResponse(object):
             #       certificate.
             if attestation_type == ATTESTATION_TYPE.SELF_ATTESTATION and not self.self_attestation_permitted:
                 raise RegistrationRejectedException('Self attestation is not permitted.')
-            is_trusted_attestation_cert = \
-                attestation_type == ATTESTATION_TYPE.BASIC \
-                    and _is_trusted_x509_attestation_cert(trust_path, trust_anchors) \
-                or attestation_type == ATTESTATION_TYPE.ECDAA \
-                    and _is_trusted_ecdaa_attestation_certificate(None, trust_anchors)
+            is_trusted_attestation_cert = ((attestation_type == ATTESTATION_TYPE.BASIC
+                                            and _is_trusted_x509_attestation_cert(trust_path, trust_anchors))
+                                           or (attestation_type == ATTESTATION_TYPE.ECDAA
+                                               and _is_trusted_ecdaa_attestation_certificate(None, trust_anchors)))
             is_signed_attestation_cert = attestation_type in SUPPORTED_ATTESTATION_TYPES
 
             if is_trusted_attestation_cert:
@@ -1788,18 +1792,25 @@ def _get_trust_anchors(attestation_type, attestation_fmt, trust_anchor_dir):
     """
     Return a list of trusted attestation root certificates.
 
-    This will fetch all CA certificates from the given directory, silently skipping any invalid ones.
+    This will fetch all CA certificates from the given directory, silently
+    skipping any invalid ones.
 
-    :param attestation_type: The attestation type being used. If the type is unsupported, an empty list is returned.
-    :type attestation_type: basestring
-    :param attestation_fmt: The attestation format being used. If the format is unsupported, an empty list is returned.
-    :type attestation_fmt: basestring
+    :param attestation_type: The attestation type being used. If the type is
+                             unsupported, an empty list is returned.
+    :type attestation_type: str
+    :param attestation_fmt: The attestation format being used. If the format is
+                            unsupported, an empty list is returned.
+    :type attestation_fmt: str
     :param trust_anchor_dir: The path to the directory that contains the CA certificates.
-    :type trust_anchor_dir: basestring
+    :type trust_anchor_dir: str
     :return: The list of trust anchors.
+    :rtype: list
     """
 
-    if attestation_type not in SUPPORTED_ATTESTATION_TYPES or attestation_fmt not in SUPPORTED_ATTESTATION_FORMATS:
+    if attestation_type not in SUPPORTED_ATTESTATION_TYPES \
+            or attestation_fmt not in SUPPORTED_ATTESTATION_FORMATS:
+        log.debug('Unsupported attestation type ({0!s}) or attestation format '
+                  '({1!s}).'.format(attestation_type, attestation_fmt))
         return []
 
     trust_anchors = []
@@ -1808,24 +1819,32 @@ def _get_trust_anchors(attestation_type, attestation_fmt, trust_anchor_dir):
         for trust_anchor_name in os.listdir(trust_anchor_dir):
             trust_anchor_path = os.path.join(trust_anchor_dir, trust_anchor_name)
             if os.path.isfile(trust_anchor_path):
-                with open(trust_anchor_path, 'rb') as f:
-                    pem_data = f.read().strip()
-                    try:
-                        pem = crypto.load_certificate(crypto.FILETYPE_PEM, pem_data)
+                try:
+                    with open(trust_anchor_path, 'rb') as f:
+                        pem_data = f.read().strip()
+                        pem = cryptography.x509.load_pem_x509_certificate(pem_data.strip())
                         trust_anchors.append(pem)
-                    except Exception:
-                        pass
+                except Exception as e:
+                    log.info('Could not load certificate {0!s}: '
+                             '{1!s}'.format(trust_anchor_path, e))
+    else:
+        log.debug('Trust anchor directory ({0!s}) not available.'.format(trust_anchor_dir))
+
+    return trust_anchors
 
 
 def _is_trusted_x509_attestation_cert(trust_path, trust_anchors):
     if not trust_path or not isinstance(trust_path, list) or not trust_anchors or not isinstance(trust_anchors, list):
         return False
 
+    # TODO: this could be a certificate chain. We should treat it as such
     attestation_cert = trust_path[0]
     store = crypto.X509Store()
+    # Since the certificates are in pyca.cryptography format, we need to convert
+    # them to the OpenSSL.crypto format
     for i in trust_anchors:
-        store.add_cert(i)
-    store_ctx = crypto.X509StoreContext(store, attestation_cert)
+        store.add_cert(crypto.X509.from_cryptography(i))
+    store_ctx = crypto.X509StoreContext(store, crypto.X509.from_cryptography(attestation_cert))
 
     try:
         store_ctx.verify_certificate()
@@ -1837,8 +1856,8 @@ def _is_trusted_x509_attestation_cert(trust_path, trust_anchors):
 
 
 def _is_trusted_ecdaa_attestation_certificate(ecdaa_issuer_public_key, trust_anchors):
-    # Unsupported
-    return False
+    # TODO: implement
+    raise NotImplementedError
 
 
 def _verify_type(received_type, expected_type):
@@ -1864,7 +1883,8 @@ def _verify_origin(client_data, origin):
 
 def _verify_token_binding_id(client_data):
     """
-    Verify tokenBinding. Currently this is unimplemented, so it will simply return false if tokenBinding is required.
+    Verify tokenBinding. Currently, this is unimplemented, so it will simply
+    return false if tokenBinding is required.
 
     The tokenBinding member contains information about the state of the
     Token Binding protocol used when communicating with the Relying Party.


### PR DESCRIPTION
Trust anchor certificates weren't used properly to verify the
attestation certificate in a register request.

ToDo: verifying a certificate chain in the 'packed' attestation format
is currently not implemented

Closes #3216 