### PR TITLE
use same convention for names, typos

### DIFF
--- a/privacyidea/lib/applications/offline.py
+++ b/privacyidea/lib/applications/offline.py
@@ -48,7 +48,7 @@ class MachineApplication(MachineApplicationBase):
 
     The server stores the information, which OTP values were issued.
 
-    options options:
+    options:
       * user: a username.
       * count: is the number of OTP values returned
 
@@ -88,7 +88,7 @@ class MachineApplication(MachineApplicationBase):
             otps[key] = pbkdf2_sha512.using(
                 rounds=rounds, salt_size=10).hash(otppw)
         # We do not disable the token, so if all offline OTP values
-        # are used, the token can be used the authenticate online again.
+        # are used, the token can be used to authenticate online again.
         # token_obj.enable(False)
         # increase the counter by the consumed values and
         # also store it in tokeninfo.
@@ -170,8 +170,8 @@ class MachineApplication(MachineApplicationBase):
             # token specific data
             if token_type.lower() == "webauthn":
                 # return the pubkey and the credential_id (contained in the otpkey)
-                ret["response"] = {"pubkey": token_obj.get_tokeninfo("pubKey"),
-                                   "credential_id": token_obj.decrypt_otpkey(),
+                ret["response"] = {"pubKey": token_obj.get_tokeninfo("pubKey"),
+                                   "credentialId": token_obj.decrypt_otpkey(),
                                    "rpId": token_obj.get_tokeninfo("relying_party_id")}
 
             elif token_type.lower() == "hotp":

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -6137,9 +6137,9 @@ class WebAuthnOfflineTestCase(MyApiTestCase):
                  'username': 'cornelius',
                  'refilltoken': '79906cc20567c6ca1e4b452500bb0662e107ce0fa14742c95b7e5c6a1417a519f829318622c1d569',
                  'repsonse': {
-                     'pubKey': 'a50102032620012158203f98500ddcedc3aa16d34ae9b7c12...ea3e37193f8f3d', 
+                     'pubKey': 'a50102032620012158203f98500ddcedc3aa16d34ae9b7c12...ea3e37193f8f3d',
                      'credentialId': 'RuBlEInU7ycsILST7u6AoT7rdqN...4xM2SHltwbtBwApFYnbQXO8g5bgrb4kFh1NErnzsT6xA',
-                     'rpId': 'netknights.it'}, 
+                     'rpId': 'netknights.it'},
                  'serial': 'WAN0001D434'}]}
             """
             response = auth_items.get("offline")[0].get("response")

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -6018,10 +6018,10 @@ class WebAuthnOfflineTestCase(MyApiTestCase):
             self.assertTrue(result.get("value"))
             detail = data.get("detail")
             self.assertEqual(self.serial, detail.get("serial"))
-            webAuthnRequest = data.get("detail").get("webAuthnRegisterRequest")
-            self.assertEqual("Please confirm with your WebAuthn token", webAuthnRequest.get("message"))
-            transaction_id = webAuthnRequest.get("transaction_id")
-            self.assertEqual(webAuthnRequest.get("attestation"), "direct")
+            web_authn_request = data.get("detail").get("webAuthnRegisterRequest")
+            self.assertEqual("Please confirm with your WebAuthn token", web_authn_request.get("message"))
+            transaction_id = web_authn_request.get("transaction_id")
+            self.assertEqual(web_authn_request.get("attestation"), "direct")
 
         # We need to change the nonce in the challenge database to use our recorded WebAuthN enrollment data
         recorded_nonce = "0fnxHW5R2maOrVruLJGrEGFpFmJHR4jPEmedJ9Pt3hk"
@@ -6062,7 +6062,7 @@ class WebAuthnOfflineTestCase(MyApiTestCase):
 
     def test_02_autenticate(self):
 
-        recorded_allowCredentials = "RuBlEInU7ycsILST7u6AoT7rdqNYjSf4jlz38x10344xM2SHl" \
+        recorded_allow_credentials = "RuBlEInU7ycsILST7u6AoT7rdqNYjSf4jlz38x10344xM2SHl" \
                                     "twbtBwApFYnbQXO8g5bgrb4kFh1NErnzsT6xA"
         recorded_challenge = "zphA4XzB8ZHkiGnsQAcqDRn8j8e4h9HcSAQ2mlt0o94"
 
@@ -6084,11 +6084,11 @@ class WebAuthnOfflineTestCase(MyApiTestCase):
                              data.get("detail").get("message"))
             detail = data.get("detail")
             self.assertEqual("webauthn", detail.get("client_mode"))
-            webAuthnSignRequest = detail.get("attributes").get("webAuthnSignRequest")
-            self.assertEqual("netknights.it", webAuthnSignRequest.get("rpId"))
-            allowCredentials = webAuthnSignRequest.get("allowCredentials")
-            self.assertEqual(1, len(allowCredentials))
-            self.assertEqual(recorded_allowCredentials, allowCredentials[0].get("id"))
+            web_authn_sign_request = detail.get("attributes").get("webAuthnSignRequest")
+            self.assertEqual("netknights.it", web_authn_sign_request.get("rpId"))
+            allow_credentials = web_authn_sign_request.get("allowCredentials")
+            self.assertEqual(1, len(allow_credentials))
+            self.assertEqual(recorded_allow_credentials, allow_credentials[0].get("id"))
             transaction_id = detail.get("transaction_id")
 
             # Update the recorded challenge in the DB
@@ -6145,6 +6145,6 @@ class WebAuthnOfflineTestCase(MyApiTestCase):
             response = auth_items.get("offline")[0].get("response")
             _refill_token = auth_items.get("offline")[0].get("refilltoken")
             # Offline returns the credential ID and the pub key
-            self.assertEqual(recorded_allowCredentials, response.get("credentialId"))
+            self.assertEqual(recorded_allow_credentials, response.get("credentialId"))
             self.assertIn("pubKey", response)
             self.assertEqual(self.rpid, response.get("rpId"))

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -6137,14 +6137,14 @@ class WebAuthnOfflineTestCase(MyApiTestCase):
                  'username': 'cornelius',
                  'refilltoken': '79906cc20567c6ca1e4b452500bb0662e107ce0fa14742c95b7e5c6a1417a519f829318622c1d569',
                  'repsonse': {
-                     'pubkey': 'a50102032620012158203f98500ddcedc3aa16d34ae9b7c12...ea3e37193f8f3d', 
-                     'credential_id': 'RuBlEInU7ycsILST7u6AoT7rdqN...4xM2SHltwbtBwApFYnbQXO8g5bgrb4kFh1NErnzsT6xA',
+                     'pubKey': 'a50102032620012158203f98500ddcedc3aa16d34ae9b7c12...ea3e37193f8f3d', 
+                     'credentialId': 'RuBlEInU7ycsILST7u6AoT7rdqN...4xM2SHltwbtBwApFYnbQXO8g5bgrb4kFh1NErnzsT6xA',
                      'rpId': 'netknights.it'}, 
                  'serial': 'WAN0001D434'}]}
             """
             response = auth_items.get("offline")[0].get("response")
             _refill_token = auth_items.get("offline")[0].get("refilltoken")
             # Offline returns the credential ID and the pub key
-            self.assertEqual(recorded_allowCredentials, response.get("credential_id"))
-            self.assertIn("pubkey", response)
+            self.assertEqual(recorded_allowCredentials, response.get("credentialId"))
+            self.assertIn("pubKey", response)
             self.assertEqual(self.rpid, response.get("rpId"))


### PR DESCRIPTION
Use CamelCase for webauthn related field names, as it already done when triggering webauthn challenges, eventhough the other naming uses underscores.