### PR TITLE
Add logged_in_user in /auth request

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -62,7 +62,7 @@ from privacyidea.lib.framework import get_app_config_value
 from privacyidea.lib.user import User, split_user, log_used_user
 from privacyidea.lib.policy import PolicyClass, REMOTE_USER
 from privacyidea.lib.realm import get_default_realm, realm_is_defined
-from privacyidea.api.lib.postpolicy import (postpolicy, get_webui_settings, add_user_detail_to_response, check_tokentype, 
+from privacyidea.api.lib.postpolicy import (postpolicy, get_webui_settings, add_user_detail_to_response, check_tokentype,
                                             check_tokeninfo, check_serial, no_detail_on_fail, no_detail_on_success,
                                             get_webui_settings)
 from privacyidea.api.lib.prepolicy import (is_remote_user_allowed, prepolicy,
@@ -384,6 +384,11 @@ def get_auth_token():
                         "exp": datetime.utcnow() + validity,
                         "rights": rights},
                        secret, algorithm='HS256')
+
+    # set the logged-in user for post-policies and post-events
+    g.logged_in_user = {"username": loginname,
+                        "realm": realm,
+                        "role": role}
 
     # Add the role to the response, so that the WebUI can make decisions
     # based on this (only show selfservice, not the admin part)


### PR DESCRIPTION
To have the recently logged in user in available in post-policy and post-events, we add the `g.logged_in_user` after a successful authentication.

Closes #3710