### PR TITLE
3378/Optimize userlist in dashboard

### DIFF
--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -139,13 +139,10 @@ $scope.getAuthentication = function () {
                   $scope.authentications.serials.push(auditentry.serial);
               }
           });
-          // Convert the dictionary to an array and sort it by the number of fails and the latest error date
+          // Convert the dictionary to an array and sort it by the latest error date
           $scope.authentications.users = Object.values($scope.authentications.users);
           $scope.authentications.users.sort(function(a, b) {
-            if (a.fails == b.fails) {
                 return b.latestError - a.latestError;
-            }
-            return b.fails - a.fails;
           });
       });
 };

--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -111,26 +111,49 @@ myApp.controller("dashboardController", ["ConfigFactory", "TokenFactory",
         });
      };
 
-     $scope.getAuthentication = function () {
-        $scope.authentications = {"success": 0, "fail": 0};
-        AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "1"},
-            function (data) {
-                $scope.authentications.success = data.result.value.count;
-            });
-        AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "0"},
-            function (data) {
-                $scope.authentications.fail = data.result.value.count;
-                $scope.authentications.users = Array();
-                $scope.authentications.serials = Array();
-                angular.forEach(data.result.value.auditdata, function(auditentry){
-                    if (auditentry.user) {
-                        $scope.authentications.users.push({"user": auditentry.user, "realm": auditentry.realm});
-                    } else {
-                        $scope.authentications.serials.push(auditentry.serial);
-                    }
-                });
-            });
-     };
+$scope.getAuthentication = function () {
+  $scope.authentications = {"success": 0, "fail": 0};
+  AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "1"},
+      function (data) {
+          $scope.authentications.success = data.result.value.count;
+      });
+  AuditFactory.get({"timelimit": "1d", "action": "*validate*", "success": "0"},
+      function (data) {
+          $scope.authentications.fail = data.result.value.count;
+          $scope.authentications.users = {}; // Declare the users object as a dictionary
+          $scope.authentications.serials = Array();
+          angular.forEach(data.result.value.auditdata, function(auditentry){
+              if (auditentry.user) {
+                  // Check if the user already exists in the dictionary
+                  if (!$scope.authentications.users[auditentry.user + "-" + auditentry.realm]) {
+                      // Add the user to the dictionary with a count of 1 and the latest error date
+                      $scope.authentications.users[auditentry.user + "-" + auditentry.realm] = {"user": auditentry.user, "realm": auditentry.realm, "fails": 1, "latestError": auditentry.date};
+                  } else {
+                      // Increment the number of fails for the existing user and update the latest error date
+                      $scope.authentications.users[auditentry.user + "-" + auditentry.realm].fails++;
+                      if (auditentry.date > $scope.authentications.users[auditentry.user + "-" + auditentry.realm].latestError) {
+                          $scope.authentications.users[auditentry.user + "-" + auditentry.realm].latestError = auditentry.date;
+                      }
+                  }
+              } else {
+                  $scope.authentications.serials.push(auditentry.serial);
+              }
+          });
+          // Convert the dictionary to an array and sort it by the number of fails and the latest error date
+          $scope.authentications.users = Object.values($scope.authentications.users);
+          $scope.authentications.users.sort(function(a, b) {
+            if (a.fails == b.fails) {
+                return b.latestError - a.latestError;
+            }
+            return b.fails - a.fails;
+          });
+          // Add the number of fails in brackets after the username
+          $scope.authentications.users = $scope.authentications.users.map(function(user) {
+              user.realm += " [" + user.fails + "]";
+              return user;
+          });
+      });
+};
 
      $scope.getAdministration = function () {
          $scope.administration = [];

--- a/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
+++ b/privacyidea/static/components/dashboard/controllers/dashboardControllers.js
@@ -147,11 +147,6 @@ $scope.getAuthentication = function () {
             }
             return b.fails - a.fails;
           });
-          // Add the number of fails in brackets after the username
-          $scope.authentications.users = $scope.authentications.users.map(function(user) {
-              user.realm += " [" + user.fails + "]";
-              return user;
-          });
       });
 };
 

--- a/privacyidea/static/components/dashboard/views/dashboard.html
+++ b/privacyidea/static/components/dashboard/views/dashboard.html
@@ -63,8 +63,8 @@
                                         {{ !$first ? "| " : "" }}
                                         <a ui-sref="user.details({
                                         username: userobj.user,
-                                        realmname: userobj.realm.split(' ')[0]})">
-                                            {{ userobj.user }}@{{ userobj.realm }}
+                                        realmname: userobj.realm})">
+                                            {{ userobj.user }}@{{ userobj.realm }}[{{ userobj.fails }}]
                                         </a>
                                     </span>
                                     <span ng-repeat="serial in authentications.serials">

--- a/privacyidea/static/components/dashboard/views/dashboard.html
+++ b/privacyidea/static/components/dashboard/views/dashboard.html
@@ -60,12 +60,16 @@
                                 <td translate>failed users / tokens</td>
                                 <td>
                                     <span ng-repeat="userobj in authentications.users">
-					    {{ ! $first ? "| " : "" }}<a ui-sref="user.details({username: userobj.user, realmname: userobj.realm})">
-                                        {{ userobj.user }}@{{ userobj.realm }}</a>
+                                        {{ !$first ? "| " : "" }}
+                                        <a ui-sref="user.details({
+                                        username: userobj.user,
+                                        realmname: userobj.realm.split(' ')[0]})">
+                                            {{ userobj.user }}@{{ userobj.realm }}
+                                        </a>
                                     </span>
                                     <span ng-repeat="serial in authentications.serials">
                                         <a ui-sref="token.details({tokenSerial: serial})">
-                                        {{ serial }}</a>
+                                            {{ serial }}</a>
                                     </span>
                                 </td>
                             </tr>


### PR DESCRIPTION
The userlist in the dashboard could be optimized.

- [x] list one failed user once.

- [x] sort them by the number of fails of this user

- [x] sort them by latest error

- [x] add the fails in brackets behind the username

closes #3378 