### PR TITLE
Make webauthn algorithms selectable

### DIFF
--- a/doc/policies/authorization.rst
+++ b/doc/policies/authorization.rst
@@ -331,7 +331,7 @@ type: string
 This action allows filtering of WebAuthn tokens by the fields of the
 attestation certificate.
 
-The action can be specified like this:
+The action can be specified like this::
 
     webauthn_req=subject/.*Yubico.*/
 

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -729,7 +729,7 @@ type: string
 This action allows filtering of WebAuthn tokens by the fields of the
 attestation certificate.
 
-The action can be specified like this:
+The action can be specified like this::
 
     webauthn_req=subject/.*Yubico.*/
 

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -629,21 +629,22 @@ supported by the token.
 .. note:: If you configure this, you will likely also want to configure
     :ref:`policy_webauthn_authn_user_verification_requirement`.
 
-.. _policy_webauthn_enroll_public_key_credential_algorithm_preference:
+.. _policy_webauthn_enroll_public_key_credential_algorithms:
 
-webauthn_public_key_credential_algorithm_preference
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+webauthn_public_key_credential_algorithms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 type: string
 
-This action configures which algorithms should be preferred for the creation
-of WebAuthn asymmetric cryptography key pairs, and in which order. privacyIDEA
-currently supports ECDSA as well as RSASSA-PSS. Please check back with the
-manufacturer of your authenticators to get information on which algorithms are
-acceptable to your model of authenticator.
+This action configures which algorithms should be available for the creation
+of WebAuthn asymmetric cryptography key pairs. privacyIDEA
+currently supports ECDSA, RSASSA-PSS and RSASSA-PKCS1-v1_5. Please check back
+with the manufacturer of your authenticators to get information on which
+algorithms are acceptable to your model of authenticator.
 
-The default is to allow both ECDSA and RSASSA-PSS, but to prefer ECDSA over
-RSASSA-PSS.
+The default is to allow both ECDSA and RSASSA-PSS.
+
+The Order of preferred algorithms is `ECDSA > RSASSA-PSS > RSASSA-PKCS1-v1_5`
 
 .. note:: Not all authenticators will supports all algorithms. It should not
     usually be necessary to configure this action. Do *not* change this

--- a/migrations/versions/00762b3f7a60_.py
+++ b/migrations/versions/00762b3f7a60_.py
@@ -1,0 +1,68 @@
+"""v3.8: migrate WebAuthn credential algorithm selection
+
+Revision ID: 00762b3f7a60
+Revises: 86f40f535d7c
+Create Date: 2022-08-31 11:24:12.226997
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '00762b3f7a60'
+down_revision = '86f40f535d7c'
+
+import re
+from alembic import op
+from sqlalchemy import orm, update
+from privacyidea.models import Policy
+
+old_policy_action = 'webauthn_public_key_credential_algorithm_preference'
+new_policy_action = 'webauthn_public_key_credential_algorithms'
+cred_alg_map = {
+    'ecdsa_preferred': 'ecdsa rsassa-pss',
+    'ecdsa_only': 'ecdsa',
+    'rsassa-pss_preferred': 'ecdsa rsassa-pss',
+    'rsassa-pss_only': 'rsassa-pss'}
+
+
+def upgrade():
+    # we need to change the enrollment policy action from
+    # "webauthn_public_key_credential_algorithm_preference" to
+    # "webauthn_public_key_credential_algorithms" and also change the value
+    # to directly use the (space separated) algorithms.
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    regex = re.compile('^{0!s}'.format(old_policy_action))
+    try:
+        for row in session.query(Policy).filter(Policy.action.like('%{0!s}%'.format(old_policy_action))):
+            # get the current setting
+            pol_actions = [x.strip() for x in row.action.split(',')]
+            for pol_action in filter(regex.match, pol_actions):
+                cred_algs = cred_alg_map[pol_action.split('=')[1]]
+                pol_actions.remove(pol_action)
+                pol_actions.append('{0!s}={1!s}'.format(new_policy_action, cred_algs))
+            row.action = ', '.join(pol_actions)
+        session.commit()
+    except Exception as e:
+        session.rollback()
+        print('Error updating the enrollment policy {0!s}: {1!s}'.format(old_policy_action, e))
+
+
+def downgrade():
+    # for the downgrade we just use the "ecdsa_preferred" setting
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    regex = re.compile('^{0!s}'.format(new_policy_action))
+    try:
+        for row in session.query(Policy).filter(Policy.action.like('%{0!s}%'.format(new_policy_action))):
+            # get the current setting
+            pol_actions = [x.strip() for x in row.action.split(',')]
+            for pol_action in filter(regex.match, pol_actions):
+                pol_actions.remove(pol_action)
+                pol_actions.append('{0!s}={1!s}'.format(old_policy_action, 'ecdsa_preferred'))
+            row.action = ', '.join(pol_actions)
+        session.commit()
+    except Exception as e:
+        session.rollback()
+        print('Error downgrading the enrollment policy {0!s}: {1!s}'.format(new_policy_action, e))
+    pass

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1922,7 +1922,7 @@ def webauthntoken_enroll(request, action):
         public_key_credential_algorithm_pref_policies = Match.user(
             g,
             scope=SCOPE.ENROLL,
-            action=WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS,
+            action=WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHMS,
             user_object=request.User if hasattr(request, 'User') else None
         ).action_values(unique=False)
         public_key_credential_algorithm_pref = public_key_credential_algorithm_pref_policies.keys() \
@@ -1931,7 +1931,7 @@ def webauthntoken_enroll(request, action):
         if not all([x in PUBLIC_KEY_CREDENTIAL_ALGORITHMS for x in public_key_credential_algorithm_pref]):
             raise PolicyError(
                 "{0!s} must be one of {1!s}"
-                    .format(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS,
+                    .format(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHMS,
                             ', '.join(PUBLIC_KEY_CREDENTIAL_ALGORITHMS.keys())))
 
         authenticator_attestation_level_policies = Match\
@@ -1985,7 +1985,7 @@ def webauthntoken_enroll(request, action):
 
         request.all_data[WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT] \
             = authenticator_attachment
-        request.all_data[WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS] \
+        request.all_data[WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHMS] \
             = [PUBLIC_KEY_CREDENTIAL_ALGORITHMS[x]
                for x in PUBKEY_CRED_ALGORITHMS_ORDER
                if x in public_key_credential_algorithm_pref]
@@ -2106,8 +2106,8 @@ def _attestation_certificate_allowed(attestation_cert, allowed_certs_pols):
     against, while attestation_certificate_required() expects the plain fields
     from the token info, containing just the issuer, serial and subject.
 
-    :param cert_info: The cert.
-    :type cert_info: X509 or None
+    :param attestation_cert: The attestation certificate.
+    :type attestation_cert: OpenSSL.crypto.X509 or None
     :param allowed_certs_pols: The policies restricting enrollment, or authorization.
     :type allowed_certs_pols: dict or None
     :return: Whether the token should be allowed to complete enrollment, or authorization, based on its attestation.

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -97,7 +97,8 @@ from privacyidea.lib.tokens.webauthn import (WebAuthnRegistrationResponse,
                                              ATTESTATION_FORMS)
 from privacyidea.lib.tokens.webauthntoken import (WEBAUTHNACTION,
                                                   DEFAULT_PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE,
-                                                  PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE_OPTIONS,
+                                                  PUBLIC_KEY_CREDENTIAL_ALGORITHMS,
+                                                  PUBKEY_CRED_ALGORITHMS_ORDER,
                                                   DEFAULT_TIMEOUT, DEFAULT_ALLOWED_TRANSPORTS,
                                                   DEFAULT_USER_VERIFICATION_REQUIREMENT,
                                                   DEFAULT_AUTHENTICATOR_ATTESTATION_LEVEL,
@@ -1917,20 +1918,21 @@ def webauthntoken_enroll(request, action):
                and list(authenticator_attachment_policies)[0] in AUTHENTICATOR_ATTACHMENT_TYPES \
             else None
 
-        public_key_credential_algorithm_preference_policies = Match\
-            .user(g,
-                  scope=SCOPE.ENROLL,
-                  action=WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE,
-                  user_object=request.User if hasattr(request, 'User') else None) \
-            .action_values(unique=True)
-        public_key_credential_algorithm_preference = list(public_key_credential_algorithm_preference_policies)[0] \
-            if public_key_credential_algorithm_preference_policies \
+        # we need to set `unique` to False since this policy can contain multiple values
+        public_key_credential_algorithm_pref_policies = Match.user(
+            g,
+            scope=SCOPE.ENROLL,
+            action=WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS,
+            user_object=request.User if hasattr(request, 'User') else None
+        ).action_values(unique=False)
+        public_key_credential_algorithm_pref = public_key_credential_algorithm_pref_policies.keys() \
+            if public_key_credential_algorithm_pref_policies \
             else DEFAULT_PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE
-        if public_key_credential_algorithm_preference not in PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE_OPTIONS.keys():
+        if not all([x in PUBLIC_KEY_CREDENTIAL_ALGORITHMS for x in public_key_credential_algorithm_pref]):
             raise PolicyError(
                 "{0!s} must be one of {1!s}"
-                    .format(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE,
-                            ', '.join(PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE_OPTIONS.keys())))
+                    .format(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS,
+                            ', '.join(PUBLIC_KEY_CREDENTIAL_ALGORITHMS.keys())))
 
         authenticator_attestation_level_policies = Match\
             .user(g,
@@ -1983,8 +1985,10 @@ def webauthntoken_enroll(request, action):
 
         request.all_data[WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT] \
             = authenticator_attachment
-        request.all_data[WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE] \
-            = PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE_OPTIONS[public_key_credential_algorithm_preference]
+        request.all_data[WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS] \
+            = [PUBLIC_KEY_CREDENTIAL_ALGORITHMS[x]
+               for x in PUBKEY_CRED_ALGORITHMS_ORDER
+               if x in public_key_credential_algorithm_pref]
         request.all_data[WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL] \
             = authenticator_attestation_level
         request.all_data[WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM] \

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -400,7 +400,6 @@ def attestation_certificate_allowed(cert_info, allowed_certs_pols):
     if not cert_info:
         return not allowed_certs_pols
 
-
     if allowed_certs_pols:
         for allowed_cert in allowed_certs_pols:
             tag, matching, _rest = allowed_cert.split("/", 3)
@@ -411,6 +410,7 @@ def attestation_certificate_allowed(cert_info, allowed_certs_pols):
                 return False
 
     return True
+
 
 def is_fqdn(x):
     """

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -298,14 +298,14 @@ def check():
                 "serial": "PIEM0000AB00",
                 "type": "email",
                 "transaction_id": "12345678901234567890",
-                "multi_challenge: [ {"serial": "PIEM0000AB00",
-                                     "transaction_id":  "12345678901234567890",
-                                     "message": "Please enter otp from your email",
-                                     "client_mode": "interactive"},
-                                    {"serial": "PISM12345678",
-                                     "transaction_id": "12345678901234567890",
-                                     "message": "Please enter otp from your SMS",
-                                     "client_mode": "interactive"}
+                "multi_challenge": [ {"serial": "PIEM0000AB00",
+                                      "transaction_id":  "12345678901234567890",
+                                      "message": "Please enter otp from your email",
+                                      "client_mode": "interactive"},
+                                     {"serial": "PISM12345678",
+                                      "transaction_id": "12345678901234567890",
+                                      "message": "Please enter otp from your SMS",
+                                      "client_mode": "interactive"}
                 ]
               },
               "id": 2,

--- a/privacyidea/lib/tokens/webauthn.py
+++ b/privacyidea/lib/tokens/webauthn.py
@@ -1171,7 +1171,8 @@ class WebAuthnRegistrationResponse(object):
                 if fmt == ATTESTATION_FORMAT.NONE:
                     raise RegistrationRejectedException('Authenticator attestation is required.')
                 else:
-                    raise RegistrationRejectedException('Unsupported authenticator attestation format.')
+                    raise RegistrationRejectedException(
+                        'Unsupported authenticator attestation format ({0!s})!'.format(fmt))
 
             # Treat as none attestation.
             #

--- a/privacyidea/lib/tokens/webauthn.py
+++ b/privacyidea/lib/tokens/webauthn.py
@@ -1206,6 +1206,9 @@ class WebAuthnRegistrationResponse(object):
         """
 
         try:
+            # As described in https://www.w3.org/TR/webauthn/#sctn-registering-a-new-credential
+            # In the docs it starts at step 5.
+            #
             # Step 1.
             #
             # Let JSONtext be the result of running UTF-8 decode on the value of

--- a/privacyidea/lib/tokens/webauthn.py
+++ b/privacyidea/lib/tokens/webauthn.py
@@ -699,7 +699,8 @@ class WebAuthnUser(object):
         self.rp_id = rp_id
 
     def __str__(self):
-        return '{} ({}, {}, {})'.format(self.user_id, self.user_name, self.user_display_name, self.sign_count)
+        return '{!r} ({}, {}, {})'.format(self.user_id, self.user_name,
+                                          self.user_display_name, self.sign_count)
 
 
 class WebAuthnCredential(object):

--- a/privacyidea/lib/tokens/webauthn.py
+++ b/privacyidea/lib/tokens/webauthn.py
@@ -425,9 +425,9 @@ class WebAuthnMakeCredentialOptions(object):
         :type rp_id: basestring
         :param user_id: The ID for the user credential being generated. This is the privacyIDEA token serial.
         :type user_id: basestring
-        :param user_name: The user name the user logs in with.
+        :param user_name: The username the user logs in with.
         :type user_name: basestring
-        :param user_display_name: The human readable name of the user.
+        :param user_display_name: The human-readable name of the user.
         :type user_display_name: basestring
         :param icon_url: An optional icon url.
         :type icon_url: basestring
@@ -664,9 +664,9 @@ class WebAuthnUser(object):
 
         :param user_id: The ID for the user credential being stored. This is the privacyIDEA token serial.
         :type user_id: basestring
-        :param user_name: The user name the user logs in with.
+        :param user_name: The username the user logs in with.
         :type user_name: basestring
-        :param user_display_name: The human readable name of the user.
+        :param user_display_name: The human-readable name of the user.
         :type user_display_name: basestring
         :param icon_url: An optional icon url.
         :type icon_url: basestring
@@ -770,8 +770,9 @@ class WebAuthnCredential(object):
 
         return not ATTESTATION_REQUIREMENT_LEVEL[self.attestation_level]['self_attestation_permitted']
 
-    def __str_(self):
-        return '{} ({}, {}, {})'.format(self.credential_id, self.rp_id, self.origin, self.sign_count)
+    def __str__(self):
+        return '{!r} ({}, {}, {})'.format(self.credential_id, self.rp_id,
+                                          self.origin, self.sign_count)
 
 
 class WebAuthnRegistrationResponse(object):

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -195,11 +195,11 @@ description of the newly created token.
 **Step 2**
 
 .. sourcecode:: http
-    
+
     POST /token/init HTTP/1.1
     Host: <privacyIDEA server>
     Accept: application/json
-    
+
     type=webauthn
     transaction_id=<transaction_id>
     description=<description>
@@ -251,7 +251,7 @@ for the token (without requiring any special permissions).
     POST /validate/check HTTP/1.1
     Host: <privacyIDEA server>
     Accept: application/json
-    
+
     user=<username>
     pass=<password>
 
@@ -314,10 +314,10 @@ using a service account (without requiring the PIN for the token).
     Host: <privacyIDEA server>
     Accept: application/json
     PI-Authorization: <authToken>
-    
+
     user=<username>
     serial=<tokenSerial>
-    
+
 Providing the *tokenSerial* is optional. If just a user is provided, a
 challenge will be triggered for every challenge response token the user has.
 
@@ -385,7 +385,7 @@ challenge will be triggered for every challenge response token the user has.
         },
         "version": "<privacyIDEA version>"
     }
-    
+
 Send the Response
 ~~~~~~~~~~~~~~~~~
 
@@ -441,7 +441,7 @@ native encoding of the language (usually utf-16).
     POST /validate/check HTTP/1.1
     Host: example.com
     Accept: application/json
-    
+
     user=<user>
     pass=
     transaction_id=<transaction_id>
@@ -1269,9 +1269,10 @@ class WebAuthnTokenClass(TokenClass):
                     getParam(options, WEBAUTHNACTION.REQ, optional)
             ):
                 log.warning(
-                    "The WebAuthn token {0!s} is not allowed to authenticate due to policy restriction {1!s}"
-                        .format(self.token.serial, WEBAUTHNACTION.REQ))
-                raise PolicyError("The WebAuthn token is not allowed to authenticate due to a policy restriction.")
+                    "The WebAuthn token {0!s} is not allowed to authenticate "
+                    "due to policy restriction {1!s}".format(self.token.serial, WEBAUTHNACTION.REQ))
+                raise PolicyError("The WebAuthn token is not allowed to "
+                                  "authenticate due to a policy restriction.")
 
             # Now we need to check, if a whitelist for AAGUIDs exists, and if
             # so, if this device is whitelisted. If not, we again raise a
@@ -1279,9 +1280,10 @@ class WebAuthnTokenClass(TokenClass):
             allowed_aaguids = getParam(options, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST, optional)
             if allowed_aaguids and self.get_tokeninfo(WEBAUTHNINFO.AAGUID) not in allowed_aaguids:
                 log.warning(
-                    "The WebAuthn token {0!s} is not allowed to authenticate due to policy restriction {1!s}"
-                        .format(self.token.serial, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST))
-                raise PolicyError("The WebAuthn token is not allowed to authenticate due to a policy restriction.")
+                    "The WebAuthn token {0!s} is not allowed to authenticate due to policy "
+                    "restriction {1!s}".format(self.token.serial, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST))
+                raise PolicyError("The WebAuthn token is not allowed to "
+                                  "authenticate due to a policy restriction.")
 
             # All clear? Nice!
             return self.get_otp_count()

--- a/privacyidea/static/components/config/views/config.policies.details.html
+++ b/privacyidea/static/components/config/views/config.policies.details.html
@@ -347,12 +347,24 @@
                                             <label for="action_{{ action.name }}_str_vals"></label>
                                             <select class="form-control"
                                                     id="action_{{ action.name }}_str_vals"
-                                                    ng-show="action.allowedValues && action.type=='str'"
+                                                    ng-show="action.allowedValues && action.type=='str' && !action.multiple"
                                                     ng-model="actionValuesStr[action.name]"
                                                     ng-disabled="!actionCheckBox[action.name]"
                                                     name="action.name"
                                                     ng-options="select for select in action.allowedValues">
                                             </select>
+                                            <label for="action_{{ action.name }}_mult_str_vals"></label>
+                                            <div isteven-multi-select
+                                                 id="action_{{ action.name }}_mult_str_vals"
+                                                 ng-show="action.allowedValues && action.type=='str' && action.multiple"
+                                                 input-model="action.allowedValues"
+                                                 output-model="actionValuesStr[action.name]"
+                                                 button-label="name"
+                                                 item-label="name"
+                                                 tick-property="ticked"
+                                                 helper-elements=""
+                                                 is-disabled="!actionCheckBox[action.name]">
+                                            </div>
                                             <label for="action_{{ action.name }}_num_vals"></label>
                                             <select class="form-control"
                                                     id="action_{{ action.name }}_num_vals"

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -17,7 +17,8 @@ from privacyidea.lib.tokens.webauthntoken import (WEBAUTHNACTION, DEFAULT_ALLOWE
                                                   DEFAULT_AUTHENTICATOR_ATTESTATION_LEVEL,
                                                   DEFAULT_AUTHENTICATOR_ATTESTATION_FORM,
                                                   DEFAULT_CHALLENGE_TEXT_ENROLL, DEFAULT_TIMEOUT,
-                                                  DEFAULT_USER_VERIFICATION_REQUIREMENT)
+                                                  DEFAULT_USER_VERIFICATION_REQUIREMENT,
+                                                  PUBKEY_CRED_ALGORITHMS_ORDER)
 from privacyidea.lib.utils import hexlify_and_unicode
 from privacyidea.lib.config import set_privacyidea_config, SYSCONF
 from .base import (MyApiTestCase)
@@ -2417,9 +2418,9 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT),
                          None)
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS),
-                         PUBLIC_KEY_CREDENTIAL_ALGORITHMS[
-                             DEFAULT_PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE
-                         ])
+                         [PUBLIC_KEY_CREDENTIAL_ALGORITHMS[x]
+                          for x in PUBKEY_CRED_ALGORITHMS_ORDER
+                          if x in DEFAULT_PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE])
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL),
                          DEFAULT_AUTHENTICATOR_ATTESTATION_LEVEL)
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM),
@@ -2450,7 +2451,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
 
         # With policies
         authenticator_attachment = AUTHENTICATOR_ATTACHMENT_TYPE.CROSS_PLATFORM
-        public_key_credential_algorithm_preference = 'ecdsa_only'
+        public_key_credential_algorithm_preference = 'ecdsa'
         authenticator_attestation_level = ATTESTATION_LEVEL.TRUSTED
         authenticator_attestation_form = ATTESTATION_FORM.INDIRECT
         challengetext = "Lorem Ipsum"
@@ -2458,7 +2459,8 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
             name="WebAuthn2",
             scope=SCOPE.ENROLL,
             action=WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT + '=' + authenticator_attachment + ','
-                   + WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS + '=' + public_key_credential_algorithm_preference + ','
+                   + WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS + '='
+                   + public_key_credential_algorithm_preference + ','
                    + WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL + '=' + authenticator_attestation_level + ','
                    + WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM + '=' + authenticator_attestation_form + ','
                    + WebAuthnTokenClass.get_class_type() + '_' + ACTION.CHALLENGETEXT + '=' + challengetext
@@ -2471,9 +2473,9 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT),
                          authenticator_attachment)
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS),
-                         PUBLIC_KEY_CREDENTIAL_ALGORITHMS[
+                         [PUBLIC_KEY_CREDENTIAL_ALGORITHMS[
                              public_key_credential_algorithm_preference
-                         ])
+                         ]])
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL),
                          authenticator_attestation_level)
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM),

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -12,7 +12,7 @@ from privacyidea.lib.tokens.webauthn import (webauthn_b64_decode, AUTHENTICATOR_
                                              USER_VERIFICATION_LEVEL)
 from privacyidea.lib.tokens.webauthntoken import (WEBAUTHNACTION, DEFAULT_ALLOWED_TRANSPORTS,
                                                   WebAuthnTokenClass, DEFAULT_CHALLENGE_TEXT_AUTH,
-                                                  PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE_OPTIONS,
+                                                  PUBLIC_KEY_CREDENTIAL_ALGORITHMS,
                                                   DEFAULT_PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE,
                                                   DEFAULT_AUTHENTICATOR_ATTESTATION_LEVEL,
                                                   DEFAULT_AUTHENTICATOR_ATTESTATION_FORM,
@@ -2416,8 +2416,8 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
                          rp_name)
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT),
                          None)
-        self.assertEqual(request.all_data.get(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE),
-                         PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE_OPTIONS[
+        self.assertEqual(request.all_data.get(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS),
+                         PUBLIC_KEY_CREDENTIAL_ALGORITHMS[
                              DEFAULT_PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE
                          ])
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL),
@@ -2439,7 +2439,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
                          None)
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT),
                          None)
-        self.assertEqual(request.all_data.get(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE),
+        self.assertEqual(request.all_data.get(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS),
                          None)
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL),
                          None)
@@ -2458,10 +2458,10 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
             name="WebAuthn2",
             scope=SCOPE.ENROLL,
             action=WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT + '=' + authenticator_attachment + ','
-                  +WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE + '=' + public_key_credential_algorithm_preference + ','
-                  +WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL + '=' + authenticator_attestation_level + ','
-                  +WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM + '=' + authenticator_attestation_form + ','
-                  +WebAuthnTokenClass.get_class_type() + '_' + ACTION.CHALLENGETEXT + '=' + challengetext
+                   + WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS + '=' + public_key_credential_algorithm_preference + ','
+                   + WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL + '=' + authenticator_attestation_level + ','
+                   + WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM + '=' + authenticator_attestation_form + ','
+                   + WebAuthnTokenClass.get_class_type() + '_' + ACTION.CHALLENGETEXT + '=' + challengetext
         )
         request = RequestMock()
         request.all_data = {
@@ -2470,8 +2470,8 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         webauthntoken_enroll(request, None)
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT),
                          authenticator_attachment)
-        self.assertEqual(request.all_data.get(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE),
-                         PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE_OPTIONS[
+        self.assertEqual(request.all_data.get(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS),
+                         PUBLIC_KEY_CREDENTIAL_ALGORITHMS[
                              public_key_credential_algorithm_preference
                          ])
         self.assertEqual(request.all_data.get(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL),
@@ -2489,7 +2489,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         set_policy(
             name="WebAuthn2",
             scope=SCOPE.ENROLL,
-            action=WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE + '=' + 'b0rked'
+            action=WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS + '=' + 'b0rked'
         )
         with self.assertRaises(PolicyError):
             webauthntoken_enroll(request, None)

--- a/tests/test_lib_tokens_webauthn.py
+++ b/tests/test_lib_tokens_webauthn.py
@@ -193,7 +193,7 @@ class WebAuthnTokenTestCase(MyTestCase):
             WEBAUTHNACTION.TIMEOUT: TIMEOUT,
             WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM: DEFAULT_AUTHENTICATOR_ATTESTATION_FORM,
             WEBAUTHNACTION.USER_VERIFICATION_REQUIREMENT: DEFAULT_USER_VERIFICATION_REQUIREMENT,
-            WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE: PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE
+            WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS: PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE
         }
 
         self.user = User(login=USER_NAME)
@@ -235,10 +235,16 @@ class WebAuthnTokenTestCase(MyTestCase):
         self.assertIn('name', web_authn_register_request.get("relyingParty"))
         self.assertEqual(RP_ID, web_authn_register_request.get("relyingParty").get('id'))
         self.assertEqual(RP_NAME, web_authn_register_request.get("relyingParty").get('name'))
-        self.assertIn('alg', web_authn_register_request.get("preferredAlgorithm"))
-        self.assertIn('type', web_authn_register_request.get("preferredAlgorithm"))
-        self.assertEqual('public-key', web_authn_register_request.get("preferredAlgorithm").get("type"))
-        self.assertEqual(COSE_ALGORITHM.ES256, web_authn_register_request.get("preferredAlgorithm").get("alg"))
+        self.assertIn('alg', web_authn_register_request.get("pubKeyCredAlgorithms")[0],
+                      web_authn_register_request)
+        self.assertIn('type', web_authn_register_request.get("pubKeyCredAlgorithms")[0],
+                      web_authn_register_request)
+        self.assertEqual('public-key',
+                         web_authn_register_request.get("pubKeyCredAlgorithms")[0].get("type"),
+                         web_authn_register_request)
+        self.assertEqual(COSE_ALGORITHM.ES256,
+                         web_authn_register_request.get("pubKeyCredAlgorithms")[0].get("alg"),
+                         web_authn_register_request)
         self.assertEqual(USER_NAME, web_authn_register_request.get("name"))
 
         self.assertEqual(RP_ID, self.token.get_tokeninfo(WEBAUTHNINFO.RELYING_PARTY_ID))
@@ -573,7 +579,7 @@ class MultipleWebAuthnTokenTestCase(MyTestCase):
             WEBAUTHNACTION.TIMEOUT: TIMEOUT,
             WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM: DEFAULT_AUTHENTICATOR_ATTESTATION_FORM,
             WEBAUTHNACTION.USER_VERIFICATION_REQUIREMENT: DEFAULT_USER_VERIFICATION_REQUIREMENT,
-            WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE: PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE
+            WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFS: PUBLIC_KEY_CREDENTIAL_ALGORITHM_PREFERENCE
         }
     auth_options = {
         WEBAUTHNACTION.ALLOWED_TRANSPORTS: ALLOWED_TRANSPORTS,

--- a/tests/test_lib_tokens_webauthn.py
+++ b/tests/test_lib_tokens_webauthn.py
@@ -114,6 +114,7 @@ CRED_KEY = {
     'alg': -7,
     'type': 'public-key'
 }
+CREDENTIAL_ID = b'ilNaaY5fYJoR1sg5IB7FL2Zoa-qBd_5Q95ZcyxNkmjkoDhiLCLgEKoKfCUElLt6_6Dmj_EUuOHZUI6x_gC32LQ'
 REGISTRATION_CHALLENGE = 'bPzpX3hHQtsp9evyKYkaZtVc9UN07PUdJ22vZUdDp94'
 ASSERTION_CHALLENGE = 'e-g-nXaRxMagEiqTJSyD82RsEc5if_6jyfJDy8bNKlw'
 RP_ID = "webauthn.io"
@@ -450,8 +451,8 @@ class WebAuthnTestCase(unittest.TestCase):
         self.assertTrue(webauthn_credential.has_signed_attestation, webauthn_credential)
         self.assertTrue(webauthn_credential.has_trusted_attestation, webauthn_credential)
         self.assertEqual(str(webauthn_credential),
-                         '{credential_id!r} ({rp_id}, {origin}, '
-                         '{sign_count})'.format(**webauthn_credential.__dict__),
+                         '{0!r} ({1!s}, {2!s}, {3!s})'.format(CREDENTIAL_ID,
+                                                              RP_ID, ORIGIN, 0),
                          webauthn_credential)
 
     def test_01b_validate_untrusted_registration(self):
@@ -489,8 +490,8 @@ class WebAuthnTestCase(unittest.TestCase):
         webauthn_assertion_response = self.getAssertionResponse()
         webauthn_user = webauthn_assertion_response.webauthn_user
         self.assertEqual(str(webauthn_user),
-                         '{user_id} ({user_name}, {user_display_name}, '
-                         '{sign_count})'.format(**webauthn_user.__dict__),
+                         '{0!r} ({1!s}, {2!s}, {3!s})'.format(USER_ID, USER_NAME,
+                                                              USER_DISPLAY_NAME, 0),
                          webauthn_user)
         webauthn_assertion_response.verify()
 


### PR DESCRIPTION
The webauthn preferred public key credential algorithm selection didn't
include the `rsassa-pkcs1v1_5` algorithm which seems to be required by
Windows Hello.
- Add a multiple selection input to the policy actions
- Make all supported algorithms available in the policy
- Order selected algorithms
- Send the complete ordered list of algorithms to the authenticator as
  `pubKeyCredAlgorithms`

TODO:
- [x] Documentation
- [x] Migration
- [x] Depends on https://github.com/privacyidea/webauthn-client/pull/14

Working on #3142