### PR TITLE
dictionary.netknights found in privacyidea/freeradius repo

### DIFF
--- a/doc/application_plugins/rlm_perl.rst
+++ b/doc/application_plugins/rlm_perl.rst
@@ -242,5 +242,5 @@ secret "test" with your clients secret.
 
 .. rubric:: Footnotes
 
-.. [#netknights_dict] https://github.com/privacyidea/privacyidea/blob/master/authmodules/FreeRADIUS/dictionary.netknights
+.. [#netknights_dict] https://github.com/privacyidea/FreeRADIUS/blob/master/dictionary.netknights
 .. [#rlmPerl] https://github.com/privacyidea/freeradius


### PR DESCRIPTION
in the docs the link to `dictionary.netknights` on the freeRADIUS plugin page leads to a 404.
This fixes the link.