### PR TITLE
Add Set and !Set comparators to Token and user info

### DIFF
--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -185,7 +185,7 @@ from privacyidea.lib.radiusserver import get_radiusservers
 from privacyidea.lib.utils import (check_time_in_range, check_pin_contents,
                                    fetch_one_resource, is_true, check_ip_in_policy,
                                    determine_logged_in_userparams, parse_string_to_dict)
-from privacyidea.lib.utils.compare import compare_values, COMPARATOR_DESCRIPTIONS
+from privacyidea.lib.utils.compare import compare_values, COMPARATOR_DESCRIPTIONS, COMPARATORS
 from privacyidea.lib.utils.export import (register_import, register_export)
 from privacyidea.lib.user import User
 from privacyidea.lib import _
@@ -962,7 +962,11 @@ class PolicyClass(object):
         if user_object is not None or dbtoken is not None:
             info = user_object.info if user_object is not None else dbtoken.get_info()
 
-            if key in info:
+            if comparator == COMPARATORS.SET:
+                return key in info
+            elif comparator == COMPARATORS.NOT_SET:
+                return not key in info
+            elif key in info:
                 try:
                     return compare_values(info[key], comparator, value)
                 except Exception as exx:

--- a/privacyidea/lib/utils/compare.py
+++ b/privacyidea/lib/utils/compare.py
@@ -204,9 +204,9 @@ COMPARATOR_DESCRIPTIONS = {
     COMPARATORS.NOT_IN: _("false if the value of the left attribute is contained in the comma-separated values on the right"),
 
     COMPARATORS.SMALLER: _("true if the integer value of the left attribute is smaller than the right integer value"),
-    COMPARATORS.BIGGER: _("true if the integer value of the left attribute is bigger than the right integer value")
+    COMPARATORS.BIGGER: _("true if the integer value of the left attribute is bigger than the right integer value"),
 
-    COMPARATORS.SET: _("true if the user- or tokeninfo is is available")
+    COMPARATORS.SET: _("true if the user- or tokeninfo is is available"),
     COMPARATORS.NOT_SET: _("true if the user- or tokeninfo is is not available")
 }
 

--- a/privacyidea/lib/utils/compare.py
+++ b/privacyidea/lib/utils/compare.py
@@ -165,6 +165,9 @@ class COMPARATORS(object):
     SMALLER = "<"
     BIGGER = ">"
 
+    SET = "set"
+    NOT_SET = "!set"
+
 
 #: This dictionary connects comparators to comparator functions.
 #: A comparison function takes three parameters ``left``, ``comparator``, ``right``.
@@ -202,6 +205,9 @@ COMPARATOR_DESCRIPTIONS = {
 
     COMPARATORS.SMALLER: _("true if the integer value of the left attribute is smaller than the right integer value"),
     COMPARATORS.BIGGER: _("true if the integer value of the left attribute is bigger than the right integer value")
+
+    COMPARATORS.SET: _("true if the user- or tokeninfo is is available")
+    COMPARATORS.NOT_SET: _("true if the user- or tokeninfo is is not available")
 }
 
 


### PR DESCRIPTION
This PR allows to test for the existence of a user- and tokeninfo key.
My requirement was that the first token a User enrolls must be a TAN token (for recovery). Thereafter the user is only allowed to enroll and delete webAuthn and TOTP tokens.
I implemented it the following way:
 One Policy only matches if the user has userinfo "enrolled" not set and only allows enrollment of  TAN tokens.
 Another Policy one matches if the user has userinfo "enrolled" set and its value is "1" and allows enrollment of the other two tokens.
 Via events the userinfo "enrolled" is set to 1 whenever a tan token is enrolled and deleted when the last token is deleted.

