### PR TITLE
Output the CLI- banner to stderr

### DIFF
--- a/privacyidea/cli/pimanage/main.py
+++ b/privacyidea/cli/pimanage/main.py
@@ -96,7 +96,7 @@ def cli():
  / .__/_/ /_/|___/\_,_/\__/\_, /___/____/___/_/ |_|
 /_/                       /___/
 {0!s:>51}
-    """.format('v{0!s}'.format(get_version_number())))
+    """.format('v{0!s}'.format(get_version_number())), err=True)
 
 
 deprecated_commands = [


### PR DESCRIPTION
In order to use `stdout` with redirection, the CLI-banner needs to be printed to `stderr`.

Working on #2498 