### PR TITLE
AES security module also encrypts empty strings

### DIFF
--- a/doc/installation/system/securitymodule.rst
+++ b/doc/installation/system/securitymodule.rst
@@ -64,7 +64,7 @@ This module uses three keys, similarly to the content of
 ``PI_ENCFILE``, identified as ``token``, ``config`` and ``value``.
 
 To activate this module add the following to the configuration file
-(:ref:`cfgfile`)
+(:ref:`cfgfile`)::
 
    PI_HSM_MODULE = "privacyidea.lib.security.aeshsm.AESHardwareSecurityModule"
 

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -316,7 +316,8 @@ def encryptPassword(password):
         ret = hsm.encrypt_password(to_bytes(password))
     except Exception as exx:  # pragma: no cover
         log.warning(exx)
-        ret = "FAILED TO ENCRYPT PASSWORD!"
+        log.info(traceback.format_exc())
+        raise HSMException("Failed to encrypt password!")
     return ret
 
 

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -187,12 +187,17 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 break
             except PyKCS11.PyKCS11Error as exx:
                 log.warning(u"Generate Random failed: {0!s}".format(exx))
-                # If something goes wrong in this process, we free memory, session and handles
-                self.pkcs11.lib.C_Finalize()
-                self.initialize_hsm()
-                retries += 1
-                if retries > self.max_retries:
-                    raise HSMException("Failed to generate random number after multiple retries.")
+                # If we get an CKR_SESSION_HANDLE_INVALID error code, we free
+                # memory, session and handles and retry
+                if exx.value == PyKCS11.CKR_SESSION_HANDLE_INVALID:
+                    self.pkcs11.lib.C_Finalize()
+                    self.initialize_hsm()
+                    retries += 1
+                    if retries > self.max_retries:
+                        raise HSMException("Failed to generate random number after multiple retries.")
+                    else:
+                        raise HSMException("HSM random number generation failed "
+                                           "with {0!s}".format(exx))
 
         # convert the array of the random integers to a string
         return int_list_to_bytestring(r_integers)
@@ -202,8 +207,6 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
 
         :rtype: bytes
         """
-        if len(data) == 0:
-            return bytes()
         log.debug("Encrypting {} bytes with key {}".format(len(data), key_id))
         m = PyKCS11.Mechanism(PyKCS11.CKM_AES_CBC_PAD, iv)
         retries = 0
@@ -215,12 +218,16 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 break
             except PyKCS11.PyKCS11Error as exx:
                 log.warning(u"Encryption failed: {0!s}".format(exx))
-                # If something goes wrong in this process, we free memory,session and handles
-                self.pkcs11.lib.C_Finalize()
-                self.initialize_hsm()
-                retries += 1
-                if retries > self.max_retries:
-                    raise HSMException("Failed to encrypt after multiple retries.")
+                # If we get an CKR_SESSION_HANDLE_INVALID error code, we free
+                # memory, session and handles and retry
+                if exx.value == PyKCS11.CKR_SESSION_HANDLE_INVALID:
+                    self.pkcs11.lib.C_Finalize()
+                    self.initialize_hsm()
+                    retries += 1
+                    if retries > self.max_retries:
+                        raise HSMException("Failed to encrypt after multiple retries")
+                else:
+                    raise HSMException("HSM encryption failed with {0!s}".format(exx))
 
         return int_list_to_bytestring(r)
 
@@ -229,8 +236,9 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
 
         :rtype bytes
         """
+        # we keep this for legacy reasons, even though it hasn't worked anyway
         if len(enc_data) == 0:
-            return bytes("")
+            return bytes()
         log.debug("Decrypting {} bytes with key {}".format(len(enc_data), key_id))
         m = PyKCS11.Mechanism(PyKCS11.CKM_AES_CBC_PAD, iv)
         start = datetime.datetime.now()
@@ -242,15 +250,19 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 self.session_lastused_time = datetime.datetime.now()
                 break
             except PyKCS11.PyKCS11Error as exx:
-                log.warning(u"Decryption retry: {0!s}".format(exx))
-                # If something goes wrong in this process, we free memory, session and handlers
-                self.pkcs11.lib.C_Finalize()
-                self.initialize_hsm()
-                retries += 1
-                if retries > self.max_retries:
-                    td = datetime.datetime.now() - start
-                    log.warning(u"Decryption finally failed: {0!s}. Time taken: {1!s}.".format(exx, td))
-                    raise HSMException("Failed to decrypt after multiple retries.")
+                log.warning("Decryption failed: {0!s}".format(exx))
+                # If we get an CKR_SESSION_HANDLE_INVALID error code, we free
+                # memory, session and handles and retry
+                if exx.value == PyKCS11.CKR_SESSION_HANDLE_INVALID:
+                    self.pkcs11.lib.C_Finalize()
+                    self.initialize_hsm()
+                    retries += 1
+                    if retries > self.max_retries:
+                        td = datetime.datetime.now() - start
+                        log.warning(u"Decryption finally failed: {0!s}. Time taken: {1!s}.".format(exx, td))
+                        raise HSMException("Failed to decrypt after multiple retries.")
+                    else:
+                        raise HSMException("HSM decrypt failed with {0!s}".format(exx))
 
         if retries > 0:
             td = datetime.datetime.now() - start
@@ -283,7 +295,6 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                 (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_AES),
                 (PyKCS11.CKA_VALUE_LEN, 32),
                 (PyKCS11.CKA_LABEL, label),
-                (PyKCS11.CKA_ID, label),
                 (PyKCS11.CKA_TOKEN, PyKCS11.CK_TRUE),
                 (PyKCS11.CKA_PRIVATE, True),
                 (PyKCS11.CKA_SENSITIVE, True),

--- a/privacyidea/lib/security/aeshsm.py
+++ b/privacyidea/lib/security/aeshsm.py
@@ -195,9 +195,9 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                     retries += 1
                     if retries > self.max_retries:
                         raise HSMException("Failed to generate random number after multiple retries.")
-                    else:
-                        raise HSMException("HSM random number generation failed "
-                                           "with {0!s}".format(exx))
+                else:
+                    raise HSMException("HSM random number generation failed "
+                                       "with {0!s}".format(exx))
 
         # convert the array of the random integers to a string
         return int_list_to_bytestring(r_integers)
@@ -261,8 +261,8 @@ class AESHardwareSecurityModule(SecurityModule):  # pragma: no cover
                         td = datetime.datetime.now() - start
                         log.warning(u"Decryption finally failed: {0!s}. Time taken: {1!s}.".format(exx, td))
                         raise HSMException("Failed to decrypt after multiple retries.")
-                    else:
-                        raise HSMException("HSM decrypt failed with {0!s}".format(exx))
+                else:
+                    raise HSMException("HSM decrypt failed with {0!s}".format(exx))
 
         if retries > 0:
             td = datetime.datetime.now() - start

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -901,7 +901,7 @@ class WebAuthnTokenClass(TokenClass):
                     uv_required=uv_req == USER_VERIFICATION_LEVEL.REQUIRED
                 ).verify([
                     # TODO: this might get slow when a lot of webauthn tokens are registered
-                    token.decrypt_otpkey() for token in get_tokens(tokentype=self.type)
+                    token.decrypt_otpkey() for token in get_tokens(tokentype=self.type) if token.get_serial() != self.get_serial()
                 ])
             except Exception as e:
                 log.warning('Enrollment of {0!s} token failed: '

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -228,7 +228,8 @@ class Token(MethodsMixin, db.Model):
         self.count_window = 10
         self.otplen = otplen
         self.pin_seed = u""
-        self.set_otpkey(otpkey)
+        if otpkey:
+            self.set_otpkey(otpkey)
 
         # also create the user assignment
         if userid and resolver and realm:

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -228,8 +228,7 @@ class Token(MethodsMixin, db.Model):
         self.count_window = 10
         self.otplen = otplen
         self.pin_seed = u""
-        if otpkey:
-            self.set_otpkey(otpkey)
+        self.set_otpkey(otpkey)
 
         # also create the user assignment
         if userid and resolver and realm:

--- a/tests/pkcs11mock.py
+++ b/tests/pkcs11mock.py
@@ -140,10 +140,13 @@ class PKCS11Mock(object):
         This is just a shortcut for calling ``simulate_failure`` on ``generateRandom``, ``encrypt``,
         ``decrypt`` and ``openSession``.
         """
-        with self.simulate_failure(self.session_mock.generateRandom, count), \
-            self.simulate_failure(self.session_mock.encrypt, count), \
-            self.simulate_failure(self.session_mock.decrypt, count), \
-            self.simulate_failure(self.mock.openSession, count):
+        with self.simulate_failure(self.session_mock.generateRandom, count,
+                                   error=PyKCS11.CKR_SESSION_HANDLE_INVALID), \
+                self.simulate_failure(self.session_mock.encrypt, count,
+                                      error=PyKCS11.CKR_SESSION_HANDLE_INVALID), \
+                self.simulate_failure(self.session_mock.decrypt, count,
+                                      error=PyKCS11.CKR_SESSION_HANDLE_INVALID), \
+                self.simulate_failure(self.mock.openSession, count):
             yield
 
     def _mock_openSession(self, slot):

--- a/tests/pkcs11mock.py
+++ b/tests/pkcs11mock.py
@@ -30,8 +30,8 @@ try:
 except ImportError:
     # PyKCS11 not installed, let's use our simple mock module
     class MockPyKCS11Error(Exception):
-        def __init__(self, code):
-            self.code = code
+        def __init__(self, value):
+            self.value = value
 
 
     MOCK_CONSTANTS = ['CKA_CLASS', 'CKO_SECRET_KEY', 'CKA_LABEL', 'CKR_SLOT_ID_INVALID', 'CKR_DEVICE_ERROR']


### PR DESCRIPTION
The AES security module encrypts empty strings and implements better
error checking for HSM/PKCS#11 issues.

When creating a new DB `Token`, we now only set the otpkey when it is
given as a parameter.

Fixes https://github.com/privacyidea/privacyidea/issues/2899