### PR TITLE
Fix #3375

### DIFF
--- a/privacyidea/lib/applications/ssh.py
+++ b/privacyidea/lib/applications/ssh.py
@@ -77,7 +77,7 @@ class MachineApplication(MachineApplicationBase):
                     user_object = toks[0].user
                     if user_object:
                         uInfo = user_object.info
-                        if uInfo and "username" in uInfo:
+                        if "username" in uInfo:
                             ret["username"] = uInfo.get("username")
                     # ret["info"] = uInfo
                 else:

--- a/privacyidea/lib/applications/ssh.py
+++ b/privacyidea/lib/applications/ssh.py
@@ -77,7 +77,7 @@ class MachineApplication(MachineApplicationBase):
                     user_object = toks[0].user
                     if user_object:
                         uInfo = user_object.info
-                        if "username" in uInfo:
+                        if uInfo and "username" in uInfo:
                             ret["username"] = uInfo.get("username")
                     # ret["info"] = uInfo
                 else:

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -305,7 +305,7 @@ class User(object):
             # An empty user has no info
             return {}
         (uid, _rtype, _resolver) = self.get_user_identifiers()
-        if uid = None:
+        if uid == None:
             return {}
         y = get_resolver_object(self.resolver)
         userInfo = y.getUserInfo(uid)

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -306,6 +306,8 @@ class User(object):
             return {}
         (uid, _rtype, _resolver) = self.get_user_identifiers()
         y = get_resolver_object(self.resolver)
+        if uid = None:
+            return None
         userInfo = y.getUserInfo(uid)
         # Now add the custom attributes, this is used e.g. in ADDUSERINRESPONSE
         userInfo.update(self.attributes)

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -301,13 +301,11 @@ class User(object):
         :return: a dict with all the userinformation
         :rtype: dict
         """
-        if self.is_empty():
+        if self.is_empty() or uid = None:
             # An empty user has no info
             return {}
         (uid, _rtype, _resolver) = self.get_user_identifiers()
         y = get_resolver_object(self.resolver)
-        if uid = None:
-            return None
         userInfo = y.getUserInfo(uid)
         # Now add the custom attributes, this is used e.g. in ADDUSERINRESPONSE
         userInfo.update(self.attributes)

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -301,10 +301,12 @@ class User(object):
         :return: a dict with all the userinformation
         :rtype: dict
         """
-        if self.is_empty() or uid = None:
+        if self.is_empty():
             # An empty user has no info
             return {}
         (uid, _rtype, _resolver) = self.get_user_identifiers()
+        if uid = None:
+            return {}
         y = get_resolver_object(self.resolver)
         userInfo = y.getUserInfo(uid)
         # Now add the custom attributes, this is used e.g. in ADDUSERINRESPONSE


### PR DESCRIPTION
This PR fixes #3375 

During troubleshooting we recognized that the impacted users were the ones who had enrolled their SSH pubkeys into privacyIDEA and afterwards been deleted (or stopped matching our LDAP filter's conditions).

This resulted in the `uid` being `None` during evaluation of `user.py`, which in turn caused `y.getUserInfo(uid)` to throw an exception (because it tried to match `None` to an `entryUUID` from LDAP).

The fix prevents `user.py` from reaching the exception condition if `uid=None`.