### PR TITLE
Fix broken Galera-Cluster installation

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+Version 3.9.3, 2024-04-04
+
+  Fixes:
+  * Fix creation of database tables with galera cluster (#3863)
+
 Version 3.9.2, 2023-12-20
 
   Fixes:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,7 +23,7 @@ import functools
 # built documents.
 #
 # The short X.Y version.
-version = '3.9.2'
+version = '3.9.3'
 # The full version, including alpha/beta/rc tags.
 #release = '2.16dev5'
 release = version

--- a/migrations/versions/5cb310101a1f_.py
+++ b/migrations/versions/5cb310101a1f_.py
@@ -26,12 +26,6 @@ Session = sessionmaker()
 def upgrade():
     migration_context = context.get_context()
     if migration_context.dialect.supports_sequences:
-        if migration_context.dialect.name in ['mariadb', 'mysql']:
-            # setting "increment" to 0 works like auto-increment but also supports replication
-            # See <https://mariadb.com/kb/en/sequence-overview/#replication>
-            inc_value = 0
-        else:
-            inc_value = 1
         bind = op.get_bind()
         # We only need a read session, so we do not need a commit
         session = Session(bind=bind)
@@ -51,7 +45,7 @@ def upgrade():
                 current_id = session.query(func.max(tbl.c.id)).one()[0] or 0
                 print(f"CurrentID in Table {tbl.name}: {current_id}")
                 try:
-                    seq = Sequence(seq_name, start=(current_id + 1), increment=inc_value)
+                    seq = Sequence(seq_name, start=(current_id + 1))
                     print(f" +++ Creating Sequence: {seq_name}")
                     op.execute(CreateSequence(seq, if_not_exists=True))
                 except OperationalError as exx:

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -81,9 +81,11 @@ def compile_datetime_mysql(type_, compiler, **kw):  # pragma: no cover
     return "DATETIME(6)"
 
 
+# Fix creation of sequences on MariaDB (and MySQL, which does not support
+# sequences anyway) with galera by adding INCREMENT BY 0 to CREATE SEQUENCE
 @compiles(CreateSequence, 'mysql')
 @compiles(CreateSequence, 'mariadb')
-def increment_by_zero(element, compiler, **kw):
+def increment_by_zero(element, compiler, **kw):  # pragma: no cover
     text = compiler.visit_create_sequence(element, **kw)
     text = text + " INCREMENT BY 0"
     return text

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import stat
 import sys
 
 #VERSION = "2.1dev4"
-VERSION = "3.9.2"
+VERSION = "3.9.3dev1"
 
 # Taken from kennethreitz/requests/setup.py
 package_directory = os.path.realpath(os.path.dirname(__file__))


### PR DESCRIPTION
Galera cluster based on MariaDB >= 10.6 was unable to create the initial tables since it needed sequences with an increment of 0. Unfortunately PostgreSQL does not work with an increment of 0 in sequences.
Compiling the SQL statements for creating a sequence differently for MySQL/MariaDB and PostgreSQL fixes this.
Database upgrades to this version still work as expected since the increment was already used in the migration script (now removed).

Fixes #3863