### PR TITLE
Do not unquote parameters from simpleSAML

### DIFF
--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -51,7 +51,8 @@ TRUSTED_JWT_ALGOS = ["ES256", "ES384", "ES512",
 # The following user-agents (with versions) do not need extra unquoting
 # TODO: we should probably switch this when we do not do the extra unquote anymore
 NO_UNQUOTE_USER_AGENTS = {
-    'privacyIDEA-LDAP-Proxy': None
+    'privacyIDEA-LDAP-Proxy': None,
+    'simpleSAMLphp': None
 }
 
 SESSION_KEY_LENGTH = 32


### PR DESCRIPTION
The simpleSAMLphp plugin already sends the data correct, we do not need to unquote them.

Working on #3337