### PR TITLE
tools/privacyidea-token-janitor: fix options examples

### DIFF
--- a/tools/privacyidea-token-janitor
+++ b/tools/privacyidea-token-janitor
@@ -96,8 +96,8 @@ Actions:
         --tokeninfo-value-less-than=<value>
         --tokeninfo-value-after=<value>
         --tokeninfo-value-before=<value>
-        --unassigned
-        --orphaned
+        --assigned false
+        --orphaned true
         --tokentype=<type>
         --serial=<regexp>
         --description=<regexp>


### PR DESCRIPTION
* The `--orphaned`-option expects a boolean option, otherwise it fails like this:

  ``` privacyidea-token-janitor find: error: argument --orphaned: expected one argument ```

* The `--unassigned` option doesn't exist, instead `--assigned false` has to be provided.