### PR TITLE
Add error in case of wrong JSON

### DIFF
--- a/privacyidea/static/components/login/factories/auth.js
+++ b/privacyidea/static/components/login/factories/auth.js
@@ -46,6 +46,7 @@ angular.module("privacyideaAuth", ['privacyideaApp.errorMessage'])
                 if (typeof (error) === "string") {
                     inform.add(gettextCatalog.getString("Failed to get a valid JSON response from the privacyIDEA server."),
                         {type: "danger", ttl: 10000});
+                    console.warn(error);
                 } else {
                     inform.add(error.result.error.message, {type: "danger", ttl: 10000});
                     if (authErrorCodes.indexOf(error.result.error.code) >= 0) {


### PR DESCRIPTION
In case of non-JSON respone and auth Error
we log the error to the browser log.

@sepp67 This will help with your debugging.