### PR TITLE
Add tokenlabel and tokenissuer to PUSH enrollment

### DIFF
--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -34,7 +34,7 @@ from dateutil.parser import isoparse
 import traceback
 
 from privacyidea.api.lib.utils import getParam
-from privacyidea.api.lib.policyhelper import get_pushtoken_add_config
+from privacyidea.api.lib.policyhelper import get_pushtoken_add_config, get_init_tokenlabel_parameters
 from privacyidea.lib.token import get_one_token, init_token
 from privacyidea.lib.utils import prepare_result, to_bytes, is_true, create_tag_dict
 from privacyidea.lib.error import (ResourceNotFoundError, ValidateError,
@@ -1068,7 +1068,11 @@ class PushTokenClass(TokenClass):
         # Create a challenge!
         c = token_obj.create_challenge(options={"session": CHALLENGE_SESSION.ENROLLMENT})
         # get details of token
-        init_details = token_obj.get_init_detail(params=params)
+        enroll_params = get_init_tokenlabel_parameters(g, user_object=user_obj,
+                                                       token_type=cls.get_class_type())
+        params.update(enroll_params)
+        init_details = token_obj.get_init_detail(params=params,
+                                                 user=user_obj)
         detail["transaction_ids"] = [c[2]]
         chal = {"transaction_id": c[2],
                 "image": init_details.get("pushurl", {}).get("img"),

--- a/tests/test_api_push_validate.py
+++ b/tests/test_api_push_validate.py
@@ -380,6 +380,8 @@ class PushAPITestCase(MyApiTestCase):
         # 1. set policies.
         set_policy("pol_passthru", scope=SCOPE.AUTH, action=ACTION.PASSTHRU)
 
+        set_policy("pol_tokenlabel", scope=SCOPE.ENROLL, action="{0!s}=Pushy".format(ACTION.TOKENLABEL))
+
         # 2. authenticate user via passthru
         with self.app.test_request_context('/validate/check',
                                            method='POST',


### PR DESCRIPTION
When enrolling PUSH tokens via_multichallenge the tokenlabel and tokenissuer were not processed. Fixed this.

Closes #3883