### PR TITLE
Remove unnecessary hexlification

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -814,7 +814,11 @@ def check_verify_enrollment(request, response):
                 tokenobj.token.rollout_state = ROLLOUTSTATE.VERIFYPENDING
                 tokenobj.token.save()
                 response.set_data(json.dumps(content))
-    else:
+    elif len(tokenobj_list) > 1:
         log.warning("No distinct token object found in enrollment response!")
+    else:
+        # Some enrollments don't provide a token in the second step (WebAuthn)
+        # Maybe we could implement a verification step for these tokens as well.
+        pass
 
     return response

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -728,7 +728,7 @@ class WebAuthnTokenClass(TokenClass):
     @staticmethod
     def get_setting_type(key):
         """
-        Fetch the type of a setting specific to WebAuthn tokens.
+        Fetch the type of setting specific to WebAuthn tokens.
 
         The WebAuthn token defines several public settings. When these are
         written to the database, the type of the setting is automatically
@@ -790,7 +790,7 @@ class WebAuthnTokenClass(TokenClass):
         :rtype: basestring
         """
 
-        return webauthn_b64_encode(binascii.unhexlify(self.token.get_otpkey().getKey()))
+        return webauthn_b64_encode(self.token.get_otpkey().getKey())
 
     def update(self, param, reset_failcount=True):
         """
@@ -866,7 +866,7 @@ class WebAuthnTokenClass(TokenClass):
                 token.decrypt_otpkey() for token in get_tokens(tokentype=self.type)
             ])
 
-            self.set_otpkey(hexlify_and_unicode(webauthn_b64_decode(web_authn_credential.credential_id)))
+            self.set_otpkey(web_authn_credential.credential_id)
             self.set_otp_count(web_authn_credential.sign_count)
             self.add_tokeninfo(WEBAUTHNINFO.PUB_KEY,
                                hexlify_and_unicode(webauthn_b64_decode(web_authn_credential.public_key)))
@@ -944,7 +944,6 @@ class WebAuthnTokenClass(TokenClass):
 
             # To aid with unit testing a fixed nonce may be passed in.
             nonce = self._get_nonce()
-
             # Create the challenge in the database
             challenge = Challenge(serial=self.token.serial,
                                   transaction_id=getParam(params, 'transaction_id', optional),

--- a/tests/test_lib_tokens_webauthn.py
+++ b/tests/test_lib_tokens_webauthn.py
@@ -175,7 +175,7 @@ class WebAuthnTokenTestCase(MyTestCase):
     USER_RESOLVER = "testresolver"
 
     def _create_challenge(self):
-        self.token.set_otpkey(hexlify_and_unicode(webauthn_b64_decode(CRED_ID)))
+        self.token.set_otpkey(webauthn_b64_decode(CRED_ID))
         self.token.add_tokeninfo(WEBAUTHNINFO.PUB_KEY, PUB_KEY)
         self.token.add_tokeninfo(WEBAUTHNINFO.RELYING_PARTY_ID, RP_ID)
         (_, _, _, response_details) = self.token.create_challenge(options=self.challenge_options)
@@ -399,7 +399,7 @@ class WebAuthnTestCase(unittest.TestCase):
             user_name=USER_NAME,
             user_display_name=USER_DISPLAY_NAME,
             icon_url=ICON_URL,
-            credential_id=credential.credential_id.decode(),
+            credential_id=webauthn_b64_encode(credential.credential_id),
             public_key=credential.public_key,
             sign_count=credential.sign_count,
             rp_id=credential.rp_id


### PR DESCRIPTION
The webauthn code does an additional hexlification of the credential id
before saving it to the db. Since it is saved in the `key_enc` column
of the token table which is limited to 1024 characters, the maximum
length of the credential id is 512 bytes (while the draft WebAuthn 3
standard proposes a length of 1023 bytes).

In the long run we could save the credential id as a tokeninfo value to
avoid db limits.

Also fixes an unnecessary warning in the `check_verify` postpolicy.

Fixes #3137