### PR TITLE
Make realm in auth-request case insensitive

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -291,6 +291,7 @@ def get_auth_token():
         user_obj = User()
         g.audit_object.log({"success": True,
                             "user": "",
+                            "realm": "",
                             "administrator": username,
                             "info": "internal admin"})
 

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -621,7 +621,7 @@ class AdminFromUserstore(OverrideConfigTestCase):
             # if no admin policy is set, the user should have all admin rights
             self.assertIn(ACTION.DELETE, result.get('value').get('rights'), result)
 
-        # Now test wirh a helpdesk policy for the admin realm
+        # Now test with a helpdesk policy for the admin realm
         set_policy(name='helpdesk', scope=SCOPE.ADMIN, adminrealm=self.realm1,
                    action=ACTION.DISABLE)
         with self.app.test_request_context('/auth',


### PR DESCRIPTION
While the user is found in the correct resolver/realm (by changing the realm to lower case), when querying for the admin rights the original realm was used and so no policy matched the realm and the admin didn't have any rights.
Fixing this by changing the realm to lower case.

Closes #3329