### PR TITLE
Speed Up MS CA Connector

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -94,7 +94,7 @@ def before_request():
     g.policy_object = PolicyClass()
     g.audit_object = getAudit(current_app.config)
     g.event_config = EventConfiguration()
-    # access_route contains the ip adresses of all clients, hops and proxies.
+    # access_route contains the ip addresses of all clients, hops and proxies.
     g.client_ip = get_client_ip(request,
                                 get_from_config(SYSCONF.OVERRIDECLIENT))
     # Save the HTTP header in the localproxy object

--- a/privacyidea/lib/caconnector.py
+++ b/privacyidea/lib/caconnector.py
@@ -42,6 +42,7 @@ from sqlalchemy import func
 from .crypto import encryptPassword, decryptPassword
 from privacyidea.lib.utils import (sanity_name_check, get_data_from_params, fetch_one_resource)
 from privacyidea.lib.utils.export import (register_import, register_export)
+from privacyidea.lib.config import get_config_object
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +74,7 @@ def save_caconnector(params):
     sanity_name_check(connector_name)
     # check the type
     if connector_type not in get_caconnector_types():
-        raise Exception("connector type : {0!s} not in {1!s}".format(connector_type, unicode(get_caconnector_types())))
+        raise Exception(u"connector type : {0!s} not in {1!s}".format(connector_type, get_caconnector_types()))
 
     # check the name
     connectors = get_caconnector_list(filter_caconnector_name=connector_name)
@@ -116,8 +117,6 @@ def save_caconnector(params):
     return connector_id
 
 
-#@log_with(log)
-#@cache.memoize(10)
 def get_caconnector_list(filter_caconnector_type=None,
                          filter_caconnector_name=None,
                          return_config=True):
@@ -132,47 +131,31 @@ def get_caconnector_list(filter_caconnector_type=None,
     :rtype: list of the connectors and their configuration
 
     """
+    all_connector_objs = get_all_caconnectors()
     Connectors = []
-    if filter_caconnector_name:
-        connectors = CAConnector.query\
-                            .filter(func.lower(CAConnector.name) ==
-                                    filter_caconnector_name.lower())
-    elif filter_caconnector_type:
-        connectors = CAConnector.query\
-                            .filter(CAConnector.catype ==
-                                    filter_caconnector_type)
-    else:
-        connectors = CAConnector.query.all()
-    
-    for conn in connectors:
-        c = {"connectorname": conn.name,
-             "type": conn.catype}
-        # Add the connector configuration
-        data = {}
-        for conf in conn.caconfig:
-            value = conf.Value
-            if conf.Type == "password":
-                value = decryptPassword(value)
-            data[conf.Key] = value
-        if return_config:
-            c["data"] = data
+    for c in all_connector_objs:
+        if filter_caconnector_name:
+            if filter_caconnector_name == c.get("connectorname"):
+                Connectors.append(c)
+        elif filter_caconnector_type:
+            if filter_caconnector_type == c.get("type"):
+                Connectors.append(c)
         else:
-            c["data"] = {}
+            Connectors.append(c)
 
-        # Also add templates
-        c_obj_class = get_caconnector_class(conn.catype)
-        if c_obj_class is None:
-            log.error(
-                "unknown CA connector class {0!s} ".format(conn.name))
-        else:
-            # create the resolver instance and load the config
-            c_obj = c_obj_class(conn.name, data)
-            if c_obj:
-                c["templates"] = templates = c_obj.get_templates()
-                if return_config:
-                    c["data"] = c_obj.get_config(data)
-
-        Connectors.append(c)
+    if not return_config:
+        # We need to copy the dict to avoid destroying the dict-by-reference
+        reduced_connectors = []
+        # we strip all config data
+        for conn in Connectors:
+            reduced_connector = {}
+            for key in conn.keys():
+                if key in ["data"]:
+                    reduced_connector[key] = {}
+                else:
+                    reduced_connector[key] = conn.get(key)
+            reduced_connectors.append(reduced_connector)
+        return reduced_connectors
 
     return Connectors
 
@@ -215,7 +198,7 @@ def get_caconnector_config(connector_name):
     :return: the config of the CA connector
     :rtype: dict
     """
-    conn = get_caconnector_list(filter_caconnector_name=connector_name)
+    conn = get_caconnector_list(filter_caconnector_name=connector_name, return_config=True)
     return conn[0].get("data", {})
 
 
@@ -279,8 +262,6 @@ def get_caconnector_type(connector_name):
     return c_type
 
 
-#@log_with(log)
-#@cache.memoize(10)
 def get_caconnector_object(connector_name):
     """
     create a CA Connector object from a connector_name
@@ -302,7 +283,13 @@ def get_caconnector_object(connector_name):
             # create the resolver instance and load the config
             c_obj = c_obj_class(connector_name)
             if c_obj is not None:
-                connector_config = get_caconnector_config(connector_name)
+                connector_config = {}
+                for conf in conn.caconfig:
+                    # Handle passwords
+                    value = conf.Value
+                    if conf.Type == "password":
+                        value = decryptPassword(value)
+                    connector_config[conf.Key] = value
                 c_obj.set_config(connector_config)
 
     return c_obj
@@ -329,3 +316,11 @@ def import_caconnector(data, name=None):
         rid = save_caconnector(res_data)
         log.info('Import of caconnector "{0!s}" finished,'
                  ' id: {1!s}'.format(res_data['caconnector'], rid))
+
+
+def get_all_caconnectors():
+    """
+    Shorthand to retrieve all caconnectors of the request-local config object
+    """
+    conf = get_config_object()
+    return conf.caconnectors

--- a/privacyidea/lib/caconnector.py
+++ b/privacyidea/lib/caconnector.py
@@ -324,3 +324,4 @@ def get_all_caconnectors():
     """
     conf = get_config_object()
     return conf.caconnectors
+

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -38,11 +38,11 @@ import sys
 import logging
 import inspect
 import threading
-
+import traceback
 
 from .log import log_with
 from ..models import (Config, db, Resolver, Realm, PRIVACYIDEA_TIMESTAMP,
-                      save_config_timestamp, Policy, EventHandler)
+                      save_config_timestamp, Policy, EventHandler, CAConnector)
 from privacyidea.lib.framework import get_request_local_store, get_app_config_value, get_app_local_store
 from privacyidea.lib.utils import to_list
 from privacyidea.lib.utils.export import (register_import, register_export)
@@ -92,6 +92,7 @@ class SharedConfigClass(object):
         self.policies = []
         self.events = []
         self.timestamp = None
+        self.caconnectors = []
 
     def _reload_from_db(self):
         """
@@ -111,6 +112,7 @@ class SharedConfigClass(object):
                 default_realm = None
                 policies = []
                 events = []
+                caconnectors = []
                 # Load system configuration
                 for sysconf in Config.query.all():
                     config[sysconf.Key] = {
@@ -151,6 +153,19 @@ class SharedConfigClass(object):
                 # Load all events
                 for event in EventHandler.query.order_by(EventHandler.ordering):
                     events.append(event.get())
+                # Load all CA connectors
+                from privacyidea.lib.caconnector import get_caconnector_object
+                for ca in CAConnector.query.all():
+                    try:
+                        ca_obj = get_caconnector_object(ca.name)
+                        caconnectors.append({"connectorname": ca.name,
+                                             "type": ca.catype,
+                                             "data": ca_obj.config,
+                                             "templates": ca_obj.get_templates()})
+                    except Exception as exx:  # pragma: no cover
+                        log.debug(u"{0!s}".format(traceback.format_exc()))
+                        log.error(exx)
+
                 # Finally, set the current timestamp
                 timestamp = datetime.datetime.now()
                 with self._config_lock:
@@ -161,6 +176,7 @@ class SharedConfigClass(object):
                     self.policies = policies
                     self.events = events
                     self.timestamp = timestamp
+                    self.caconnectors = caconnectors
 
     def _clone(self):
         """
@@ -174,6 +190,7 @@ class SharedConfigClass(object):
                 self.default_realm,
                 self.policies,
                 self.events,
+                self.caconnectors,
                 self.timestamp
             )
 
@@ -195,13 +212,14 @@ class LocalConfigClass(object):
     It will be cloned from the shared config object at the beginning of the
     request and is supposed to stay alive and unchanged during the request.
     """
-    def __init__(self, config, resolver, realm, default_realm, policies, events, timestamp):
+    def __init__(self, config, resolver, realm, default_realm, policies, events, caconnectors, timestamp):
         self.config = config
         self.resolver = resolver
         self.realm = realm
         self.default_realm = default_realm
         self.policies = policies
         self.events = events
+        self.caconnectors = caconnectors
         self.timestamp = timestamp
 
     def get_config(self, key=None, default=None, role="admin",

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -960,7 +960,7 @@ class Realm(TimestampMethodsMixin, db.Model):
         return ret
 
 
-class CAConnector(MethodsMixin, db.Model):
+class CAConnector(TimestampMethodsMixin, db.Model):
     """
     The table "caconnector" contains the names and types of the defined
     CA connectors. Each connector has a different configuration, that is
@@ -990,6 +990,7 @@ class CAConnector(MethodsMixin, db.Model):
                   .delete()
         # Delete the CA itself
         db.session.delete(self)
+        save_config_timestamp()
         db.session.commit()
         return ret
 
@@ -1036,6 +1037,7 @@ class CAConnectorConfig(db.Model):
     def save(self):
         c = CAConnectorConfig.query.filter_by(caconnector_id=self.caconnector_id,
                                            Key=self.Key).first()
+        save_config_timestamp()
         if c is None:
             # create a new one
             db.session.add(self)

--- a/tests/test_api_caconnector.py
+++ b/tests/test_api_caconnector.py
@@ -52,9 +52,9 @@ class CAConnectorTestCase(MyApiTestCase):
 
         ca_list = get_caconnector_list()
         self.assertEqual(len(ca_list), 1)
-        self.assertEqual(ca_list[0].get("data"), {u'cacert': u'/etc/cert.pem',
-                                                  u'cakey': u'/etc/key.pem',
-                                                  u'name': u'con1'})
+        self.assertEqual(ca_list[0].get("data").get("cacert"), '/etc/cert.pem')
+        self.assertEqual(ca_list[0].get("data").get("cakey"), '/etc/key.pem')
+        self.assertEqual(ca_list[0].get("data").get("name"), 'con1')
 
     def test_04_read_ca_connector(self):
         with self.app.test_request_context('/caconnector/',
@@ -69,8 +69,17 @@ class CAConnectorTestCase(MyApiTestCase):
             self.assertEqual(len(value), 1)
 
         # create a second CA connector
-        save_caconnector({"caconnector": "con2",
-                          "type": "local"})
+        with self.app.test_request_context('/caconnector/con2',
+                                           data={'type': 'local',
+                                                 'cakey': '/etc/key2.pem',
+                                                 'cacert': '/etc/cert2.pem'},
+                                           method='POST',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertTrue(result["status"] is True, result)
+            self.assertTrue(result["value"] == 2, result)
 
         with self.app.test_request_context('/caconnector/',
                                            data={},

--- a/tests/test_lib_caconnector.py
+++ b/tests/test_lib_caconnector.py
@@ -160,7 +160,7 @@ class CAConnectorTestCase(MyTestCase):
                                   "cakey": "/opt/ca/key.pem",
                                   "cacert": "/opt/ca/cert.pem"})
         self.assertTrue(ca_id > 0, ca_id)
-        # Update the CA connector
+        # Update the CA connector. Thus we check if SharedConfigClass is updated.
         save_caconnector({"caconnector": "myCA",
                           "type": "local",
                           "WorkingDir": "/opt/ca",


### PR DESCRIPTION
The CA config is cashed in the SharedConfigObject. Thus we do not need to reread the templates on each request which speeds up the CA connector read dramatically.

Closes #3365