### PR TITLE
Add encoding check to SMPP provider

### DIFF
--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -312,7 +312,7 @@ class EmailTokenClass(HotpTokenClass):
             except Exception as e:
                 info = _("The PIN was correct, but the "
                          "EMail could not be sent!")
-                log.warning(info + " ({0!s})".format(e))
+                log.warning(info + " ({0!r})".format(e))
                 log.debug(u"{0!s}".format(traceback.format_exc()))
                 return_message = info
                 if is_true(options.get("exception")):

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -353,7 +353,7 @@ class SmsTokenClass(HotpTokenClass):
             except Exception as e:
                 info = _("The PIN was correct, but the "
                          "SMS could not be sent!")
-                log.warning(info + " ({0!s})".format(e))
+                log.warning(info + " ({0!r})".format(e))
                 log.debug("{0!s}".format(traceback.format_exc()))
                 return_message = info
                 if is_true(options.get("exception")):

--- a/tests/smppmock.py
+++ b/tests/smppmock.py
@@ -25,6 +25,7 @@ from __future__ import (
 )
 
 from collections import namedtuple
+from mock import Mock
 
 try:
     from collections import Sequence, Sized
@@ -114,13 +115,17 @@ class SmppMock(object):
     def _on_transmitter(self, SMPP, systemid, password):
         if systemid != self.systemid or password != self.password:
             raise Exception("Wrong credentials")
-        return None
+        BindTransmitterRespMock = Mock()
+        BindTransmitterRespMock.get_status_desc.return_value = 'No Error'
+        return BindTransmitterRespMock
 
     def _on_send_message(self, SMPP, source_addr_ton=None, source_addr_npi=None,
                          source_addr=None, dest_addr_ton=None,
                          dest_addr_npi=None, destination_addr=None,
-                         short_message=None):
-        pass
+                         short_message=None, data_coding=None, esm_class=None):
+        SubmitSMMock = Mock()
+        SubmitSMMock.get_status_desc.return_value = 'No Error'
+        return SubmitSMMock
 
     def start(self):
         import mock

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -633,7 +633,6 @@ class SmppSMSTestCase(MyTestCase):
               'SMSC_PORT': "1234",
               'SYSTEM_ID': "privacyIDEA",
               'PASSWORD': "secret",
-              'SYSTEM_ID': "privacyIDEA",
               'S_ADDR_TON': "0x5",
               'S_ADDR_NPI': "0x1",
               'S_ADDR': "privacyIDEA",


### PR DESCRIPTION
In order to allow SMS with non-ascii characters, the SMPP library offers a check for the given encoding.
Also print the `repr()` of an error since just the value of a `KeyError` is not very meaningful.
And the return values of the SMPP library are added to the debug log.

Closes #3321