### PR TITLE
multiple audit_entries in realm and resolver are now possible

### DIFF
--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -277,7 +277,9 @@ class Audit(AuditBase):
         It should hash the data and do a hash chain and sign the data
         """
         try:
-            self.audit_data["policies"] = ",".join(self.audit_data.get("policies", []))
+            for entry, value in self.audit_data.items():
+                if isinstance(value, list):
+                    self.audit_data[entry] = ",".join(value)
             if self.config.get("PI_AUDIT_SQL_TRUNCATE"):
                 self._truncate_data()
             if "tokentype" in self.audit_data:

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -533,7 +533,6 @@ class AuthApiTestCase(MyApiTestCase):
         aentry = self.find_most_recent_audit_entry(action='POST /auth')
         self.assertEqual(aentry['action'], 'POST /auth', aentry)
         self.assertEqual(aentry['success'], 0, aentry)
-        self.assertEqual(aentry['policies'], '', aentry)
 
         # check split@sign is working correctly
         set_policy(name="remote", scope=SCOPE.WEBUI, realm=self.realm1,

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -533,6 +533,7 @@ class AuthApiTestCase(MyApiTestCase):
         aentry = self.find_most_recent_audit_entry(action='POST /auth')
         self.assertEqual(aentry['action'], 'POST /auth', aentry)
         self.assertEqual(aentry['success'], 0, aentry)
+        self.assertEqual(None, aentry['policies'], aentry)
 
         # check split@sign is working correctly
         set_policy(name="remote", scope=SCOPE.WEBUI, realm=self.realm1,


### PR DESCRIPTION
Links to the users do not go logically. Since there are possibilities that the user is not in one of the realms. Here it should be considered whether the generation of links should be reconsidered/adjusted.