### PR TITLE
Only fetch tokengroups of a token if admin is allowed to.

### DIFF
--- a/privacyidea/static/components/token/controllers/tokenDetailController.js
+++ b/privacyidea/static/components/token/controllers/tokenDetailController.js
@@ -352,9 +352,11 @@ myApp.controller("tokenDetailController", ['$scope', 'TokenFactory',
             $scope.realms = data.result.value;
         });
 
-        ConfigFactory.getTokengroup("", function (data) {
-            $scope.tokengroups = data.result.value;
-        });
+        if (AuthFactory.checkRight("tokengroup_list")) {
+            ConfigFactory.getTokengroup("", function (data) {
+                $scope.tokengroups = data.result.value;
+            });
+        }
 
         $scope.attachMachine = function () {
             // newToken.serial, application

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -337,7 +337,7 @@
             </td>
         </tr>
 
-        <tr>
+        <tr ng-show="checkRight('tokengroup_list')">
             <td>Token groups</td>
             <td>
                 <span ng-hide="editTokenGroups">
@@ -368,7 +368,7 @@
                     </button>
                     <button class="btn btn-primary"
                             id="tgSaveButton"
-                            ng-show="editTokenGroups"
+                            ng-show="editTokenGroups && checkRight('tokengroups')"
                             ng-click="saveTokenGroups()"
                             translate>Save Token Groups
                     </button>


### PR DESCRIPTION
The tokengroups of a token are only fetched if the user has the right "tokengroup_list".

Fixes #3441