### PR TITLE
Mark privacyidea token in the qr code

### DIFF
--- a/privacyidea/lib/apps.py
+++ b/privacyidea/lib/apps.py
@@ -98,7 +98,7 @@ def create_google_authenticator_url(key=None, user=None,
                                     serial="mylabel", tokenlabel="<s>",
                                     hash_algo="SHA1", digits="6",
                                     issuer="privacyIDEA", user_obj=None,
-                                    extra_data=None):
+                                    creator="privacyidea", extra_data=None):
     """
     This creates the google authenticator URL.
     This url may only be 119 characters long.
@@ -153,6 +153,7 @@ def create_google_authenticator_url(key=None, user=None,
         hash_algo = ""
 
     if tokentype.lower() == "totp":
+        tokentype = "totp"
         period = "period={0!s}&".format(period)
     elif tokentype.lower() == "daypassword":
         period = "period={0!s}&".format(parse_time_sec_int(period))
@@ -162,12 +163,12 @@ def create_google_authenticator_url(key=None, user=None,
     return ("otpauth://{tokentype!s}/{label!s}?secret={secret!s}&"
             "{counter!s}{hash!s}{period!s}"
             "digits={digits!s}&"
-            "creator=privacyidea&"
+            "creator={creator}&"
             "issuer={issuer!s}{extra}".format(tokentype=tokentype,
                                        label=url_label, secret=otpkey,
                                        hash=hash_algo, period=period,
                                        digits=digits, issuer=url_issuer,
-                                       counter=counter,
+                                       counter=counter, creator=creator,
                                        extra=_construct_extra_parameters(extra_data)))
 
 @log_with(log)

--- a/privacyidea/lib/apps.py
+++ b/privacyidea/lib/apps.py
@@ -162,6 +162,7 @@ def create_google_authenticator_url(key=None, user=None,
     return ("otpauth://{tokentype!s}/{label!s}?secret={secret!s}&"
             "{counter!s}{hash!s}{period!s}"
             "digits={digits!s}&"
+            "creator=privacyidea&"
             "issuer={issuer!s}{extra}".format(tokentype=tokentype,
                                        label=url_label, secret=otpkey,
                                        hash=hash_algo, period=period,

--- a/privacyidea/lib/apps.py
+++ b/privacyidea/lib/apps.py
@@ -107,12 +107,12 @@ def create_google_authenticator_url(key=None, user=None,
     We expect the key to be hexlified!
     """
     extra_data = extra_data or {}
+    tokentype = tokentype.lower()
 
     # policy depends on some lib.util
 
     user_obj = user_obj or User()
-    if tokentype.lower() == "hotp":
-        tokentype = "hotp"
+    if tokentype == "hotp":
         counter = "counter=1&"
     else:
         counter = ""
@@ -152,10 +152,9 @@ def create_google_authenticator_url(key=None, user=None,
         # the QR code simpler
         hash_algo = ""
 
-    if tokentype.lower() == "totp":
-        tokentype = "totp"
+    if tokentype == "totp":
         period = "period={0!s}&".format(period)
-    elif tokentype.lower() == "daypassword":
+    elif tokentype == "daypassword":
         period = "period={0!s}&".format(parse_time_sec_int(period))
     else:
         period = ""

--- a/tests/test_lib_apps.py
+++ b/tests/test_lib_apps.py
@@ -17,7 +17,7 @@ class AppsTestCase(MyTestCase):
         self.assertTrue("otpauth://hotp/mylabel?secret=CI2FM6A&counter=1" in
                         r, r)
 
-        r = create_google_authenticator_url(tokentype="totp", key="123456",
+        r = create_google_authenticator_url(tokentype="TOTP", key="123456",
                                             period=60)
         self.assertTrue("otpauth://totp/mylabel?secret=CI2FM&period"
                         "=60&digits=6&creator=privacyidea&issuer=privacyIDEA" in r, r)

--- a/tests/test_lib_apps.py
+++ b/tests/test_lib_apps.py
@@ -20,7 +20,7 @@ class AppsTestCase(MyTestCase):
         r = create_google_authenticator_url(tokentype="TOTP", key="123456",
                                             period=60)
         self.assertTrue("otpauth://TOTP/mylabel?secret=CI2FM&period"
-                        "=60&digits=6&issuer=privacyIDEA" in r, r)
+                        "=60&digits=6&creator=privacyidea&issuer=privacyIDEA" in r, r)
 
         r = create_oathtoken_url("12345678")
         self.assertEqual(r, "oathtoken:///addToken?name=mylabel&"

--- a/tests/test_lib_apps.py
+++ b/tests/test_lib_apps.py
@@ -17,9 +17,9 @@ class AppsTestCase(MyTestCase):
         self.assertTrue("otpauth://hotp/mylabel?secret=CI2FM6A&counter=1" in
                         r, r)
 
-        r = create_google_authenticator_url(tokentype="TOTP", key="123456",
+        r = create_google_authenticator_url(tokentype="totp", key="123456",
                                             period=60)
-        self.assertTrue("otpauth://TOTP/mylabel?secret=CI2FM&period"
+        self.assertTrue("otpauth://totp/mylabel?secret=CI2FM&period"
                         "=60&digits=6&creator=privacyidea&issuer=privacyIDEA" in r, r)
 
         r = create_oathtoken_url("12345678")


### PR DESCRIPTION
closes #3902 

Is 'creator' fine as the new tag?

![frame](https://github.com/privacyidea/privacyidea/assets/63372780/b111841a-c55c-47f9-956a-e4451d1763d2)

This is an example QR code. Please make sure that all apps work with it.