### PR TITLE
UX improvement: reveal otp seeds

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -3060,6 +3060,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr "Sdílené tajemství (klíč)"
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/de.po
+++ b/po/de.po
@@ -3208,6 +3208,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr "Der OTP-Schlüssel"
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/es.po
+++ b/po/es.po
@@ -3183,6 +3183,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr "Clave OTP"
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3189,6 +3189,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr "La clé OTP"
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/hu.po
+++ b/po/hu.po
@@ -2996,6 +2996,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/it.po
+++ b/po/it.po
@@ -3132,6 +3132,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/mn.po
+++ b/po/mn.po
@@ -3016,6 +3016,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -2998,6 +2998,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/nl.po
+++ b/po/nl.po
@@ -3275,6 +3275,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr "De OTP-sleutel"
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/pl.po
+++ b/po/pl.po
@@ -2990,6 +2990,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2996,6 +2996,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/ru.po
+++ b/po/ru.po
@@ -3036,6 +3036,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/si.po
+++ b/po/si.po
@@ -2996,6 +2996,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/template.pot
+++ b/po/template.pot
@@ -2947,6 +2947,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/tr.po
+++ b/po/tr.po
@@ -3260,6 +3260,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr "OTP tuşu"
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/uk.po
+++ b/po/uk.po
@@ -3220,6 +3220,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -2996,6 +2996,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr ""
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -3268,6 +3268,12 @@ msgstr ""
 msgid "The OTP key"
 msgstr "OTP 金鑰"
 
+#: privacyidea/static/components/token/views/token.enrolled.hotp.html:13
+#: privacyidea/static/components/token/views/token.enrolled.motp.html:10
+#: privacyidea/static/components/token/views/token.enrolled.totp.html:13
+msgid "click to reveal"
+msgstr ""
+
 #: privacyidea/static/components/token/views/token.enrolled.paper.html:6
 #: privacyidea/static/components/token/views/token.enrolled.tan.html:6
 msgid "The OTP values"

--- a/privacyidea/static/components/token/views/token.enrolled.hotp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.hotp.html
@@ -10,7 +10,7 @@
         <uib-accordion close-others="oneAtATime" ng-show="show_seed">
             <div uib-accordion-group
                  class="panel-default"
-                 heading="{{ 'The OTP key'|translate }}">
+                 heading="{{ 'The OTP key'|translate }} ({{ 'click to reveal'|translate }}">
                 Hex: {{ enrolledToken.otpkey.value }}<br/>
                 Base32: {{ enrolledToken.otpkey.value_b32 }}
             </div>

--- a/privacyidea/static/components/token/views/token.enrolled.hotp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.hotp.html
@@ -10,7 +10,7 @@
         <uib-accordion close-others="oneAtATime" ng-show="show_seed">
             <div uib-accordion-group
                  class="panel-default"
-                 heading="{{ 'The OTP key'|translate }} ({{ 'click to reveal'|translate }}">
+                 heading="{{ 'The OTP key'|translate }} ({{ 'click to reveal'|translate }})">
                 Hex: {{ enrolledToken.otpkey.value }}<br/>
                 Base32: {{ enrolledToken.otpkey.value_b32 }}
             </div>

--- a/privacyidea/static/components/token/views/token.enrolled.motp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.motp.html
@@ -7,7 +7,7 @@
         <uib-accordion close-others="oneAtATime">
             <div uib-accordion-group
                  class="panel-default"
-                 heading="{{ 'The OTP key'|translate }}">
+                 heading="{{ 'The OTP key'|translate }} ({{ 'click to reveal'|translate }}">
                 {{ enrolledToken.otpkey.value }}
             </div>
         </uib-accordion>

--- a/privacyidea/static/components/token/views/token.enrolled.motp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.motp.html
@@ -7,7 +7,7 @@
         <uib-accordion close-others="oneAtATime">
             <div uib-accordion-group
                  class="panel-default"
-                 heading="{{ 'The OTP key'|translate }} ({{ 'click to reveal'|translate }}">
+                 heading="{{ 'The OTP key'|translate }} ({{ 'click to reveal'|translate }})">
                 {{ enrolledToken.otpkey.value }}
             </div>
         </uib-accordion>

--- a/privacyidea/static/components/token/views/token.enrolled.totp.html
+++ b/privacyidea/static/components/token/views/token.enrolled.totp.html
@@ -10,7 +10,7 @@
         <uib-accordion close-others="oneAtATime" ng-show="show_seed">
             <div uib-accordion-group
                  class="panel-default"
-                 heading="{{ 'The OTP key'|translate }}">
+                 heading="{{ 'The OTP key'|translate }} ({{ 'click to reveal'|translate }})">
                 Hex: {{ enrolledToken.otpkey.value }}<br/>
                 Base32: {{ enrolledToken.otpkey.value_b32 }}
             </div>


### PR DESCRIPTION
We had a lot of users confused about user experience on the enroll token UI. Few users recognized that "The OTP key" actually was a clickable link which could be used to reveal the OTP seed for import into Keepass or similar tools.

This pull request adds " (click to reveal)" to the UI to make this more intuitive for users.

![20220912_12h27m02s_grim](https://user-images.githubusercontent.com/124074/189648722-4a524ee2-fe5d-4fa6-be3c-cea593e197cf.png)
![20220912_12h27m39s_grim](https://user-images.githubusercontent.com/124074/189648738-4047988d-e1b8-467b-a1a1-433cd3c385fb.png)

(The shown token is a throw-away token, of course)