### PR TITLE
PI_VASCO_LIBRARY Error message from log to debug

### DIFF
--- a/privacyidea/lib/tokens/vasco.py
+++ b/privacyidea/lib/tokens/vasco.py
@@ -53,7 +53,7 @@ try:
         log.info("Loading VASCO library from {!s} ...".format(vasco_library_path))
         vasco_dll = CDLL(vasco_library_path)
     else:
-        log.info("PI_VASCO_LIBRARY option is not set, functionality disabled")
+        log.debug("PI_VASCO_LIBRARY option is not set, functionality disabled")
 except Exception as exx:
     log.warning("Could not load VASCO library: {!r}".format(exx))
 


### PR DESCRIPTION
Just change this from log to debug, so that the log didn't get spamed if someone didn't use the vasco token