### PR TITLE
Change AUTHTYPE.SASL_KERBEROS behaviour if upn is present in userinfo values for multidomain support

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -1,6 +1,8 @@
 #  Copyright (C) 2014 Cornelius Kölbel
 #  contact:  corny@cornelinux.de
 #
+#  2024-06-25 Raphael Topel <raphael.topel@esh.essen.de>
+#             Change AUTHTYPE.SASL_KERBEROS behaviour if upn ist present in userinfo values for multidomain support
 #  2018-12-14 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add censored password functionality
 #  2017-12-22 Cornelius Kölbel <cornelius.koelbel@netknights.it>

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -344,7 +344,10 @@ class IdResolver (UserIdResolver):
                 return False
             # we need to check credentials with kerberos differently since we
             # can not use bind for every user
-            name = gssapi.Name(self.getUserInfo(uid).get('username'))
+            if self.getUserInfo(uid).get('upn') != None and self.getUserInfo(uid).get('upn') != "None" and  self.getUserInfo(uid).get('upn') != "":
+                name = gssapi.Name(self.getUserInfo(uid).get('upn').upper())
+            else:
+                name = gssapi.Name(self.getUserInfo(uid).get('username'))
             try:
                 gssapi.raw.ext_password.acquire_cred_with_password(name, to_bytes(password))
             except gssapi.exceptions.GSSError as e:

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -346,7 +346,9 @@ class IdResolver (UserIdResolver):
                 return False
             # we need to check credentials with kerberos differently since we
             # can not use bind for every user
-            if self.getUserInfo(uid).get('upn') != None and self.getUserInfo(uid).get('upn') != "None" and  self.getUserInfo(uid).get('upn') != "":
+            if self.getUserInfo(uid).get('upn') is not None \
+                and self.getUserInfo(uid).get('upn') != "None" \
+                and self.getUserInfo(uid).get('upn') != "":
                 name = gssapi.Name(self.getUserInfo(uid).get('upn').upper())
             else:
                 name = gssapi.Name(self.getUserInfo(uid).get('username'))

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -2,7 +2,7 @@
 #  contact:  corny@cornelinux.de
 #
 #  2024-06-25 Raphael Topel <raphael.topel@esh.essen.de>
-#             Change AUTHTYPE.SASL_KERBEROS behaviour if upn ist present in userinfo values for multidomain support
+#             Change AUTHTYPE.SASL_KERBEROS behaviour if upn is present in userinfo values for multidomain support
 #  2018-12-14 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Add censored password functionality
 #  2017-12-22 Cornelius Kölbel <cornelius.koelbel@netknights.it>

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -346,10 +346,11 @@ class IdResolver (UserIdResolver):
                 return False
             # we need to check credentials with kerberos differently since we
             # can not use bind for every user
-            if self.getUserInfo(uid).get('upn') is not None \
-                and self.getUserInfo(uid).get('upn') != "None" \
-                and self.getUserInfo(uid).get('upn') != "":
-                name = gssapi.Name(self.getUserInfo(uid).get('upn').upper())
+            upn = self.getUserInfo(uid).get('upn')
+            if upn is not None \
+                and upn != "None" \
+                and upn != "":
+                name = gssapi.Name(upn.upper())
             else:
                 name = gssapi.Name(self.getUserInfo(uid).get('username'))
             try:


### PR DESCRIPTION
We use privacyIdea with multiple ldap resolvers, want to use Kerberos authentication and had the problem that just one domain the default domain works fine. All users not being part of default domain got an error - and in log file it seems they were matched to default domain.

This fix shouldn't break the default behaviour but works with multiple ldap resolvers / multiple domains and kerberos authentication if following the next steps:

- Required Kerberos configuration incl. keytab files on Linux machine
- ADD "upn" : "userPrincipalName" (works if ldap is ActiveDirectory) to attribute values in ldap resolver configuration
- Switch bind type to "SASL Kerberos"

The fix takes care if there is a value in upn, modify this value to uppercase and use the result instead of just the username (without realm).


