### PR TITLE
Add filter for options

### DIFF
--- a/doc/machines/index.rst
+++ b/doc/machines/index.rst
@@ -47,6 +47,10 @@ user parameter
 can login with the private key of the SSH token.
 
 The ``service_id`` identifies the SSH servers or group of SSH servers, where the login is allowed to occur.
+Read more about :ref:`serviceids`.
+
+authorized keys command
+.......................
 
 To facilitate this, the SSH server fetches the managed SSH keys from the privacyIDEA server on demand.
 The SSH server uses the ``AuthorizedKeysCommand`` in the ``sshd_config`` to do this.
@@ -78,6 +82,12 @@ The Python script however expects a configuration file
 
 In this example the SSH keys that are attached to the service_id "webservers" are fetched from the
 privacyIDEA server.
+
+managing in WebUI
+.................
+
+The administrator can view all SSH keys attached to service in the WebUI at *Tokens -> Token Applications*. There the
+admininistrator can filter for service_ids., to find all SSH keys that are attached e.g. to webservers.
 
 .. note:: To disable a SSH key for all servers, you simply can disable the
     distinct SSH token in privacyIDEA.
@@ -135,3 +145,8 @@ The caching is implemented in the privacyIDEA PAM module.
 The server increases the counter to the last offline cached OTP value, so
 that it will not be possible to authenticate with those OTP values available
 offline on the client side.
+
+managing in WebUI
+.................
+
+The administrator can view all offline tokens in the WebUI at *Tokens -> Token Applications*.

--- a/doc/webui/index.rst
+++ b/doc/webui/index.rst
@@ -46,6 +46,10 @@ user. The administrator can see all the details of the token.
 The administrator can click on one token, to show more details of this token
 and to perform actions on this token. Read on in :ref:`token_details`.
 
+In the *Token Applications* the administrator can check for all SSH Keys attached to
+services and for HOTP tokens attached to machines for offline authentication.
+Also see :ref:`machines`.
+
 .. _usersview:
 
 Users

--- a/privacyidea/static/components/config/views/config.serviceid.list.html
+++ b/privacyidea/static/components/config/views/config.serviceid.list.html
@@ -1,3 +1,6 @@
+<p>Serivice IDs can be used to attach e.g. SSH keys to certain machines and services.
+To view attached tokens go to <a ui-sref="token.applications">token applications</a>.</p>
+
 <div class="table-responsive">
     <table class="table table-bordered table-responsive table-striped">
         <thead>

--- a/privacyidea/static/components/token/controllers/tokenApplicationsController.js
+++ b/privacyidea/static/components/token/controllers/tokenApplicationsController.js
@@ -1,0 +1,66 @@
+
+myApp.controller("tokenApplicationsController", ['$scope', 'TokenFactory', 'MachineFactory',
+                                               'UserFactory', '$stateParams',
+                                               '$state', '$rootScope',
+                                               'ValidateFactory', 'AuthFactory', 'gettextCatalog',
+                                               function ($scope, TokenFactory, MachineFactory,
+                                                         UserFactory, $stateParams,
+                                                         $state, $rootScope,
+                                                         ValidateFactory,
+                                                         AuthFactory, gettextCatalog) {
+    $scope.tokenSerial = "";
+    // This is the parents object
+    $scope.loggedInUser = AuthFactory.getUser();
+    $scope.form = {filter: {}};
+    $scope.formInit = {
+        applications: {"ssh": gettextCatalog.getString("SSH: Attaching ssh keys to services."),
+            "offline": gettextCatalog.getString("offline: Use HOTP token for offline login to notebooks.")
+        }}
+
+    // scroll to the top of the page
+    document.body.scrollTop = document.documentElement.scrollTop = 0;
+
+    // define functions
+    $scope.changeApplication = function() {
+        $scope.get();
+    };
+    // Change the pagination
+    $scope.pageChanged = function () {
+        //debug: console.log('Page changed to: ' + $scope.params.page);
+        $scope.get();
+    };
+
+    $scope.get = function (live_search) {
+        if ((!$rootScope.search_on_enter) || ($rootScope.search_on_enter && !live_search)) {
+            $scope.params = {};
+            $scope.params.application = $scope.currentApplication;
+            for (kf in $scope.form.filter) {
+                $scope.params[kf] = "*" + ($scope.form.filter[kf] || "") + "*";
+            }
+            MachineFactory.getMachineTokens($scope.params, function (data) {
+                console.log(data.result.value);
+                $scope.machinetokens = data.result.value;
+            });
+        }
+    };
+
+    // Change the pagination
+    $scope.machinetokenPageChanged = function () {
+        //debug: console.log('Page changed to: ' + $scope.params.page);
+        $scope.get();
+    };
+
+    $scope.return_to = function () {
+        // After deleting the token, we return here.
+        // history.back();
+        $state.go($rootScope.previousState.state,
+            $rootScope.previousState.params);
+    };
+
+    // initialize
+    $scope.get();
+
+    // listen to the reload broadcast
+    $scope.$on("piReload", $scope.get);
+
+}]);

--- a/privacyidea/static/components/token/controllers/tokenApplicationsController.js
+++ b/privacyidea/static/components/token/controllers/tokenApplicationsController.js
@@ -2,15 +2,15 @@
 myApp.controller("tokenApplicationsController", ['$scope', 'TokenFactory', 'MachineFactory',
                                                'UserFactory', '$stateParams',
                                                '$state', '$rootScope',
-                                               'ValidateFactory', 'AuthFactory', 'gettextCatalog',
+                                               'ValidateFactory', 'AuthFactory', 'gettextCatalog', '$location',
                                                function ($scope, TokenFactory, MachineFactory,
                                                          UserFactory, $stateParams,
                                                          $state, $rootScope,
                                                          ValidateFactory,
-                                                         AuthFactory, gettextCatalog) {
+                                                         AuthFactory, gettextCatalog, $location) {
     $scope.tokenSerial = "";
-    // This is the parents object
-    $scope.loggedInUser = AuthFactory.getUser();
+    //$scope.loggedInUser = AuthFactory.getUser();
+    $scope.currentApplication = $stateParams.application;
     $scope.form = {filter: {}};
     $scope.sortby = "serial";
     $scope.reverse = false;
@@ -24,6 +24,7 @@ myApp.controller("tokenApplicationsController", ['$scope', 'TokenFactory', 'Mach
 
     // define functions
     $scope.changeApplication = function() {
+        $location.path("/token/applications/" + $scope.currentApplication);
         $scope.get();
     };
     // Change the pagination

--- a/privacyidea/static/components/token/controllers/tokenApplicationsController.js
+++ b/privacyidea/static/components/token/controllers/tokenApplicationsController.js
@@ -12,6 +12,8 @@ myApp.controller("tokenApplicationsController", ['$scope', 'TokenFactory', 'Mach
     // This is the parents object
     $scope.loggedInUser = AuthFactory.getUser();
     $scope.form = {filter: {}};
+    $scope.sortby = "serial";
+    $scope.reverse = false;
     $scope.formInit = {
         applications: {"ssh": gettextCatalog.getString("SSH: Attaching ssh keys to services."),
             "offline": gettextCatalog.getString("offline: Use HOTP token for offline login to notebooks.")
@@ -37,8 +39,15 @@ myApp.controller("tokenApplicationsController", ['$scope', 'TokenFactory', 'Mach
             for (kf in $scope.form.filter) {
                 $scope.params[kf] = "*" + ($scope.form.filter[kf] || "") + "*";
             }
+            $scope.params.pagesize = 15;
+            $scope.params.sortby = this.sortby;
+            if (this.reverse) {
+                $scope.params.sortdir = "desc";
+            } else {
+                $scope.params.sortdir = "asc";
+            }
+
             MachineFactory.getMachineTokens($scope.params, function (data) {
-                console.log(data.result.value);
                 $scope.machinetokens = data.result.value;
             });
         }

--- a/privacyidea/static/components/token/states/states.js
+++ b/privacyidea/static/components/token/states/states.js
@@ -89,8 +89,9 @@ angular.module('privacyideaApp.tokenStates', ['ui.router', 'privacyideaApp.versi
                     controller: "tokenChallengesController"
                 })
                 .state('token.applications', {
-                    url: "/applications",
+                    url: "/applications/:application",
                     templateUrl: tokenpath + "token.applications.html" + versioningSuffixProviderProvider.$get().$get(),
-                    controller: "tokenApplicationsController"
+                    controller: "tokenApplicationsController",
+                    params: { "application": "ssh"}
                 });
         }]);

--- a/privacyidea/static/components/token/states/states.js
+++ b/privacyidea/static/components/token/states/states.js
@@ -87,5 +87,10 @@ angular.module('privacyideaApp.tokenStates', ['ui.router', 'privacyideaApp.versi
                     url: "/challenges",
                     templateUrl: tokenpath + "token.challenges.html" + versioningSuffixProviderProvider.$get().$get(),
                     controller: "tokenChallengesController"
+                })
+                .state('token.applications', {
+                    url: "/applications",
+                    templateUrl: tokenpath + "token.applications.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "tokenApplicationsController"
                 });
         }]);

--- a/privacyidea/static/components/token/views/token.applications.html
+++ b/privacyidea/static/components/token/views/token.applications.html
@@ -1,0 +1,16 @@
+<form name="formTokenApplications" role="form" validate>
+
+Application:          <select class="form-control"
+                    id="application"
+                    ng-change="changeApplication()"
+                    ng-model="currentApplication"
+                    ng-options="application as desc for (application, desc) in formInit.applications">
+            </select>
+
+        <!-- This is the token data section. It differs for every token type-->
+        <ng-include src="instanceUrl +
+        '/static/components/token/views/token.applications.'
+         + currentApplication + '.html' + fileVersionSuffix">
+        </ng-include>
+
+</form>

--- a/privacyidea/static/components/token/views/token.applications.html
+++ b/privacyidea/static/components/token/views/token.applications.html
@@ -12,5 +12,4 @@ Application:          <select class="form-control"
         '/static/components/token/views/token.applications.'
          + currentApplication + '.html' + fileVersionSuffix">
         </ng-include>
-
 </form>

--- a/privacyidea/static/components/token/views/token.applications.offline.html
+++ b/privacyidea/static/components/token/views/token.applications.offline.html
@@ -1,0 +1,66 @@
+
+
+<h3><translate>Offline tokens attached to notebooks</translate></h3>
+
+<p><translate>HOTP tokens can be attached with offline to e.g. notebooks.</translate></p>
+
+<div uib-pagination ng-show="machinetokens.count > 15"
+     total-items="machinetokens.count" ng-model="params.page"
+     previous-text="{{ 'Previous'|translate }}"
+     next-text="{{ 'Next'|translate }}"
+     last-text="{{ 'Last'|translate }}"
+     first-text="{{ 'First'|translate }}"
+     items-per-page="15"
+     max-size="5"
+     boundary-links="true" ng-change="machientokenPageChanged()"></div>
+
+<div class="table-responsive">
+    <table class="table table-bordered table-striped" id="tablemachinetokens">
+        <thead>
+        <tr>
+            <!-- | token serial | application (offline) | tokenowner | <options> | -->
+            <th class="pifilter">
+                <button class="btn btn-default unsorted"
+                        pi-sort-by="serial"
+                        translate>serial
+                </button>
+                <pi-filter ng-model="form.filter.serial"
+                           ng-change="get('livesearch')"
+                           ng-keypress="($event.which==13)?get():return"
+                ></pi-filter>
+            </th>
+            <th class="pifilter">
+                <button pi-sort-by="count"
+                        class="btn btn-default
+                            unsorted"
+                        translate>Count
+                </button>
+                <pi-filter ng-model="form.filter.count"
+                           ng-change="get('livesearch')"
+                           ng-keypress="($event.which==13)?get():return"
+                ></pi-filter>
+            </th>
+            <th class="pifilter">
+                <button pi-sort-by="rounds"
+                        class="btn btn-default
+                            unsorted"
+                        translate>Rounds
+                </button>
+                <pi-filter ng-model="form.filter.rounds"
+                           ng-change="get('livesearch')"
+                           ng-keypress="($event.which==13)?get():return"
+                ></pi-filter>
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr ng-repeat="mtok in machinetokens">
+            <td><a ui-sref="token.details({tokenSerial:mtok.serial})"
+                   ng-click="$rootScope.returnTo=token.applications;">
+                {{ mtok.serial }}</a></td>
+            <td>{{ mtok.options.count }}</td>
+            <td>{{ mtok.options.rounds }}</td>
+        </tr>
+        </tbody>
+    </table>
+</div>

--- a/privacyidea/static/components/token/views/token.applications.ssh.html
+++ b/privacyidea/static/components/token/views/token.applications.ssh.html
@@ -1,0 +1,66 @@
+
+
+<h3><translate>SSH Tokens attached to services</translate></h3>
+
+<p><translate>SSH Tokens can be attached to a service ID with a user. The user is the user on the SSH server
+and may differ from the token owner. To attach the token to a service ID go to the token details.</translate></p>
+
+<p><translate>To define service IDs go to <a ui-sref="config.serviceid">Service ID config</a></translate></p>
+
+<div uib-pagination ng-show="machinetokens.count > 15"
+     total-items="machinetokens.count" ng-model="params.page"
+     previous-text="{{ 'Previous'|translate }}"
+     next-text="{{ 'Next'|translate }}"
+     last-text="{{ 'Last'|translate }}"
+     first-text="{{ 'First'|translate }}"
+     items-per-page="15"
+     max-size="5"
+     boundary-links="true" ng-change="machientokenPageChanged()"></div>
+
+<div class="table-responsive">
+    <table class="table table-bordered table-striped" id="tablemachinetokens">
+        <thead>
+        <tr>
+            <!-- | token serial | application (offline) | tokenowner | <options> | -->
+            <th class="pifilter">
+                <button class="btn btn-default unsorted"
+                        pi-sort-by="serial"
+                        translate>serial
+                </button>
+                <pi-filter ng-model="form.filter.serial"
+                           ng-change="get('livesearch')"
+                           ng-keypress="($event.which==13)?get():return"
+                ></pi-filter>
+            </th>
+            <th class="pifilter">
+                <button pi-sort-by="service_id"
+                        class="btn btn-default
+                            unsorted"
+                        translate>Service ID
+                </button>
+                <pi-filter ng-model="form.filter.service_id"
+                           ng-change="get('livesearch')"
+                           ng-keypress="($event.which==13)?get():return"></pi-filter>
+            </th>
+            <th class="pifilter">
+                <button pi-sort-by="user"
+                        class="btn btn-default
+                            unsorted"
+                        translate>SSH user
+                </button>
+                <pi-filter ng-model="form.filter.user"
+                           ng-change="get()"></pi-filter>
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr ng-repeat="mtok in machinetokens">
+            <td><a ui-sref="token.details({tokenSerial:mtok.serial})"
+                   ng-click="$rootScope.returnTo=token.applications;">
+                {{ mtok.serial }}</a></td>
+            <td>{{ mtok.options.service_id }}</td>
+            <td>{{ mtok.options.user }}</td>
+        </tr>
+        </tbody>
+    </table>
+</div>

--- a/privacyidea/static/components/token/views/token.html
+++ b/privacyidea/static/components/token/views/token.html
@@ -64,8 +64,10 @@
                     </li>
                     <li role="presentation"
                         ng-class="{active: $state.includes('token.applications')}"
-                        ng-show="loggedInUser.role == 'admin'">
-                        <!-- FIXME: Add checkRight() -->
+                        ng-show="loggedInUser.role == 'admin' &&
+                            checkRight('listtoken') &&
+                            checkRight('machinelist') &&
+                            checkRight('manage_machine_tokens')">
                         <a ui-sref="token.applications">
                             <span class="glyphicon glyphicon-hdd"></span>
                             <span translate>Token Applications</span>

--- a/privacyidea/static/components/token/views/token.html
+++ b/privacyidea/static/components/token/views/token.html
@@ -62,6 +62,15 @@
                             <span translate>List Challenges</span>
                         </a>
                     </li>
+                    <li role="presentation"
+                        ng-class="{active: $state.includes('token.applications')}"
+                        ng-show="loggedInUser.role == 'admin'">
+                        <!-- FIXME: Add checkRight() -->
+                        <a ui-sref="token.applications">
+                            <span class="glyphicon glyphicon-hdd"></span>
+                            <span translate>Token Applications</span>
+                        </a>
+                    </li>
                     <hr>
                     <li role="presentation"
                         ng-class="{active: $state.includes('token.lost')}"

--- a/privacyidea/static/components/token/views/token.html
+++ b/privacyidea/static/components/token/views/token.html
@@ -65,7 +65,7 @@
                     <li role="presentation"
                         ng-class="{active: $state.includes('token.applications')}"
                         ng-show="loggedInUser.role == 'admin' &&
-                            checkRight('listtoken') &&
+                            checkRight('tokenlist') &&
                             checkRight('machinelist') &&
                             checkRight('manage_machine_tokens')">
                         <a ui-sref="token.applications">

--- a/privacyidea/static/templates/footer.html
+++ b/privacyidea/static/templates/footer.html
@@ -48,6 +48,7 @@
 <script src="{{ instance }}/{{ "static/components/token/controllers/tokenLostController.js" | versioned }}"></script>
 <script src="{{ instance }}/{{ "static/components/token/controllers/tokenGetSerialController.js" | versioned }}"></script>
 <script src="{{ instance }}/{{ "static/components/token/controllers/tokenChallengesController.js" | versioned }}"></script>
+<script src="{{ instance }}/{{ "static/components/token/controllers/tokenApplicationsController.js" | versioned }}"></script>
 <script src="{{ instance }}/{{ "static/components/user/factories/user.js" | versioned }}"></script>
 <script src="{{ instance }}/{{ "static/components/user/states/states.js" | versioned }}"></script>
 <script src="{{ instance }}/{{ "static/components/user/controllers/userControllers.js" | versioned }}"></script>

--- a/tests/test_api_machines_serviceid.py
+++ b/tests/test_api_machines_serviceid.py
@@ -50,8 +50,10 @@ class APIMachinesServiceIDTestCase(MyApiTestCase):
         self.assertEqual(token_obj.type, "sshkey")
 
     def test_02_attach_tokens(self):
-        # Attach token S1 to webserver and mailserver
-        # Attach token S2 to mailserver
+        # Do the following token attachemends:
+        # * S1: webserver and mailserver
+        # * S2: only mailserver
+        # Attach token S1 to webserver
         with self.app.test_request_context('/machine/token',
                                            method='POST',
                                            data={"serial": self.serial1,
@@ -220,6 +222,7 @@ class APIMachinesServiceIDTestCase(MyApiTestCase):
             self.assertEqual(value[1].get("options").get("service_id"), self.serviceID2)
             self.assertEqual(value[1].get("serial"), self.serial2)
 
+        # Get token for service_id self.serviceID2 and the application=ssh and the user=admin
         with self.app.test_request_context(
                 '/machine/token?service_id={0!s}&application=ssh&user=admin'.format(self.serviceID2),
                 method='GET',

--- a/tests/test_api_machines_serviceid.py
+++ b/tests/test_api_machines_serviceid.py
@@ -292,3 +292,19 @@ class APIMachinesServiceIDTestCase(MyApiTestCase):
             for v in value:
                 # We only get SSHKEY1
                 self.assertEqual(v.get("serial"), self.serial1)
+
+        # sort by service_id
+        with self.app.test_request_context(
+                '/machine/token?application=ssh&serial=*KEY1&sortby=service_id',
+                method='GET',
+                headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            # One token is attached via user "admin"
+            self.assertEqual(len(value), 3)
+            self.assertEqual(value[0].get("options").get("user"), "root")
+            self.assertEqual(value[1].get("options").get("user"), "admin")
+            self.assertEqual(value[2].get("options").get("user"), "root")

--- a/tests/test_api_machines_serviceid.py
+++ b/tests/test_api_machines_serviceid.py
@@ -1,0 +1,235 @@
+"""
+This testcase is used to test the REST API  in api/machines.py
+to fetch machine information and to attach token to machines
+"""
+import passlib
+
+from privacyidea.lib.user import User
+from .base import MyApiTestCase
+import json
+from privacyidea.lib.token import init_token, get_tokens, remove_token
+from privacyidea.lib.machine import attach_token, detach_token, ANY_MACHINE, NO_RESOLVER
+from privacyidea.lib.policy import (set_policy, delete_policy, ACTION, SCOPE)
+
+HOSTSFILE = "tests/testdata/hosts"
+
+SSHKEY = "ssh-rsa " \
+         "AAAAB3NzaC1yc2EAAAADAQABAAACAQDJy0rLoxqc8SsY8DVAFijMsQyCv" \
+         "hBu4K40hdZOacXK4O6OgnacnSKN56MP6pzz2+4svzvDzwvkFsvf34pbsgD" \
+         "F67PPSCsimmjEQjf0UfamBKh0cl181CbPYsph3UTBOCgHh3FFDXBduPK4DQz" \
+         "EVQpmqe80h+lsvQ81qPYagbRW6fpd0uWn9H7a/qiLQZsiKLL07HGB+NwWue4os" \
+         "0r9s4qxeG76K6QM7nZKyC0KRAz7CjAf+0X7YzCOu2pzyxVdj/T+KArFcMmq8V" \
+         "dz24mhcFFXTzU3wveas1A9rwamYWB+Spuohh/OrK3wDsrryStKQv7yofgnPMs" \
+         "TdaL7XxyQVPCmh2jVl5ro9BPIjTXsre9EUxZYFVr3EIECRDNWy3xEnUHk7Rzs" \
+         "734Rp6XxGSzcSLSju8/MBzUVe35iXfXDRcqTcoA0700pIb1ANYrPUO8Up05v4" \
+         "EjIyBeU61b4ilJ3PNcEVld6FHwP3Z7F068ef4DXEC/d7pibrp4Up61WYQIXV/" \
+         "utDt3NDg/Zf3iqoYcJNM/zIZx2j1kQQwqtnbGqxJMrL6LtClmeWteR4420uZx" \
+         "afLE9AtAL4nnMPuubC87L0wJ88un9teza/N02KJMHy01Yz3iJKt3Ou9eV6kqO" \
+         "ei3kvLs5dXmriTHp6g9whtnN6/Liv9SzZPJTs8YfThi34Wccrw== " \
+         "NetKnights GmbH"
+SSHKEY_ecdsa = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzd" \
+               "HAyNTYAAABBBHGCdIk0pO1HFr/mF4oLb43ZRyQJ4K7ICLrAhAiQERVa0tUvyY5TE" \
+               "zurWTqxSMx203rY77t6xnHLZBMPPpv8rk0= cornelius@puck"
+OTPKEY = "3132333435363738393031323334353637383930"
+
+
+class APIMachinesServiceIDTestCase(MyApiTestCase):
+
+    serial1 = "SSHKEY1"
+    serial2 = "SSHKEY2"
+    serviceID1 = "webserver"
+    serviceID2 = "mailserver"
+
+    def test_01_create_sshkeys(self):
+        # create two tokens
+        token_obj = init_token({"serial": self.serial1, "type": "sshkey",
+                                "sshkey": SSHKEY})
+        self.assertEqual(token_obj.type, "sshkey")
+        token_obj = init_token({"serial": self.serial2, "type": "sshkey",
+                                "sshkey": SSHKEY_ecdsa})
+        self.assertEqual(token_obj.type, "sshkey")
+
+    def test_02_attach_tokens(self):
+        # Attach token S1 to webserver and mailserver
+        # Attach token S2 to mailserver
+        with self.app.test_request_context('/machine/token',
+                                           method='POST',
+                                           data={"serial": self.serial1,
+                                                 "application": "ssh",
+                                                 "user": "root",
+                                                 "service_id": self.serviceID1},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            self.assertTrue(result["value"] >= 1)
+            mtid = result.get("value")
+
+        # Attach S1 to mailserver
+        with self.app.test_request_context('/machine/token',
+                                           method='POST',
+                                           data={"serial": self.serial1,
+                                                 "application": "ssh",
+                                                 "user": "root",
+                                                 "service_id": self.serviceID2},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            self.assertTrue(result["value"] >= 1)
+            mtid = result.get("value")
+
+        # Attach S2 to mailserver
+        with self.app.test_request_context('/machine/token',
+                                           method='POST',
+                                           data={"serial": self.serial2,
+                                                 "application": "ssh",
+                                                 "user": "root",
+                                                 "service_id": self.serviceID2},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            self.assertTrue(result["value"] >= 1)
+            mtid = result.get("value")
+
+    def test_03_get_service_ids(self):
+        # Get all machinetokens
+        with self.app.test_request_context('/machine/token',
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            self.assertEqual(len(value), 3)
+            self.assertEqual(value[0]["application"], "ssh")
+            self.assertEqual(value[1]["application"], "ssh")
+            self.assertEqual(value[2]["application"], "ssh")
+
+        # Get tokens for service_id self.serviceID1
+        with self.app.test_request_context('/machine/token?service_id={0!s}'.format(self.serviceID1),
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            self.assertEqual(len(value), 1)
+            self.assertEqual(value[0]["application"], "ssh")
+            self.assertEqual(value[0].get("options").get("service_id"), self.serviceID1)
+            self.assertEqual(value[0].get("serial"), self.serial1)
+
+        # Get token for service_id self.serviceID2
+        with self.app.test_request_context('/machine/token?service_id={0!s}'.format(self.serviceID2),
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            self.assertEqual(len(value), 2)
+            self.assertEqual(value[0]["application"], "ssh")
+            self.assertEqual(value[0].get("options").get("service_id"), self.serviceID2)
+            self.assertEqual(value[0].get("serial"), self.serial1)
+            self.assertEqual(value[1]["application"], "ssh")
+            self.assertEqual(value[1].get("options").get("service_id"), self.serviceID2)
+            self.assertEqual(value[1].get("serial"), self.serial2)
+
+        # combine filter and get service_id self.serviceID2 for serial1
+        with self.app.test_request_context('/machine/token?service_id={0!s}&serial={1!s}'.format(
+                self.serviceID2, self.serial1),
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            self.assertEqual(len(value), 1)
+            self.assertEqual(value[0]["application"], "ssh")
+            self.assertEqual(value[0].get("options").get("service_id"), self.serviceID2)
+            self.assertEqual(value[0].get("serial"), self.serial1)
+
+        # Get token for service_id self.serviceID2 and the correct application
+        with self.app.test_request_context('/machine/token?service_id={0!s}&application=ssh'.format(self.serviceID2),
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            self.assertEqual(len(value), 2)
+            self.assertEqual(value[0]["application"], "ssh")
+            self.assertEqual(value[0].get("options").get("service_id"), self.serviceID2)
+            self.assertEqual(value[0].get("serial"), self.serial1)
+            self.assertEqual(value[1]["application"], "ssh")
+            self.assertEqual(value[1].get("options").get("service_id"), self.serviceID2)
+            self.assertEqual(value[1].get("serial"), self.serial2)
+
+        # Get token for service_id self.serviceID2 and the wrong application
+        with self.app.test_request_context(
+                '/machine/token?service_id={0!s}&application=openssh'.format(self.serviceID2),
+                method='GET',
+                headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            self.assertEqual(len(value), 0)
+
+    def test_04_get_service_id_for_different_users(self):
+        # Add another SSH key for user admin to self.serviceID2
+        with self.app.test_request_context('/machine/token',
+                                           method='POST',
+                                           data={"serial": self.serial1,
+                                                 "application": "ssh",
+                                                 "user": "admin",
+                                                 "service_id": self.serviceID2},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            self.assertTrue(result["value"] >= 1)
+            mtid = result.get("value")
+
+        # Get token for service_id self.serviceID2 and the application=ssh and the user=root
+        with self.app.test_request_context(
+                '/machine/token?service_id={0!s}&application=ssh&user=root'.format(self.serviceID2),
+                method='GET',
+                headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            self.assertEqual(len(value), 2)
+            self.assertEqual(value[0]["application"], "ssh")
+            self.assertEqual(value[0].get("options").get("service_id"), self.serviceID2)
+            self.assertEqual(value[0].get("serial"), self.serial1)
+            self.assertEqual(value[1]["application"], "ssh")
+            self.assertEqual(value[1].get("options").get("service_id"), self.serviceID2)
+            self.assertEqual(value[1].get("serial"), self.serial2)
+
+        with self.app.test_request_context(
+                '/machine/token?service_id={0!s}&application=ssh&user=admin'.format(self.serviceID2),
+                method='GET',
+                headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertEqual(result["status"], True)
+            value = result.get("value")
+            self.assertEqual(len(value), 1)
+            self.assertEqual(value[0]["application"], "ssh")
+            self.assertEqual(value[0].get("options").get("service_id"), self.serviceID2)
+            self.assertEqual(value[0].get("serial"), self.serial1)


### PR DESCRIPTION
The GET /machine/token call now allows to filter for all options like "service_id" or "user".

Closes #3573

I added the WebUI to view SSH applications and offline.
It displays the token serial and the application options.
Can be sorted and filterd. Currently I do no pagination, since we do not do this on the database level. 

@NNLemling please take a look at the code, which is finish. I am wondering, where I should still add some documentation.