### PR TITLE
Fix broken login from UI

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -116,7 +116,7 @@ def before_request():
         # On endpoints like /auth/rights, this is not available
         loginname, realm = split_user(username)
         # overwrite the split realm if we have a realm parameter. Default back to default_realm
-        realm = getParam(request.all_data, "realm", default=realm) or get_default_realm()
+        realm = getParam(request.all_data, "realm") or realm or get_default_realm()
         # Prefill the request.User. This is used by some pre-event handlers
         try:
             request.User = User(loginname, realm)

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -52,6 +52,9 @@ class AuthApiTestCase(MyApiTestCase):
             self.assertEqual(4031, result['error']['code'], result)
             self.assertEqual('Authentication failure. Wrong credentials',
                              result['error']['message'], result)
+        aentry = self.find_most_recent_audit_entry(action='POST /auth')
+        self.assertEqual(aentry['action'], 'POST /auth', aentry)
+        self.assertEqual(aentry['success'], 0, aentry)
 
         # test with realm added to user
         with self.app.test_request_context('/auth',
@@ -119,6 +122,8 @@ class AuthApiTestCase(MyApiTestCase):
             self.assertIn('token', result.get("value"), result)
             # realm1 should be the default realm
             self.assertEqual('realm1', result['value']['realm'], result)
+
+        # TODO: Add test with empty realm parameter and user@realm not in default realm
 
         # test with realm parameter and wrong realm added to user
         with mock.patch("logging.Logger.error") as mock_log:

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -607,8 +607,9 @@ class AuthApiTestCase(MyApiTestCase):
         ldap3mock.set_exception(False)
 
     def test_06_auth_user_not_in_defrealm(self):
-        self.setUp_user_realm3()
         self.setUp_user_realms()
+        self.setUp_user_realm3()
+        set_default_realm(self.realm3)
         # check that realm3 is the default realm
         self.assertEqual(self.realm3, get_default_realm())
         # authentication with "@realm1" works


### PR DESCRIPTION
When a user logs in via the WebUI, there is always a `realm` parameter added to the `/auth` request, even if no realm is given (empty string). With the changes from fa643349 this lead to the user not being found if the login was `user@realm` and `realm` wasn't the default realm.

Closes #3416