### PR TITLE
Add MULTIVALUEATTRIBUTE to ldap resolver class...

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -1042,7 +1042,8 @@ class IdResolver (UserIdResolver):
                                 'SERVERPOOL_SKIP': 'int',
                                 'SERVERPOOL_PERSISTENT': 'bool',
                                 'OBJECT_CLASSES': 'string',
-                                'DN_TEMPLATE': 'string'}
+                                'DN_TEMPLATE': 'string',
+                                'MULTIVALUEATTRIBUTES': 'string'}
         return {typ: descriptor}
 
     @classmethod


### PR DESCRIPTION
description, to avoid a warning the log file.

Closes #3854