### PR TITLE
Fix wrong otplen of indexed secret

### DIFF
--- a/privacyidea/lib/tokens/indexedsecrettoken.py
+++ b/privacyidea/lib/tokens/indexedsecrettoken.py
@@ -175,9 +175,6 @@ class IndexedSecretTokenClass(TokenClass):
 
         TokenClass.update(self, param, reset_failcount)
 
-        # finally we set the otplen of the token, no matter if the otpkey was generated or not
-        key = self.token.get_otpkey().getKey()
-        self.set_otplen(len(key))
         return
 
     @log_with(log)
@@ -295,7 +292,7 @@ class IndexedSecretTokenClass(TokenClass):
                             # increase the received_count
                             challengeobject.set_otp_status()
                     else:
-                        log.debug("Length of password does not match the requested number of positions.")
+                        log.info("Length of password does not match the requested number of positions.")
                         # increase the received_count
                         challengeobject.set_otp_status()
 

--- a/privacyidea/lib/tokens/indexedsecrettoken.py
+++ b/privacyidea/lib/tokens/indexedsecrettoken.py
@@ -170,10 +170,14 @@ class IndexedSecretTokenClass(TokenClass):
         :return: nothing
 
         """
-        if 'genkey' not in param and 'otpkey' not in param:
+        if 'verify' not in param and 'genkey' not in param and 'otpkey' not in param:
             param['genkey'] = 1
 
         TokenClass.update(self, param, reset_failcount)
+
+        # finally we set the otplen of the token, no matter if the otpkey was generated or not
+        key = self.token.get_otpkey().getKey()
+        self.set_otplen(len(key))
         return
 
     @log_with(log)

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -2753,8 +2753,8 @@ class APITokenTestCase(MyApiTestCase):
             tokenobj_list = get_tokens(serial=serial)
             # Check the token rollout state
             self.assertEqual(ROLLOUTSTATE.VERIFYPENDING, tokenobj_list[0].token.rollout_state)
-            # Check the otplen of the token
-            self.assertEqual(len(SECRET), tokenobj_list[0].token.otplen)
+            # Check the default otplen
+            self.assertEqual(6, tokenobj_list[0].token.otplen)
             s_pos = message.strip("Please enter the positions ").strip(" from your secret.")
             positions = [int(x) for x in s_pos.split(",")]
 
@@ -2777,8 +2777,8 @@ class APITokenTestCase(MyApiTestCase):
             tokenobj_list = get_tokens(serial=serial)
             # Check the token rollout state, it is empty now.
             self.assertEqual(ROLLOUTSTATE.ENROLLED, tokenobj_list[0].token.rollout_state)
-            # Check the otplen of the token
-            self.assertEqual(len(SECRET), tokenobj_list[0].token.otplen)
+            # Check the default otplen of the token
+            self.assertEqual(6, tokenobj_list[0].token.otplen)
 
         delete_policy("verify_toks1")
 

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -2746,13 +2746,15 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             self.assertEqual(SECRET, secret)
-            self.assertEqual(detail.get("rollout_state"), ROLLOUTSTATE.VERIFYPENDING)
+            self.assertEqual(ROLLOUTSTATE.VERIFYPENDING, detail.get("rollout_state"))
             message = detail.get("verify").get("message")
             self.assertTrue(message.startswith("Please enter the positions"))
             serial = detail.get("serial")
             tokenobj_list = get_tokens(serial=serial)
             # Check the token rollout state
-            self.assertEqual(tokenobj_list[0].token.rollout_state, ROLLOUTSTATE.VERIFYPENDING)
+            self.assertEqual(ROLLOUTSTATE.VERIFYPENDING, tokenobj_list[0].token.rollout_state)
+            # Check the otplen of the token
+            self.assertEqual(len(SECRET), tokenobj_list[0].token.otplen)
             s_pos = message.strip("Please enter the positions ").strip(" from your secret.")
             positions = [int(x) for x in s_pos.split(",")]
 
@@ -2775,6 +2777,8 @@ class APITokenTestCase(MyApiTestCase):
             tokenobj_list = get_tokens(serial=serial)
             # Check the token rollout state, it is empty now.
             self.assertEqual(ROLLOUTSTATE.ENROLLED, tokenobj_list[0].token.rollout_state)
+            # Check the otplen of the token
+            self.assertEqual(len(SECRET), tokenobj_list[0].token.otplen)
 
         delete_policy("verify_toks1")
 


### PR DESCRIPTION
During verify enroll of the indexed secret token the otpkey gets regenerated in the second step.

Closes #3869