### PR TITLE
Update CircleCI configuration to use mariadb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,23 @@ executors:
           MYSQL_USER: pi
           MYSQL_PASSWORD: test123
           MYSQL_RANDOM_ROOT_PASSWORD: yes
+  mariadb:
+    docker:
+      - image: cimg/python:3.10
+        environment:
+          TEST_DATABASE_URL: mysql+pymysql://pi:test123@localhost/pi
+      - image: cimg/mariadb:10.6
+        environment:
+          MARIADB_DATABASE: pi
+          MARIADB_USER: pi
+          MARIADB_PASSWORD: test123
+          MARIADB_RANDOM_ROOT_PASSWORD: yes
   postgres: &postgres-executor
     docker:
       - image: cimg/python:3.10
         environment:
           TEST_DATABASE_URL: postgresql+psycopg2://pi:test123@localhost/pi
-      - image: cimg/postgres:14.5
+      - image: cimg/postgres:14.6
         environment:
           POSTGRES_DB: pi
           POSTGRES_USER: pi
@@ -99,4 +110,4 @@ workflows:
       - test_database:
           matrix:
             parameters:
-              db: ['mysql', 'postgres']
+              db: ['mysql', 'postgres', 'mariadb']


### PR DESCRIPTION
Add MariaDB to nightly db tests (using the version available in Ubuntu 22.04)