### PR TITLE
tests/testdata: recreate passwd hashes with `mkpasswd -m sha-512`

### DIFF
--- a/tests/testdata/passwd-duplicate-name
+++ b/tests/testdata/passwd-duplicate-name
@@ -1,2 +1,2 @@
-testadmin:H9Y6eYntkrrKo:1004:1004:::
-someuser:H9Y6eYntkrrKo:1005:1005:::
+testadmin:$6$.jIGOPJO3wzw6Aj1$aNUQyxvaNR5lAvnCwUMoEfi4Qqozc01MzApGE/X3tteuEe1M3nY4Ax3fWKDOGncTo6Lw523XagISrIEV8..Ua0:1004:1004:::
+someuser:$6$k2iAT/7meR1ymsIb$VlrqjfzdEZFb/AaTJEId4.VrXGpZ80TvlzmEAq0bAXmuXWCLKxZWtoKgkSWey3TsywZw5sXmL3PArq7RWZX550:1005:1005:::

--- a/tests/testdata/passwords
+++ b/tests/testdata/passwords
@@ -1,18 +1,17 @@
-cornelius:IX7BdMthIBUvI:1000:1000:Cornelius,field2,+491111111,+491234566,user@localhost.localdomain::
+cornelius:$6$2Qgbc373ijbL0dCj$s3McoKE6YZaHbicinECTJuLXTOkSsv1SJ3pjsJFAmIVb8DtnZdSi8NiYgqerhf9MZYXqbNzaG6u3di1ii43mZ/:1000:1000:Cornelius,field2,+491111111,+491234566,user@localhost.localdomain::
 
 
 shadow:x:1001:1001:field1,field2,field3::
 nopw::1002:1002:field1,field2,field3::
-#autoassignuser:4LgsIGvQd7PeQ:1003:1003:::
-autoassignuser:dkT.cLhc8hyJw:1003:1003:::
-selfservice:H9Y6eYntkrrKo:1004:1004:::
-timelimituser:H9Y6eYntkrrKo:1005:1005:::
-passthru:LOu9UA0wkh5OU:1006:1006:::
-disableduser:DgT1djMaFfpEs:1112:1112:::
-lockeduser:DgT1djMaFfpEs:1113:1113:::
+autoassignuser:$6$/TytwRo.7v7GqQUX$gtKKgyc.FFf2N9Ab74OxNWbGp8icog6YbcSvnRBlW3RAvOsUn6GO.YwHTfqYmZzv4OJ6LiEMNMSBdsHhmK4dd/:1003:1003:::
+selfservice:$6$k2iAT/7meR1ymsIb$VlrqjfzdEZFb/AaTJEId4.VrXGpZ80TvlzmEAq0bAXmuXWCLKxZWtoKgkSWey3TsywZw5sXmL3PArq7RWZX550:1004:1004:::
+timelimituser:$6$/e2CFzHmqwoyODq2$VGVjEGePob0vFO26W82ZORxvMLT1AcUC94ptLiS0H4qoB5EV..6yTwQ3ugxJhNGlaLK0n1bXSLjaMIHGlo8FB1:1005:1005:::
+passthru:$6$aaKECZpmVcO4k4P4$pNsPFB1QpoWVmCZmQzUFLgs/VPHZK2FZxd5YFRU9upD511QUy3Lz2ulbHGIxw5JIDXMOQPLoaY7km9BLf4Kiq1:1006:1006:::
+disableduser:$6$m28emqdIYdHEtCwl$GSCGgPaSuq9pMiUD9kfdpWAJsKToxdBTC0i7RE0xTWKPobchH0BEATQaMDFsmEQ20PR1yABMgRRPrehzIaF5k1:1112:1112:::
+lockeduser:$6$m28emqdIYdHEtCwl$GSCGgPaSuq9pMiUD9kfdpWAJsKToxdBTC0i7RE0xTWKPobchH0BEATQaMDFsmEQ20PR1yABMgRRPrehzIaF5k1:1113:1113:::
 usernotoken::1114:1114:::
 multichal::1115:1115:::
-nönäscii:IXsH4ttQlw2xA:1116:1116:Nön,field2,field3,field4,field5::
+nönäscii:$6$fQqNLMhHk5BeU/Xv$tk2VAYncX5RZLPxA5hNkPjx2d65rhjZKVYR/w2EtL.2rusQNq/6s06acuGe7gZ.5Vk8QwdcVgPFVcnqg4s.qq0:1116:1116:Nön,field2,field3,field4,field5::
 user@test::1117:1117:::
 hans::1118:1118:::
 pwpercent:$6$v2DXJ54ZkmA3bv2R$g6f4A8c8Sfy10r5F99uF.s5IH1pQue.4cEzyXWjtiZe9GtYB58nAKTeCTdok3lyI0LuF3Tq6MQIblpHLgW3Vj1:1119:1119:::


### PR DESCRIPTION
When running the tests on a distribution using `libxcrypt`[1] with support for "modern" hashes only, like the upcoming NixOS 23.05 will do, then the tests for the passwd-resolver fail with
`OSError(22, 'Invalid argument')`. Recreating all test hashes with `mkpasswd -m sha-512` fixes the issue for me.

Closes #3613.

[1] https://github.com/besser82/libxcrypt