### PR TITLE
Fix reset of user filter

### DIFF
--- a/privacyidea/static/components/user/states/states.js
+++ b/privacyidea/static/components/user/states/states.js
@@ -35,7 +35,8 @@ angular.module('privacyideaApp.userStates', ['ui.router', 'privacyideaApp.versio
                 })
                 .state('user.list', {
                     url: "/list",
-                    templateUrl: userpath + "user.list.html" + versioningSuffixProviderProvider.$get().$get()
+                    templateUrl: userpath + "user.list.html" + versioningSuffixProviderProvider.$get().$get(),
+                    controller: "userController"
                 })
                 .state('user.details', {
                     url: "/details/{realmname:.*}/{username:.*}",


### PR DESCRIPTION
The $scope was not correctly transferred from the
html template (where the pi-filter is used) to the javascript controller. By explicitly addding the controller to the state definition the scope is correctly linked.

Fixes #3543