### PR TITLE
cancel polltransaction in all cases

### DIFF
--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -380,18 +380,21 @@ angular.module("privacyideaApp")
                 }, function (response) {
                     console.log('Authentication failed after polling!');
                     console.log(response.data);
+                    PollingAuthFactory.stop();
                 });
-                PollingAuthFactory.stop();
             }
             // if result.value is false, the challenge hasn't been answered yet.
             // Continue polling
         }, function(response) {
-            // the /validate/polltransaction endpoint returned an error
+            // the /validate/polltransaction endpoint returned an error therefore polling should be stopped
             console.warn("Polling for transactions returned an error: " + response.data);
+            PollingAuthFactory.stop();
         });
     };
 
     $scope.do_login_stuff = function(data) {
+        PollingAuthFactory.stop();
+
         AuthFactory.setUser(data.result.value.username,
                 data.result.value.realm,
                 data.result.value.token,


### PR DESCRIPTION
There are 3 points at which polling for the transaction should be stopped:
* Successful login with any token type. This is now done in `do_login_stuff` instead of `then` which only accounts for push logins.
* Failure of /auth after polltransaction returned success. In this case the authentication has to be restarted.
* General failure of /polltransaction. There is no point in trying again if there was an error.

closes #3861 