### PR TITLE
Allow a mailto to support email

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -64,7 +64,8 @@ from privacyidea.lib.realm import get_default_realm
 from privacyidea.lib.subscriptions import (subscription_status,
                                            get_subscription,
                                            check_subscription,
-                                           SubscriptionError)
+                                           SubscriptionError,
+                                           EXPIRE_MESSAGE)
 from privacyidea.lib.utils import create_img
 from privacyidea.lib.config import get_privacyidea_node
 from privacyidea.lib.tokenclass import ROLLOUTSTATE
@@ -678,10 +679,10 @@ def get_webui_settings(request, response):
             if len(subscriptions) == 1:
                 subscription = subscriptions[0]
                 try:
-                    check_subscription("privacyidea")
                     subject = subscription.get("for_name")
+                    check_subscription("privacyidea")
                 except SubscriptionError:
-                    subject = "My subscription has expired."
+                    subject = EXPIRE_MESSAGE
                 # Check policy, if the admin is allowed to save config
                 action_allowed = Match.generic(g, scope=role,
                                                action=ACTION.SYSTEMWRITE,

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -701,9 +701,9 @@ def get_webui_settings(request, response):
                                                adminuser=loginname,
                                                adminrealm=realm).allowed()
                 if action_allowed:
-                    body = BODY_TEMPLATE.format(subscriptions = subscriptions,
-                                                version = version,
-                                                subscriber_name = subscription.get("for_name"))
+                    body = BODY_TEMPLATE.format(subscriptions=subscriptions,
+                                                version=version,
+                                                subscriber_name=subscription.get("for_name"))
 
                     body = quote(body)
                     content["result"]["value"]["supportmail"] = \

--- a/privacyidea/lib/subscriptions.py
+++ b/privacyidea/lib/subscriptions.py
@@ -32,6 +32,7 @@ from ..models import Subscription
 from privacyidea.lib.error import SubscriptionError
 from privacyidea.lib.token import get_tokens
 from privacyidea.lib.crypto import Sign
+from privacyidea.lib import _
 import functools
 from privacyidea.lib.framework import get_app_config_value
 import os
@@ -39,7 +40,7 @@ import traceback
 from sqlalchemy import func
 
 
-EXPIRE_MESSAGE = "My subscription has expired."
+EXPIRE_MESSAGE = _("My subscription has expired.")
 SUBSCRIPTION_DATE_FORMAT = "%Y-%m-%d"
 SIGN_FORMAT = """{application}
 {for_name}

--- a/privacyidea/lib/subscriptions.py
+++ b/privacyidea/lib/subscriptions.py
@@ -39,6 +39,7 @@ import traceback
 from sqlalchemy import func
 
 
+EXPIRE_MESSAGE = "My subscription has expired."
 SUBSCRIPTION_DATE_FORMAT = "%Y-%m-%d"
 SIGN_FORMAT = """{application}
 {for_name}

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -417,7 +417,10 @@ angular.module("privacyideaApp")
             $scope.backend_debug_passwords = data.result.value.debug_passwords;
             $scope.privacyideaVersionNumber = data.versionnumber;
             var lang = gettextCatalog.getCurrentLanguage();
-            $scope.privacyideaSupportLink = "https://netknights.it/" + lang + "/support-link-" + data.result.value.role;
+            if (data.result.value.hasOwnProperty("supportmail"))
+                $scope.privacyideaSupportLink = data.result.value.supportmail;
+            else
+                $scope.privacyideaSupportLink = "https://netknights.it/" + lang + "/support-link-" + data.result.value.role;
             $scope.loggedInUser = AuthFactory.getUser();
             $scope.token_wizard = data.result.value.token_wizard;
             $scope.token_wizard_2nd = data.result.value.token_wizard_2nd;

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -417,10 +417,11 @@ angular.module("privacyideaApp")
             $scope.backend_debug_passwords = data.result.value.debug_passwords;
             $scope.privacyideaVersionNumber = data.versionnumber;
             var lang = gettextCatalog.getCurrentLanguage();
-            if (data.result.value.hasOwnProperty("supportmail"))
+            if (data.result.value.hasOwnProperty("supportmail")) {
                 $scope.privacyideaSupportLink = data.result.value.supportmail;
-            else
+            } else {
                 $scope.privacyideaSupportLink = "https://netknights.it/" + lang + "/support-link-" + data.result.value.role;
+            }
             $scope.loggedInUser = AuthFactory.getUser();
             $scope.token_wizard = data.result.value.token_wizard;
             $scope.token_wizard_2nd = data.result.value.token_wizard_2nd;

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -3804,8 +3804,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         except Exception:
             print("no need to unassign token")
 
-        # The request with an OTP value and a PIN of a user, who has not
-        # token assigned
+        # The request with an OTP value and a PIN of a user, who has no token assigned
         builder = EnvironBuilder(method='POST',
                                  data={},
                                  headers={})
@@ -3864,8 +3863,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         except Exception as e:
             print("no need to unassign token")
 
-        # The request with an OTP value and a PIN of a user, who has not
-        # token assigned
+        # The request with an OTP value and a PIN of a user, who has no token assigned
         builder = EnvironBuilder(method='POST',
                                  data={},
                                  headers={})
@@ -3929,8 +3927,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         self.assertEqual(mt.token.serial, serial)
         self.assertEqual(mt.token.machine_list[0].machine_id, "192.168.0.1")
 
-        # The request with an OTP value and a PIN of a user, who has not
-        # token assigned
+        # The request with an OTP value and a PIN of a user, who has no token assigned
         builder = EnvironBuilder(method='POST',
                                  data={},
                                  headers={})
@@ -3978,8 +3975,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         serial = "offline01"
         # Do prepend_pin == False
         set_privacyidea_config(SYSCONF.PREPENDPIN, False)
-        # The request with an OTP value and a PIN of a user, who has not
-        # token assigned
+        # The request with an OTP value and a PIN of a user, who has no token assigned
         builder = EnvironBuilder(method='POST',
                                  data={},
                                  headers={})
@@ -4071,8 +4067,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
 
     def test_08_get_webui_settings(self):
         self.setUp_user_realms()
-        # The request with an OTP value and a PIN of a user, who has not
-        # token assigned
+        # The request with an OTP value and a PIN of a user, who has no token assigned
         builder = EnvironBuilder(method='POST',
                                  data={},
                                  headers={})
@@ -4224,8 +4219,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # Test that policies like tokenpagesize are also user dependent
         self.setUp_user_realms()
 
-        # The request with an OTP value and a PIN of a user, who has not
-        # token assigned
+        # The request with an OTP value and a PIN of a user, who has no token assigned
         builder = EnvironBuilder(method='POST',
                                  data={},
                                  headers={})
@@ -4279,8 +4273,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # Test admin_dashboard
         self.setUp_user_realms()
 
-        # The request with an OTP value and a PIN of a user, who has not
-        # token assigned
+        # The request with an OTP value and a PIN of a user, who has no token assigned
         builder = EnvironBuilder(method='POST',
                                  data={},
                                  headers={})
@@ -4318,8 +4311,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # Test the link to the support
         self.setUp_user_realms()
 
-        # The request with an OTP value and a PIN of a user, who has not
-        # token assigned
+        # The request with an OTP value and a PIN of a user, who has no token assigned
         builder = EnvironBuilder(method='POST',
                                  data={},
                                  headers={})

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -22,6 +22,7 @@ from privacyidea.lib.utils import hexlify_and_unicode
 from privacyidea.lib.config import set_privacyidea_config, SYSCONF
 from .base import (MyApiTestCase)
 
+from privacyidea.lib.subscriptions import EXPIRE_MESSAGE
 from privacyidea.lib.policy import (set_policy, delete_policy, enable_policy,
                                     PolicyClass, SCOPE, ACTION, REMOTE_USER,
                                     AUTOASSIGNVALUE, AUTHORIZED)
@@ -4312,6 +4313,52 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         self.assertTrue(jresult.get("result").get("value").get(ACTION.ADMIN_DASHBOARD))
 
         delete_policy("pol_dashboard")
+
+    def test_11_get_webui_settings_support_link(self):
+        # Test the link to the support
+        self.setUp_user_realms()
+
+        # The request with an OTP value and a PIN of a user, who has not
+        # token assigned
+        builder = EnvironBuilder(method='POST',
+                                 data={},
+                                 headers={})
+        env = builder.get_environ()
+        env["REMOTE_ADDR"] = "192.168.0.1"
+        g.client_ip = env["REMOTE_ADDR"]
+        req = Request(env)
+        req.all_data = {}
+
+        res = {"jsonrpc": "2.0",
+               "result": {"status": True,
+                          "value": {"role": "admin",
+                                    "username": "cornelius"}},
+               "version": "privacyIDEA test",
+               "id": 1}
+        resp = jsonify(res)
+
+        new_response = get_webui_settings(req, resp)
+        jresult = new_response.json
+        self.assertNotIn("supportmail", jresult.get("result").get("value"))
+
+        # Add a subscription
+        from privacyidea.models import Subscription
+        s = Subscription(application="privacyidea",
+                         for_name="testuser",
+                         for_email="admin@example.com",
+                         for_phone="0",
+                         by_name="privacyIDEA project",
+                         by_email="privacyidea@example.com",
+                         date_from=datetime.utcnow(),
+                         date_till=datetime.utcnow() + timedelta(days=365),
+                         num_users=100,
+                         num_tokens=100,
+                         num_clients=100
+                         ).save()
+        new_response = get_webui_settings(req, resp)
+        jresult = new_response.json
+        self.assertIn("privacyidea@example.com", jresult.get("result").get("value").get("supportmail"))
+        self.assertIn(EXPIRE_MESSAGE, jresult.get("result").get("value").get("supportmail"))
 
     def test_16_init_token_defaults(self):
         g.logged_in_user = {"username": "cornelius",


### PR DESCRIPTION
If the setup has a subscription, the green Support button will create a mailto to the support email address from the subscription.

In case:
- The logged in user is an admin
- and has the right to configwrite.

Working on #3919