### PR TITLE
3578/Threat ID for POST requests

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -92,8 +92,6 @@ def before_request():
     g.event_config = EventConfiguration()
     # Save the HTTP header in the localproxy object
     g.request_headers = request.headers
-
-
     username = getParam(request.all_data, "username")
     if username:
         # We only fill request.User, if we really have a username.

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -89,26 +89,10 @@ def before_request():
     """
     This is executed before the request
     """
-    ensure_no_config_object()
-    request.all_data = get_all_params(request)
-    privacyidea_server = get_app_config_value("PI_AUDIT_SERVERNAME", get_privacyidea_node(request.host))
-    g.policy_object = PolicyClass()
-    g.audit_object = getAudit(current_app.config)
     g.event_config = EventConfiguration()
-    # access_route contains the ip addresses of all clients, hops and proxies.
-    g.client_ip = get_client_ip(request,
-                                get_from_config(SYSCONF.OVERRIDECLIENT))
     # Save the HTTP header in the localproxy object
     g.request_headers = request.headers
-    g.serial = getParam(request.all_data, "serial", default=None)
-    g.audit_object.log({"success": False,
-                        "client": g.client_ip,
-                        "client_user_agent": request.user_agent.browser,
-                        "privacyidea_server": privacyidea_server,
-                        "action": "{0!s} {1!s}".format(request.method, request.url_rule),
-                        "action_detail": "",
-                        "thread_id": "{0!s}".format(threading.current_thread().ident),
-                        "info": ""})
+
 
     username = getParam(request.all_data, "username")
     if username:

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -55,28 +55,24 @@ from datetime import (datetime,
                       timedelta)
 from privacyidea.lib.error import AuthError, ERROR
 from privacyidea.lib.crypto import geturandom, init_hsm
-from privacyidea.lib.audit import getAudit
 from privacyidea.lib.auth import (check_webui_user, ROLE, verify_db_admin,
                                   db_admin_exist)
-from privacyidea.lib.framework import get_app_config_value
 from privacyidea.lib.user import User, split_user, log_used_user
-from privacyidea.lib.policy import PolicyClass, REMOTE_USER
+from privacyidea.lib.policy import REMOTE_USER
 from privacyidea.lib.realm import get_default_realm, realm_is_defined
-from privacyidea.api.lib.postpolicy import (postpolicy, get_webui_settings, add_user_detail_to_response, check_tokentype, 
-                                            check_tokeninfo, check_serial, no_detail_on_fail, no_detail_on_success,
+from privacyidea.api.lib.postpolicy import (postpolicy, add_user_detail_to_response, check_tokentype,
+                                            check_tokeninfo, check_serial, no_detail_on_success,
                                             get_webui_settings)
 from privacyidea.api.lib.prepolicy import (is_remote_user_allowed, prepolicy,
                                            pushtoken_disable_wait, webauthntoken_authz, webauthntoken_request,
                                            webauthntoken_auth, increase_failcounter_on_challenge)
-from privacyidea.api.lib.utils import (send_result, get_all_params,
+from privacyidea.api.lib.utils import (send_result,
                                        verify_auth_token, getParam)
-from privacyidea.lib.utils import get_client_ip, hexlify_and_unicode, to_unicode
-from privacyidea.lib.config import get_from_config, SYSCONF, ensure_no_config_object, get_privacyidea_node
+from privacyidea.lib.utils import hexlify_and_unicode, to_unicode
 from privacyidea.lib.event import event, EventConfiguration
 from privacyidea.lib import _
 import logging
 import traceback
-import threading
 
 log = logging.getLogger(__name__)
 
@@ -90,8 +86,6 @@ def before_request():
     This is executed before the request
     """
     g.event_config = EventConfiguration()
-    # Save the HTTP header in the localproxy object
-    g.request_headers = request.headers
     username = getParam(request.all_data, "username")
     if username:
         # We only fill request.User, if we really have a username.

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -99,7 +99,7 @@ def log_begin_request():
     # can be passed to the innerpolicies.
     g.policy_object = PolicyClass()
     g.audit_object = getAudit(current_app.config)
-    # access_route contains the ip adresses of all clients, hops and proxies.
+    # access_route contains the ip addresses of all clients, hops and proxies.
     g.client_ip = get_client_ip(request,
                                 get_from_config(SYSCONF.OVERRIDECLIENT))
     g.serial = getParam(request.all_data, "serial", default=None)

--- a/privacyidea/api/ttype.py
+++ b/privacyidea/api/ttype.py
@@ -34,30 +34,17 @@ The TiQR Token uses this API to implement its special functionalities. See
 from flask import (Blueprint,
                    request)
 from .lib.utils import getParam
-from ..lib.framework import get_app_config_value
 from ..lib.log import log_with
 from flask import g, jsonify, current_app
 import logging
-from privacyidea.api.lib.utils import get_all_params
 from privacyidea.lib.error import ParameterError
-from privacyidea.lib.policy import PolicyClass
-from privacyidea.lib.audit import getAudit
-from privacyidea.lib.config import (get_token_class, get_from_config,
-                                    SYSCONF, ensure_no_config_object, get_privacyidea_node)
+from privacyidea.lib.config import get_token_class
 from privacyidea.lib.user import get_user_from_param
-from privacyidea.lib.utils import get_client_ip
 import json
 
 log = logging.getLogger(__name__)
 
 ttype_blueprint = Blueprint('ttype_blueprint', __name__)
-
-
-@ttype_blueprint.before_request
-def before_request():
-    """
-    This is executed before the request
-    """
 
 
 @ttype_blueprint.route('/<ttype>', methods=['POST', 'GET'])

--- a/privacyidea/api/ttype.py
+++ b/privacyidea/api/ttype.py
@@ -58,26 +58,6 @@ def before_request():
     """
     This is executed before the request
     """
-    ensure_no_config_object()
-    request.all_data = get_all_params(request)
-    privacyidea_server = get_app_config_value("PI_AUDIT_SERVERNAME", get_privacyidea_node(request.host))
-    # Create a policy_object, that reads the database audit settings
-    # and contains the complete policy definition during the request.
-    # This audit_object can be used in the postpolicy and prepolicy and it
-    # can be passed to the innerpolicies.
-    g.policy_object = PolicyClass()
-    g.audit_object = getAudit(current_app.config)
-    # access_route contains the ip adresses of all clients, hops and proxies.
-    g.client_ip = get_client_ip(request,
-                                get_from_config(SYSCONF.OVERRIDECLIENT))
-    g.serial = getParam(request.all_data, "serial") or None
-    g.audit_object.log({"success": False,
-                        "action_detail": "",
-                        "client": g.client_ip,
-                        "client_user_agent": request.user_agent.browser,
-                        "privacyidea_server": privacyidea_server,
-                        "action": "{0!s} {1!s}".format(request.method, request.url_rule),
-                        "info": ""})
 
 
 @ttype_blueprint.route('/<ttype>', methods=['POST', 'GET'])

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -66,7 +66,7 @@ In case if authenticating a serial number:
  * :func:`privacyidea.lib.tokenclass.TokenClass.check_otp`
 
 """
-from flask import (Blueprint, request, g, current_app)
+from flask import (Blueprint, request, g)
 from privacyidea.lib.user import get_user_from_param, log_used_user
 from .lib.utils import send_result, getParam
 from ..lib.decorators import (check_user_or_serial_in_request)
@@ -75,11 +75,8 @@ from privacyidea.lib.error import ParameterError
 from privacyidea.lib.token import (check_user_pass, check_serial_pass,
                                    check_otp, create_challenges_from_tokens, get_one_token)
 from privacyidea.lib.utils import is_true
-from privacyidea.api.lib.utils import get_all_params
-from privacyidea.lib.config import (return_saml_attributes, get_from_config,
-                                    return_saml_attributes_on_fail,
-                                    SYSCONF, ensure_no_config_object, get_privacyidea_node)
-from privacyidea.lib.audit import getAudit
+from privacyidea.lib.config import (return_saml_attributes,
+                                    return_saml_attributes_on_fail)
 from privacyidea.api.lib.decorators import add_serial_from_response_to_g
 from privacyidea.api.lib.prepolicy import (prepolicy, set_realm,
                                            api_key_required, mangle,
@@ -96,12 +93,10 @@ from privacyidea.api.lib.postpolicy import (postpolicy,
                                             add_user_detail_to_response, construct_radius_response,
                                             mangle_challenge_response, is_authorized,
                                             multichallenge_enroll_via_validate, preferred_client_mode)
-from privacyidea.lib.policy import PolicyClass
 from privacyidea.lib.event import EventConfiguration
 import logging
 from privacyidea.api.register import register_blueprint
 from privacyidea.api.recover import recover_blueprint
-from privacyidea.lib.utils import get_client_ip
 from privacyidea.lib.event import event
 from privacyidea.lib.challenge import get_challenges, extract_answered_challenges
 from privacyidea.lib.subscriptions import CheckSubscription
@@ -111,9 +106,6 @@ from privacyidea.lib.token import get_tokens
 from privacyidea.lib.machine import list_machine_tokens
 from privacyidea.lib.applications.offline import MachineApplication
 import json
-import threading
-
-from ..lib.framework import get_app_config_value
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -111,6 +111,7 @@ from privacyidea.lib.token import get_tokens
 from privacyidea.lib.machine import list_machine_tokens
 from privacyidea.lib.applications.offline import MachineApplication
 import json
+import threading
 
 from ..lib.framework import get_app_config_value
 
@@ -126,31 +127,10 @@ def before_request():
     """
     This is executed before the request
     """
-    ensure_no_config_object()
-    request.all_data = get_all_params(request)
     request.User = get_user_from_param(request.all_data)
-    privacyidea_server = get_app_config_value("PI_AUDIT_SERVERNAME", get_privacyidea_node(request.host))
-    # Create a policy_object, that reads the database audit settings
-    # and contains the complete policy definition during the request.
-    # This audit_object can be used in the postpolicy and prepolicy and it
-    # can be passed to the innerpolicies.
-
-    g.policy_object = PolicyClass()
-
-    g.audit_object = getAudit(current_app.config, g.startdate)
     g.event_config = EventConfiguration()
-    # access_route contains the ip addresses of all clients, hops and proxies.
-    g.client_ip = get_client_ip(request, get_from_config(SYSCONF.OVERRIDECLIENT))
     # Save the HTTP header in the localproxy object
     g.request_headers = request.headers
-    g.serial = getParam(request.all_data, "serial", default=None)
-    g.audit_object.log({"success": False,
-                        "action_detail": "",
-                        "client": g.client_ip,
-                        "client_user_agent": request.user_agent.browser,
-                        "privacyidea_server": privacyidea_server,
-                        "action": "{0!s} {1!s}".format(request.method, request.url_rule),
-                        "info": ""})
 
 
 @validate_blueprint.route('/offlinerefill', methods=['POST'])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -41,7 +41,7 @@ class AppTestCase(unittest.TestCase):
                       'policy_blueprint', 'login_blueprint', 'jwtauth', 'user_blueprint',
                       'audit_blueprint', 'machineresolver_blueprint', 'machine_blueprint',
                       'application_blueprint', 'caconnector_blueprint', 'cert_blueprint',
-                      'ttype_blueprint', 'register_blueprint', 'smtpserver_blueprint',
+                      'register_blueprint', 'smtpserver_blueprint',
                       'recover_blueprint', 'radiusserver_blueprint', 'periodictask_blueprint',
                       'privacyideaserver_blueprint', 'eventhandling_blueprint',
                       'smsgateway_blueprint', 'client_blueprint', 'subscriptions_blueprint',


### PR DESCRIPTION
The matching code from the following functions:

https://github.com/privacyidea/privacyidea/blob/bffc54f23d1444706bbb343101b283127954be6e/privacyidea/api/before_after.py#L150
https://github.com/privacyidea/privacyidea/blob/bffc54f23d1444706bbb343101b283127954be6e/privacyidea/api/auth.py#L88
https://github.com/privacyidea/privacyidea/blob/bffc54f23d1444706bbb343101b283127954be6e/privacyidea/api/validate.py#L125
https://github.com/privacyidea/privacyidea/blob/bffc54f23d1444706bbb343101b283127954be6e/privacyidea/api/ttype.py#L57

Has been combined into:
https://github.com/privacyidea/privacyidea/blob/0a9c618e6e6c6c8a43cb33df490cf45a802b2cbd/privacyidea/api/before_after.py#L87

In addition, the threatid is now also stored in the audit log for POST requests.

closes #3578 