### PR TITLE
Container realms

### DIFF
--- a/migrations/versions/1344dfe78b17_.py
+++ b/migrations/versions/1344dfe78b17_.py
@@ -15,15 +15,19 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.create_table('tokencontainerrealm',
-                    sa.Column('container_id', sa.Integer(), nullable=True),
-                    sa.Column('realm_id', sa.Integer(), nullable=False),
-                    sa.ForeignKeyConstraint(['container_id'], ['tokencontainer.id'], ),
-                    sa.ForeignKeyConstraint(['realm_id'], ['realm.id'], ),
-                    sa.PrimaryKeyConstraint('container_id', 'realm_id'),
-                    sa.UniqueConstraint('container_id', 'realm_id'),
-                    mysql_row_format='DYNAMIC'
-                    )
+    try:
+        op.create_table('tokencontainerrealm',
+                        sa.Column('container_id', sa.Integer(), nullable=True),
+                        sa.Column('realm_id', sa.Integer(), nullable=False),
+                        sa.ForeignKeyConstraint(['container_id'], ['tokencontainer.id'], ),
+                        sa.ForeignKeyConstraint(['realm_id'], ['realm.id'], ),
+                        sa.PrimaryKeyConstraint('container_id', 'realm_id'),
+                        sa.UniqueConstraint('container_id', 'realm_id'),
+                        mysql_row_format='DYNAMIC'
+                        )
+    except Exception as e:
+        print("Could not add table 'tokencontainerrealm' - probably already exists!")
+        print(e)
 
 
 def downgrade():

--- a/migrations/versions/1344dfe78b17_.py
+++ b/migrations/versions/1344dfe78b17_.py
@@ -1,0 +1,30 @@
+"""v3.10: Add new association table tokencontainerrealm
+
+Revision ID: 1344dfe78b17
+Revises: cd51b7fe9d03
+Create Date: 2024-06-17 14:24:31.100842
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1344dfe78b17'
+down_revision = 'cd51b7fe9d03'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('tokencontainerrealm',
+                    sa.Column('container_id', sa.Integer(), nullable=True),
+                    sa.Column('realm_id', sa.Integer(), nullable=False),
+                    sa.ForeignKeyConstraint(['container_id'], ['tokencontainer.id'], ),
+                    sa.ForeignKeyConstraint(['realm_id'], ['realm.id'], ),
+                    sa.PrimaryKeyConstraint('container_id', 'realm_id'),
+                    sa.UniqueConstraint('container_id', 'realm_id'),
+                    mysql_row_format='DYNAMIC'
+                    )
+
+
+def downgrade():
+    op.drop_table('tokencontainerrealm')

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -320,8 +320,8 @@ def init():
         init_details = tokenobject.get_init_detail(param, user)
         response_details.update(init_details)
         # Check if a containerSerial is set and assign the token to the container
-        if "containerSerial" in param:
-            container_serial = param.get("containerSerial")
+        if "container_serial" in param:
+            container_serial = param.get("container_serial")
             # TODO should this be caught here? The enrollment should not be blocked by the error?
             try:
                 find_container_by_serial(container_serial).add_token(tokenobject)

--- a/privacyidea/lib/container.py
+++ b/privacyidea/lib/container.py
@@ -285,8 +285,12 @@ def init_container(params):
     container = create_container_from_db_object(db_container)
     user = params.get("user")
     realm = params.get("realm")
-    if user and not realm or realm and not user:
+    realms = []
+    if user and not realm:
         log.error(f"Assigning a container to user on creation requires both user and realm parameters!")
+    elif realm and not user:
+        realms.append(realm)
+        container.set_realms(realms, add=True)
     elif user and realm:
         container.add_user(User(login=user, realm=realm))
 

--- a/privacyidea/lib/containerclass.py
+++ b/privacyidea/lib/containerclass.py
@@ -84,7 +84,7 @@ class TokenContainerClass:
                 realm_db = Realm.query.filter_by(name=realm).first()
                 if not realm_db:
                     result[realm] = False
-                    #raise ParameterError(f"Realm {realm} does not exist.")
+                    log.debug(f"Realm {realm} does not exist.")
                 else:
                     realm_id = realm_db.id
                     if not TokenContainerRealm.query.filter_by(container_id=self._db_container.id,

--- a/privacyidea/lib/containerclass.py
+++ b/privacyidea/lib/containerclass.py
@@ -136,7 +136,9 @@ class TokenContainerClass:
                                 user_id=user_id,
                                 resolver=resolver_name,
                                 realm_id=user.realm_id).save()
-            self.realms = [user.realm_id]
+            # Add user realm to container realms
+            realm_db = Realm.query.filter_by(name=user.realm).first()
+            self._db_container.realms.append(realm_db)
             self.update_last_updated()
             return True
         return False

--- a/privacyidea/lib/containerclass.py
+++ b/privacyidea/lib/containerclass.py
@@ -9,7 +9,8 @@ from privacyidea.lib.log import log_with
 from privacyidea.lib.token import create_tokenclass_object
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.user import User
-from privacyidea.models import TokenContainerOwner, Realm, Token, db, TokenContainerStates, TokenContainerInfo
+from privacyidea.models import TokenContainerOwner, Realm, Token, db, TokenContainerStates, TokenContainerInfo, \
+    TokenContainerRealm
 
 log = logging.getLogger(__name__)
 
@@ -63,6 +64,41 @@ class TokenContainerClass:
         self._db_container.save()
         self.update_last_seen()
 
+    @property
+    def realms(self):
+        return self._db_container.realms
+
+    def set_realms(self, realms, add=False):
+        result = {}
+
+        # delete all container realms
+        if not add:
+            TokenContainerRealm.query.filter_by(container_id=self._db_container.id).delete()
+            result["deleted"] = True
+            self._db_container.save()
+        else:
+            result["deleted"] = False
+
+        for realm in realms:
+            if realm:
+                realm_db = Realm.query.filter_by(name=realm).first()
+                if not realm_db:
+                    result[realm] = False
+                    #raise ParameterError(f"Realm {realm} does not exist.")
+                else:
+                    realm_id = realm_db.id
+                    if not TokenContainerRealm.query.filter_by(container_id=self._db_container.id,
+                                                               realm_id=realm_id).first():
+                        # Check if realm is already assigned to the container
+                        self._db_container.realms.append(realm_db)
+                        result[realm] = True
+                    else:
+                        result[realm] = False
+        self._db_container.save()
+        self.update_last_updated()
+
+        return result
+
     def remove_token(self, serial: str):
         token = Token.query.filter(Token.serial == serial).first()
         if token:
@@ -87,14 +123,20 @@ class TokenContainerClass:
         return self._db_container.delete()
 
     def add_user(self, user: User):
+        """
+        Assign a user to the container if the container does not have an owner yet.
+        Otherwise, the new user will not be assigned and the original owner will remain.
+
+        :param user: User object
+        :return: True if the user was assigned, False if the container already has an owner
+        """
         (user_id, resolver_type, resolver_name) = user.get_user_identifiers()
-        if not TokenContainerOwner.query.filter_by(container_id=self._db_container.id,
-                                                   user_id=user_id,
-                                                   resolver=resolver_name).first():
+        if not TokenContainerOwner.query.filter_by(container_id=self._db_container.id).first():
             TokenContainerOwner(container_id=self._db_container.id,
                                 user_id=user_id,
                                 resolver=resolver_name,
                                 realm_id=user.realm_id).save()
+            self.realms = [user.realm_id]
             self.update_last_updated()
             return True
         return False

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -946,6 +946,7 @@ class Realm(TimestampMethodsMixin, db.Model):
     resolver_list = db.relationship('ResolverRealm',
                                     lazy='select',
                                     back_populates='realm')
+    container = db.relationship('TokenContainer', secondary='tokencontainerrealm', back_populates='realms')
 
     @log_with(log)
     def __init__(self, realm):
@@ -3330,8 +3331,7 @@ class TokenContainer(MethodsMixin, db.Model):
     id = db.Column("id", db.Integer, db.Identity(), primary_key=True)
     type = db.Column(db.Unicode(100), default='Generic', nullable=False)
     description = db.Column(db.Unicode(1024), default='')
-    tokens = db.relationship('Token', secondary='tokencontainertoken',
-                             back_populates='container')
+    tokens = db.relationship('Token', secondary='tokencontainertoken', back_populates='container')
     serial = db.Column(db.Unicode(40), default='', unique=True, nullable=False, index=True)
     owners = db.relationship('TokenContainerOwner', lazy='dynamic', back_populates='container',
                              cascade="all, delete-orphan")
@@ -3341,6 +3341,7 @@ class TokenContainer(MethodsMixin, db.Model):
                              cascade="all, delete-orphan")
     info_list = db.relationship('TokenContainerInfo', lazy='select', back_populates='container',
                                 cascade="all, delete-orphan")
+    realms = db.relationship('Realm', secondary='tokencontainerrealm', back_populates='container')
 
     def __init__(self, serial, container_type="Generic", tokens=None, description="", states=None):
         self.serial = serial
@@ -3519,3 +3520,17 @@ class TokenContainerInfo(MethodsMixin, db.Model):
         if persistent:
             db.session.commit()
         return ret
+
+
+class TokenContainerRealm(MethodsMixin, db.Model):
+    """
+    This table stores to which realms a container is assigned. A container is in the
+    realm of the user it is assigned to. But a container can also be put into
+    many additional realms.
+    """
+    __tablename__ = 'tokencontainerrealm'
+    container_id = db.Column(db.Integer(), db.ForeignKey("tokencontainer.id"), primary_key=True)
+    realm_id = db.Column(db.Integer(), db.ForeignKey('realm.id'), primary_key=True)
+
+    __table_args__ = (db.UniqueConstraint('container_id', 'realm_id'),
+                      {'mysql_row_format': 'DYNAMIC'})

--- a/privacyidea/static/components/token/controllers/containerControllers.js
+++ b/privacyidea/static/components/token/controllers/containerControllers.js
@@ -280,10 +280,9 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
         };
 
         $scope.deleteContainerButton = false;
-        $scope.deleteContainerMode = function (deleteAllTokens) {
-            if (deleteAllTokens) {
-                $scope.selectAllTokens(true);
-                $scope.deleteTokens();
+        $scope.deleteContainerMode = function (deleteTokens) {
+            if (deleteTokens) {
+                $scope.deleteAllTokens();
             }
             ContainerFactory.deleteContainer($scope.containerSerial, $scope.returnTo);
         };
@@ -428,6 +427,7 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
                     TokenFactory.delete(token);
                 }
             });
+            $scope.showDialogAll = false;
         };
 
         // --- Add token functions ---

--- a/privacyidea/static/components/token/controllers/containerControllers.js
+++ b/privacyidea/static/components/token/controllers/containerControllers.js
@@ -294,23 +294,23 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
 
         $scope.editContainerRealms = false;
         $scope.startEditRealms = function () {
-            // fill the selectedRealms with the realms of the token
+            // fill the selectedRealms with the realms of the container
             $scope.selectedRealms = {};
             $scope.editContainerRealms = true;
-            angular.forEach($scope.container.realms, function (realmname, _index) {
-                $scope.selectedRealms[realmname] = true;
+            angular.forEach($scope.container.realms, function (realmName, _index) {
+                $scope.selectedRealms[realmName] = true;
             });
         };
 
         $scope.saveRealms = function () {
-            let realms = "";
+            let realmList = "";
             for (const realm in $scope.selectedRealms) {
                 if ($scope.selectedRealms[realm] === true) {
-                    realms += realm + ",";
+                    realmList += realm + ",";
                 }
             }
-            realms = realms.slice(0, -1);
-            const realmParams = {"container_serial": $scope.containerSerial, "realms": realms};
+            realmList = realmList.slice(0, -1);
+            const realmParams = {"container_serial": $scope.containerSerial, "realms": realmList};
             ContainerFactory.setRealms(realmParams, $scope.getContainer);
             $scope.cancelEditRealms();
         };

--- a/privacyidea/static/components/token/controllers/containerControllers.js
+++ b/privacyidea/static/components/token/controllers/containerControllers.js
@@ -106,7 +106,7 @@ myApp.controller("containerCreateController", ['$scope', '$http', '$q', '$state'
             }
 
             ContainerFactory.createContainer(params, function (data) {
-                $state.go("token.containerdetails", {"containerSerial": data.result.value.serial});
+                $state.go("token.containerdetails", {"containerSerial": data.result.value.container_serial});
             });
         };
     }]);
@@ -292,6 +292,34 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
             ContainerFactory.setDescription($scope.containerSerial, description, $scope.getContainer);
         };
 
+        $scope.editContainerRealms = false;
+        $scope.startEditRealms = function () {
+            // fill the selectedRealms with the realms of the token
+            $scope.selectedRealms = {};
+            $scope.editContainerRealms = true;
+            angular.forEach($scope.container.realms, function (realmname, _index) {
+                $scope.selectedRealms[realmname] = true;
+            });
+        };
+
+        $scope.saveRealms = function () {
+            let realms = "";
+            for (const realm in $scope.selectedRealms) {
+                if ($scope.selectedRealms[realm] === true) {
+                    realms += realm + ",";
+                }
+            }
+            realms = realms.slice(0, -1);
+            const realmParams = {"container_serial": $scope.containerSerial, "realms": realms};
+            ContainerFactory.setRealms(realmParams, $scope.getContainer);
+            $scope.cancelEditRealms();
+        };
+
+        $scope.cancelEditRealms = function () {
+            $scope.editContainerRealms = false;
+            $scope.selectedRealms = {};
+        };
+
         $scope.newUser = {user: "", realm: $scope.defaultRealm};
         $scope.assignUser = function () {
             ContainerFactory.assignUser(
@@ -383,7 +411,7 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
             let tokenSerialList = $scope.getAllTokenSerials();
             if (tokenSerialList.length > 0) {
                 ContainerFactory.removeAllTokensFromContainer({
-                    'serial': $scope.containerSerial,
+                    'container_serial': $scope.containerSerial,
                     'serial_list': tokenSerialList
                 }, $scope.getContainer);
             }
@@ -465,8 +493,8 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
         };
         $scope.removeOneToken = function (token_serial) {
             let params = {
-                "serial": $scope.containerSerial,
-                "tokenSerial": token_serial
+                "container_serial": $scope.containerSerial,
+                "serial": token_serial
             };
             ContainerFactory.removeTokenFromContainer(params, $scope.getContainer);
         }
@@ -479,8 +507,8 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
         }
         $scope.addToken = function (token_serial) {
             ContainerFactory.addTokenToContainer({
-                "serial": $scope.containerSerial,
-                "tokenSerial": token_serial
+                "container_serial": $scope.containerSerial,
+                "serial": token_serial
             }, function () {
                 $scope.getContainer();
                 $scope.get();

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -201,7 +201,7 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
             type: $scope.default_tokentype,
             hashlib: "sha1",
             'radius.system_settings': true,
-            containerSerial: $stateParams.containerSerial,
+            container_serial: $stateParams.containerSerial,
         };
         if ($state.includes('token.rollover')) {
             $scope.form.serial = $stateParams.tokenSerial;
@@ -458,8 +458,8 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
             $scope.webAuthnToken = {};
             $scope.enrolledToken = data.detail;
             $scope.click_wait = false;
-            if ($scope.form.containerSerial !== null && $scope.form.containerSerial !== "createnew") {
-                $scope.enrolledToken.containerSerial = $scope.form.containerSerial;
+            if ($scope.form.container_serial !== null && $scope.form.container_serial !== "createnew") {
+                $scope.enrolledToken.containerSerial = $scope.form.container_serial;
             }
             if ($scope.enrolledToken.otps) {
                 const otps_count = Object.keys($scope.enrolledToken.otps).length;
@@ -511,8 +511,8 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
             $scope.form.validity_period_start = date_object_to_string($scope.form.validity_period_start);
             $scope.form.validity_period_end = date_object_to_string($scope.form.validity_period_end);
 
-            if ($scope.form.containerSerial === "createnew") {
-                delete $scope.form.containerSerial
+            if ($scope.form.container_serial === "createnew") {
+                delete $scope.form.container_serial
             }
 
             TokenFactory.enroll($scope.newUser,

--- a/privacyidea/static/components/token/factories/container.js
+++ b/privacyidea/static/components/token/factories/container.js
@@ -49,7 +49,7 @@ myApp.factory("ContainerFactory", ['AuthFactory', '$http', 'containerUrl', '$q',
                 });
             },
             addTokenToContainer: function (params, callback) {
-                $http.post(containerUrl + "/" + params["container_serial"] + "/add", {serial: params["tokenSerial"]}, {
+                $http.post(containerUrl + "/" + params["container_serial"] + "/add", {serial: params["serial"]}, {
                     headers: {'PI-Authorization': AuthFactory.getAuthToken()}
                 }).then(function (response) {
                     callback(response.data);
@@ -67,7 +67,7 @@ myApp.factory("ContainerFactory", ['AuthFactory', '$http', 'containerUrl', '$q',
                 });
             },
             removeTokenFromContainer: function (params, callback) {
-                $http.post(containerUrl + "/" + params["container_serial"] + "/remove", {serial: params["tokenSerial"]}, {
+                $http.post(containerUrl + "/" + params["container_serial"] + "/remove", {serial: params["serial"]}, {
                     headers: {'PI-Authorization': AuthFactory.getAuthToken()}
                 }).then(function (response) {
                     callback(response.data);
@@ -76,7 +76,8 @@ myApp.factory("ContainerFactory", ['AuthFactory', '$http', 'containerUrl', '$q',
                 });
             },
             removeAllTokensFromContainer: function (params, callback) {
-                $http.post(containerUrl + "/" + params["container_serial"] + "/remove", {serial_list: params["token_serial_list"]}, {
+                $http.post(containerUrl + "/" + params["container_serial"] + "/remove",
+                    {serial_list: params["serial_list"]}, {
                     headers: {'PI-Authorization': AuthFactory.getAuthToken()}
                 }).then(function (response) {
                     callback(response.data);
@@ -165,6 +166,15 @@ myApp.factory("ContainerFactory", ['AuthFactory', '$http', 'containerUrl', '$q',
                     callback(response.data);
                 }, function (error) {
                     AuthFactory.authError(error.data);
+                });
+            },
+            setRealms: function (params, callback) {
+                $http.post(containerUrl + "/" + params["container_serial"] + "/realms", params, {
+                    headers: {'PI-Authorization': AuthFactory.getAuthToken()}
+                }).then(function (response) {
+                    callback(response.data);
+                }, function (error) {
+                    AuthFactory.authError(error.data)
                 });
             }
         }

--- a/privacyidea/static/components/token/views/token.containerdetails.html
+++ b/privacyidea/static/components/token/views/token.containerdetails.html
@@ -19,12 +19,12 @@
                 <fieldset ng-hide="!deleteContainerButton || (!checkRight('delete') && hide_buttons)"
                           ng-disabled="!checkRight('delete')">
                     <button class="btn btn-danger"
-                            ng-click="deleteContainerMode(deleteAllTokens=false)">
+                            ng-click="deleteContainerMode(deleteTokens=false)">
                         <span class="glyphicon glyphicon-trash"></span>
                         <span translate>Delete Container</span>
                     </button>
                     <button class="btn btn-danger"
-                            ng-click="deleteContainerMode(deleteAllTokens=true)">
+                            ng-click="deleteContainerMode(deleteTokens=true)">
                         <span class="glyphicon glyphicon-trash"></span>
                         <span translate>Delete Container and Tokens</span>
                     </button>

--- a/privacyidea/static/components/token/views/token.containerdetails.html
+++ b/privacyidea/static/components/token/views/token.containerdetails.html
@@ -123,6 +123,51 @@
             </td>
         </tr>
         <tr>
+            <td translate> Realms</td>
+            <td>
+                <span ng-hide="editContainerRealms">
+                    <ul ng-click="editContainerRealms=true">
+                        <li ng-repeat="realm in container.realms">{{ realm }}</li>
+                    </ul>
+                </span>
+                <span ng-show="editContainerRealms">
+                    <span ng-repeat="(realmname, realm) in realms">
+                        <label for="{{ realmname }}">
+                            <input type="checkbox"
+                                   ng-model="selectedRealms[realmname]"
+                                   name="group"
+                                   id="{{ realmname }}"
+                                   ng-checked="selectedRealms[realmname]">
+                            {{ realmname }}
+                        </label><br>
+                    </span>
+                </span>
+            </td>
+            <td>
+                <div ng-show="loggedInUser.role == 'admin'">
+                    <button class="btn btn-primary"
+                            id="cRealmsEditButton"
+                            ng-hide="editContainerRealms || (!checkRight('tokenrealms') && hide_buttons)"
+                            ng-disabled="!checkRight('tokenrealms')"
+                            ng-click="startEditRealms()"
+                            translate>Edit
+                    </button>
+                    <button class="btn btn-primary"
+                            id="cRealmsSaveButton"
+                            ng-show="editContainerRealms"
+                            ng-click="saveRealms()"
+                            translate>Save realms
+                    </button>
+                    <button class="btn btn-danger"
+                            id="cRealmsCancelButton"
+                            ng-show="editContainerRealms"
+                            ng-click="cancelEditRealms();"
+                            translate>Cancel
+                    </button>
+                </div>
+            </td>
+        </tr>
+        <tr>
             <td translate> Last Seen</td>
             <td>{{ container.last_seen | date:'yyyy-MM-dd H:mm:ss'}}</td>
             <td></td>

--- a/privacyidea/static/components/token/views/token.containerdetails.html
+++ b/privacyidea/static/components/token/views/token.containerdetails.html
@@ -144,10 +144,10 @@
                 </span>
             </td>
             <td>
-                <div ng-show="loggedInUser.role == 'admin'">
+                <fieldset ng-disabled="loggedInUser.role == 'user'">
                     <button class="btn btn-primary"
                             id="cRealmsEditButton"
-                            ng-hide="editContainerRealms || (!checkRight('tokenrealms') && hide_buttons)"
+                            ng-hide="editContainerRealms || ((!checkRight('tokenrealms') || loggedInUser.role == 'user') && hide_buttons)"
                             ng-disabled="!checkRight('tokenrealms')"
                             ng-click="startEditRealms()"
                             translate>Edit
@@ -164,7 +164,7 @@
                             ng-click="cancelEditRealms();"
                             translate>Cancel
                     </button>
-                </div>
+                </fieldset>
             </td>
         </tr>
         <tr>

--- a/privacyidea/static/components/token/views/token.containerlist.html
+++ b/privacyidea/static/components/token/views/token.containerlist.html
@@ -87,8 +87,10 @@
                 <a ui-sref="config.realms.list">{{ container.users[0].user_realm }}</a>
             </td>
             <td ng-show="loggedInUser.role == 'admin'">
-                <a ui-sref="config.realms.list" ng-repeat="c_realm in container.realms">
-                    {{ c_realm }}</a>&nbsp;
+                <span ng-repeat="c_realm in container.realms">
+                    <a ui-sref="config.realms.list">
+                    {{ c_realm }}</a><span ng-show="!$last ">,</span>
+                </span>
             </td>
         </tr>
         <!-- Tokens of each container -->

--- a/privacyidea/static/components/token/views/token.containerlist.html
+++ b/privacyidea/static/components/token/views/token.containerlist.html
@@ -48,6 +48,12 @@
             <th ng-show="loggedInUser.role == 'admin'">
                 User
             </th>
+            <th ng-show="loggedInUser.role == 'admin'">
+                Realm
+            </th>
+            <th ng-show="loggedInUser.role == 'admin'">
+                Container Realms
+            </th>
         </tr>
         </thead>
         <tbody>
@@ -76,6 +82,13 @@
                             resolvername: token.resolver,
                             editable: false})">
                     {{ container.users[0].user_name }}</a>
+            </td>
+            <td ng-show="loggedInUser.role == 'admin'">
+                <a ui-sref="config.realms.list">{{ container.users[0].user_realm }}</a>
+            </td>
+            <td ng-show="loggedInUser.role == 'admin'">
+                <a ui-sref="config.realms.list" ng-repeat="c_realm in container.realms">
+                    {{ c_realm }}</a>&nbsp;
             </td>
         </tr>
         <!-- Tokens of each container -->

--- a/privacyidea/static/components/token/views/token.list.html
+++ b/privacyidea/static/components/token/views/token.list.html
@@ -131,8 +131,10 @@
             </td>
 
             <td ng-show="loggedInUser.role == 'admin'">
-                <a ui-sref="config.realms.list" ng-repeat="t_realm in token.realms">
-                    {{ t_realm }}</a>&nbsp;
+                <span ng-repeat="t_realm in token.realms">
+                    <a ui-sref="config.realms.list">
+                    {{ t_realm }}</a><span ng-show="!$last ">,</span>
+                </span>
             </td>
 
             <td ng-show="loggedInUser.role == 'admin' &&

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -37,24 +37,17 @@ class TokenContainerManagementTestCase(MyTestCase):
 
     def test_03_container_with_tokens_users(self):
         # Create users and tokens first
-        rid = save_resolver({"resolver": self.resolvername1,
-                             "type": "passwdresolver",
-                             "fileName": "tests/testdata/passwd"})
-        self.assertTrue(rid > 0, rid)
-
-        (added, failed) = set_realm(self.realm1, [{'name': self.resolvername1}])
-        self.assertTrue(len(failed) == 0)
-        self.assertTrue(len(added) == 1)
+        self.setUp_user_realms()
 
         # Create a container with tokens and user
         serial = init_container({"type": "generic", "description": "test container"})
         container = find_container_by_serial(serial)
-        user_root = User(login="root", realm=self.realm1, resolver=self.resolvername1)
-        container.add_user(user_root)
+        user_hans = User(login="hans", realm=self.realm1, resolver=self.resolvername1)
+        container.add_user(user_hans)
         tokens = []
         params = {"genkey": "1"}
         for i in range(5):
-            t = init_token(params, user=user_root)
+            t = init_token(params, user=user_hans)
             tokens.append(t)
             container.add_token(t)
         all_serials = [t.get_serial() for t in tokens]
@@ -81,7 +74,7 @@ class TokenContainerManagementTestCase(MyTestCase):
         for u in cusers:
             self.assertTrue(container.remove_user(u) > 0)
         self.assertEqual(0, len(container.get_users()))
-        container.add_user(user_root)
+        container.add_user(user_hans)
         self.assertEqual(1, len(container.get_users()))
 
     def test_04_get_all_containers_paginate(self):

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -40,14 +40,11 @@ class TokenContainerManagementTestCase(MyTestCase):
         self.assertTrue(len(failed) == 0)
         self.assertTrue(len(added) == 1)
 
-        # Create a container with tokens and users
+        # Create a container with tokens and user
         serial = init_container({"type": "generic", "description": "test container"})
         container = find_container_by_serial(serial)
         user_root = User(login="root", realm=self.realm1, resolver=self.resolvername1)
-        user_statd = User(login="statd", realm=self.realm1, resolver=self.resolvername1)
-        users = [user_root, user_statd]
-        for u in users:
-            container.add_user(u)
+        container.add_user(user_root)
         tokens = []
         params = {"genkey": "1"}
         for i in range(5):
@@ -58,7 +55,7 @@ class TokenContainerManagementTestCase(MyTestCase):
 
         self.assertEqual(5, len(container.get_tokens()))
         self.assertEqual("test container", container.description)
-        self.assertEqual(2, len(container.get_users()))
+        self.assertEqual(1, len(container.get_users()))
 
         # Manipulate the tokens
         to_remove = [t for t in tokens[0:2]]
@@ -73,14 +70,13 @@ class TokenContainerManagementTestCase(MyTestCase):
         for serial in [t.get_serial() for t in container.tokens]:
             self.assertTrue(serial in all_serials)
 
-        # Manipulate the users
+        # Manipulate the user
         cusers = container.get_users()
         for u in cusers:
             self.assertTrue(container.remove_user(u) > 0)
         self.assertEqual(0, len(container.get_users()))
-        for u in users:
-            container.add_user(u)
-        self.assertEqual(2, len(container.get_users()))
+        container.add_user(user_root)
+        self.assertEqual(1, len(container.get_users()))
 
     def test_04_get_all_containers_paginate(self):
         TokenContainer.query.delete()

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -21,6 +21,12 @@ class TokenContainerManagementTestCase(MyTestCase):
         rid = container.delete()
         self.assertTrue(rid > 0)
 
+        # Init container with realm
+        self.setUp_user_realms()
+        serial = init_container({"type": "Generic", "description": "test container", "realm": self.realm1})
+        container = find_container_by_serial(serial)
+        self.assertEqual(self.realm1, container.realms[0].name)
+
     def test_02_fails(self):
         self.assertRaises(ParameterError, delete_container_by_id, None)
         self.assertRaises(ResourceNotFoundError, delete_container_by_id, 11)
@@ -157,6 +163,10 @@ class TokenContainerManagementTestCase(MyTestCase):
         self.assertFalse(result['deleted'])
         container_realms = [realm.name for realm in container.realms]
         self.assertIn(self.realm1, container_realms)
+
+        # Add same realm
+        result = container.set_realms([self.realm1], add=True)
+        self.assertFalse(result[self.realm1])
 
         # Add one non-existing realm
         result = container.set_realms(["nonexisting", self.realm2], add=True)


### PR DESCRIPTION
* Added container realms: A container can be in multiple realms even if no user is assigned. If a user is assigned to the container the realm of the user is added to the realms of the container.
* Limit number of container owners to one
* Fix: Using 'container_serial' for containers and 'serial' for tokens in all requests