### PR TITLE
Use Tokendefaults and policies in validate-enrollment

### DIFF
--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1791,6 +1791,16 @@ class TokenClass(object):
         :type params: dict
         :return: default parameters
         """
+        return cls._get_default_settings(g)
+
+    @classmethod
+    def _get_default_settings(cls, g, role="user", username=None, userrealm=None,
+                                      adminuser=None, adminrealm=None):
+        """
+        Internal function that can be called either during enrollment via /token/init or during
+        enrollment via validate/check.
+        This way we have consistent policy handling.
+        """
         return {}
 
     def check_last_auth_newer(self, last_auth):

--- a/privacyidea/lib/tokens/daypasswordtoken.py
+++ b/privacyidea/lib/tokens/daypasswordtoken.py
@@ -364,7 +364,8 @@ class DayPasswordTokenClass(TotpTokenClass):
         return settings.get(key, "")
 
     @classmethod
-    def get_default_settings(cls, g, params):
+    def _get_default_settings(cls, g, role="user", username=None, userrealm=None,
+                              adminuser=None, adminrealm=None ):
         """
         This method returns a dictionary with default settings for token
         enrollment.
@@ -374,17 +375,8 @@ class DayPasswordTokenClass(TotpTokenClass):
         with these values.
 
         The returned dictionary is added to the parameters of the API call.
-
-        :param g: context object, see documentation of ``Match``
-        :param params: The call parameters
-        :type params: dict
-        :return: default parameters
         """
         ret = {}
-        if not g.logged_in_user:
-            return ret
-        (role, username, userrealm, adminuser, adminrealm) = determine_logged_in_userparams(g.logged_in_user,
-                                                                                            params)
         hashlib_pol = Match.generic(g, scope=role,
                                     action="daypassword_hashlib",
                                     user=username,

--- a/privacyidea/lib/tokens/daypasswordtoken.py
+++ b/privacyidea/lib/tokens/daypasswordtoken.py
@@ -365,7 +365,7 @@ class DayPasswordTokenClass(TotpTokenClass):
 
     @classmethod
     def _get_default_settings(cls, g, role="user", username=None, userrealm=None,
-                              adminuser=None, adminrealm=None ):
+                              adminuser=None, adminrealm=None):
         """
         This method returns a dictionary with default settings for token
         enrollment.

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -634,26 +634,15 @@ class TotpTokenClass(HotpTokenClass):
         return settings.get(key, "")
 
     @classmethod
-    def get_default_settings(cls, g, params):
+    def _get_default_settings(cls, g, role="user", username=None, userrealm=None,
+                              adminuser=None, adminrealm=None):
         """
-        This method returns a dictionary with default settings for token
-        enrollment.
-        These default settings are defined in SCOPE.USER or SCOPE.ADMIN and are
-        totp_hashlib, totp_timestep and totp_otplen.
-        If these are set, the user or admin will only be able to enroll tokens
-        with these values.
+        Internal function that can be called either during enrollment via /token/init or during
+        enrollment via validate/check.
+        This way we have consistent policy handling.
+        """
 
-        The returned dictionary is added to the parameters of the API call.
-        :param g: context object, see documentation of ``Match``
-        :param params: The call parameters
-        :type params: dict
-        :return: default parameters
-        """
         ret = {}
-        if not g.logged_in_user:
-            return ret
-        (role, username, userrealm, adminuser, adminrealm) = determine_logged_in_userparams(g.logged_in_user,
-                                                                                            params)
         hashlib_pol = Match.generic(g, scope=role,
                                     action="totp_hashlib",
                                     user=username,
@@ -682,6 +671,7 @@ class TotpTokenClass(HotpTokenClass):
             ret["otplen"] = list(otplen_pol)[0]
 
         return ret
+
 
     @staticmethod
     def get_import_csv(l):

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -5629,7 +5629,7 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         """
         Verify that the QR code was generated with SHA256, this is in the log file.
         It will be indicated by this text:
-        Entering create_google_authenticator_url with arguments () and keywords ... 'hash_algo': 'sha1'
+        Entering create_google_authenticator_url with arguments () and keywords ... 'hash_algo': 'sha256'
         """
         sha256regexp = re.compile(r"Entering create_google_authenticator_url with arguments.*'hash_algo': 'sha256'")
         self.assertTrue(sha256regexp.search(log_msg), log_msg)

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -5628,7 +5628,7 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         logging.getLogger('privacyidea').setLevel(logging.INFO)
         """
         Verify that the QR code was generated with SHA256, this is in the log file.
-        It will be indicated by this text:        
+        It will be indicated by this text:
         Entering create_google_authenticator_url with arguments () and keywords ... 'hash_algo': 'sha1'
         """
         sha256regexp = re.compile(r"Entering create_google_authenticator_url with arguments.*'hash_algo': 'sha256'")

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -5628,12 +5628,11 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         logging.getLogger('privacyidea').setLevel(logging.INFO)
         """
         Verify that the QR code was generated with SHA256, this is in the log file.
-        It will be indicated by this text:
-        
-              Entering create_google_authenticator_url with arguments () and keywords ... 'hash_algo': 'sha1'
+        It will be indicated by this text:        
+        Entering create_google_authenticator_url with arguments () and keywords ... 'hash_algo': 'sha1'
         """
-        sha256rebexp = re.compile(r"Entering create_google_authenticator_url with arguments.*'hash_algo': 'sha256'")
-        self.assertTrue(sha256rebexp.search(log_msg), log_msg)
+        sha256regexp = re.compile(r"Entering create_google_authenticator_url with arguments.*'hash_algo': 'sha256'")
+        self.assertTrue(sha256regexp.search(log_msg), log_msg)
 
         # Check SHA256 of the token.
         self.assertEqual("sha256", token_obj.get_tokeninfo("hashlib"))
@@ -5735,8 +5734,8 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             self.assertTrue(result.get("value"))
             self.assertEqual(result.get("authentication"), "ACCEPT")
 
-        sha256rebexp = re.compile(r"Entering create_google_authenticator_url with arguments.*'hash_algo': 'sha256'")
-        self.assertTrue(sha256rebexp.search(log_msg), log_msg)
+        sha256regexp = re.compile(r"Entering create_google_authenticator_url with arguments.*'hash_algo': 'sha256'")
+        self.assertTrue(sha256regexp.search(log_msg), log_msg)
         # Check SHA256 of the token.
         self.assertEqual("sha256", token_obj.get_tokeninfo("hashlib"))
         # Cleanup

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -47,6 +47,7 @@ import datetime
 import time
 import responses
 import mock
+import re
 from . import smtpmock, ldap3mock, radiusmock
 
 
@@ -5573,6 +5574,8 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         # Set force_app_pin
         set_policy("pol_forcepin", scope=SCOPE.ENROLL,
                    action="hotp_{0!s}=True".format(ACTION.FORCE_APP_PIN))
+        # Set token default
+        set_privacyidea_config("hotp.hashlib", "sha256")
         # Now we should get an authentication Challenge
         with self.app.test_request_context('/validate/check',
                                            method='POST',
@@ -5623,23 +5626,38 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         self.assertIn('Exiting get_init_tokenlabel_parameters with result {\'force_app_pin\': True}',
                       log_msg, log_msg)
         logging.getLogger('privacyidea').setLevel(logging.INFO)
+        """
+        Verify that the QR code was generated with SHA256, this is in the log file.
+        It will be indicated by this text:
+        
+              Entering create_google_authenticator_url with arguments () and keywords ... 'hash_algo': 'sha1'
+        """
+        sha256rebexp = re.compile(r"Entering create_google_authenticator_url with arguments.*'hash_algo': 'sha256'")
+        self.assertTrue(sha256rebexp.search(log_msg), log_msg)
+
+        # Check SHA256 of the token.
+        self.assertEqual("sha256", token_obj.get_tokeninfo("hashlib"))
 
         # Cleanup
         delete_policy("pol_passthru")
         delete_policy("pol_multienroll")
         delete_policy("pol_forcepin")
+        set_privacyidea_config("hotp.hashlib", "sha1")
         remove_token(serial)
 
     @ldap3mock.activate
-    def test_02_enroll_TOTP(self):
+    @log_capture(level=logging.DEBUG)
+    def test_02_enroll_TOTP(self, capture):
         # Init LDAP
         ldap3mock.setLDAPDirectory(LDAPDirectory)
+        logging.getLogger('privacyidea.lib.tokens.totptoken').setLevel(logging.DEBUG)
+        logging.getLogger('privacyidea.lib.apps').setLevel(logging.DEBUG)
         # create realm
         set_realm("ldaprealm", resolvers=[{'name': "catchall"}])
         set_default_realm("ldaprealm")
 
         # 1. set policies.
-        # Policy scope:auth, action:enroll_via_multichallenge=hotp
+        # Policy scope:auth, action:enroll_via_multichallenge=totp
         set_policy("pol_passthru", scope=SCOPE.AUTH, action=ACTION.PASSTHRU)
 
         # 2. authenticate user via passthru
@@ -5657,6 +5675,11 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         # Set enroll policy
         set_policy("pol_multienroll", scope=SCOPE.AUTH,
                    action="{0!s}=totp".format(ACTION.ENROLL_VIA_MULTICHALLENGE))
+
+        # Set totp_hashlib=sha256 user policy
+        set_policy("pol_sha256", scope=SCOPE.USER,
+                   action="totp_hashlib=sha256")
+
         # Now we should get an authentication Challenge
         with self.app.test_request_context('/validate/check',
                                            method='POST',
@@ -5683,6 +5706,8 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         token_obj = get_tokens(serial=serial)[0]
         counter = int(time.time() / 30)
         otp = token_obj._calc_otp(counter)
+        # Capture the log for later hash validation
+        log_msg = str(capture)
 
         # 4a. fail to authenticate with a wrong OTP value
         with self.app.test_request_context('/validate/check',
@@ -5710,9 +5735,14 @@ class MultiChallengeEnrollTest(MyApiTestCase):
             self.assertTrue(result.get("value"))
             self.assertEqual(result.get("authentication"), "ACCEPT")
 
+        sha256rebexp = re.compile(r"Entering create_google_authenticator_url with arguments.*'hash_algo': 'sha256'")
+        self.assertTrue(sha256rebexp.search(log_msg), log_msg)
+        # Check SHA256 of the token.
+        self.assertEqual("sha256", token_obj.get_tokeninfo("hashlib"))
         # Cleanup
         delete_policy("pol_passthru")
         delete_policy("pol_multienroll")
+        delete_policy("pol_sha256")
         remove_token(serial)
 
     @ldap3mock.activate


### PR DESCRIPTION
During validate/enrollment we now also use the token defaults (like hashlib) and also the user policies for hashlib, otp length and timestep.

Fixes #3976