### PR TITLE
Check token assignment before deleting tokengroups

### DIFF
--- a/privacyidea/lib/tokengroup.py
+++ b/privacyidea/lib/tokengroup.py
@@ -60,10 +60,10 @@ def delete_tokengroup(name=None, tokengroup_id=None):
         else:
             tg = fetch_one_resource(Tokengroup, id=tokengroup_id)
     if tg:
-        tok_cnt = TokenTokengroup.query.filter_by(tokengroup_id=tg.id).count()
-        if tok_cnt > 0:
+        tok_count = TokenTokengroup.query.filter_by(tokengroup_id=tg.id).count()
+        if tok_count > 0:
             raise privacyIDEAError('The tokengroup with name {0!s} still has '
-                                   '{1:d} tokens assigned.'.format(tg.name, tok_cnt))
+                                   '{1:d} tokens assigned.'.format(tg.name, tok_count))
         tg.delete()
         db.session.commit()
     else:

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -254,9 +254,8 @@ class Token(MethodsMixin, db.Model):
             
     @log_with(log)
     def delete(self):
-        # some DBs (eg. DB2) run in deadlock, if the TokenRealm entry
-        # is deleted via  key relation
-        # so we delete it explicit
+        # some DBs (e.g. DB2) run in deadlock, if the TokenRealm entry
+        # is deleted via  key relation, so we delete it explicit
         ret = self.id
         db.session.query(TokenRealm)\
                   .filter(TokenRealm.token_id == self.id)\
@@ -273,6 +272,9 @@ class Token(MethodsMixin, db.Model):
         db.session.query(TokenInfo)\
                   .filter(TokenInfo.token_id == self.id)\
                   .delete()
+        db.session.query(TokenTokengroup)\
+            .filter(TokenTokengroup.token_id == self.id)\
+            .delete()
         db.session.delete(self)
         db.session.commit()
         return ret
@@ -653,7 +655,9 @@ class Token(MethodsMixin, db.Model):
         If tokengroup name and id are omitted, all tokengroups are deleted.
 
         :param tokengroup: The name of the tokengroup
+        :type tokengroup: str
         :param tokengroup_id: The id of the tokengroup
+        :type tokengroup_id: int
         :return:
         """
         if tokengroup:

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -274,7 +274,7 @@
                     <button class="btn btn-primary"
                             id="tiEditButton"
                             ng-hide="editTokenInfo || (!checkRight('set') && hide_buttons)"
-                            ng-disable="!checkRight('set')"
+                            ng-disabled="!checkRight('set')"
                             ng-click="startEditTokenInfo()"
                             translate>Edit
                     </button>
@@ -317,7 +317,7 @@
                     <button class="btn btn-primary"
                             id="trEditButton"
                             ng-hide="editTokenRealm || (!checkRight('tokenrealms') && hide_buttons)"
-                            ng-disable="!checkRight('tokenrealms')"
+                            ng-disabled="!checkRight('tokenrealms')"
                             ng-click="startEditRealm()"
                             translate>Edit
                     </button>
@@ -362,7 +362,7 @@
                     <button class="btn btn-primary"
                             id="tgEditButton"
                             ng-hide="editTokenGroups || (!checkRight('tokengroups') && hide_buttons)"
-                            ng-disable="!checkRight('tokengroups')"
+                            ng-disabled="!checkRight('tokengroups')"
                             ng-click="startEditTokenGroups()"
                             translate>Edit
                     </button>

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -2105,6 +2105,11 @@ class TokenGroupTestCase(MyTestCase):
         tok2 = get_one_token(serial="s2")
         self.assertEqual(len(tok2.token.tokengroup_list), 0)
 
+        # check that deleting a tokengroup with tokens still assigned results in an error
+        self.assertRaises(privacyIDEAError, delete_tokengroup, name='g2')
+
         # cleanup
         for s in serials:
             remove_token(s)
+        delete_tokengroup('g1')
+        delete_tokengroup('g2')

--- a/tests/test_lib_tokengroup.py
+++ b/tests/test_lib_tokengroup.py
@@ -13,55 +13,8 @@ getTokens4UserOrSerial
 gettokensoftype
 getToken....
 """
-from .base import MyTestCase, FakeAudit, FakeFlaskG
-from privacyidea.lib.user import (User)
-from privacyidea.lib.tokenclass import TokenClass, TOKENKIND, FAILCOUNTER_EXCEEDED, FAILCOUNTER_CLEAR_TIMEOUT
-from privacyidea.lib.token import weigh_token_type
-from privacyidea.lib.tokens.totptoken import TotpTokenClass
-from privacyidea.models import (Token, Challenge, TokenRealm)
-from privacyidea.lib.config import (set_privacyidea_config, get_token_types, delete_privacyidea_config, SYSCONF)
-from privacyidea.lib.policy import set_policy, SCOPE, ACTION, delete_policy, PolicyClass, delete_policy
-from privacyidea.lib.utils import b32encode_and_unicode, hexlify_and_unicode
-from privacyidea.lib.error import PolicyError
-import datetime
-from dateutil import parser
-import hashlib
-import binascii
-import warnings
-from privacyidea.lib.token import (create_tokenclass_object,
-                                   get_tokens,
-                                   get_token_type, check_serial,
-                                   get_num_tokens_in_realm,
-                                   get_realms_of_token,
-                                   token_exist, get_token_owner, is_token_owner,
-                                   get_tokenclass_info,
-                                   get_tokens_in_resolver, get_otp,
-                                   get_token_by_otp, get_serial_by_otp,
-                                   gen_serial, init_token, remove_token,
-                                   set_realms, set_defaults, assign_token,
-                                   unassign_token, resync_token,
-                                   reset_token, set_pin, set_pin_user,
-                                   set_pin_so, enable_token,
-                                   is_token_active, set_hashlib, set_otplen,
-                                   set_count_auth, add_tokeninfo,
-                                   set_sync_window, set_count_window,
-                                   set_description, get_multi_otp,
-                                   set_max_failcount, copy_token_pin,
-                                   copy_token_user, lost_token,
-                                   check_token_list, check_serial_pass,
-                                   check_realm_pass,
-                                   check_user_pass,
-                                   get_dynamic_policy_definitions,
-                                   get_tokens_paginate,
-                                   set_validity_period_end,
-                                   set_validity_period_start, remove_token, delete_tokeninfo,
-                                   import_token, get_one_token, get_tokens_from_serial_or_user,
-                                   get_tokens_paginated_generator)
-
-from privacyidea.lib.error import (TokenAdminError, ParameterError,
-                                   privacyIDEAError, ResourceNotFoundError)
-from privacyidea.lib.tokenclass import DATE_FORMAT
-from dateutil.tz import tzlocal
+from .base import MyTestCase
+from privacyidea.lib.error import privacyIDEAError, ResourceNotFoundError
 
 from privacyidea.lib.tokengroup import set_tokengroup, delete_tokengroup, get_tokengroups
 from privacyidea.models import Tokengroup
@@ -92,11 +45,14 @@ class TokenTestCase(MyTestCase):
         r = set_tokengroup("gruppe1", "my other first group")
         self.assertGreaterEqual(r, 1)
 
-        delete_tokengroup(id=r)
+        self.assertRaises(privacyIDEAError,
+                          delete_tokengroup, tokengroup_id=(r + 1), name='gruppe1')
+
+        delete_tokengroup(tokengroup_id=r)
         tg = Tokengroup.query.filter_by(name="gruppe1").all()
         self.assertEqual(len(tg), 0)
 
-        self.assertRaises(privacyIDEAError, delete_tokengroup)
+        self.assertRaises(ResourceNotFoundError, delete_tokengroup)
 
     def test_03_get_tokengroups(self):
         r1 = set_tokengroup("gruppe1", "my first group")


### PR DESCRIPTION
Deleting a tokengroup which has still tokens assigned to it, now fails with an error.
Also when deleting a token, the tokengroup assignment will be deleted as well.
And a bug in the UI has been fixed which prevented the "save tokengroup" button to be displayed in the token-view.

Fixes #3423