### PR TITLE
Fix the wrong naming of ca_connector

### DIFF
--- a/privacyidea/lib/caconnector.py
+++ b/privacyidea/lib/caconnector.py
@@ -292,6 +292,9 @@ def get_caconnector_object(connector_name):
                     connector_config[conf.Key] = value
                 c_obj.set_config(connector_config)
 
+    if not c_obj:
+        log.warning("A CA connector with the name {0!s} could not be found!".format(connector_name))
+
     return c_obj
 
 

--- a/privacyidea/lib/tokens/certificatetoken.py
+++ b/privacyidea/lib/tokens/certificatetoken.py
@@ -67,7 +67,7 @@ class ACTION(BASE_ACTION):
     __doc__ = """This is the list of special certificate actions."""
     TRUSTED_CA_PATH = "certificate_trusted_Attestation_CA_path"
     REQUIRE_ATTESTATION = "certificate_require_attestation"
-    CA_CONNECTOR = "ca_connector"
+    CA_CONNECTOR = "certificate_ca_connector"
     CERTIFICATE_TEMPLATE = "certificate_template"
     CERTIFICATE_REQUEST_SUBJECT_COMPONENT = "certificate_request_subject_component"
 


### PR DESCRIPTION
The policy action that is saved is certificate_ca_connector. So when fetching the policy in the prepolicy, we will not find the configuration and query the wrong ca.

Also add a failsafe warning to the log file, if a wrong CA connector name is specified.

Fixes #3479