### PR TITLE
Get containers with pagesize

### DIFF
--- a/privacyidea/lib/container.py
+++ b/privacyidea/lib/container.py
@@ -98,7 +98,8 @@ def find_container_by_serial(serial: str):
     return TokenContainerClass(db_container)
 
 
-def _create_container_query(user: User = None, serial=None, type=None, token_serial=None, sortby='serial', sortdir='asc'):
+def _create_container_query(user: User = None, serial=None, type=None, token_serial=None, sortby='serial',
+                            sortdir='asc'):
     """
     Returns a sql query for getting containers
     """

--- a/privacyidea/lib/container.py
+++ b/privacyidea/lib/container.py
@@ -98,18 +98,28 @@ def find_container_by_serial(serial: str):
     return TokenContainerClass(db_container)
 
 
-def get_all_containers(user: User = None, serial=None, sortby='serial', sortdir='asc'):
+def _create_container_query(user: User = None, serial=None, type=None, token_serial=None, sortby='serial', sortdir='asc'):
     """
-    Returns a list of all TokenContainerClass objects for the given user or all containers if no user is given
+    Returns a sql query for getting containers
     """
-    # TODO add user role policy
-
     sql_query = TokenContainer.query
     if user:
         # Get all containers for the given user
         sql_query = sql_query.join(TokenContainer.owners).filter(TokenContainerOwner.user_id == user.uid)
     if serial:
         sql_query = sql_query.filter(TokenContainer.serial == serial)
+
+    if type:
+        sql_query = sql_query.filter(TokenContainer.type == type)
+    if token_serial:
+        token = Token.query.filter(Token.serial == token_serial).first()
+        if token:
+            token_container_token = TokenContainerToken.query.filter(TokenContainerToken.token_id == token.id).all()
+            container_ids = [t.container_id for t in token_container_token]
+            sql_query = sql_query.filter(TokenContainer.id.in_(container_ids))
+        else:
+            log.warning(
+                'Unknown token serial "{0!s}". Containers are not filtered by "token_serial"'.format(token_serial))
 
     if isinstance(sortby, str):
         # check that the sort column exists and convert it to a Token column
@@ -126,14 +136,81 @@ def get_all_containers(user: User = None, serial=None, sortby='serial', sortdir=
     else:
         sql_query = sql_query.order_by(sortby.asc())
 
+    return sql_query
+
+
+def get_all_containers(user: User = None, serial=None, type=None, token_serial=None, sortby='serial', sortdir='asc'):
+    """
+    Returns a list of all TokenContainerClass objects for the given user or all containers if no user is given
+    """
+    # TODO add user role policy
+
+    sql_query = _create_container_query(user=user, serial=serial, type=type, token_serial=token_serial, sortby=sortby,
+                                        sortdir=sortdir)
+
     db_containers = sql_query.all()
-    containers: List[TokenContainerClass] = []
+
+    container_list = [create_container_class_object(db_container) for db_container in db_containers]
+
+    return container_list
+
+
+def get_all_containers_paginate(user: User = None, serial=None, type=None, token_serial=None, sortby='serial',
+                                sortdir='asc', page=1, pagesize=15):
+    """
+    This function is used to retrieve a container list, that can be displayed in
+    the Web UI. It supports pagination.
+    Each retrieved page will also contain a "next" and a "prev", indicating
+    the next or previous page. If either does not exist, it is None.
+
+    :param user: The user for which to retrieve the containers
+    :param serial: Filter by container serial
+    :param type: Filter by container type
+    :param token_serial: Filter by token serial
+    :param sortby: A Token column or a string. Default is "serial"
+    :param sortdir: "asc" or "desc". Default is "asc"
+    :param page: The number of the page to view. Starts with 1 ;-)
+    :type page: int
+    :param psize: The size of the page
+    :type psize: int
+    """
+    # TODO add user role policy
+
+    sql_query = _create_container_query(user=user, serial=serial, type=type, token_serial=token_serial, sortby=sortby,
+                                        sortdir=sortdir)
+
+    # paginate containers
+    pagination = sql_query.paginate(page, per_page=pagesize, error_out=False)
+    db_containers = pagination.items
+
+    prev = None
+    if pagination.has_prev:
+        prev = page - 1
+    next = None
+    if pagination.has_next:
+        next = page + 1
+
+    container_list = [create_container_class_object(db_container) for db_container in db_containers]
+
+    ret = {
+        "containers": container_list,
+        "prev": prev,
+        "next": next,
+        "current": page,
+        "count": pagination.total}
+    return ret
+
+
+def create_container_class_object(db_container):
+    """
+    Create a TokenContainerClass object from the given db object
+    """
+    container = None
     container_classes = get_container_classes()
-    for db_container in db_containers:
-        for ctype, cls in container_classes.items():
-            if ctype.lower() == db_container.type.lower():
-                containers.append(cls(db_container))
-    return containers
+    for ctype, cls in container_classes.items():
+        if ctype.lower() == db_container.type.lower():
+            container = cls(db_container)
+    return container
 
 
 def find_container_for_token(serial):

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -371,10 +371,52 @@ def get_tokens_paginated_generator(tokentype=None, realm=None, assigned=None, us
             break
 
 
+def convert_token_objects_to_dicts(tokens, hidden_tokeninfo=None):
+    """
+    Convert a list of token objects to a list of dictionaries.
+
+    :param tokens: A list of token objects
+    :type tokens: list
+    :return: A list of dictionaries
+    :rtype: list
+    """
+    token_dict_list = []
+    for tokenobject in tokens:
+        if isinstance(tokenobject, TokenClass):
+            token_dict = tokenobject.get_as_dict()
+            # add user information
+            # In certain cases the LDAP or SQL server might not be reachable.
+            # Then an exception is raised
+            token_dict["username"] = ""
+            token_dict["user_realm"] = ""
+            try:
+                userobject = tokenobject.user
+                if userobject:
+                    token_dict["username"] = userobject.login
+                    token_dict["user_realm"] = userobject.realm
+                    token_dict["user_editable"] = get_resolver_object(
+                        userobject.resolver).editable
+            except Exception as exx:
+                log.error("User information can not be retrieved: {0!s}".format(exx))
+                log.debug(traceback.format_exc())
+                token_dict["username"] = "**resolver error**"
+
+            # check if token is in a container
+            token_dict["container_serial"] = ""
+            from privacyidea.lib.container import find_container_for_token
+            container = find_container_for_token(tokenobject.get_serial())
+            if container:
+                token_dict["container_serial"] = container.serial
+
+            token_dict_list.append(token_dict)
+
+    return token_dict_list
+
+
 @log_with(log)
 # @cache.memoize(10)
 def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
-               serial=None, serial_wildcard=None, active=None, resolver=None, rollout_state=None,
+               serial=None, serial_wildcard=None, serial_list=None, active=None, resolver=None, rollout_state=None,
                count=False, revoked=None, locked=None, tokeninfo=None,
                maxfail=None):
     """
@@ -428,7 +470,7 @@ def get_tokens(tokentype=None, realm=None, assigned=None, user=None,
     token_list = []
     sql_query = _create_token_query(tokentype=tokentype, realm=realm,
                                     assigned=assigned, user=user,
-                                    serial_exact=serial, serial_wildcard=serial_wildcard,
+                                    serial_exact=serial, serial_wildcard=serial_wildcard, serial_list=serial_list,
                                     active=active, resolver=resolver,
                                     rollout_state=rollout_state,
                                     revoked=revoked, locked=locked,

--- a/privacyidea/static/components/token/controllers/containerControllers.js
+++ b/privacyidea/static/components/token/controllers/containerControllers.js
@@ -79,25 +79,34 @@ myApp.controller("containerCreateController", ['$scope', '$http', '$q', 'Contain
         }
     }]);
 
-myApp.controller("containerListController", ['$scope', '$http', '$q', 'ContainerFactory', 'AuthFactory', 'ConfigFactory', 'TokenFactory', '$rootScope',
-    function containerListController($scope, $http, $q, ContainerFactory, AuthFactory, ConfigFactory, TokenFactory, $rootScope) {
+myApp.controller("containerListController", ['$scope', '$http', '$q', 'ContainerFactory', 'AuthFactory',
+    'ConfigFactory', 'TokenFactory',
+    function containerListController($scope, $http, $q, ContainerFactory, AuthFactory, ConfigFactory, TokenFactory) {
+        $scope.containersPerPage = $scope.token_page_size;
         $scope.loggedInUser = AuthFactory.getUser();
         $scope.params = {sortdir: "asc"};
-        $scope.containers = []
+        $scope.containerdata = []
+
+        // Change the pagination
+        $scope.pageChanged = function () {
+            //debug: console.log('Page changed to: ' + $scope.params.page);
+            $scope.get();
+        };
 
         // Get all containers
         $scope.get = function () {
-
+            $scope.expandedRows = []
             $scope.params.sortby = $scope.sortby;
             if ($scope.reverse) {
                 $scope.params.sortdir = "desc";
             } else {
                 $scope.params.sortdir = "asc";
             }
+            $scope.params.pagesize = $scope.token_page_size;
 
             ContainerFactory.getContainers($scope.params,
                 function (data) {
-                    $scope.containers = data.result.value
+                    $scope.containerdata = data.result.value
                 })
 
         }
@@ -118,8 +127,8 @@ myApp.controller("containerListController", ['$scope', '$http', '$q', 'Container
         $scope.expandedRows = []
         $scope.expandTokenView = function (containerRow) {
             if (containerRow < 0) {
-                for (let i = 0; i < $scope.containers.length; i++) {
-                    if ($scope.containers[i].tokens_paginated.count > 0) {
+                for (let i = 0; i < $scope.containerdata.containers.length; i++) {
+                    if ($scope.containerdata.containers[i].tokens.length > 0) {
                         $scope.expandedRows.push(i)
                     }
                 }
@@ -150,16 +159,9 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
         $scope.container = {}
         $scope.containerOwner = {}
         ContainerFactory.getContainerForSerial($scope.containerSerial, function (data) {
-            $scope.container = data.result.value[0]
+            $scope.container = data.result.value.containers[0]
             $scope.containerOwner = $scope.container.users[0]
         })
-
-        $scope.params.container_serial = $scope.containerSerial
-        $scope.tokendata = {}
-        TokenFactory.getTokens(
-            function (data) {
-                $scope.tokendata = data.result.value
-            }, $scope.params)
 
         $scope.enrollToken = function () {
             // go to token.enroll with the users data of the container owner

--- a/privacyidea/static/components/token/views/token.containerdetails.html
+++ b/privacyidea/static/components/token/views/token.containerdetails.html
@@ -69,13 +69,9 @@
     </button>
 </div>
 
+<!-- =================== Tokens ================= -->
+
 <h3 translate>Tokens in container</h3>
-<!-- Tokens in container -->
-<div uib-pagination ng-show="tokendata.count > 5"
-     total-items="tokendata.count" ng-model="params.page"
-     items-per-page="{{ tokensPerPage }}"
-     max-size="5"
-     boundary-links="true" ng-change="pageChanged()"></div>
 
 <div class="table-responsive form-group">
     <table class="table table-bordered table-striped">
@@ -93,7 +89,7 @@
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="token in tokendata.tokens">
+        <tr ng-repeat="token in container.tokens">
             <td><a ui-sref="token.details({tokenSerial:token.serial,
             currentToken:token})"
                    ng-click="$rootScope.returnTo=user.list;">

--- a/privacyidea/static/components/token/views/token.containerlist.html
+++ b/privacyidea/static/components/token/views/token.containerlist.html
@@ -9,7 +9,7 @@
      boundary-links="true" ng-change="pageChanged()">
 </div>
 
-<span translate>total containers: {{ containerdata.count }}</span>
+<span translate>Total Containers: {{ containerdata.count }}</span>
 
 <div class="row">
     <label>
@@ -36,7 +36,7 @@
             <th class="pifilter">
                 <button class="btn btn-default unsorted"
                         pi-sort-by="serial"
-                        translate>serial
+                        translate>Serial
                 </button>
             </th>
             <th>
@@ -82,8 +82,8 @@
         <!-- Tokens of each container -->
         <tr ng-if="expandedRows.includes($index)" ng-repeat-end="">
             <td colspan="5">
-                <span translate><b>contained tokens: </b></span>
-                <table class="table table-bordered table-striped" id="tableContainerTokenList"
+                <span style="margin-left:20px" translate><b>Contained Tokens: </b></span>
+                <table class="table table-bordered table-striped" style="margin-left:20px"  id="tableContainerTokenList"
                        ng-if="container.tokens.length > 0">
                     <tbody>
                     <tr ng-repeat="token in container.tokens">

--- a/privacyidea/static/components/token/views/token.containerlist.html
+++ b/privacyidea/static/components/token/views/token.containerlist.html
@@ -82,97 +82,20 @@
         <!-- Tokens of each container -->
         <tr ng-if="expandedRows.includes($index)" ng-repeat-end="">
             <td colspan="5">
-                <span translate><b>contained tokens: {{ container.tokens.length }}</b></span>
+                <span translate><b>contained tokens: </b></span>
                 <table class="table table-bordered table-striped" id="tableContainerTokenList"
                        ng-if="container.tokens.length > 0">
-                    <thead>
-                    <tr>
-                        <th translate>serial
-                        </th>
-                        <th translate>type
-                        </th>
-                        <th translate>active
-                        </th>
-                        <th translate>description
-                        </th>
-                        <th translate>failcounter
-                        </th>
-                        <th translate>rollout state
-                        </th>
-                        <th ng-show="loggedInUser.role == 'admin'" translate>user</th>
-                        <th ng-show="loggedInUser.role == 'admin'" translate>realm</th>
-                        <th ng-show="loggedInUser.role == 'admin'">
-                            <translate>Token realms</translate>
-                        </th>
-                        <th ng-show="loggedInUser.role == 'admin' && user_details_in_tokenlist"
-                            translate>UserId
-                        </th>
-                        <th ng-show="loggedInUser.role == 'admin' && user_details_in_tokenlist"
-                            translate>Resolver
-                        </th>
-                    </tr>
-                    </thead>
                     <tbody>
                     <tr ng-repeat="token in container.tokens">
                         <td><a ui-sref="token.details({tokenSerial:token.serial,
             currentToken:token})"
                                ng-click="$rootScope.returnTo=token.list;">
-                            {{ token.serial }}</a></td>
-                        <td>{{ token.tokentype }}</td>
-                        <td>
-                <span class="label label-success" ng-show="token.active"
-                      ng-click="disable(token.serial)"
-                      title="{{ 'Disable token'|translate }}"
-                      translate>active
-                </span>
-                            <span class="label label-danger" ng-hide="token.active"
-                                  ng-click="enable(token.serial)"
-                                  title="{{ 'Enable token'|translate }}"
-                                  translate>disabled
-                </span>
-                        </td>
-                        <!--<td>{{ token.count_window }}</td>-->
-                        <td>{{ token.description }}</td>
-
-                        <td><span class="label"
-                                  title="{{ 'Reset Failcounter'|translate }}"
-                                  ng-click="reset(token.serial)"
-                                  ng-class="{'label-success': token.failcount<=0,
-                                   'label-warning': token.failcount>0,
-                                   'label-danger': token.failcount>=token.maxfail}">
-                            {{ token.failcount }}
-                            </span>
-                        </td>
-                        <!--<td>{{ token.maxfail }}</td>-->
-                        <!--<td>{{ token.otplen }}</td>-->
-                        <td>{{ token.rollout_state }}</td>
-                        <td ng-show="loggedInUser.role == 'admin'">
-                            <a ui-sref="user.details({username: token.username,
-                            realmname: token.user_realm,
-                            resolvername: token.resolver,
-                            editable: token.user_editable})">
-                                {{ token.username }}</a>
-                        </td>
-                        <td ng-show="loggedInUser.role == 'admin'">
-                            <a ui-sref="config.realms.list">{{ token.user_realm }}</a>
-                        </td>
-
-                        <td ng-show="loggedInUser.role == 'admin'">
-                            <a ui-sref="config.realms.list" ng-repeat="t_realm in token.realms">
-                                {{ t_realm }}</a>&nbsp;
-                        </td>
-
-                        <td ng-show="loggedInUser.role == 'admin' && user_details_in_tokenlist">
-                            {{ token.user_id }}
-                        </td>
-                        <td ng-show="loggedInUser.role == 'admin' && user_details_in_tokenlist">
-                            <a ui-sref="config.resolvers.list">{{ token.resolver }}</a>
+                            {{ "[" + token.tokentype + "] " + token.serial + ": " + token.description}}</a>
                         </td>
                     </tr>
                     </tbody>
                 </table>
             </td>
         </tr>
-
     </table>
 </div>

--- a/privacyidea/static/components/token/views/token.containerlist.html
+++ b/privacyidea/static/components/token/views/token.containerlist.html
@@ -1,7 +1,20 @@
+<div uib-pagination ng-show="containerdata.count > containersPerPage"
+     total-items="containerdata.count" ng-model="params.page"
+     previous-text="{{ 'Previous'|translate }}"
+     next-text="{{ 'Next'|translate }}"
+     last-text="{{ 'Last'|translate }}"
+     first-text="{{ 'First'|translate }}"
+     items-per-page="{{ containersPerPage }}"
+     max-size="5"
+     boundary-links="true" ng-change="pageChanged()">
+</div>
+
+<span translate>total containers: {{ containerdata.count }}</span>
+
 <div class="row">
     <label>
         <button class="btn btn-default"
-                ng-disabled="expandedRows.length == containers.length"
+                ng-disabled="expandedRows.length == containerdata.containers.length"
                 ng-click="expandTokenView(-1)">
             Expand all containers
         </button>
@@ -39,7 +52,7 @@
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat-start="container in containers track by $index">
+        <tr ng-repeat-start="container in containerdata.containers track by $index">
             <td>
                 <button class="btn btn-default"
                         ng-if="expandedRows.includes($index)"
@@ -47,7 +60,7 @@
                 </button>
                 <button class="btn btn-default"
                         ng-if="!expandedRows.includes($index)"
-                        ng-disabled="container.tokens_paginated.count == 0"
+                        ng-disabled="container.tokens.length == 0"
                         ng-click="expandTokenView($index)">+
                 </button>
                 <a ui-sref="token.containerdetails({containerSerial: container.serial})">{{ container.serial }}</a>
@@ -69,9 +82,9 @@
         <!-- Tokens of each container -->
         <tr ng-if="expandedRows.includes($index)" ng-repeat-end="">
             <td colspan="5">
-                <b>Contained Tokens:</b>
+                <span translate><b>contained tokens: {{ container.tokens.length }}</b></span>
                 <table class="table table-bordered table-striped" id="tableContainerTokenList"
-                       ng-if="container.tokens_paginated.count > 0">
+                       ng-if="container.tokens.length > 0">
                     <thead>
                     <tr>
                         <th translate>serial
@@ -100,7 +113,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    <tr ng-repeat="token in container.tokens_paginated.tokens">
+                    <tr ng-repeat="token in container.tokens">
                         <td><a ui-sref="token.details({tokenSerial:token.serial,
             currentToken:token})"
                                ng-click="$rootScope.returnTo=token.list;">

--- a/privacyidea/static/components/user/controllers/userControllers.js
+++ b/privacyidea/static/components/user/controllers/userControllers.js
@@ -121,8 +121,10 @@ angular.module("privacyideaApp")
                   instanceUrl, $location,
                   inform, gettextCatalog) {
             $scope.tokensPerPage = 5;
+            $scope.containersPerPage = 5;
             $scope.newToken = {"serial": "", pin: ""};
             $scope.params = {page: 1};
+            $scope.containerParams = {page: 1};
             $scope.instanceUrl = instanceUrl;
             $scope.editUser = false;
             $scope.hideUsernmae = true;// scroll to the top of the page
@@ -144,6 +146,8 @@ angular.module("privacyideaApp")
                 ContainerFactory.getContainerForUser({
                     user: $scope.username,
                     realm: $scope.realmname,
+                    pagesize: $scope.containersPerPage,
+                    page: $scope.containerParams.page
                 }, function (data) {
                     $scope.containerdata = data.result.value;
                 });
@@ -153,6 +157,7 @@ angular.module("privacyideaApp")
             $scope.pageChanged = function () {
                 //debug: console.log('Page changed to: ' + $scope.params.page);
                 $scope._getUserToken();
+                $scope.getUserContainer();
             };
 
             $scope.getResolverDetails = function (resolvername) {

--- a/privacyidea/static/components/user/views/user.details.html
+++ b/privacyidea/static/components/user/views/user.details.html
@@ -219,10 +219,21 @@
             src="instanceUrl + '/static/components/user/views/dialog.ask_user_delete.html'">
     </ng-include>
 
-       <!-- ===================== Containers ===================== -->
-    <h3 ng-if="containerdata.length > 0"> translate>Containers for user {{ username }}</h3>
+    <!-- ===================== Containers ===================== -->
+    <h3 ng-if="containerdata.count > 0"> translate>Containers for user {{ username }}</h3>
 
-    <div class="table-responsive" ng-if="containerdata.length > 0">
+    <div uib-pagination ng-show="containerdata.count > containersPerPage"
+         total-items="containerdata.count" ng-model="containerParams.page"
+         previous-text="{{ 'Previous'|translate }}"
+         next-text="{{ 'Next'|translate }}"
+         last-text="{{ 'Last'|translate }}"
+         first-text="{{ 'First'|translate }}"
+         items-per-page="{{ containersPerPage }}"
+         max-size="5"
+         boundary-links="true" ng-change="pageChanged()">
+    </div>
+
+    <div class="table-responsive" ng-if="containerdata.count > 0">
         <table class="table table-bordered table-striped" id="tableContainerList">
             <thead>
             <tr>
@@ -238,7 +249,7 @@
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="container in containerdata">
+            <tr ng-repeat="container in containerdata.containers">
                 <td>
                     <a ui-sref="token.containerdetails({containerSerial: container.serial})">{{ container.serial }}</a>
                 </td>

--- a/tests/test_api_container.py
+++ b/tests/test_api_container.py
@@ -1,4 +1,4 @@
-from privacyidea.lib.container import init_container
+from privacyidea.lib.container import init_container, find_container_by_serial
 from privacyidea.lib.realm import set_realm
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.token import init_token
@@ -93,16 +93,113 @@ class APIContainer(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             json = res.json
             self.assertTrue(json["result"]["status"])
-            self.assertEqual(json["result"]["value"][0]["type"], "generic")
-            self.assertEqual(json["result"]["value"][0]["description"], "testcontainer")
-            self.assertTrue(len(json["result"]["value"][0]["serial"]) > 0)
+            self.assertEqual(json["result"]["value"]["containers"][0]["type"], "generic")
+            self.assertEqual(json["result"]["value"]["containers"][0]["description"], "testcontainer")
+            self.assertTrue(len(json["result"]["value"]["containers"][0]["serial"]) > 0)
 
-            users_res = json["result"]["value"][0]["users"]
+            users_res = json["result"]["value"]["containers"][0]["users"]
             for u in users_res:
                 self.assertEqual(u["user_realm"], "realm1")
 
-            tokens_res = json["result"]["value"][0]["tokens"]
+            tokens_res = json["result"]["value"]["containers"][0]["tokens"]
             for token in tokens_res:
-                # token are dicts of {"type": "serial"}
-                self.assertTrue("hotp" in token)
-                self.assertTrue(token["hotp"] in token_serials)
+                # token are dicts
+                self.assertTrue(token["serial"] in token_serials)
+                self.assertEqual(token["tokentype"], 'hotp')
+
+    def test_04_get_all_containers_paginate(self):
+        types = ["Smartphone", "generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
+        container_serials = []
+        for type in types:
+            serial = init_container({"type": type, "description": "test container"})
+            container_serials.append(serial)
+
+        # Filter for container serial
+        with self.app.test_request_context('/container/',
+                                           method='GET',
+                                           data={"serial": container_serials[3]},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            containerdata = res.json["result"]["value"]
+            self.assertEqual(containerdata["count"], 1)
+            self.assertEqual(containerdata["containers"][0]["serial"], container_serials[3])
+
+        # filter for type
+        with self.app.test_request_context('/container/',
+                                           method='GET',
+                                           data={"type": "generic"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            containerdata = res.json["result"]["value"]
+            self.assertEqual(containerdata["count"], 2)
+            self.assertEqual(containerdata["containers"][0]["type"], "generic")
+
+        # Assign token
+        tokens = []
+        params = {"genkey": "1"}
+        for i in range(3):
+            t = init_token(params)
+            tokens.append(t)
+        token_serials = [t.get_serial() for t in tokens]
+
+        for serial in container_serials[2:4]:
+            container = find_container_by_serial(serial)
+            for token in tokens:
+                container.add_token(token)
+
+        # Filter for token serial
+        with self.app.test_request_context('/container/',
+                                           method='GET',
+                                           data={'token_serial': token_serials[1]},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            containerdata = res.json["result"]["value"]
+            self.assertEqual(containerdata["count"], 2)
+            self.assertTrue(containerdata["containers"][0]["serial"] in container_serials[2:4])
+            self.assertTrue(containerdata["containers"][1]["serial"] in container_serials[2:4])
+
+    def test_05_get_all_containers_paginate_wrong_arguments(self):
+        types = ["Smartphone", "generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
+        container_serials = []
+        for type in types:
+            serial = init_container({"type": type, "description": "test container"})
+            container_serials.append(serial)
+
+        # Filter for container serial
+        with self.app.test_request_context('/container/',
+                                           method='GET',
+                                           data={"serial": 'wrong_serial'},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            containerdata = res.json["result"]["value"]
+            self.assertEqual(0, containerdata["count"])
+
+        # filter for type
+        with self.app.test_request_context('/container/',
+                                           method='GET',
+                                           data={"type": "wrong_type"},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            containerdata = res.json["result"]["value"]
+            self.assertEqual(0, containerdata["count"])
+
+        # Assign token
+        tokens = []
+        params = {"genkey": "1"}
+        for i in range(3):
+            t = init_token(params)
+            tokens.append(t)
+
+        for serial in container_serials[2:4]:
+            container = find_container_by_serial(serial)
+            for token in tokens:
+                container.add_token(token)
+
+        # Filter for token serial
+        with self.app.test_request_context('/container/',
+                                           method='GET',
+                                           data={'token_serial': 'wrong_token_serial'},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            containerdata = res.json["result"]["value"]
+            self.assertEqual(len(container_serials), containerdata["count"])

--- a/tests/test_api_container.py
+++ b/tests/test_api_container.py
@@ -3,6 +3,7 @@ from privacyidea.lib.realm import set_realm
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.token import init_token
 from privacyidea.lib.user import User
+from privacyidea.models import TokenContainer
 from tests.base import MyApiTestCase
 
 
@@ -108,6 +109,7 @@ class APIContainer(MyApiTestCase):
                 self.assertEqual(token["tokentype"], 'hotp')
 
     def test_04_get_all_containers_paginate(self):
+
         types = ["Smartphone", "generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
         container_serials = []
         for type in types:
@@ -131,8 +133,11 @@ class APIContainer(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             containerdata = res.json["result"]["value"]
-            self.assertEqual(containerdata["count"], 2)
-            self.assertEqual(containerdata["containers"][0]["type"], "generic")
+            count = 0
+            for container in containerdata["containers"]:
+                self.assertEqual(container["type"], "generic")
+                count += 1
+            self.assertEqual(containerdata["count"], count)
 
         # Assign token
         tokens = []
@@ -154,11 +159,14 @@ class APIContainer(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             containerdata = res.json["result"]["value"]
-            self.assertEqual(containerdata["count"], 2)
-            self.assertTrue(containerdata["containers"][0]["serial"] in container_serials[2:4])
-            self.assertTrue(containerdata["containers"][1]["serial"] in container_serials[2:4])
+            count = 0
+            for container in containerdata["containers"]:
+                self.assertTrue(container["serial"] in container_serials[2:4])
+                count += 1
+            self.assertEqual(containerdata["count"], count)
 
     def test_05_get_all_containers_paginate_wrong_arguments(self):
+        TokenContainer.query.delete()
         types = ["Smartphone", "generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
         container_serials = []
         for type in types:

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -6,6 +6,7 @@ from privacyidea.lib.realm import set_realm
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.token import init_token
 from privacyidea.lib.user import User
+from privacyidea.models import TokenContainer
 from .base import MyTestCase
 
 
@@ -83,6 +84,7 @@ class TokenContainerManagementTestCase(MyTestCase):
 
 
     def test_04_get_all_containers_paginate(self):
+        TokenContainer.query.delete()
         types = ["Smartphone", "generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
         container_serials = []
         for type in types:
@@ -91,13 +93,14 @@ class TokenContainerManagementTestCase(MyTestCase):
 
         # Filter for container serial
         containerdata = get_all_containers_paginate(serial=container_serials[3])
-        self.assertEqual(containerdata["count"], 1)
+        self.assertEqual(1, containerdata["count"])
         self.assertEqual(containerdata["containers"][0].serial, container_serials[3])
 
         # filter for type
         containerdata = get_all_containers_paginate(type="generic")
-        self.assertEqual(containerdata["count"], 2)
-        self.assertEqual(containerdata["containers"][0].type, "generic")
+        for container in containerdata["containers"]:
+            self.assertEqual(container.type, "generic")
+        self.assertEqual(2, containerdata["count"])
 
         # Assign token
         tokens = []
@@ -114,9 +117,9 @@ class TokenContainerManagementTestCase(MyTestCase):
 
         # Filter for token serial
         containerdata = get_all_containers_paginate(token_serial=token_serials[1])
-        self.assertEqual(containerdata["count"], 2)
-        self.assertTrue(containerdata["containers"][0].serial in container_serials[2:4])
-        self.assertTrue(containerdata["containers"][1].serial in container_serials[2:4])
+        for container in containerdata["containers"]:
+            self.assertTrue(container.serial in container_serials[2:4])
+        self.assertEqual(2, containerdata["count"])
 
 
     def test_99_container_classes(self):

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -82,7 +82,6 @@ class TokenContainerManagementTestCase(MyTestCase):
             container.add_user(u)
         self.assertEqual(2, len(container.get_users()))
 
-
     def test_04_get_all_containers_paginate(self):
         TokenContainer.query.delete()
         types = ["Smartphone", "generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
@@ -120,7 +119,6 @@ class TokenContainerManagementTestCase(MyTestCase):
         for container in containerdata["containers"]:
             self.assertTrue(container.serial in container_serials[2:4])
         self.assertEqual(2, containerdata["count"])
-
 
     def test_99_container_classes(self):
         classes = get_container_classes()


### PR DESCRIPTION
Changed GET/container
- return container as paginated object
- the tokens of the container are returned as simple dict instead of a paginate object

Simplified token visualization in the container list