### PR TITLE
Send correct QR-code image to client

### DIFF
--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -836,7 +836,6 @@ class HotpTokenClass(TokenClass):
         detail["transaction_ids"] = [c[2]]
         chal = {"transaction_id": c[2],
                 "image": init_details.get("googleurl").get("img"),
-                "token_uri": init_details.get("googleurl").get("value"),
                 "client_mode": CLIENTMODE.INTERACTIVE,
                 "serial": token_obj.token.serial,
                 "type": token_obj.type,

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -832,10 +832,11 @@ class HotpTokenClass(TokenClass):
         # Create a challenge!
         c = token_obj.create_challenge()
         # get details of token
-        init_details = token_obj.get_init_detail()
+        init_details = token_obj.get_init_detail(user=user_obj)
         detail["transaction_ids"] = [c[2]]
         chal = {"transaction_id": c[2],
-                "image": init_details.get("otpkey").get("img"),
+                "image": init_details.get("googleurl").get("img"),
+                "token_uri": init_details.get("googleurl").get("value"),
                 "client_mode": CLIENTMODE.INTERACTIVE,
                 "serial": token_obj.token.serial,
                 "type": token_obj.type,

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -5377,12 +5377,11 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             transaction_id = detail.get("transaction_id")
             self.assertTrue("Please scan the QR code!" in detail.get("message"), detail.get("message"))
             # Get image and client_mode
-            self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("client_mode"))
+            self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("client_mode"), detail)
             # Check, that multi_challenge is also contained.
             chal = detail.get("multi_challenge")[0]
-            self.assertEqual(CLIENTMODE.INTERACTIVE, chal.get("client_mode"))
-            self.assertIn("image", detail)
-            self.assertTrue(chal.get("token_uri").startswith('otpauth://'), detail)
+            self.assertEqual(CLIENTMODE.INTERACTIVE, chal.get("client_mode"), detail)
+            self.assertIn("image", detail, detail)
             serial = detail.get("serial")
 
         # 3. scan the qrcode / Get the OTP value

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -5379,8 +5379,10 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             # Get image and client_mode
             self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("client_mode"))
             # Check, that multi_challenge is also contained.
-            self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("multi_challenge")[0].get("client_mode"))
+            chal = detail.get("multi_challenge")[0]
+            self.assertEqual(CLIENTMODE.INTERACTIVE, chal.get("client_mode"))
             self.assertIn("image", detail)
+            self.assertTrue(chal.get("token_uri").startswith('otpauth://'), detail)
             serial = detail.get("serial")
 
         # 3. scan the qrcode / Get the OTP value


### PR DESCRIPTION
The QR-code sent to the client after enrollment during validate/check was incorrect, it just contained the token secret without the necessary HOTP/TOTP parameter.

Fixes #3427 