### PR TITLE
Make JWT validity configurable

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -65,7 +65,8 @@ from privacyidea.api.lib.postpolicy import (postpolicy, get_webui_settings, add_
                                             get_webui_settings)
 from privacyidea.api.lib.prepolicy import (is_remote_user_allowed, prepolicy,
                                            pushtoken_disable_wait, webauthntoken_authz, webauthntoken_request,
-                                           webauthntoken_auth, increase_failcounter_on_challenge)
+                                           webauthntoken_auth, increase_failcounter_on_challenge,
+                                           jwt_validity)
 from privacyidea.api.lib.utils import (send_result, get_all_params,
                                        verify_auth_token, getParam)
 from privacyidea.lib.utils import get_client_ip, hexlify_and_unicode, to_unicode, get_plugin_info_from_useragent
@@ -131,6 +132,7 @@ def before_request():
 @prepolicy(webauthntoken_request, request=request)
 @prepolicy(webauthntoken_authz, request=request)
 @prepolicy(webauthntoken_auth, request=request)
+@prepolicy(jwt_validity, request)
 @postpolicy(get_webui_settings)
 @postpolicy(no_detail_on_success, request=request)
 @postpolicy(add_user_detail_to_response, request=request)
@@ -212,7 +214,8 @@ def get_auth_token():
        }
 
     """
-    validity = timedelta(hours=1)
+    jwt_validaty = getParam(request.all_data, "jwt_validity")
+    validity = timedelta(seconds=int(jwt_validaty))
     username = getParam(request.all_data, "username")
     password = getParam(request.all_data, "password")
     realm_param = getParam(request.all_data, "realm")

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -128,6 +128,7 @@ class prepolicy(object):
     A prepolicy decorator then will modify the request data or raise an
     exception
     """
+
     def __init__(self, function, request, action=None):
         """
         :param function: This is the policy function the is to be called
@@ -152,6 +153,7 @@ class prepolicy(object):
         :type wrapped_function: API function
         :return: None
         """
+
         @functools.wraps(wrapped_function)
         def policy_wrapper(*args, **kwds):
             self.function(request=self.request,
@@ -173,7 +175,7 @@ def _generate_pin_from_policy(policy, size=6):
     charlists_dict = generate_charlists_from_pin_policy(policy)
 
     pin = generate_password(size=size, characters=charlists_dict['base'],
-                      requirements=charlists_dict['requirements'])
+                            requirements=charlists_dict['requirements'])
     return pin
 
 
@@ -216,7 +218,7 @@ def set_random_pin(request=None, action=None):
 
         if len(pol_contents) == 1:
             log.info("Creating random OTP PIN with length {0!s} "
-                      "matching the contents policy {1!s}".format(list(pin_pols)[0], list(pol_contents)[0]))
+                     "matching the contents policy {1!s}".format(list(pin_pols)[0], list(pol_contents)[0]))
             # generate a pin which matches the contents requirement
             r = _generate_pin_from_policy(list(pol_contents)[0], size=int(list(pin_pols)[0]))
             request.all_data["pin"] = r
@@ -252,7 +254,7 @@ def init_random_pin(request=None, action=None):
 
         if len(pol_contents) == 1:
             log.info("Creating random OTP PIN with length {0!s} "
-                      "matching the contents policy {1!s}".format(list(pin_pols)[0], list(pol_contents)[0]))
+                     "matching the contents policy {1!s}".format(list(pin_pols)[0], list(pol_contents)[0]))
             # generate a pin which matches the contents requirement
             r = _generate_pin_from_policy(list(pol_contents)[0], size=int(list(pin_pols)[0]))
             request.all_data["pin"] = r
@@ -480,8 +482,8 @@ def enroll_pin(request=None, action=None):
     enrollment. If not, it deleted the PIN from the request.
     """
     resolver = request.User.resolver if request.User else None
-    (role, username, userrealm, adminuser, adminrealm ) = determine_logged_in_userparams(g.logged_in_user,
-                                                                                         request.all_data)
+    (role, username, userrealm, adminuser, adminrealm) = determine_logged_in_userparams(g.logged_in_user,
+                                                                                        request.all_data)
     allowed_action = Match.generic(g, scope=role,
                                    action=ACTION.ENROLLPIN,
                                    user_object=request.User,
@@ -547,12 +549,12 @@ def init_token_length_contents(request=None, action=None):
 
     user_object = get_user_from_param(params)
     length_pols = Match.user(g, scope=SCOPE.ENROLL, action=length_action,
-                            user_object=user_object).action_values(unique=True)
+                             user_object=user_object).action_values(unique=True)
     if len(length_pols) == 1:
         request.all_data[length_action] = list(length_pols)[0]
         no_length_policy = False
     content_pols = Match.user(g, scope=SCOPE.ENROLL, action=contents_action,
-                            user_object=user_object).action_values(unique=True)
+                              user_object=user_object).action_values(unique=True)
     if len(content_pols) == 1:
         request.all_data[contents_action] = list(content_pols)[0]
         no_content_policy = False
@@ -725,7 +727,7 @@ def twostep_enrollment_parameters(request=None, action=None):
     # Differentiate between an admin enrolling a token for the
     # user and a user self-enrolling a token.
     (role, username, userrealm, adminuser, adminrealm) = determine_logged_in_userparams(g.logged_in_user,
-                                                                                         request.all_data)
+                                                                                        request.all_data)
     # Tokentypes have separate twostep actions
     if is_true(getParam(request.all_data, "2stepinit", optional)):
         parameters = ("2step_serversize", "2step_clientsize", "2step_difficulty")
@@ -1473,7 +1475,7 @@ def pushtoken_validate(request, action):
     """
     user_object = request.User
     waiting = Match.user(g, scope=SCOPE.AUTH, action=PUSH_ACTION.WAIT,
-                         user_object=user_object if user_object else None)\
+                         user_object=user_object if user_object else None) \
         .action_values(unique=True, allow_white_space_in_action=True)
     if len(waiting) >= 1:
         request.all_data[PUSH_ACTION.WAIT] = int(list(waiting)[0])
@@ -1481,7 +1483,7 @@ def pushtoken_validate(request, action):
         request.all_data[PUSH_ACTION.WAIT] = False
 
     require_presence = Match.user(g, scope=SCOPE.AUTH, action=PUSH_ACTION.REQUIRE_PRESENCE,
-                       user_object=user_object if user_object else None).action_values(unique=True)
+                                  user_object=user_object if user_object else None).action_values(unique=True)
     if len(require_presence) >= 1:
         request.all_data[PUSH_ACTION.REQUIRE_PRESENCE] = list(require_presence)[0]
     else:
@@ -1560,11 +1562,11 @@ def u2ftoken_allowed(request, action):
         # We just check, if the issuer is allowed, not if the certificate
         # is still valid! (verify_cert=False)
         attestation_cert, user_pub_key, key_handle, \
-        signature, description = parse_registration_data(reg_data,
-                                                         verify_cert=False)
+            signature, description = parse_registration_data(reg_data,
+                                                             verify_cert=False)
 
         allowed_certs_pols = Match.user(g, scope=SCOPE.ENROLL, action=U2FACTION.REQ,
-                                        user_object=request.User if request.User else None)\
+                                        user_object=request.User if request.User else None) \
             .action_values(unique=False)
 
         if len(allowed_certs_pols) and not _attestation_certificate_allowed(attestation_cert, allowed_certs_pols):
@@ -1693,7 +1695,7 @@ def webauthntoken_request(request, action):
     if not request.all_data.get("type") \
             and not is_webauthn_assertion_response(request.all_data) \
             and ('serial' not in request.all_data
-                or request.all_data['serial'].startswith(WebAuthnTokenClass.get_class_prefix())):
+                 or request.all_data['serial'].startswith(WebAuthnTokenClass.get_class_prefix())):
         webauthn = True
         scope = SCOPE.AUTH
 
@@ -1726,8 +1728,8 @@ def webauthntoken_request(request, action):
             if user_verification_requirement not in USER_VERIFICATION_LEVELS:
                 raise PolicyError(
                     "{0!s} must be one of {1!s}"
-                        .format(WEBAUTHNACTION.USER_VERIFICATION_REQUIREMENT,
-                                ", ".join(USER_VERIFICATION_LEVELS)))
+                    .format(WEBAUTHNACTION.USER_VERIFICATION_REQUIREMENT,
+                            ", ".join(USER_VERIFICATION_LEVELS)))
 
             request.all_data[WEBAUTHNACTION.USER_VERIFICATION_REQUIREMENT] \
                 = user_verification_requirement
@@ -1777,7 +1779,7 @@ def webauthntoken_authz(request, action):
 
     # If a WebAuthn token is being authorized.
     if is_webauthn_assertion_response(request.all_data):
-        allowed_certs_pols = Match\
+        allowed_certs_pols = Match \
             .user(g,
                   scope=SCOPE.AUTHZ,
                   action=WEBAUTHNACTION.REQ,
@@ -1828,7 +1830,7 @@ def webauthntoken_auth(request, action):
             and not is_webauthn_assertion_response(request.all_data) \
             and ('serial' not in request.all_data
                  or request.all_data['serial'].startswith(WebAuthnTokenClass.get_class_prefix())):
-        allowed_transports_policies = Match\
+        allowed_transports_policies = Match \
             .user(g,
                   scope=SCOPE.AUTH,
                   action=WEBAUTHNACTION.ALLOWED_TRANSPORTS,
@@ -1845,7 +1847,7 @@ def webauthntoken_auth(request, action):
             for transport in allowed_transports_policy.split()
         )
 
-        challengetext_policies = Match\
+        challengetext_policies = Match \
             .user(g,
                   scope=SCOPE.AUTH,
                   action="{0!s}_{1!s}".format(WebAuthnTokenClass.get_class_type(), ACTION.CHALLENGETEXT),
@@ -1900,7 +1902,7 @@ def webauthntoken_enroll(request, action):
 
     ttype = request.all_data.get("type")
     if ttype and ttype.lower() == WebAuthnTokenClass.get_class_type():
-        rp_id_policies = Match\
+        rp_id_policies = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action=WEBAUTHNACTION.RELYING_PARTY_ID,
@@ -1911,7 +1913,7 @@ def webauthntoken_enroll(request, action):
         else:
             raise PolicyError("Missing enrollment policy for WebauthnToken: " + WEBAUTHNACTION.RELYING_PARTY_ID)
 
-        rp_name_policies = Match\
+        rp_name_policies = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action=WEBAUTHNACTION.RELYING_PARTY_NAME,
@@ -1927,12 +1929,12 @@ def webauthntoken_enroll(request, action):
         if not is_fqdn(rp_id):
             log.warning(
                 "Illegal value for {0!s} (must be a domain name): {1!s}"
-                    .format(WEBAUTHNACTION.RELYING_PARTY_ID, rp_id))
+                .format(WEBAUTHNACTION.RELYING_PARTY_ID, rp_id))
             raise PolicyError(
                 "Illegal value for {0!s} (must be a domain name)."
-                    .format(WEBAUTHNACTION.RELYING_PARTY_ID))
+                .format(WEBAUTHNACTION.RELYING_PARTY_ID))
 
-        authenticator_attachment_policies = Match\
+        authenticator_attachment_policies = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action=WEBAUTHNACTION.AUTHENTICATOR_ATTACHMENT,
@@ -1956,10 +1958,10 @@ def webauthntoken_enroll(request, action):
         if not all([x in PUBLIC_KEY_CREDENTIAL_ALGORITHMS for x in public_key_credential_algorithm_pref]):
             raise PolicyError(
                 "{0!s} must be one of {1!s}"
-                    .format(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHMS,
-                            ', '.join(PUBLIC_KEY_CREDENTIAL_ALGORITHMS.keys())))
+                .format(WEBAUTHNACTION.PUBLIC_KEY_CREDENTIAL_ALGORITHMS,
+                        ', '.join(PUBLIC_KEY_CREDENTIAL_ALGORITHMS.keys())))
 
-        authenticator_attestation_level_policies = Match\
+        authenticator_attestation_level_policies = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action=WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL,
@@ -1973,7 +1975,7 @@ def webauthntoken_enroll(request, action):
                 "{0!s} must be one of {1!s}".format(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_LEVEL,
                                                     ', '.join(ATTESTATION_LEVELS)))
 
-        authenticator_attestation_form_policies = Match\
+        authenticator_attestation_form_policies = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action=WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM,
@@ -1987,7 +1989,7 @@ def webauthntoken_enroll(request, action):
                 "{0!s} must be one of {1!s}".format(WEBAUTHNACTION.AUTHENTICATOR_ATTESTATION_FORM,
                                                     ', '.join(ATTESTATION_FORMS)))
 
-        challengetext_policies = Match\
+        challengetext_policies = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action="{0!s}_{1!s}".format(WebAuthnTokenClass.get_class_type(), ACTION.CHALLENGETEXT),
@@ -1999,7 +2001,7 @@ def webauthntoken_enroll(request, action):
             if challengetext_policies \
             else DEFAULT_CHALLENGE_TEXT_ENROLL
 
-        avoid_double_registration_policy = Match\
+        avoid_double_registration_policy = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action=WEBAUTHNACTION.AVOID_DOUBLE_REGISTRATION,
@@ -2072,7 +2074,7 @@ def webauthntoken_allowed(request, action):
                                                                       auth_data=att_obj.get('authData'))
 
         attestation_cert = crypto.X509.from_cryptography(trust_path[0]) if trust_path else None
-        allowed_certs_pols = Match\
+        allowed_certs_pols = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action=WEBAUTHNACTION.REQ,
@@ -2103,13 +2105,13 @@ def webauthntoken_allowed(request, action):
         if allowed_certs_pols and not _attestation_certificate_allowed(attestation_cert, allowed_certs_pols):
             log.warning(
                 "The WebAuthn token {0!s} is not allowed to be registered due to policy restriction {1!s}"
-                    .format(serial, WEBAUTHNACTION.REQ))
+                .format(serial, WEBAUTHNACTION.REQ))
             raise PolicyError("The WebAuthn token is not allowed to be registered due to a policy restriction.")
 
         if allowed_aaguids and aaguid not in [allowed_aaguid.replace("-", "") for allowed_aaguid in allowed_aaguids]:
             log.warning(
                 "The WebAuthn token {0!s} is not allowed to be registered due to policy restriction {1!s}"
-                    .format(serial, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST))
+                .format(serial, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST))
             raise PolicyError("The WebAuthn token is not allowed to be registered due to a policy restriction.")
 
     return True
@@ -2169,7 +2171,7 @@ def required_piv_attestation(request, action=None):
     if ttype and ttype.lower() == "certificate":
         # Get attestation certificate requirement
         require_att = Match.user(g, scope=SCOPE.ENROLL, action=ACTION.REQUIRE_ATTESTATION,
-                                     user_object=request.User if request.User else None).action_values(unique=True)
+                                 user_object=request.User if request.User else None).action_values(unique=True)
         if REQUIRE_ACTIONS.REQUIRE_AND_VERIFY in list(require_att):
             if not request.all_data.get("attestation"):
                 # There is no attestation certificate in the request, although it is required!
@@ -2198,7 +2200,7 @@ def hide_tokeninfo(request=None, action=None):
     :rtype: bool
     """
     hidden_fields = Match.admin_or_user(g, action=ACTION.HIDE_TOKENINFO,
-                                        user_obj=request.User)\
+                                        user_obj=request.User) \
         .action_values(unique=False)
 
     request.all_data['hidden_tokeninfo'] = list(hidden_fields)
@@ -2234,12 +2236,12 @@ def require_description(request=None, action=None):
     (role, username, realm, adminuser, adminrealm) = determine_logged_in_userparams(g.logged_in_user, params)
 
     action_values = Match.generic(g, action=ACTION.REQUIRE_DESCRIPTION,
-                             scope=SCOPE.ENROLL,
-                             adminrealm=adminrealm,
-                             adminuser=adminuser,
-                             user=username,
-                             realm=realm,
-                             user_object=user_object).action_values(unique=False)
+                                  scope=SCOPE.ENROLL,
+                                  adminrealm=adminrealm,
+                                  adminuser=adminuser,
+                                  user=username,
+                                  realm=realm,
+                                  user_object=user_object).action_values(unique=False)
 
     token_types = list(action_values.keys())
     type_value = request.all_data.get("type") or 'hotp'
@@ -2262,16 +2264,15 @@ def jwt_validity(request, action):
     :param action:
     :return:
     """
-    jwt_validity_pol = (Match.user(g, scope=SCOPE.WEBUI, action=ACTION.JWTVALIDITY,
-                                   user_object=request.User if hasattr(request, 'User') else None)
-                        .action_values(unique=True))
+    validity_time_pol = (Match.user(g, scope=SCOPE.WEBUI, action=ACTION.JWTVALIDITY,
+                                    user_object=request.User if hasattr(request, 'User') else None)
+                         .action_values(unique=True))
 
-    jwt_validity = DEFAULT_JWT_VALIDITY
-    if len(jwt_validity_pol) == 1:
+    validity_time = DEFAULT_JWT_VALIDITY
+    if len(validity_time_pol) == 1:
         try:
-            jwt_validity = int(list(jwt_validity_pol)[0])
+            validity_time = int(list(validity_time_pol)[0])
         except ValueError:
-            log.warning("Invalid JWT validity period: {0!s}. Using the default of 1 hour.".format(jwt_validity_pol))
-    request.all_data[ACTION.JWTVALIDITY] = jwt_validity
+            log.warning(f"Invalid JWT validity period: {validity_time}. Using the default of 1 hour.")
+    request.all_data[ACTION.JWTVALIDITY] = validity_time
     return True
-

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -258,6 +258,7 @@ class ACTION(object):
     LOGINMODE = "login_mode"
     LOGOUT_REDIRECT = "logout_redirect"
     LOGOUTTIME = "logout_time"
+    JWTVALIDITY = "jwt_validity"
     LOSTTOKEN = 'losttoken'
     LOSTTOKENPWLEN = "losttoken_PW_length"
     LOSTTOKENPWCONTENTS = "losttoken_PW_contents"
@@ -2556,6 +2557,11 @@ def get_static_policy_definitions(scope=None):
                 'type': 'int',
                 'desc': _("Set the time in seconds after which the user will "
                           "be logged out from the WebUI. Default: 120")
+            },
+            ACTION.JWTVALIDITY: {
+                'type': 'int',
+                'desc': _("privacyIDEA issues a JWT when the user or admins logs in to the WebUI. "
+                          "The default validity is 1 hour. You can specify different validity times in seconds.")
             },
             ACTION.TOKENPAGESIZE: {
                 'type': 'int',

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -3459,7 +3459,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         # Set policy
         set_policy(name="jwt_validity",
                    scope=SCOPE.WEBUI,
-                   action=["{0!s}=12".format(ACTION.JWTVALIDITY)])
+                   action=[f"{ACTION.JWTVALIDITY}=12"])
         req = Request(env)
         req.User = User("cornelius")
         req.all_data = {}
@@ -3472,7 +3472,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         # Now test a bogus policy
         set_policy(name="jwt_validity",
                    scope=SCOPE.WEBUI,
-                   action=["{0!s}=oneMinute".format(ACTION.JWTVALIDITY)])
+                   action=[f"{ACTION.JWTVALIDITY}=oneMinute"])
         req = Request(env)
         req.User = User("cornelius")
         req.all_data = {}
@@ -3482,6 +3482,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         self.assertEqual(3600, req.all_data.get("jwt_validity"))
 
         delete_policy("jwt_validity")
+
 
 class PostPolicyDecoratorTestCase(MyApiTestCase):
 


### PR DESCRIPTION
A WebUI policy can now define the validity of the
JWT in seconds.

Closes #3996