### PR TITLE
Add CP to list of user agents where parameters do not need to be unquoted

### DIFF
--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -51,7 +51,8 @@ TRUSTED_JWT_ALGOS = ["ES256", "ES384", "ES512",
 # TODO: we should probably switch this when we do not do the extra unquote anymore
 NO_UNQUOTE_USER_AGENTS = {
     'privacyIDEA-LDAP-Proxy': None,
-    'simpleSAMLphp': None
+    'simpleSAMLphp': None,
+    'privacyidea-cp': None
 }
 
 SESSION_KEY_LENGTH = 32

--- a/tests/test_api_lib_utils.py
+++ b/tests/test_api_lib_utils.py
@@ -305,6 +305,15 @@ class UtilsTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
 
+        # And check the Credential Provider plugin
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={'username': 'pwpercent',
+                                                 'password': 'pw%45#test'},
+                                           headers={'User-Agent': 'privacyidea-cp/2.0'}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+
         # now check the /validate/check endpoint
         set_policy(name="otppin",
                    scope=SCOPE.AUTH,
@@ -341,6 +350,18 @@ class UtilsTestCase(MyApiTestCase):
                                                  "realm": self.realm1,
                                                  "pass": "pw%45#test"},
                                            headers={'User-Agent': 'simpleSAMLphp'}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200, res)
+            result = res.json.get("result")
+            self.assertTrue(result.get("value"), res.json)
+
+        # when using the correct user-agent (CredentialProvider), quoting is not necessary
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "pwpercent",
+                                                 "realm": self.realm1,
+                                                 "pass": "pw%45#test"},
+                                           headers={'User-Agent': 'privacyidea-cp/3.0'}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200, res)
             result = res.json.get("result")


### PR DESCRIPTION
Since the latest release of the Credential Provider, it properly quotes the parameter send to privacyIDEA. We do not need an extra unquote step for it.

Closes #3770