### PR TITLE
Fix calculation of TOTP values

### DIFF
--- a/privacyidea/lib/tokens/daypasswordtoken.py
+++ b/privacyidea/lib/tokens/daypasswordtoken.py
@@ -290,8 +290,7 @@ class DayPasswordTokenClass(TotpTokenClass):
         if current_time:
             time_seconds = self._time2float(current_time)
 
-        # we don't need to round here as we have already float
-        counter = int((time_seconds / self.timestep) + 0.5)
+        counter = int(time_seconds / self.timestep)
         otpval = hmac2Otp.generate(counter=counter,
                                    inc_counter=False,
                                    do_truncation=do_truncation,
@@ -316,7 +315,7 @@ class DayPasswordTokenClass(TotpTokenClass):
         :param epoch_start: not implemented
         :param epoch_end: not implemented
         :param curTime: Simulate the servertime
-        :type curTime: datetime
+        :type curTime: datetime.datetime
         :param timestamp: Simulate the servertime
         :type timestamp: epoch time
         :return: tuple of status: boolean, error: text and the OTP dictionary
@@ -340,10 +339,9 @@ class DayPasswordTokenClass(TotpTokenClass):
             tCounter = int(timestamp)
         else:
             # use the current server time
-            tCounter = self._time2float(datetime.datetime.now())
+            tCounter = int(time.time())
 
-        # we don't need to round here as we have already float
-        counter = int((tCounter / self.timestep))
+        counter = int(tCounter / self.timestep)
 
         if count > 0:
             error = "OK"


### PR DESCRIPTION
Instead of using the `floor` function for calculating the counter of the *TOTP* algorithm, the counter was rounded to the nearest integer value. Thus the validity of a single *OTP* value was always shifted `timestep / 2` into the future.
For the regular *TOTP* algorithm this wasn't a problem since it also defines a time-drift and a time-window for checking the value. The *DayPassword* token which is derived from the *TOTP* algorithm however does not use a time-window.

This fix should not severely affect existing *TOTP* tokens since the algorithm already accounts for time-drifts.

Closes #3734