### PR TITLE
Add policy for alternative enrollment text

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -421,8 +421,8 @@ there is no additional authentication step anymore during enrollment.
 
 .. _policy_enroll_via_multichallenge_text:
 
-enroll_via_multichallenge
-~~~~~~~~~~~~~~~~~~~~~~~~~
+enroll_via_multichallenge_text
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 type: string
 

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -374,7 +374,7 @@ type: string
 
 This policy allows the rollout of tokens during the authentication via `/validate/check`.
 
-The policy action can take one of the followig token types: `hotp`, `totp`, `push`, `email`, `sms`.
+The policy action can take one of the following token types: `hotp`, `totp`, `push`, `email`, `sms`.
 
 The clients and plugins should make use of this policy in a transparent way and using multiple consecutive
 challenges.
@@ -417,6 +417,17 @@ there is no additional authentication step anymore during enrollment.
 
 .. note:: Enrolling multiple token types one after another is not supported. It is currently possible to
    enroll only one token type.
+
+
+.. _policy_enroll_via_multichallenge_text:
+
+enroll_via_multichallenge
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+type: string
+
+There is a default text that is shown to the user, when a token via
+multichallenge is enrolled. The administrator can change this text using this policy.
 
 
 .. _policy_u2f_facets:

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -772,8 +772,15 @@ def multichallenge_enroll_via_validate(request, response):
                 #       Here: If the user has one token of this type.
                 if len(get_tokens(tokentype=tokentype, user=user_obj)) == 0:
                     if tokentype.lower() in get_multichallenge_enrollable_tokentypes():
+                        # Now get the alternative text from the policies
+                        text_pol = Match.user(g, scope=SCOPE.AUTH, action=ACTION.ENROLL_VIA_MULTICHALLENGE_TEXT,
+                                   user_object=user_obj).action_values(unique=True, write_to_audit_log=False)
+                        message = None
+                        if text_pol:
+                            message = list(text_pol)[0]
+                        # message = list(text_pol)[0] if text_pol else None
                         tclass = get_token_class(tokentype)
-                        tclass.enroll_via_validate(g, content, user_obj)
+                        tclass.enroll_via_validate(g, content, user_obj, message)
                         response.set_data(json.dumps(content))
 
     return response

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -774,11 +774,12 @@ def multichallenge_enroll_via_validate(request, response):
                     if tokentype.lower() in get_multichallenge_enrollable_tokentypes():
                         # Now get the alternative text from the policies
                         text_pol = Match.user(g, scope=SCOPE.AUTH, action=ACTION.ENROLL_VIA_MULTICHALLENGE_TEXT,
-                                   user_object=user_obj).action_values(unique=True, write_to_audit_log=False)
+                                              user_object=user_obj).action_values(unique=True,
+                                                                                  write_to_audit_log=False,
+                                                                                  allow_white_space_in_action=True)
                         message = None
                         if text_pol:
                             message = list(text_pol)[0]
-                        # message = list(text_pol)[0] if text_pol else None
                         tclass = get_token_class(tokentype)
                         tclass.enroll_via_validate(g, content, user_obj, message)
                         response.set_data(json.dumps(content))

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -353,6 +353,7 @@ class ACTION(object):
     CHANGE_PIN_VIA_VALIDATE = "change_pin_via_validate"
     RESYNC_VIA_MULTICHALLENGE = "resync_via_multichallenge"
     ENROLL_VIA_MULTICHALLENGE = "enroll_via_multichallenge"
+    ENROLL_VIA_MULTICHALLENGE_TEXT = "enroll_via_multichallenge_text"
     CLIENTTYPE = "clienttype"
     REGISTERBODY = "registration_body"
     RESETALLTOKENS = "reset_all_user_tokens"
@@ -2345,6 +2346,10 @@ def get_static_policy_definitions(scope=None):
                 'desc': _("In case of a successful authentication the following tokentype is enrolled. The "
                           "maximum number of tokens for a user is checked."),
                 'value': [t.upper() for t in get_multichallenge_enrollable_tokentypes()]
+            },
+            ACTION.ENROLL_VIA_MULTICHALLENGE_TEXT: {
+                'type': 'str',
+                'desc': _("Change the default text that is shown during enrolling a token.")
             },
             ACTION.PASSTHRU: {
                 'type': 'str',

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1927,7 +1927,7 @@ class TokenClass(object):
         return False
 
     @classmethod
-    def enroll_via_validate(cls, g, content, user_obj):
+    def enroll_via_validate(cls, g, content, user_obj, message=None):
         """
         This class method is used in the policy ENROLL_VIA_MULTICHALLENGE.
         It enrolls a new token of this type and returns the necessary information
@@ -1936,6 +1936,7 @@ class TokenClass(object):
         :param g: context object
         :param content: The content of a response
         :param user_obj: A user object
+        :param message: An alternative message displayed to the user during enrollment
         :return: None, the content is modified
         """
         return True

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -514,7 +514,7 @@ class EmailTokenClass(HotpTokenClass):
         return {"message": VERIFY_ENROLLMENT_MESSAGE}
 
     @classmethod
-    def enroll_via_validate(cls, g, content, user_obj):
+    def enroll_via_validate(cls, g, content, user_obj, message=None):
         """
         This class method is used in the policy ENROLL_VIA_MULTICHALLENGE.
         It enrolls a new token of this type and returns the necessary information
@@ -523,6 +523,7 @@ class EmailTokenClass(HotpTokenClass):
         :param g: context object
         :param content: The content of a response
         :param user_obj: A user object
+        :param message: An alternative message displayed to the user during enrollment
         :return: None, the content is modified
         """
         from privacyidea.lib.token import init_token
@@ -543,7 +544,7 @@ class EmailTokenClass(HotpTokenClass):
                 "client_mode": CLIENTMODE.INTERACTIVE,
                 "serial": token_obj.token.serial,
                 "type": token_obj.type,
-                "message": _("Please enter your new email address!")}
+                "message": message or _("Please enter your new email address!")}
         detail["multi_challenge"] = [chal]
         detail.update(chal)
 

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -815,7 +815,7 @@ class HotpTokenClass(TokenClass):
         return r >= 0
 
     @classmethod
-    def enroll_via_validate(cls, g, content, user_obj):
+    def enroll_via_validate(cls, g, content, user_obj, message=None):
         """
         This class method is used in the policy ENROLL_VIA_MULTICHALLENGE.
         It enrolls a new token of this type and returns the necessary information
@@ -824,9 +824,10 @@ class HotpTokenClass(TokenClass):
         :param g: context object
         :param content: The content of a response
         :param user_obj: A user object
+        :param message: An alternative message displayed to the user during enrollment
         :return: None, the content is modified
         """
-        message = _("Please scan the QR code!")
+        message = message or _("Please scan the QR code and enter the OTP value!")
         token_obj = init_token({"type": cls.get_class_type(),
                                 "genkey": 1}, user=user_obj)
         content.get("result")["value"] = False

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -1041,7 +1041,7 @@ class PushTokenClass(TokenClass):
         return otp_counter
 
     @classmethod
-    def enroll_via_validate(cls, g, content, user_obj):
+    def enroll_via_validate(cls, g, content, user_obj, message=None):
         """
         This class method is used in the policy ENROLL_VIA_MULTICHALLENGE.
         It enrolls a new token of this type and returns the necessary information
@@ -1050,6 +1050,7 @@ class PushTokenClass(TokenClass):
         :param g: context object
         :param content: The content of a response
         :param user_obj: A user object
+        :param message: An alternative message displayed to the user during enrollment
         :return: None, the content is modified
         """
         # Get the firebase configuration from the policies
@@ -1079,6 +1080,6 @@ class PushTokenClass(TokenClass):
                 "client_mode": CLIENTMODE.POLL,
                 "serial": token_obj.token.serial,
                 "type": token_obj.type,
-                "message": _("Please scan the QR code!")}
+                "message": message or _("Please scan the QR code!")}
         detail["multi_challenge"] = [chal]
         detail.update(chal)

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -571,7 +571,7 @@ class SmsTokenClass(HotpTokenClass):
         return {"message": VERIFY_ENROLLMENT_MESSAGE}
 
     @classmethod
-    def enroll_via_validate(cls, g, content, user_obj):
+    def enroll_via_validate(cls, g, content, user_obj, message=None):
         """
         This class method is used in the policy ENROLL_VIA_MULTICHALLENGE.
         It enrolls a new token of this type and returns the necessary information
@@ -580,6 +580,7 @@ class SmsTokenClass(HotpTokenClass):
         :param g: context object
         :param content: The content of a response
         :param user_obj: A user object
+        :param message: An alternative message displayed to the user during enrollment
         :return: None, the content is modified
         """
         from privacyidea.lib.token import init_token
@@ -600,7 +601,7 @@ class SmsTokenClass(HotpTokenClass):
                 "client_mode": CLIENTMODE.INTERACTIVE,
                 "serial": token_obj.token.serial,
                 "type": token_obj.type,
-                "message": _("Please enter your new phone number!")}
+                "message": message or _("Please enter your new phone number!")}
         detail["multi_challenge"] = [chal]
         detail.update(chal)
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -5586,7 +5586,8 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             self.assertEqual(result.get("authentication"), "CHALLENGE")
             detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
-            self.assertTrue("Please scan the QR code and enter the OTP value!" in detail.get("message"), detail.get("message"))
+            self.assertTrue("Please scan the QR code and enter the OTP value!" in detail.get("message"),
+                            detail.get("message"))
             # Get image and client_mode
             self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("client_mode"), detail)
             # Check, that multi_challenge is also contained.
@@ -5619,7 +5620,8 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         self.assertNotIn('ldappw', log_msg, log_msg)
         self.assertIn('HIDDEN', log_msg, log_msg)
         # Verify that the force_pin enrollment policy worked for validate-check-enrollment
-        self.assertIn('Exiting get_init_tokenlabel_parameters with result {\'force_app_pin\': True}', log_msg, log_msg)
+        self.assertIn('Exiting get_init_tokenlabel_parameters with result {\'force_app_pin\': True}',
+                      log_msg, log_msg)
         logging.getLogger('privacyidea').setLevel(logging.INFO)
 
         # Cleanup
@@ -5668,7 +5670,8 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             self.assertEqual(result.get("authentication"), "CHALLENGE")
             detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
-            self.assertTrue("Please scan the QR code and enter the OTP value!" in detail.get("message"), detail.get("message"))
+            self.assertTrue("Please scan the QR code and enter the OTP value!" in detail.get("message"),
+                            detail.get("message"))
             # Get image and client_mode
             self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("client_mode"))
             # Check, that multi_challenge is also contained.

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -5586,7 +5586,7 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             self.assertEqual(result.get("authentication"), "CHALLENGE")
             detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
-            self.assertTrue("Please scan the QR code!" in detail.get("message"), detail.get("message"))
+            self.assertTrue("Please scan the QR code and enter the OTP value!" in detail.get("message"), detail.get("message"))
             # Get image and client_mode
             self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("client_mode"), detail)
             # Check, that multi_challenge is also contained.
@@ -5594,7 +5594,7 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             self.assertEqual(CLIENTMODE.INTERACTIVE, chal.get("client_mode"), detail)
             self.assertIn("image", detail, detail)
             self.assertEqual(1, len(detail.get("messages")))
-            self.assertEqual("Please scan the QR code!", detail.get("messages")[0])
+            self.assertEqual("Please scan the QR code and enter the OTP value!", detail.get("messages")[0])
             serial = detail.get("serial")
 
         # 3. scan the qrcode / Get the OTP value
@@ -5668,7 +5668,7 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             self.assertEqual(result.get("authentication"), "CHALLENGE")
             detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
-            self.assertTrue("Please scan the QR code!" in detail.get("message"), detail.get("message"))
+            self.assertTrue("Please scan the QR code and enter the OTP value!" in detail.get("message"), detail.get("message"))
             # Get image and client_mode
             self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("client_mode"))
             # Check, that multi_challenge is also contained.
@@ -5829,6 +5829,9 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         # Set Policy scope:auth, action:enroll_via_multichallenge=email
         set_policy("pol_multienroll", scope=SCOPE.AUTH,
                    action="{0!s}=sms".format(ACTION.ENROLL_VIA_MULTICHALLENGE))
+        # Set an individual text
+        set_policy("pol_multienroll_text", scope=SCOPE.AUTH,
+                   action="{0!s}='Phone number enter you must!'".format(ACTION.ENROLL_VIA_MULTICHALLENGE_TEXT))
         # Now we should get an authentication Challenge
         with self.app.test_request_context('/validate/check',
                                            method='POST',
@@ -5842,7 +5845,7 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             self.assertEqual(result.get("authentication"), "CHALLENGE")
             detail = res.json.get("detail")
             transaction_id = detail.get("transaction_id")
-            self.assertTrue("Please enter your new phone number!" in detail.get("message"), detail.get("message"))
+            self.assertTrue("Phone number enter you must!" in detail.get("message"), detail.get("message"))
             # Get image and client_mode
             self.assertEqual(CLIENTMODE.INTERACTIVE, detail.get("client_mode"))
             # Check, that multi_challenge is also contained.


### PR DESCRIPTION
Add a policy that allows to set the text during
the enrollment via multichallenge.
This way the admin can give individual information to the user.

Closes #3884