### PR TITLE
Rename RegEx assertions in tests

### DIFF
--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -2949,10 +2949,10 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
             scope=SCOPE.ENROLL,
             action=WEBAUTHNACTION.REQ + "=" + allowed_certs
         )
-        self.assertRaisesRegexp(PolicyError,
-                                'The WebAuthn token is not allowed to be registered '
-                                'due to a policy restriction.',
-                                webauthntoken_allowed, request, None)
+        self.assertRaisesRegex(PolicyError,
+                               'The WebAuthn token is not allowed to be registered '
+                               'due to a policy restriction.',
+                               webauthntoken_allowed, request, None)
 
         set_policy(
             name="WebAuthn",
@@ -3173,7 +3173,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
 
         # first test without any policy to delete the department. This is not allowed
         req.all_data = {"user": "cornelius", "realm": self.realm1, "attrkey": "department"}
-        self.assertRaisesRegexp(PolicyError,
+        self.assertRaisesRegex(PolicyError,
                                 "ERR303: You are not allowed to delete the custom user attribute department!",
                                 check_custom_user_attributes, req, "delete")
 
@@ -3218,9 +3218,9 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         # You are not allowed to set a different department
         req.all_data = {"user": "cornelius", "realm": self.realm1,
                         "key": "department", "value": "different"}
-        self.assertRaisesRegexp(PolicyError,
-                                "ERR303: You are not allowed to set the custom user attribute department!",
-                                check_custom_user_attributes, req, "set")
+        self.assertRaisesRegex(PolicyError,
+                               "ERR303: You are not allowed to set the custom user attribute department!",
+                               check_custom_user_attributes, req, "set")
 
         # You are allowed to set color to any value
         req.all_data = {"user": "cornelius", "realm": self.realm1,
@@ -3372,9 +3372,9 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
 
         # This should not work, a description is required for hotp
         req.all_data = {"type": "hotp"}
-        self.assertRaisesRegexp(PolicyError,
-                                "ERR303: Description required for hotp token.",
-                                require_description, req)
+        self.assertRaisesRegex(PolicyError,
+                               "ERR303: Description required for hotp token.",
+                               require_description, req)
 
         delete_policy("require_description")
 

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -82,7 +82,7 @@ class UtilsTestCase(MyApiTestCase):
                                 algorithm="RS256")
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=DeprecationWarning)
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 AuthError,
                 "The username hanswurst is not allowed to impersonate via JWT.",
                 verify_auth_token, auth_token=auth_token, required_role="user")
@@ -97,7 +97,7 @@ class UtilsTestCase(MyApiTestCase):
                                 algorithm="RS256")
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=DeprecationWarning)
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 AuthError,
                 "The username kleinerhans is not allowed to impersonate via JWT.",
                 verify_auth_token, auth_token=auth_token, required_role="user")

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -790,10 +790,10 @@ class APITokenTestCase(MyApiTestCase):
 #                             "ERR1103: Token already assigned to user "
 #                             "User(login='cornelius', realm='realm1', "
 #                             "resolver='resolver1')")
-            self.assertRegexpMatches(error.get('message'),
-                                     r"ERR1103: Token already assigned to user "
-                                     r"User\(login=u?'cornelius', "
-                                     r"realm=u?'realm1', resolver=u?'resolver1'\)")
+            self.assertRegex(error.get('message'),
+                             r"ERR1103: Token already assigned to user "
+                             r"User\(login=u?'cornelius', "
+                             r"realm=u?'realm1', resolver=u?'resolver1'\)")
 
         # Now the user tries to assign a foreign token
         with self.app.test_request_context('/auth',

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -3135,9 +3135,9 @@ class RegistrationAndPasswordToken(MyApiTestCase):
             regcode = detail.get("registrationcode")
             self.assertEqual(DEFAULT_LENGTH_REG, len(regcode))
             # Check if a number is contained
-            self.assertRegexpMatches(regcode, "[0-9]+")
+            self.assertRegex(regcode, "[0-9]+")
             # Check if a character is contained
-            self.assertRegexpMatches(regcode, "[a-zA-Z]+")
+            self.assertRegex(regcode, "[a-zA-Z]+")
 
         # now check if authentication
         with self.app.test_request_context('/validate/check',
@@ -3263,9 +3263,9 @@ class RegistrationAndPasswordToken(MyApiTestCase):
             password = detail.get("password")
             self.assertEqual(DEFAULT_LENGTH_PW, len(password))
             # Check if a number is contained
-            self.assertRegexpMatches(password, "[0-9]+")
+            self.assertRegex(password, "[0-9]+")
             # Check if a character is contained
-            self.assertRegexpMatches(password, "[a-zA-Z]+")
+            self.assertRegex(password, "[a-zA-Z]+")
 
         # now check the authentication
         with self.app.test_request_context('/validate/check',

--- a/tests/test_lib_caconnector.py
+++ b/tests/test_lib_caconnector.py
@@ -470,10 +470,10 @@ class MSCATestCase(MyTestCase):
             self.assertEqual(description[key], "string")
 
         # Check, if an error is raised if a required attribute is missing:
-        self.assertRaisesRegexp(CAError, "required argument 'port' is missing.",
-                                MSCAConnector, "billsCA", {MS_ATTR.HOSTNAME: "hans"})
-        self.assertRaisesRegexp(CAError, "required argument 'hostname' is missing.",
-                                MSCAConnector, "billsCA", {MS_ATTR.PORT: "shanghai"})
+        self.assertRaisesRegex(CAError, "required argument 'port' is missing.",
+                               MSCAConnector, "billsCA", {MS_ATTR.HOSTNAME: "hans"})
+        self.assertRaisesRegex(CAError, "required argument 'hostname' is missing.",
+                               MSCAConnector, "billsCA", {MS_ATTR.PORT: "shanghai"})
 
     def test_02_test_get_templates(self):
         # Mock the connection to the worker
@@ -504,16 +504,16 @@ class MSCATestCase(MyTestCase):
                                                                "ca_templates": MOCK_CA_TEMPLATES,
                                                                "csr_disposition": 5})
             cacon = MSCAConnector("billsCA", CONF)
-            self.assertRaisesRegexp(CSRPending, "ERR505: CSR pending",
-                                    cacon.sign_request, REQUEST, {"template": "ApprovalRequired"})
+            self.assertRaisesRegex(CSRPending, "ERR505: CSR pending",
+                                   cacon.sign_request, REQUEST, {"template": "ApprovalRequired"})
             # Mock the CA to simulate a failed Request - dispoisition -1
             mock_conncect_worker.return_value = CAServiceMock(CONF,
                                                               {"available_cas": MOCK_AVAILABLE_CAS,
                                                                "ca_templates": MOCK_CA_TEMPLATES,
                                                                "csr_disposition": -1})
             cacon = MSCAConnector("billsCA", CONF)
-            self.assertRaisesRegexp(CSRError, "ERR504: CSR invalid",
-                                    cacon.sign_request, REQUEST, {"template": "NonExisting"})
+            self.assertRaisesRegex(CSRError, "ERR504: CSR invalid",
+                                   cacon.sign_request, REQUEST, {"template": "NonExisting"})
             # Mock the CA to simulate a signed request - disposition 3
             mock_conncect_worker.return_value = CAServiceMock(CONF,
                                                               {"available_cas": MOCK_AVAILABLE_CAS,

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1222,11 +1222,11 @@ class PolicyTestCase(MyTestCase):
         user3.info = {"type": "notverysecure", "groups": ["b", "c"]}
 
         # no user => policy error
-        with self.assertRaisesRegexp(PolicyError, ".* an according object is not available.*"):
+        with self.assertRaisesRegex(PolicyError, ".* an according object is not available.*"):
             P.match_policies(user_object=None)
 
         # empty user => policy error
-        with self.assertRaisesRegexp(PolicyError, ".*Unknown key.*"):
+        with self.assertRaisesRegex(PolicyError, ".*Unknown key.*"):
             P.match_policies(user_object=empty_user)
 
         # user1 => verysecure matches
@@ -1242,7 +1242,7 @@ class PolicyTestCase(MyTestCase):
         # an unforeseen error in the comparison function => policy error
         with mock.patch("privacyidea.lib.policy.compare_values") as mock_function:
             mock_function.side_effect = ValueError
-            with self.assertRaisesRegexp(PolicyError, r".*Invalid comparison.*"):
+            with self.assertRaisesRegex(PolicyError, r".*Invalid comparison.*"):
                 P.match_policies(user_object=user1)
 
         for policy in ["verysecure", "notverysecure"]:
@@ -1281,7 +1281,7 @@ class PolicyTestCase(MyTestCase):
         # an unknown section in the condition
         set_policy("unknownsection", scope=SCOPE.AUTH, action="{0!s}=userstore".format(ACTION.OTPPIN),
                     conditions=[("somesection", "bla", "equals", "verysecure", True)])
-        with self.assertRaisesRegexp(PolicyError, r".*unknown section.*"):
+        with self.assertRaisesRegex(PolicyError, r".*unknown section.*"):
             P.match_policies(user_object=user1)
         delete_policy("unknownsection")
 
@@ -1295,7 +1295,7 @@ class PolicyTestCase(MyTestCase):
         # an unknown key in the condition
         set_policy("unknownkey", scope=SCOPE.AUTH, action="{0!s}=userstore".format(ACTION.OTPPIN),
                     conditions=[("userinfo", "bla", "equals", "verysecure", True)])
-        with self.assertRaisesRegexp(PolicyError, r".*Unknown key.*"):
+        with self.assertRaisesRegex(PolicyError, r".*Unknown key.*"):
             P.match_policies(user_object=user1)
         delete_policy("unknownkey")
 
@@ -1305,7 +1305,7 @@ class PolicyTestCase(MyTestCase):
 
         set_policy("error", scope=SCOPE.AUTH, action="{0!s}=userstore".format(ACTION.OTPPIN),
                    conditions=[("userinfo", "number", "contains", "b", True)])
-        with self.assertRaisesRegexp(PolicyError, r".*Invalid comparison.*"):
+        with self.assertRaisesRegex(PolicyError, r".*Invalid comparison.*"):
             P.match_policies(user_object=user4)
         delete_policy("error")
 

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -2858,7 +2858,7 @@ class HTTPResolverTestCase(MyTestCase):
         self.assertEqual(response.get('a_static_key'), 'a static value')
 
         # Test with invalid response
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             Exception,
             'Received an error while searching for user: PepePerez',
             instance.getUserInfo, 'PepePerez'

--- a/tests/test_lib_subscriptions.py
+++ b/tests/test_lib_subscriptions.py
@@ -125,12 +125,14 @@ class SubscriptionApplicationTestCase(MyTestCase):
 
         sub1 = SUBSCRIPTION1.copy()
         sub1['by_name'] = 'unknown vendor'
-        with self.assertRaisesRegexp(SubscriptionError, 'Verifying the signature '
-                                                        'of your subscription'):
+        with self.assertRaisesRegex(
+                SubscriptionError,
+                'Verifying the signature of your subscription'):
             save_subscription(sub1)
 
         sub1 = SUBSCRIPTION1.copy()
         sub1['signature'] = str(int(sub1['signature']) + 1)
-        with self.assertRaisesRegexp(SubscriptionError, 'Signature of your '
-                                                        'subscription does not'):
+        with self.assertRaisesRegex(
+                SubscriptionError,
+                'Signature of your subscription does not'):
             save_subscription(sub1)

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -1289,15 +1289,15 @@ class TokenTestCase(MyTestCase):
                          binascii.hexlify(otpkey))
         remove_token("NEW001")
         # unknown encoding
-        self.assertRaisesRegexp(ParameterError,
-                                "Unknown OTP key format",
-                                init_token,
-                                {"serial": "NEW001",
-                                 "type": "hotp",
-                                 "otpkey": binascii.hexlify(otpkey),
-                                 "otpkeyformat": "foobar"},
-                                user=User(login="cornelius",
-                                          realm=self.realm1))
+        self.assertRaisesRegex(ParameterError,
+                               "Unknown OTP key format",
+                               init_token,
+                               {"serial": "NEW001",
+                                "type": "hotp",
+                                "otpkey": binascii.hexlify(otpkey),
+                                "otpkeyformat": "foobar"},
+                               user=User(login="cornelius",
+                                         realm=self.realm1))
 
         # successful base32check encoding
         base32check_encoding = b32encode_and_unicode(checksum + otpkey).strip("=")
@@ -1341,56 +1341,56 @@ class TokenTestCase(MyTestCase):
         # invalid base32check encoding (incorrect checksum due to typo)
         base32check_encoding = b32encode_and_unicode(checksum + otpkey)
         base32check_encoding = "A" + base32check_encoding[1:]
-        self.assertRaisesRegexp(ParameterError,
-                                "Incorrect checksum",
-                                init_token,
-                                {"serial": "NEW004", "type": "hotp",
-                                 "otpkey": base32check_encoding,
-                                 "otpkeyformat": "base32check"},
-                                user=User(login="cornelius", realm=self.realm1))
+        self.assertRaisesRegex(ParameterError,
+                               "Incorrect checksum",
+                               init_token,
+                               {"serial": "NEW004", "type": "hotp",
+                                "otpkey": base32check_encoding,
+                                "otpkeyformat": "base32check"},
+                               user=User(login="cornelius", realm=self.realm1))
 
         # invalid base32check encoding (missing four characters => incorrect checksum)
         base32check_encoding = b32encode_and_unicode(checksum + otpkey)
         base32check_encoding = base32check_encoding[:-4]
-        self.assertRaisesRegexp(ParameterError,
-                                "Incorrect checksum",
-                                init_token,
-                                {"serial": "NEW005", "type": "hotp",
-                                 "otpkey": base32check_encoding,
-                                 "otpkeyformat": "base32check"},
-                                user=User(login="cornelius", realm=self.realm1))
+        self.assertRaisesRegex(ParameterError,
+                               "Incorrect checksum",
+                               init_token,
+                               {"serial": "NEW005", "type": "hotp",
+                                "otpkey": base32check_encoding,
+                                "otpkeyformat": "base32check"},
+                               user=User(login="cornelius", realm=self.realm1))
 
         # invalid base32check encoding (too many =)
         base32check_encoding = b32encode_and_unicode(checksum + otpkey)
         base32check_encoding = base32check_encoding + "==="
-        self.assertRaisesRegexp(ParameterError,
-                                "Invalid base32",
-                                init_token,
-                                {"serial": "NEW006", "type": "hotp",
-                                 "otpkey": base32check_encoding,
-                                 "otpkeyformat": "base32check"},
-                                user=User(login="cornelius", realm=self.realm1))
+        self.assertRaisesRegex(ParameterError,
+                               "Invalid base32",
+                               init_token,
+                               {"serial": "NEW006", "type": "hotp",
+                                "otpkey": base32check_encoding,
+                                "otpkeyformat": "base32check"},
+                               user=User(login="cornelius", realm=self.realm1))
 
         # invalid base32check encoding (wrong characters)
         base32check_encoding = b32encode_and_unicode(checksum + otpkey)
         base32check_encoding = "1" + base32check_encoding[1:]
-        self.assertRaisesRegexp(ParameterError,
-                                "Invalid base32",
-                                init_token,
-                                {"serial": "NEW006", "type": "hotp",
-                                 "otpkey": base32check_encoding,
-                                 "otpkeyformat": "base32check"},
-                                user=User(login="cornelius", realm=self.realm1))
+        self.assertRaisesRegex(ParameterError,
+                               "Invalid base32",
+                               init_token,
+                               {"serial": "NEW006", "type": "hotp",
+                                "otpkey": base32check_encoding,
+                                "otpkeyformat": "base32check"},
+                               user=User(login="cornelius", realm=self.realm1))
 
         # invalid key (too short)
         base32check_encoding = b32encode_and_unicode(b'Yo')
-        self.assertRaisesRegexp(ParameterError,
-                                "Too short",
-                                init_token,
-                                {"serial": "NEW006", "type": "hotp",
-                                 "otpkey": base32check_encoding,
-                                 "otpkeyformat": "base32check"},
-                                user=User(login="cornelius", realm=self.realm1))
+        self.assertRaisesRegex(ParameterError,
+                               "Too short",
+                               init_token,
+                               {"serial": "NEW006", "type": "hotp",
+                                "otpkey": base32check_encoding,
+                                "otpkeyformat": "base32check"},
+                               user=User(login="cornelius", realm=self.realm1))
 
     def test_51_tokenkind(self):
         # A normal token will be of kind "software"
@@ -2046,7 +2046,7 @@ class PINChangeTestCase(MyTestCase):
         newpin = "test"
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=DeprecationWarning)
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 PolicyError, "The minimum OTP PIN length is 5", check_token_list,
                 [tok, tok2], newpin, user=user_obj,
                 options={"transaction_id": transaction_id,

--- a/tests/test_lib_tokens_hotp.py
+++ b/tests/test_lib_tokens_hotp.py
@@ -807,7 +807,7 @@ class HOTPTokenTestCase(MyTestCase):
         # wrong checksum
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=DeprecationWarning)
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 ParameterError,
                 "Incorrect checksum",
                 token.update,

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -457,7 +457,7 @@ class SMSTokenTestCase(MyTestCase):
             smstext = token._get_sms_text(options)
             self.assertEqual(pol_text.strip("'"), smstext)
             r, message = token._send_sms(smstext, options)
-            self.assertRegexpMatches(message, result_text)
+            self.assertRegex(message, result_text)
 
         # Test AUTOSMS
         p = set_policy(name="autosms",

--- a/tests/test_lib_tokens_tiqr.py
+++ b/tests/test_lib_tokens_tiqr.py
@@ -538,7 +538,7 @@ class TiQRTokenTestCase(MyApiTestCase):
         self.assertEqual(r[0], "plain")
         # check the failed response count
         fcnt1 = token.get_max_failcount() - token.get_failcount()
-        self.assertRegexpMatches(r[1], r"INVALID_RESPONSE:{0!s}".format(fcnt1))
+        self.assertRegex(r[1], r"INVALID_RESPONSE:{0!s}".format(fcnt1))
 
         # Try another wrong response
         req.all_data = {"response": "67890",
@@ -549,7 +549,7 @@ class TiQRTokenTestCase(MyApiTestCase):
         self.assertEqual(r[0], "plain")
         # check the failed response count
         fcnt2 = token.get_max_failcount() - token.get_failcount()
-        self.assertRegexpMatches(r[1], r"INVALID_RESPONSE:{0!s}".format(fcnt2))
+        self.assertRegex(r[1], r"INVALID_RESPONSE:{0!s}".format(fcnt2))
         # has the failcounter decreased?
         self.assertEqual(fcnt1 - 1, fcnt2)
 
@@ -706,7 +706,7 @@ class TiQRTokenTestCase(MyApiTestCase):
                         "operation": "login"}
         r = TiqrTokenClass.api_endpoint(req, g)
         self.assertEqual(r[0], "plain")
-        self.assertRegexpMatches(r[1], r"INVALID_RESPONSE:[0-9]+")
+        self.assertRegex(r[1], r"INVALID_RESPONSE:[0-9]+")
 
         # Check that the OTP status is still incorrect
         r = token.check_challenge_response(options={"transaction_id":

--- a/tests/test_lib_tokens_u2f.py
+++ b/tests/test_lib_tokens_u2f.py
@@ -216,8 +216,8 @@ class U2FTokenTestCase(MyTestCase):
 
         # modify signature
         broken_sig = 'ff' + signature[2:]
-        with self.assertRaisesRegexp(Exception,
-                                     'Error checking the signature of the registration data.'):
+        with self.assertRaisesRegex(Exception,
+                                    'Error checking the signature of the registration data.'):
             check_registration_data(cert, "https://demo.yubico.com", client_data_str,
                                     user_pub_key, key_handle, broken_sig)
 
@@ -248,8 +248,8 @@ class U2FTokenTestCase(MyTestCase):
                    'm_6eVnZMQjDmwFdymwEN4OxfnM5MkcKCYhjqgIGruWkVHsFnJa8qjZXneV' \
                    'vKoiepuUQyDEJ2GcqvhU2YKY1zBFAiEAqqVKbLnZuWYyzjcsb1YnHEyuk-' \
                    'dmM77Q66iExrj8h2cCIHAvpisjLj-D2KvnZZcIQ_fFjFj9OX5jkfmJ65QVQ9bE'
-        with self.assertRaisesRegexp(Exception,
-                                     'The registration data is in a wrong format.'):
+        with self.assertRaisesRegex(Exception,
+                                    'The registration data is in a wrong format.'):
             parse_registration_data(reg_data)
 
 

--- a/tests/test_lib_tokens_webauthn.py
+++ b/tests/test_lib_tokens_webauthn.py
@@ -471,12 +471,13 @@ class WebAuthnTokenTestCase(MyTestCase):
             "HTTP_ORIGIN": ORIGIN,
             WEBAUTHNACTION.REQ: ['subject/.*Feitian.*/']
         }
-        self.assertRaisesRegexp(PolicyError,
-                                "The WebAuthn token is not allowed to authenticate "
-                                "due to a policy restriction.",
-                                self.token.check_otp,
-                                **{'otpval': None,
-                                   'options': options})
+        self.assertRaisesRegex(
+            PolicyError,
+            r"The WebAuthn token is not allowed to authenticate due to a policy "
+            r"restriction.",
+            self.token.check_otp,
+            **{'otpval': None,
+               'options': options})
 
     def test_10a_aaguid_allowed(self):
         self._setup_token()
@@ -496,21 +497,22 @@ class WebAuthnTokenTestCase(MyTestCase):
     def test_10b_aaguid_not_allowed(self):
         self._setup_token()
         # check token with an invalid aaguid
-        self.assertRaisesRegexp(PolicyError,
-                                "The WebAuthn token is not allowed to authenticate "
-                                "due to a policy restriction.",
-                                self.token.check_otp,
-                                **{'otpval': None,
-                                   'options': {
-                                       "credentialid": CRED_ID,
-                                       "authenticatordata": ASSERTION_RESPONSE_TMPL['authData'],
-                                       "clientdata": ASSERTION_RESPONSE_TMPL['clientData'],
-                                       "signaturedata": ASSERTION_RESPONSE_TMPL['signature'],
-                                       "user": self.user,
-                                       "challenge": hexlify_and_unicode(webauthn_b64_decode(ASSERTION_CHALLENGE)),
-                                       "HTTP_ORIGIN": ORIGIN,
-                                       WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST: ['ffff0000000000000000000000000000']
-                                   }})
+        self.assertRaisesRegex(
+            PolicyError,
+            r"The WebAuthn token is not allowed to authenticate due to a "
+            r"policy restriction.",
+            self.token.check_otp,
+            **{'otpval': None,
+               'options': {
+                   "credentialid": CRED_ID,
+                   "authenticatordata": ASSERTION_RESPONSE_TMPL['authData'],
+                   "clientdata": ASSERTION_RESPONSE_TMPL['clientData'],
+                   "signaturedata": ASSERTION_RESPONSE_TMPL['signature'],
+                   "user": self.user,
+                   "challenge": hexlify_and_unicode(webauthn_b64_decode(ASSERTION_CHALLENGE)),
+                   "HTTP_ORIGIN": ORIGIN,
+                   WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST: ['ffff0000000000000000000000000000']
+               }})
 
 
 class WebAuthnTestCase(unittest.TestCase):
@@ -611,8 +613,8 @@ class WebAuthnTestCase(unittest.TestCase):
             expected_registration_client_extensions=EXPECTED_REGISTRATION_CLIENT_EXTENSIONS
         )
 
-        with self.assertRaisesRegexp(RegistrationRejectedException,
-                                     'Malformed request received.'):
+        with self.assertRaisesRegex(RegistrationRejectedException,
+                                    'Malformed request received.'):
             registration_response.verify()
 
     def test_03_validate_assertion(self):
@@ -657,8 +659,8 @@ class WebAuthnTestCase(unittest.TestCase):
         webauthn_assertion_response = self.getAssertionResponse()
         webauthn_assertion_response.webauthn_user.sign_count = ASSERTION_RESPONSE_SIGN_COUNT
 
-        with self.assertRaisesRegexp(AuthenticationRejectedException,
-                                     'Duplicate authentication detected.'):
+        with self.assertRaisesRegex(AuthenticationRejectedException,
+                                    'Duplicate authentication detected.'):
             webauthn_assertion_response.verify()
         # TODO: we should add a test for a missing sign_count (or 0) but we need
         #  to change the auth data for that.
@@ -667,8 +669,8 @@ class WebAuthnTestCase(unittest.TestCase):
         self.assertEqual(webauthn_b64_decode(URL_DECODE_TEST_STRING), URL_DECODE_EXPECTED_RESULT)
 
     def test_08_registration_invalid_requirement_level(self):
-        with self.assertRaisesRegexp(ValueError,
-                                     'Illegal attestation_requirement_level.'):
+        with self.assertRaisesRegex(ValueError,
+                                    'Illegal attestation_requirement_level.'):
             WebAuthnRegistrationResponse(
                 rp_id=RP_ID,
                 origin=ORIGIN,
@@ -709,7 +711,7 @@ class WebAuthnTestCase(unittest.TestCase):
             ).verify)
 
     def test_09c_registration_self_Attestation_alg_mismatch(self):
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RegistrationRejectedException,
             'does not match algorithm from attestation statement',
             WebAuthnRegistrationResponse(
@@ -723,7 +725,7 @@ class WebAuthnTestCase(unittest.TestCase):
             ).verify)
 
     def test_09d_registration_self_Attestation_broken_signature(self):
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RegistrationRejectedException,
             'Invalid signature received.',
             WebAuthnRegistrationResponse(

--- a/tests/test_lib_utils.py
+++ b/tests/test_lib_utils.py
@@ -748,10 +748,10 @@ class UtilsTestCase(MyTestCase):
 
     def test_24_sanity_name_check(self):
         self.assertTrue(sanity_name_check('Hello_World'))
-        with self.assertRaisesRegexp(Exception, "non conformant characters in the name"):
+        with self.assertRaisesRegex(Exception, "non conformant characters in the name"):
             sanity_name_check('Hello World!')
         self.assertTrue(sanity_name_check('Hello World', name_exp='^[A-Za-z\\ ]+$'))
-        with self.assertRaisesRegexp(Exception, "non conformant characters in the name"):
+        with self.assertRaisesRegex(Exception, "non conformant characters in the name"):
             sanity_name_check('Hello_World', name_exp='^[A-Za-z]+$')
 
     def test_25_encodings(self):


### PR DESCRIPTION
Move `assertRegexpMatches()` to `assertRegex()` and `assertRaisesRegexp()` to `assertRaisesRegex()`.

Working on #2128