### PR TITLE
Handle undefined action values in JS

### DIFF
--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -281,7 +281,7 @@ myApp.controller("policyDetailsController", ["$scope", "$stateParams",
                             if (value.multiple === true) {
                                 let vals = $scope.actions.find(x => x.name === key).allowedValues;
                                 policyActions[key].split(' ').forEach(function(n) {
-                                    vals.find(x => x.name === n).ticked = true;
+                                    (vals.find(x => x.name === n) || {}).ticked = true;
                                 })
                             }
                         }
@@ -1248,8 +1248,8 @@ myApp.controller("HTTPResolverController", ["$scope", "ConfigFactory", "$state",
   };
 
   $scope.$watch(
-    'params.hasSpecialErrorHandler;', 
-    function (incomingValue) { 
+    'params.hasSpecialErrorHandler;',
+    function (incomingValue) {
         const value = (incomingValue + '').toLowerCase()
         $scope.params.hasSpecialErrorHandler = value === 'true'
     });


### PR DESCRIPTION
In case of an unknown action value which isn't in the `allowedValues` list, the processing of the action failed and the policy action list isn't rendered properly.
Ignoring an unknown action value fixes this.
This was the case i.e. when `email` was added to the `challenge_response` action value in a version < v3.9 but the email-token is a challenge-response token by default and thus was removed from the list of token types where challenge-response was an alternative.