### PR TITLE
Token description requirement works with verify enroll

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -87,7 +87,6 @@ from privacyidea.lib.clientapplication import save_clientapplication
 from privacyidea.lib.config import (get_token_class)
 from privacyidea.lib.tokenclass import ROLLOUTSTATE
 from privacyidea.lib.tokens.certificatetoken import ACTION as CERTIFICATE_ACTION
-from privacyidea.lib.tokenclass import ROLLOUTSTATE
 from privacyidea.lib.token import get_one_token
 import functools
 import jwt

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -69,7 +69,7 @@ import logging
 
 from OpenSSL import crypto
 from privacyidea.lib import _
-from privacyidea.lib.error import PolicyError, RegistrationError, TokenAdminError, ResourceNotFoundError
+from privacyidea.lib.error import PolicyError, RegistrationError, TokenAdminError, ResourceNotFoundError, ParameterError
 from flask import g, current_app
 from privacyidea.lib.policy import SCOPE, ACTION, REMOTE_USER
 from privacyidea.lib.policy import Match, check_pin
@@ -87,6 +87,8 @@ from privacyidea.lib.clientapplication import save_clientapplication
 from privacyidea.lib.config import (get_token_class)
 from privacyidea.lib.tokenclass import ROLLOUTSTATE
 from privacyidea.lib.tokens.certificatetoken import ACTION as CERTIFICATE_ACTION
+from privacyidea.lib.tokenclass import ROLLOUTSTATE
+from privacyidea.lib.token import get_one_token
 import functools
 import jwt
 import re
@@ -2233,6 +2235,12 @@ def require_description(request=None, action=None):
     token_types = list(action_values.keys())
     type_value = request.all_data.get("type") or 'hotp'
     if type_value in token_types:
-        if not request.all_data.get("description"):
+        tok = None
+        serial = getParam(params, "serial")
+        if serial:
+            tok = get_one_token(serial=serial, rollout_state=ROLLOUTSTATE.VERIFYPENDING, silent_fail=True) or \
+                  get_one_token(serial=serial, rollout_state=ROLLOUTSTATE.CLIENTWAIT, silent_fail=True)
+        # only if no token exists, yet, we need to check the description
+        if not tok and not request.all_data.get("description"):
             log.warning(_("Missing description for {} token.".format(type_value)))
             raise PolicyError(_("Description required for {} token.".format(type_value)))

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -554,16 +554,21 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
     return ret
 
 
-def get_one_token(*args, **kwargs):
+def get_one_token(*args, silent_fail=False, **kwargs):
     """
     Fetch exactly one token according to the given filter arguments, which are passed to
     ``get_tokens``. Raise ``ResourceNotFoundError`` if no token was found. Raise
     ``ParameterError`` if more than one token was found.
+
+    :param silent_fail: Instead of raising an exception we return None silently
+    :returns: Token object
     """
     result = get_tokens(*args, **kwargs)
     if not result:
+        if silent_fail: return
         raise ResourceNotFoundError(_("The requested token could not be found."))
     elif len(result) > 1:
+        if silent_fail: return
         raise ParameterError(_("More than one matching token were found."))
     else:
         return result[0]

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -565,11 +565,14 @@ def get_one_token(*args, silent_fail=False, **kwargs):
     """
     result = get_tokens(*args, **kwargs)
     if not result:
-        if silent_fail: return
+        if silent_fail:
+            return None
         raise ResourceNotFoundError(_("The requested token could not be found."))
     elif len(result) > 1:
-        if silent_fail: return
-        raise ParameterError(_("More than one matching token were found."))
+        if silent_fail:
+            log.warning("More than one matching token was found.")
+            return None
+        raise ParameterError(_("More than one matching token was found."))
     else:
         return result[0]
 


### PR DESCRIPTION
Enrollment with verification (enter OTP) breaks the token description, since the 2nd /token/init call does not contain a description.

We identify the 2nd call and do not require the description.

Fixes #3798