### PR TITLE
Fix wrong start counter for new sequences

### DIFF
--- a/migrations/versions/5cb310101a1f_.py
+++ b/migrations/versions/5cb310101a1f_.py
@@ -48,7 +48,7 @@ def upgrade():
                     continue
 
                 # Create the sequence with the correct next_id!
-                current_id = session.query(func.max(tbl.c.id)).one()[0] or 1
+                current_id = session.query(func.max(tbl.c.id)).one()[0] or 0
                 print(f"CurrentID in Table {tbl.name}: {current_id}")
                 try:
                     seq = Sequence(seq_name, start=(current_id + 1), increment=inc_value)


### PR DESCRIPTION
The initial migration script for adding missing sequences had an issue where new sequences started with 2 instead of 1.

Working on #3778 