### PR TITLE
Move challenge cleanup to pi-manage

### DIFF
--- a/doc/configuration/system_config.rst
+++ b/doc/configuration/system_config.rst
@@ -262,3 +262,5 @@ The challenge validity time
 This setting defines the timeout for a challenge response
 authentication. If the response is received after the given time interval, the
 response is not accepted anymore.
+
+To clean up expired challenges read the :ref:`pimanage_challenge` section.

--- a/doc/installation/system/pi-manage.rst
+++ b/doc/installation/system/pi-manage.rst
@@ -81,6 +81,22 @@ log rotation::
 You can specify a highwatermark and a lowwatermark, age or a config file. Read more
 about it at :ref:`audit_rotate`.
 
+.. _pimanage_challenge:
+
+Clean up challenges
+-------------------
+
+The challenges of challenge response tokens are stored in a database table.
+Each challenge has a validity time. You can clean up old challenges with::
+
+   pi-manage challenge cleanup
+
+This will clean up all expired challenges. If you want to clean up challenges older than a certain age, you can use::
+
+   pi-manage challenge cleanup --age 10
+
+to clean up challenge that are older than 10 minutes.
+
 API Keys
 --------
 

--- a/doc/tokens/authentication_modes.rst
+++ b/doc/tokens/authentication_modes.rst
@@ -150,6 +150,8 @@ The *Service* is an application that is protected with a second factor by privac
 
  and privacyIDEA returns whether the authentication request succeeded or not.
 
+To clean up expired challenges read the :ref:`pimanage_challenge` section.
+
 .. _authentication_mode_outofband:
 
 ``outofband`` mode

--- a/migrations/versions/2100d1fad908_.py
+++ b/migrations/versions/2100d1fad908_.py
@@ -1,0 +1,30 @@
+"""v3.10: Add index to expiration in challenge table
+
+Revision ID: 2100d1fad908
+Revises: 250931d82e51
+Create Date: 2024-05-06 13:36:45.910206
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2100d1fad908'
+down_revision = '250931d82e51'
+
+from alembic import op
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+def upgrade():
+    try:
+        op.create_index(op.f('ix_challenge_expiration'), 'challenge', ['expiration'], unique=False)
+    except (OperationalError, ProgrammingError) as exx:
+        if "Index already exists" in str(exx.orig).lower():
+            print("Ok, Index 'expiration' in table 'challenge' already exists.")
+        else:
+            print(exx)
+    except Exception as exx:
+        print("Could not create index 'expiration' on table 'challenge'")
+        print(exx)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_challenge_expiration'), table_name='challenge')

--- a/migrations/versions/2100d1fad908_.py
+++ b/migrations/versions/2100d1fad908_.py
@@ -13,6 +13,7 @@ down_revision = '250931d82e51'
 from alembic import op
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
+
 def upgrade():
     try:
         op.create_index(op.f('ix_challenge_expiration'), 'challenge', ['expiration'], unique=False)

--- a/privacyidea/cli/pimanage/challenge.py
+++ b/privacyidea/cli/pimanage/challenge.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (C) 2024 Cornelius Kölbel <cornelius.koelbel@netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Info: https://privacyidea.org
+#
+# This code is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import re
+import sys
+import click
+import yaml
+from flask import current_app
+from flask.cli import AppGroup
+from sqlalchemy import create_engine, MetaData
+from sqlalchemy.orm import sessionmaker
+
+from privacyidea.lib.audit import getAudit
+from privacyidea.models import Challenge
+from privacyidea.lib.sqlutils import delete_matching_rows
+from privacyidea.lib.utils import parse_timedelta
+
+challenge_cli = AppGroup("challenge", help="Manage challenge data")
+
+
+@challenge_cli.command("cleanup",
+                       help="Clean up all expired challenges.")
+@click.option('--chunksize', type=int,
+              help="Delete entries in chunks of the given size to avoid deadlocks")
+@click.option('--age', type=int,
+              help="Instead of deleting expired challenges "
+                   "delete challenge entries older than these number of minutes.")
+@click.option('--dryrun', is_flag=True,
+              help="Do not actually delete, only show what would be done.")
+def cleanup_challenge(chunksize, age, dryrun=False):
+    """
+    Delete all expired challenges from the challenge table
+    """
+    metadata = MetaData()
+    if chunksize is not None:
+        chunksize = int(chunksize)
+
+    token_db_uri = current_app.config.get("SQLALCHEMY_DATABASE_URI")
+    engine = create_engine(token_db_uri)
+    # create a configured "Session" class
+    session = sessionmaker(bind=engine)()
+    # create a Session
+    metadata.create_all(engine)
+
+    if age:
+        # Delete challenges created earlier than age minutes ago
+        now = datetime.datetime.now() - datetime.timedelta(minutes=age)
+        click.echo("Deleting challenges older than {0!s}".format(now))
+        criterion = Challenge.timestamp < now
+    else:
+        # Delete expired challenges
+        click.echo("Deleting expired challenges.")
+        now = datetime.datetime.now()
+        criterion = Challenge.expiration < now
+
+    if dryrun:
+        r = Challenge.query.filter(criterion).count()
+        click.echo("Would delete {0!s} challenge entries.".format(r))
+    else:
+        r = delete_matching_rows(session, Challenge.__table__, criterion, chunksize)
+        click.echo("{0!s} entries deleted.".format(r))

--- a/privacyidea/cli/pimanage/main.py
+++ b/privacyidea/cli/pimanage/main.py
@@ -56,6 +56,7 @@ from privacyidea.cli import create_silent_app
 from privacyidea.lib.utils import get_version_number
 from .admin import admin_cli
 from .audit import audit_cli, rotate_audit as audit_rotate_audit
+from .challenge import challenge_cli
 from .backup import backup_cli
 from .pi_setup import (setup_cli, encrypt_enckey, create_enckey, create_tables,
                        create_pgp_keys, create_audit_keys, drop_tables)
@@ -106,6 +107,7 @@ cli.add_command(admin_cli)
 cli.add_command(audit_cli)
 cli.add_command(setup_cli)
 cli.add_command(config_cli)
+cli.add_command(challenge_cli)
 cli.add_command(backup_cli)
 cli.add_command(api_cli)
 cli.add_command(ca_cli)

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1660,14 +1660,13 @@ class TokenClass(object):
         """
         return False
 
-    @staticmethod
-    def challenge_janitor():
+    def challenge_janitor(self):
         """
         Just clean up all challenges, for which the expiration has expired.
 
         :return: None
         """
-        cleanup_challenges()
+        cleanup_challenges(self.token.serial)
 
     def create_challenge(self, transactionid=None, options=None):
         """

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -364,8 +364,9 @@ class TiqrTokenClass(OcraTokenClass):
                             maxfail = token.get_max_failcount()
                             res = "INVALID_RESPONSE:{0!s}".format(maxfail - fail)
                             break
-
-            cleanup_challenges()
+                if not challenge.is_valid():
+                    # The challenge is not valid anymore. We delete the challenge.
+                    challenge.delete()
 
             return "plain", res
 

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -1399,7 +1399,7 @@ class Challenge(MethodsMixin, db.Model):
     # The token serial number
     serial = db.Column(db.Unicode(40), default='', index=True)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow(), index=True)
-    expiration = db.Column(db.DateTime)
+    expiration = db.Column(db.DateTime, index=True)
     received_count = db.Column(db.Integer(), default=0)
     otp_valid = db.Column(db.Boolean, default=False)
 
@@ -1512,14 +1512,14 @@ class Challenge(MethodsMixin, db.Model):
         return "{0!s}".format(descr)
 
 
-def cleanup_challenges():
+def cleanup_challenges(serial):
     """
     Delete all challenges, that have expired.
 
     :return: None
     """
     c_now = datetime.utcnow()
-    Challenge.query.filter(Challenge.expiration < c_now).delete()
+    Challenge.query.filter(Challenge.expiration < c_now, Challenge.serial == serial).delete()
     db.session.commit()
 
 


### PR DESCRIPTION
In the code only challenges from a destinct token
are cleaned up. This avoids locking the complete table.

pi-manage now has a command "challenge" to clean up expired challenges or challenges by age.

Closes #3920