### PR TITLE
3399/Allow to change phone numbers via regexp in all SMSProviders

### DIFF
--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -48,27 +48,12 @@ from privacyidea.lib.smsprovider.SMSProvider import (ISMSProvider, SMSError)
 from privacyidea.lib import _
 import requests
 from urllib.parse import urlparse
-import re
 import logging
 
 log = logging.getLogger(__name__)
 
 
 class HttpSMSProvider(ISMSProvider):
-
-    @staticmethod
-    def _mangle_phone(phone, config):
-        regexp = config.get("REGEXP")
-        if regexp:
-            try:
-                m = re.match("^/(.*)/(.*)/$", regexp)
-                if m:
-                    phone = re.sub(m.group(1), m.group(2), phone)
-            except re.error:
-                log.warning("Can not mangle phone number. "
-                            "Please check your REGEXP: {0!s}".format(regexp))
-
-        return phone
 
     def submit_message(self, phone, message):
         """

--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -276,7 +276,7 @@ class HttpSMSProvider(ISMSProvider):
                           "values": ["yes", "no"]
                       },
                       "REGEXP": {
-                          "description": _(ISMSProvider.REGEXP_description)
+                          "description": cls.REGEXP_description
                       },
                       "PROXY": {"description": _("An optional proxy string. DEPRECATED. Do not use "
                                                  "this anymore. Rather use HTTP_PROXY for http "

--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -277,7 +277,7 @@ class HttpSMSProvider(ISMSProvider):
                           "values": ["yes", "no"]
                       },
                       "REGEXP": {
-                          "description": cls.REGEXP_description
+                          "description": cls.regexp_description
                       },
                       "PROXY": {"description": _("An optional proxy string. DEPRECATED. Do not use "
                                                  "this anymore. Rather use HTTP_PROXY for http "

--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -63,7 +63,6 @@ class HttpSMSProvider(ISMSProvider):
         :param message: the message to submit to the phone
         :return:
         """
-        log.debug("submitting message {0!r} to {1!s}".format(message, phone))
         parameter = {}
         headers = {}
         if self.smsgateway:
@@ -100,6 +99,8 @@ class HttpSMSProvider(ISMSProvider):
             https_proxy = self.config.get('HTTPS_PROXY')
             parameter = self._get_parameters(message, phone)
             timeout = self.config.get("TIMEOUT") or 3
+
+        log.debug("submitting message {0!r} to {1!s}".format(message, phone))
 
         if url is None:
             log.warning("can not submit message. URL is missing.")

--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -276,10 +276,7 @@ class HttpSMSProvider(ISMSProvider):
                           "values": ["yes", "no"]
                       },
                       "REGEXP": {
-                          "description": _("Regular expression to modify the phone number "                 
-                                           "to make it compatible with provider. "
-                                           "Enter something like '/[\\+/]//' to remove "
-                                           "pluses and slashes.")
+                          "description": _(ISMSProvider.REGEXP_description)
                       },
                       "PROXY": {"description": _("An optional proxy string. DEPRECATED. Do not use "
                                                  "this anymore. Rather use HTTP_PROXY for http "

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -38,6 +38,7 @@ from privacyidea.lib.error import ConfigAdminError
 from privacyidea.models import SMSGateway, SMSGatewayOption
 from privacyidea.lib.utils import fetch_one_resource, get_module_class
 from privacyidea.lib.utils.export import (register_import, register_export)
+from privacyidea.lib import _
 import re
 import logging
 log = logging.getLogger(__name__)
@@ -72,8 +73,8 @@ class SMSError(Exception):
 class ISMSProvider(object):
     """ the SMS Provider Interface - BaseClass """
 
-    REGEXP_description = "Regular expression to modify the phone number to make it compatible with provider." \
-                         "For example to remove pluses and slashes enter something like '/[\\+/]//'."
+    REGEXP_description = _("Regular expression to modify the phone number to make it compatible with provider. "
+                           "For example to remove pluses and slashes enter something like '/[\\+/]//'.")
 
     def __init__(self, db_smsprovider_object=None, smsgateway=None):
         """

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -38,6 +38,7 @@ from privacyidea.lib.error import ConfigAdminError
 from privacyidea.models import SMSGateway, SMSGatewayOption
 from privacyidea.lib.utils import fetch_one_resource, get_module_class
 from privacyidea.lib.utils.export import (register_import, register_export)
+import re
 import logging
 log = logging.getLogger(__name__)
 
@@ -134,6 +135,21 @@ class ISMSProvider(object):
                   },
                   }
         return params
+
+    @staticmethod
+    def _mangle_phone(phone, config):
+        regexp = config.get("REGEXP")
+        if regexp:
+            try:
+                m = re.match("^/(.*)/(.*)/$", regexp)
+                if m:
+                    phone = re.sub(m.group(1), m.group(2), phone)
+            except re.error:
+                log.warning("Can not mangle phone number. "
+                            "Please check your REGEXP: {0!s}".format(regexp))
+
+        return phone
+
 
     def load_config(self, config_dict):
         """

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -73,7 +73,7 @@ class SMSError(Exception):
 class ISMSProvider(object):
     """ the SMS Provider Interface - BaseClass """
 
-    REGEXP_description = _("Regular expression to modify the phone number to make it compatible with provider. "
+    regexp_description = _("Regular expression to modify the phone number to make it compatible with provider. "
                            "For example to remove pluses and slashes enter something like '/[\\+/]//'.")
 
     def __init__(self, db_smsprovider_object=None, smsgateway=None):

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -71,6 +71,10 @@ class SMSError(Exception):
 
 class ISMSProvider(object):
     """ the SMS Provider Interface - BaseClass """
+
+    REGEXP_description = "Regular expression to modify the phone number to make it compatible with provider." \
+                         "For example to remove pluses and slashes enter something like '/[\\+/]//'."
+
     def __init__(self, db_smsprovider_object=None, smsgateway=None):
         """
         Create a new SMS Provider object fom a DB SMS provider object

--- a/privacyidea/lib/smsprovider/ScriptSMSProvider.py
+++ b/privacyidea/lib/smsprovider/ScriptSMSProvider.py
@@ -114,7 +114,7 @@ class ScriptSMSProvider(ISMSProvider):
                                            "Expects phone as the parameter and the message from stdin.")
                       },
                       "REGEXP": {
-                          "description": cls.REGEXP_description
+                          "description": cls.regexp_description
                       },
                       "background": {
                           "required": True,

--- a/privacyidea/lib/smsprovider/ScriptSMSProvider.py
+++ b/privacyidea/lib/smsprovider/ScriptSMSProvider.py
@@ -114,7 +114,7 @@ class ScriptSMSProvider(ISMSProvider):
                                            "Expects phone as the parameter and the message from stdin.")
                       },
                       "REGEXP": {
-                          "description": _(ISMSProvider.REGEXP_description)
+                          "description": cls.REGEXP_description
                       },
                       "background": {
                           "required": True,

--- a/privacyidea/lib/smsprovider/ScriptSMSProvider.py
+++ b/privacyidea/lib/smsprovider/ScriptSMSProvider.py
@@ -59,6 +59,7 @@ class ScriptSMSProvider(ISMSProvider):
         :param message: the message to submit to the phone
         :return:
         """
+        phone = self._mangle_phone(phone, self.config)
         log.debug("submitting message {0!s} to {1!s}".format(message, phone))
         if not self.smsgateway:
             # this should not happen. We now always use sms gateway definitions.
@@ -111,6 +112,12 @@ class ScriptSMSProvider(ISMSProvider):
                           "required": True,
                           "description": _("The script in script directory PI_SCRIPT_SMSPROVIDER_DIRECTORY to call. "
                                            "Expects phone as the parameter and the message from stdin.")
+                      },
+                      "REGEXP": {
+                          "description": _("Regular expression to modify the phone number "
+                                           "to make it compatible with provider. "
+                                           "Enter something like '/[\\+/]//' to remove "
+                                           "pluses and slashes.")
                       },
                       "background": {
                           "required": True,

--- a/privacyidea/lib/smsprovider/ScriptSMSProvider.py
+++ b/privacyidea/lib/smsprovider/ScriptSMSProvider.py
@@ -59,19 +59,19 @@ class ScriptSMSProvider(ISMSProvider):
         :param message: the message to submit to the phone
         :return:
         """
-        phone = self._mangle_phone(phone, self.config)
-        log.debug("submitting message {0!s} to {1!s}".format(message, phone))
         if not self.smsgateway:
             # this should not happen. We now always use sms gateway definitions.
             log.warning("Missing smsgateway definition!")
             raise SMSError(-1, "Missing smsgateway definition!")
 
+        phone = self._mangle_phone(phone, self.smsgateway.option_dict)
+        log.debug("submitting message {0!s} to {1!s}".format(message, phone))
+
         script = self.smsgateway.option_dict.get("script")
         background = self.smsgateway.option_dict.get("background")
 
         script_name = self.script_directory + "/" + script
-        proc_args = [script_name]
-        proc_args.append(phone)
+        proc_args = [script_name, phone]
 
         # As the message can contain blanks... it is passed via stdin
         rcode = 0

--- a/privacyidea/lib/smsprovider/ScriptSMSProvider.py
+++ b/privacyidea/lib/smsprovider/ScriptSMSProvider.py
@@ -114,10 +114,7 @@ class ScriptSMSProvider(ISMSProvider):
                                            "Expects phone as the parameter and the message from stdin.")
                       },
                       "REGEXP": {
-                          "description": _("Regular expression to modify the phone number "
-                                           "to make it compatible with provider. "
-                                           "Enter something like '/[\\+/]//' to remove "
-                                           "pluses and slashes.")
+                          "description": _(ISMSProvider.REGEXP_description)
                       },
                       "background": {
                           "required": True,

--- a/privacyidea/lib/smsprovider/SipgateSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SipgateSMSProvider.py
@@ -28,6 +28,7 @@ __doc__="""This module provides sending SMS via sipgate
 The code is tested in tests/test_lib_smsprovider
 """
 from privacyidea.lib.smsprovider.SMSProvider import ISMSProvider, SMSError
+from privacyidea.lib import _
 import logging
 import requests
 log = logging.getLogger(__name__)
@@ -67,6 +68,7 @@ class SipgateSMSProvider(ISMSProvider):
     # They provide the self.config dictionary.
 
     def submit_message(self, phone, message):
+        phone = self._mangle_phone(phone, self.config)
         if self.smsgateway:
             username = self.smsgateway.option_dict.get("USERNAME")
             password = self.smsgateway.option_dict.get("PASSWORD")
@@ -117,6 +119,12 @@ class SipgateSMSProvider(ISMSProvider):
                           "description": "The sipgate password."},
                       "PROXY": {
                           "description": "An optional proxy URI."
+                      },
+                      "REGEXP": {
+                          "description": _("Regular expression to modify the phone number "
+                                           "to make it compatible with provider. "
+                                           "Enter something like '/[\\+/]//' to remove "
+                                           "pluses and slashes.")
                       }
                   }
                   }

--- a/privacyidea/lib/smsprovider/SipgateSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SipgateSMSProvider.py
@@ -121,10 +121,7 @@ class SipgateSMSProvider(ISMSProvider):
                           "description": "An optional proxy URI."
                       },
                       "REGEXP": {
-                          "description": _("Regular expression to modify the phone number "
-                                           "to make it compatible with provider. "
-                                           "Enter something like '/[\\+/]//' to remove "
-                                           "pluses and slashes.")
+                          "description": _(ISMSProvider.REGEXP_description)
                       }
                   }
                   }

--- a/privacyidea/lib/smsprovider/SipgateSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SipgateSMSProvider.py
@@ -122,7 +122,7 @@ class SipgateSMSProvider(ISMSProvider):
                           "description": "An optional proxy URI."
                       },
                       "REGEXP": {
-                          "description": cls.REGEXP_description
+                          "description": cls.regexp_description
                       }
                   }
                   }

--- a/privacyidea/lib/smsprovider/SipgateSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SipgateSMSProvider.py
@@ -121,7 +121,7 @@ class SipgateSMSProvider(ISMSProvider):
                           "description": "An optional proxy URI."
                       },
                       "REGEXP": {
-                          "description": _(ISMSProvider.REGEXP_description)
+                          "description": cls.REGEXP_description
                       }
                   }
                   }

--- a/privacyidea/lib/smsprovider/SipgateSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SipgateSMSProvider.py
@@ -61,6 +61,7 @@ REQUEST_XML='''<?xml version="1.0" encoding="UTF-8"?>
 
 URL = "https://samurai.sipgate.net/RPC2"
 
+
 class SipgateSMSProvider(ISMSProvider):
 
     # We do not need to overwrite the __init__ and
@@ -82,6 +83,7 @@ class SipgateSMSProvider(ISMSProvider):
             protocol = proxy.split(":")[0]
             proxies = {protocol: proxy}
 
+        log.debug("submitting message {0!r} to {1!s}".format(message, phone))
         r = requests.post(URL,
                           data=REQUEST_XML % (phone.strip().strip("+"),
                                               message),
@@ -96,7 +98,6 @@ class SipgateSMSProvider(ISMSProvider):
             raise SMSError(r.status_code, "SMS could not be "
                                           "sent: %s" % r.status_code)
         return True
-
 
     @classmethod
     def parameters(cls):

--- a/privacyidea/lib/smsprovider/SmppSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmppSMSProvider.py
@@ -41,18 +41,19 @@ class SmppSMSProvider(ISMSProvider):
 
     def submit_message(self, phone, message):
         """
-        send a message to a phone via an smpp protocol to smsc
+        send a message to a phone via a smpp protocol to smsc
 
         :param phone: the phone number
         :param message: the message to submit to the phone
         :return:
         """
-        phone = self._mangle_phone(phone, self.config)
-        log.debug("submitting message {0!s} to {1!s}".format(message, phone))
         if not self.smsgateway:
             # this should not happen. We now always use sms gateway definitions.
             log.warning("Missing smsgateway definition!")
             raise SMSError(-1, "Missing smsgateway definition!")
+
+        phone = self._mangle_phone(phone, self.smsgateway.option_dict)
+        log.debug("submitting message {0!r} to {1!s}".format(message, phone))
 
         smsc_host = self.smsgateway.option_dict.get("SMSC_HOST")
         smsc_port = self.smsgateway.option_dict.get("SMSC_PORT")

--- a/privacyidea/lib/smsprovider/SmppSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmppSMSProvider.py
@@ -140,7 +140,7 @@ class SmppSMSProvider(ISMSProvider):
                         "D_ADDR_TON": {"description": _("DESTINATION_ADDR_TON Special Flag")},
                         "D_ADDR_NPI": {"description": _("D_ADDR_NPI Special Flag")},
                         "REGEXP": {
-                            "description": _(ISMSProvider.REGEXP_description)
+                            "description": cls.REGEXP_description
                         }
                     }
                     }

--- a/privacyidea/lib/smsprovider/SmppSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmppSMSProvider.py
@@ -140,10 +140,7 @@ class SmppSMSProvider(ISMSProvider):
                         "D_ADDR_TON": {"description": _("DESTINATION_ADDR_TON Special Flag")},
                         "D_ADDR_NPI": {"description": _("D_ADDR_NPI Special Flag")},
                         "REGEXP": {
-                            "description": _("Regular expression to modify the phone number "
-                                             "to make it compatible with provider. "
-                                             "Enter something like '/[\\+/]//' to remove "
-                                             "pluses and slashes.")
+                            "description": _(ISMSProvider.REGEXP_description)
                         }
                     }
                     }

--- a/privacyidea/lib/smsprovider/SmppSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmppSMSProvider.py
@@ -47,6 +47,7 @@ class SmppSMSProvider(ISMSProvider):
         :param message: the message to submit to the phone
         :return:
         """
+        phone = self._mangle_phone(phone, self.config)
         log.debug("submitting message {0!s} to {1!s}".format(message, phone))
         if not self.smsgateway:
             # this should not happen. We now always use sms gateway definitions.
@@ -137,7 +138,13 @@ class SmppSMSProvider(ISMSProvider):
                         "S_ADDR": {
                             "description": _("Source address (SMS sender)")},
                         "D_ADDR_TON": {"description": _("DESTINATION_ADDR_TON Special Flag")},
-                        "D_ADDR_NPI": {"description": _("D_ADDR_NPI Special Flag")}
+                        "D_ADDR_NPI": {"description": _("D_ADDR_NPI Special Flag")},
+                        "REGEXP": {
+                            "description": _("Regular expression to modify the phone number "
+                                             "to make it compatible with provider. "
+                                             "Enter something like '/[\\+/]//' to remove "
+                                             "pluses and slashes.")
+                        }
                     }
                     }
         return params

--- a/privacyidea/lib/smsprovider/SmppSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmppSMSProvider.py
@@ -141,7 +141,7 @@ class SmppSMSProvider(ISMSProvider):
                         "D_ADDR_TON": {"description": _("DESTINATION_ADDR_TON Special Flag")},
                         "D_ADDR_NPI": {"description": _("D_ADDR_NPI Special Flag")},
                         "REGEXP": {
-                            "description": cls.REGEXP_description
+                            "description": cls.regexp_description
                         }
                     }
                     }

--- a/privacyidea/lib/smsprovider/SmtpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmtpSMSProvider.py
@@ -129,9 +129,9 @@ class SmtpSMSProvider(ISMSProvider):
                       "BODY": {
                           "description": "The optional body of the email. "
                                          "Use tags {phone} and {otp}.",
-                          "type": "text" },
+                          "type": "text"},
                       "REGEXP": {
-                          "description": _(ISMSProvider.REGEXP_description)
+                          "description": cls.REGEXP_description
                       }
                   }
                   }

--- a/privacyidea/lib/smsprovider/SmtpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmtpSMSProvider.py
@@ -131,10 +131,7 @@ class SmtpSMSProvider(ISMSProvider):
                                          "Use tags {phone} and {otp}.",
                           "type": "text" },
                       "REGEXP": {
-                          "description": _("Regular expression to modify the phone number "
-                                           "to make it compatible with provider. "
-                                           "Enter something like '/[\\+/]//' to remove "
-                                           "pluses and slashes.")
+                          "description": _(ISMSProvider.REGEXP_description)
                       }
                   }
                   }

--- a/privacyidea/lib/smsprovider/SmtpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmtpSMSProvider.py
@@ -131,7 +131,7 @@ class SmtpSMSProvider(ISMSProvider):
                                          "Use tags {phone} and {otp}.",
                           "type": "text"},
                       "REGEXP": {
-                          "description": cls.REGEXP_description
+                          "description": cls.regexp_description
                       }
                   }
                   }

--- a/privacyidea/lib/smsprovider/SmtpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmtpSMSProvider.py
@@ -54,6 +54,7 @@ class SmtpSMSProvider(ISMSProvider):
         In case of a failure an exception is raised
         """
         if self.smsgateway:
+            phone = self._mangle_phone(phone, self.smsgateway.option_dict)
             identifier = self.smsgateway.option_dict.get("SMTPIDENTIFIER")
             recipient = self.smsgateway.option_dict.get("MAILTO").format(
                 otp=message, phone=phone)
@@ -63,6 +64,7 @@ class SmtpSMSProvider(ISMSProvider):
             body = self.smsgateway.option_dict.get("BODY", "{otp}").format(
                 otp=message, phone=phone)
         else:
+            phone = self._mangle_phone(phone, self.config)
             identifier = self.config.get("IDENTIFIER")
             server = self.config.get("MAILSERVER")
             sender = self.config.get("MAILSENDER")
@@ -126,7 +128,13 @@ class SmtpSMSProvider(ISMSProvider):
                       "BODY": {
                           "description": "The optional body of the email. "
                                          "Use tags {phone} and {otp}.",
-                          "type": "text" }
+                          "type": "text" },
+                      "REGEXP": {
+                          "description": _("Regular expression to modify the phone number "
+                                           "to make it compatible with provider. "
+                                           "Enter something like '/[\\+/]//' to remove "
+                                           "pluses and slashes.")
+                      }
                   }
                   }
         return params

--- a/privacyidea/lib/smsprovider/SmtpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmtpSMSProvider.py
@@ -79,13 +79,13 @@ class SmtpSMSProvider(ISMSProvider):
                           "MAILSERVER and MAILSENDER) needed" % self.config)
                 raise SMSError(-1, "Incomplete SMS config.")
 
-            log.debug("submitting message {0!r} to {1!s}".format(body, phone))
             recipient = recipient.replace(PHONE_TAG, phone)
             subject = subject.replace(PHONE_TAG, phone)
             subject = subject.replace(MSG_TAG, message)
             body = body.replace(PHONE_TAG, phone)
             body = body.replace(MSG_TAG, message)
 
+        log.debug("submitting message {0!r} to {1!s}".format(body, phone))
         if identifier:
             r = send_email_identifier(identifier, recipient, subject, body)
         else:

--- a/privacyidea/lib/smsprovider/SmtpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmtpSMSProvider.py
@@ -36,6 +36,7 @@ The code is tested in tests/test_lib_smsprovider
 """
 from privacyidea.lib.smsprovider.SMSProvider import ISMSProvider, SMSError
 from privacyidea.lib.smtpserver import send_email_identifier, send_email_data
+from privacyidea.lib import _
 import logging
 log = logging.getLogger(__name__)
 

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -307,17 +307,9 @@ class SipgateSMSTestCase(MyTestCase):
               'PASSWORD': "password",
               'PROXY': "https://user:pw@1.2.3.4:8089"}
 
-    config_regexp = {'USERNAME': "user",
-                     'PASSWORD': "password",
-                     'PROXY': "https://user:pw@1.2.3.4:8089",
-                     "REGEXP": "/[+-/. ]//"}
-
     def setUp(self):
         self.provider = SipgateSMSProvider()
         self.provider.load_config(self.config)
-
-        self.regexp_provider = SipgateSMSProvider()
-        self.regexp_provider.load_config(self.config_regexp)
 
     @responses.activate
     def test_01_success(self):
@@ -337,10 +329,16 @@ class SipgateSMSTestCase(MyTestCase):
 
     @responses.activate
     def test_03_send_sms_regexp_success(self):
+        config_regexp = {'USERNAME': "user",
+                         'PASSWORD': "password",
+                         'PROXY': "https://user:pw@1.2.3.4:8089",
+                         "REGEXP": "/[+-/. ]//"}
+        regexp_provider = SipgateSMSProvider()
+        regexp_provider.load_config(config_regexp)
         responses.add(responses.POST,
                       self.url)
         # Here we need to send the SMS
-        r = self.regexp_provider.submit_message("+49 123/456-78", "Hello")
+        r = regexp_provider.submit_message("+49 123/456-78", "Hello")
         self.assertTrue(r)
 
     @responses.activate
@@ -670,17 +668,6 @@ class SmppSMSTestCase(MyTestCase):
               'D_ADDR_TON': "0x5",
               'D_ADDR_NPI': "0x1"}
 
-    config_regexp = {'SMSC_HOST': "192.168.1.1",
-                     'SMSC_PORT': "1234",
-                     'SYSTEM_ID': "privacyIDEA",
-                     'PASSWORD': "secret",
-                     'S_ADDR_TON': "0x5",
-                     'S_ADDR_NPI': "0x1",
-                     'S_ADDR': "privacyIDEA",
-                     'D_ADDR_TON': "0x5",
-                     'D_ADDR_NPI': "0x1",
-                     "REGEXP": "/[+-/. ]//"}
-
     provider_module = "privacyidea.lib.smsprovider.SmppSMSProvider" \
                       ".SmppSMSProvider"
 
@@ -693,13 +680,6 @@ class SmppSMSTestCase(MyTestCase):
         self.assertTrue(id > 0)
         self.provider = create_sms_instance(identifier=identifier)
         self.assertEqual(type(self.provider), SmppSMSProvider)
-
-        identifier_regexp = "myregexpSmppGW"
-        id_regexp = set_smsgateway(identifier_regexp, self.provider_module, description="test",
-                            options=self.config_regexp)
-        self.assertTrue(id_regexp > 0)
-        self.regexp_provider = create_sms_instance(identifier=identifier_regexp)
-        self.assertEqual(type(self.regexp_provider), SmppSMSProvider)
 
     def test_00_config(self):
         r = SmppSMSProvider.parameters()
@@ -751,10 +731,27 @@ class SmppSMSTestCase(MyTestCase):
 
     @smppmock.activate
     def test_04_send_sms_regexp_success(self):
+        config_regexp = {'SMSC_HOST': "192.168.1.1",
+                         'SMSC_PORT': "1234",
+                         'SYSTEM_ID': "privacyIDEA",
+                         'PASSWORD': "secret",
+                         'S_ADDR_TON': "0x5",
+                         'S_ADDR_NPI': "0x1",
+                         'S_ADDR': "privacyIDEA",
+                         'D_ADDR_TON': "0x5",
+                         'D_ADDR_NPI': "0x1",
+                         "REGEXP": "/[+-/. ]//"}
+
+        identifier_regexp = "myregexpSmppGW"
+        id_regexp = set_smsgateway(identifier_regexp, self.provider_module, description="test",
+                                   options=config_regexp)
+        self.assertTrue(id_regexp > 0)
+        regexp_provider = create_sms_instance(identifier=identifier_regexp)
+        self.assertEqual(type(regexp_provider), SmppSMSProvider)
         smppmock.setdata(connection_success=True,
                          systemid="privacyIDEA",
                          password="secret")
         # Here we need to send the SMS
-        r = self.regexp_provider.submit_message("+49 123/456-78", "Hello")
+        r = regexp_provider.submit_message("+49 123/456-78", "Hello")
         self.assertTrue(r)
 


### PR DESCRIPTION
This should make regexp available in all SMSProviders except the Firebase provider