### PR TITLE
2996/rename createdb and dropdb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ First You need to create a `config-file <https://privacyidea.readthedocs
 
 Then create the database and encryption key::
 
-    ./pi-manage createdb
+    ./pi-manage create_tables
     ./pi-manage create_enckey
 
 If You want to keep the development database upgradable, You should `stamp

--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ Running it
 First You need to create a `config-file <https://privacyidea.readthedocs
 .io/en/latest/installation/system/inifile.html>`_.
 
-Then create the database and encryption key::
+Then create the database tables and the encryption key::
 
     ./pi-manage create_tables
     ./pi-manage create_enckey

--- a/deploy/reset-db.sh
+++ b/deploy/reset-db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 heroku pg:reset DATABASE_URL --app privacyidea-test
-heroku run python ./pi-manage createdb --app privacyidea-test
+heroku run python ./pi-manage create_tables --app privacyidea-test
 heroku run --app privacyidea-test --  python ./pi-manage admin add -p 'Test1234!' admin admin@localhost
 heroku run --app privacyidea-test -- python ./pi-manage resolver create resolver1 passwdresolver deploy/heroku/default-resolver
 heroku run --app privacyidea-test -- python ./pi-manage realm create default resolver1

--- a/doc/installation/centos.rst
+++ b/doc/installation/centos.rst
@@ -141,7 +141,7 @@ From now on the ``pi-manage``-tool can be used to configure and manage the priva
 
     (privacyidea)$ pi-manage create_enckey  # encryption key for the database
     (privacyidea)$ pi-manage create_audit_keys  # key for verification of audit log entries
-    (privacyidea)$ pi-manage createdb  # create the database structure
+    (privacyidea)$ pi-manage create_tables  # create the database structure
     (privacyidea)$ pi-manage db stamp head -d /opt/privacyidea/lib/privacyidea/migrations/  # stamp the db
 
 An administrative account is needed to configure and maintain privacyIDEA:

--- a/doc/installation/pip.rst
+++ b/doc/installation/pip.rst
@@ -95,7 +95,7 @@ executed inside the virtual environment)::
 
 To create the database tables execute::
 
-    pi-manage createdb
+    pi-manage create_tables
 
 Stamping the database to the current database schema version is important for
 the update process later::

--- a/doc/installation/system/wsgiscript.rst
+++ b/doc/installation/system/wsgiscript.rst
@@ -50,6 +50,6 @@ To create the new database you need the command *pi-manage*. The command
 If you want to use another instance with another config file, you need to set
 an environment variable and create the database like this::
 
-   PRIVACYIDEA_CONFIGFILE=/etc/privacyidea3/pi.cfg pi-manage createdb
+   PRIVACYIDEA_CONFIGFILE=/etc/privacyidea3/pi.cfg pi-manage create_tables
 
 This way you can use *pi-manage* for each instance.

--- a/pi-manage
+++ b/pi-manage
@@ -48,12 +48,13 @@
 #
 # ./manage.py db init
 # ./manage.py db migrate
-# ./manage.py createdb
+# ./manage.py create_tables
 #
 from __future__ import print_function
 import os
 import sys
 import datetime
+import warnings
 from datetime import timedelta
 import re
 from subprocess import call, Popen, PIPE
@@ -579,7 +580,17 @@ def createdb(stamp=False):
         migration_dir = os.path.dirname(os.path.abspath(p[0]))
         fm_stamp(directory=migration_dir)
     db.session.commit()
+    warnings.warn("The function createdb() will be removed in Version 4.0", DeprecationWarning)
 
+
+@manager.option('--stamp', '-s', help='Stamp database to current head revision.',
+                default=False, action='store_true')
+def create_tables(stamp=False):
+    """
+    Initially create the tables in the database. The database must exist
+    (an SQLite database will be created).
+    """
+    createdb(stamp=False)
 
 @manager.command
 def dropdb(dropit=None):
@@ -603,6 +614,12 @@ def dropdb(dropit=None):
                                        checkfirst=True)
     else:
         print("Not dropping anything!")
+    warnings.warn("The function dropdb() will be removed in Version 4.0", DeprecationWarning)
+
+
+@manager.command
+def drop_tables(dropit=None):
+    dropdb(dropit=None)
 
 
 @manager.command

--- a/pi-manage
+++ b/pi-manage
@@ -564,9 +564,22 @@ def create_audit_keys(keysize=2048):
     print("Please ensure, that it is owned by the right user.")
 
 
-@manager.option('--stamp', '-s', help='Stamp database to current head revision.',
+@manager.option('--stamp', '-s', help='Stamp database to current head revision. This function will be '
+                                      'removed with Version 4.0',
                 default=False, action='store_true')
 def createdb(stamp=False):
+    """
+    Initially create the tables in the database. The database must exist
+    (an SQLite database will be created).
+    """
+    create_tables(stamp)
+
+    warnings.warn("This function will be removed in Version 4.0", DeprecationWarning)
+
+
+@manager.option('--stamp', '-s', help='Stamp database to current head revision.',
+                default=False, action='store_true')
+def create_tables(stamp=False):
     """
     Initially create the tables in the database. The database must exist
     (an SQLite database will be created).
@@ -580,21 +593,24 @@ def createdb(stamp=False):
         migration_dir = os.path.dirname(os.path.abspath(p[0]))
         fm_stamp(directory=migration_dir)
     db.session.commit()
-    warnings.warn("The function createdb() will be removed in Version 4.0", DeprecationWarning)
-
-
-@manager.option('--stamp', '-s', help='Stamp database to current head revision.',
-                default=False, action='store_true')
-def create_tables(stamp=False):
-    """
-    Initially create the tables in the database. The database must exist
-    (an SQLite database will be created).
-    """
-    createdb(stamp=False)
 
 
 @manager.command
 def dropdb(dropit=None):
+    """
+    This drops all the privacyIDEA database tables.
+    Use with caution! All data will be lost!
+
+    For safety reason you need to pass
+        --dropit==yes
+    Otherwise the command will not drop anything.
+    """
+    drop_tables(dropit)
+    warnings.warn("This function will be removed in Version 4.0", DeprecationWarning)
+
+
+@manager.command
+def drop_tables(dropit=None):
     """
     This drops all the privacyIDEA database tables.
     Use with caution! All data will be lost!
@@ -615,20 +631,6 @@ def dropdb(dropit=None):
                                        checkfirst=True)
     else:
         print("Not dropping anything!")
-    warnings.warn("The function dropdb() will be removed in Version 4.0", DeprecationWarning)
-
-
-@manager.command
-def drop_tables(dropit=None):
-    """
-    This drops all the privacyIDEA database tables.
-    Use with caution! All data will be lost!
-
-    For safety reason you need to pass
-        --dropit==yes
-    Otherwise the command will not drop anything.
-    """
-    dropdb(dropit=None)
 
 
 @manager.command
@@ -1357,7 +1359,7 @@ exp_fmt_dict = {
                             '{0!s}'.format(', '.join(['all'] + list(EXPORT_FUNCTIONS.keys()))),
                        )
 @config_manager.option('-n', '--name',
-                       help = 'The name of the configuration object to export (default: export all)')
+                       help='The name of the configuration object to export (default: export all)')
 def exporter(output, fmt, types, name=None):
     """
     Export server configuration using specific or all registered exporter types.
@@ -1390,7 +1392,7 @@ imp_fmt_dict = {
                             'Currently registered importer types are: '
                             '{0!s}'.format(', '.join(['all'] + list(IMPORT_FUNCTIONS.keys()))))
 @config_manager.option('-n', '--name',
-                       help = 'The name of the configuration object to import (default: import all)')
+                       help='The name of the configuration object to import (default: import all)')
 def importer(infile, types, name=None):
     """
     Import server configuration using specific or all registered importer types.

--- a/pi-manage
+++ b/pi-manage
@@ -592,6 +592,7 @@ def create_tables(stamp=False):
     """
     createdb(stamp=False)
 
+
 @manager.command
 def dropdb(dropit=None):
     """
@@ -619,6 +620,14 @@ def dropdb(dropit=None):
 
 @manager.command
 def drop_tables(dropit=None):
+    """
+    This drops all the privacyIDEA database tables.
+    Use with caution! All data will be lost!
+
+    For safety reason you need to pass
+        --dropit==yes
+    Otherwise the command will not drop anything.
+    """
     dropdb(dropit=None)
 
 

--- a/pi-manage
+++ b/pi-manage
@@ -564,13 +564,12 @@ def create_audit_keys(keysize=2048):
     print("Please ensure, that it is owned by the right user.")
 
 
-@manager.option('--stamp', '-s', help='Stamp database to current head revision. This function will be '
-                                      'removed with Version 4.0',
+@manager.option('--stamp', '-s', help='Stamp database to current head revision.',
                 default=False, action='store_true')
 def createdb(stamp=False):
     """
     Initially create the tables in the database. The database must exist
-    (an SQLite database will be created).
+    (an SQLite database will be created). This function will be removed with Version 4.0.
     """
     create_tables(stamp)
 
@@ -604,6 +603,7 @@ def dropdb(dropit=None):
     For safety reason you need to pass
         --dropit==yes
     Otherwise the command will not drop anything.
+    This function will be removed with Version 4.0.
     """
     drop_tables(dropit)
     warnings.warn("This function will be removed in Version 4.0", DeprecationWarning)

--- a/tools/privacyidea-standalone
+++ b/tools/privacyidea-standalone
@@ -229,7 +229,7 @@ def create():
             # create an enckey
             invoke_pi_manage(['create_enckey'], pi_cfg)
             invoke_pi_manage(['create_audit_keys'], pi_cfg)
-            invoke_pi_manage(['createdb'], pi_cfg)
+            invoke_pi_manage(['create_tables'], pi_cfg)
 
             print()
             print('Please enter a password for the new admin `super`.')

--- a/tools/reset-privacyidea
+++ b/tools/reset-privacyidea
@@ -5,7 +5,7 @@ create_files() {
         mkdir -p /var/lib/privacyidea
         touch /var/log/privacyidea/privacyidea.log
         pi-manage create_enckey || true > /dev/null
-        pi-manage createdb || true > /dev/null
+        pi-manage create_tables || true > /dev/null
         pi-manage create_audit_keys || true > /dev/null
         chown -R $USERNAME /var/log/privacyidea
         chown -R $USERNAME /var/lib/privacyidea


### PR DESCRIPTION
- added new functions create_tables() and drop_tables() which call createdb() and dropdb()
- added deprecation warning to createdb() and dropdb() that these two functions will be removed in version 4.0
- changed createdb() to create_tables() and dropdb() to drop_tables() in docs