### PR TITLE
Make SMS text policy available during verify

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -963,7 +963,8 @@ def check_verify_enrollment(request, response):
                     g.audit_object.add_policy(verify_pol_dict.get(toks))
             if do_verify_enrollment:
                 content = response.json
-                content["detail"]["verify"] = tokenobj.prepare_verify_enrollment()
+                options = {"g": g, "user": request.User, "exception": request.all_data.get("exception", 0)}
+                content["detail"]["verify"] = tokenobj.prepare_verify_enrollment(options=options)
                 content["detail"]["rollout_state"] = ROLLOUTSTATE.VERIFYPENDING
                 tokenobj.token.rollout_state = ROLLOUTSTATE.VERIFYPENDING
                 tokenobj.token.save()

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -524,7 +524,7 @@ def get_token_classes():
     <class 'privacyidea.lib.tokens.hotptoken.HotpTokenClass'>]
 
     :return: array of token classes
-    :rtype: array
+    :rtype: list
     """
     if "pi_token_classes" not in this.config:
         (t_classes, t_types) = get_token_class_dict()

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -2305,9 +2305,13 @@ def get_static_policy_definitions(scope=None):
                 'value': list(get_email_validators().keys())},
             ACTION.VERIFY_ENROLLMENT: {
                 'type': 'str',
-                'desc': _("Specify a white space separated list of token types, "
-                          "that should be verified during enrollment."),
-                'group': GROUP.TOKEN}
+                'desc': _("Specify the list of token types, "
+                          "that must be verified during enrollment."),
+                'group': GROUP.TOKEN,
+                'multiple': True,
+                'value': [token_obj.get_class_type() for token_obj in get_token_classes() if
+                          token_obj.can_verify_enrollment]
+            }
         },
         SCOPE.AUTH: {
             ACTION.OTPPIN: {
@@ -2319,8 +2323,8 @@ def get_static_policy_definitions(scope=None):
                           'component.')},
             ACTION.CHALLENGERESPONSE: {
                 'type': 'str',
-                'desc': _('This is a whitespace separated list of tokentypes, '
-                          'that can be used with challenge response.'),
+                'desc': _('Specify the list of token types, '
+                          'that must be used with challenge response.'),
                 'multiple': True,
                 'value': [token_obj.get_class_type() for token_obj in get_token_classes() if "challenge" in token_obj.mode and len(token_obj.mode) > 1]
             },

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -59,7 +59,7 @@ This is the Token Base class, which is inherited by all token types.
 It depends on lib.user and lib.config.
 
 The token object also contains a database token object as self.token.
-The token object runs the self.update() method during the initialization 
+The token object runs the self.update() method during the initialization
 process in the API /token/init.
 
 The update method takes a dictionary. Some of the following parameters:
@@ -70,8 +70,8 @@ genkey      -> genkey=1 : privacyIDEA generates an OTPKey, creates the token
 2stepinit   -> Will do a two step rollout.
                privacyIDEA creates the first part of the OTPKey, sends it
                to the client and the clients needs to send back the second part.
-               
-In case of 2stepinit the key is generated from the server_component and the 
+
+In case of 2stepinit the key is generated from the server_component and the
 client_component using the TokenClass method generate_symmetric_key.
 This method is supposed to be overwritten by the corresponding token classes.
 """
@@ -89,7 +89,7 @@ from .log import log_with
 from .config import (get_from_config, get_prepend_pin)
 from .user import (User,
                    get_username)
-from ..models import (TokenOwner, TokenTokengroup, Tokengroup, Challenge, cleanup_challenges)
+from ..models import (TokenOwner, TokenTokengroup, Challenge, cleanup_challenges)
 from .challenge import get_challenges
 from privacyidea.lib.crypto import (encryptPassword, decryptPassword,
                                     generate_otpkey)
@@ -106,10 +106,7 @@ from base64 import b32encode
 from binascii import unhexlify
 
 
-
-#DATE_FORMAT = "%d/%m/%y %H:%M"
 DATE_FORMAT = '%Y-%m-%dT%H:%M%z'
-# LASTAUTH is utcnow()
 AUTH_DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f%z"
 optional = True
 required = False
@@ -150,7 +147,7 @@ class CLIENTMODE(object):
     U2F = 'u2f'
     WEBAUTHN = 'webauthn'
 
-    
+
 class ROLLOUTSTATE(object):
     CLIENTWAIT = 'clientwait'
     # The rollout is pending in the backend, like CSRs that need to be approved
@@ -175,12 +172,11 @@ class TokenClass(object):
     # If the token is enrollable via multichallenge
     is_multichallenge_enrollable = False
 
-
     @log_with(log)
     def __init__(self, db_token):
         """
         Create a new token object.
-        
+
         :param db_token: A database token object
         :type db_token: Token
         :return: A TokenClass object
@@ -200,7 +196,7 @@ class TokenClass(object):
         """
         Set the tokentype in this object and
         also in the underlying database-Token-object.
-        
+
         :param tokentype: The type of the token like HOTP or TOTP
         :type tokentype: string
         """
@@ -231,7 +227,7 @@ class TokenClass(object):
     def add_user(self, user, report=None):
         """
         Set the user attributes (uid, resolvername, resolvertype) of a token.
-        
+
         :param user: a User() object, consisting of loginname and realm
         :param report: tbdf.
         :return: None
@@ -307,8 +303,8 @@ class TokenClass(object):
     def is_orphaned(self):
         """
         Return True if the token is orphaned.
-        
-        An orphaned token means, that it has a user assigned, but the user 
+
+        An orphaned token means, that it has a user assigned, but the user
         does not exist in the user store (anymore)
 
         :return: True / False
@@ -337,7 +333,7 @@ class TokenClass(object):
         user_info = user_object.info
         user_identifier = "{0!s}_{1!s}".format(user_object.login, user_object.realm)
         user_displayname = "{0!s} {1!s}".format(user_info.get("givenname", "."),
-                                      user_info.get("surname", "."))
+                                                user_info.get("surname", "."))
         return user_identifier, user_displayname
 
     @check_token_locked
@@ -445,7 +441,7 @@ class TokenClass(object):
         The default token does not support getting the otp value
         will return a tuple of four values
         a negative value is a failure.
-        
+
         :return: something like:  (1, pin, otpval, combined)
         """
         return -2, 0, 0, 0
@@ -535,7 +531,6 @@ class TokenClass(object):
             pin_match = self.check_pin(pin, user=user, options=options)
             if pin_match is True:
                 otp_counter = self.check_otp(otpval, options=options)
-                #self.set_otp_count(otp_counter)
 
         return pin_match, otp_counter, reply
 
@@ -565,7 +560,7 @@ class TokenClass(object):
     def update(self, param, reset_failcount=True):
         """
         Update the token object
-        
+
         :param param: a dictionary with different params like keysize,
                       description, genkey, otpkey, pin
         :type: param: dict
@@ -610,8 +605,7 @@ class TokenClass(object):
             # The token is disabled
             self.token.active = False
 
-
-        #if genkey not in [0, 1]:
+        # if genkey not in [0, 1]:
         #    raise ParameterError("TokenClass supports only genkey in  range ["
         #                         "0,1] : %r" % genkey)
 
@@ -622,7 +616,7 @@ class TokenClass(object):
         if otpKey is None and genkey:
             otpKey = self._genOtpKey_(key_size)
 
-        # otpKey still None?? - raise the exception, if an otpkey is required and we are not in verify state
+        # otpKey still None?? - raise the exception, if an otpkey is required, and we are not in verify state
         if otpKey is None and self.hKeyRequired is True and not verify:
             otpKey = getParam(param, "otpkey", required)
 
@@ -667,9 +661,9 @@ class TokenClass(object):
         return
 
     def _genOtpKey_(self, otpkeylen=None):
-        '''
+        """
         private method, to create an otpkey
-        '''
+        """
         if otpkeylen is None:
             if hasattr(self, 'otpkeylen'):
                 otpkeylen = getattr(self, 'otpkeylen')
@@ -681,13 +675,14 @@ class TokenClass(object):
     def set_description(self, description):
         """
         Set the description on the database level
-        
+
         :param description: description of the token
         :type description: string
         """
         self.token.set_description('' + description)
         return
 
+    @check_token_locked
     def set_defaults(self):
         """
         Set the default values on the database level
@@ -764,6 +759,7 @@ class TokenClass(object):
     def get_failcount(self):
         return self.token.failcount
 
+    @check_token_locked
     def set_failcount(self, failcount):
         """
         Set the failcounter in the database
@@ -790,6 +786,7 @@ class TokenClass(object):
         """
         self.token.set_tokengroups(tokengroups, add=add)
 
+    @check_token_locked
     def set_realms(self, realms, add=False):
         """
         Set the list of the realms of a token.
@@ -800,7 +797,7 @@ class TokenClass(object):
         :type add: boolean
         """
         self.token.set_realms(realms, add=add)
-        
+
     def get_realms(self):
         """
         Return a list of realms the token is assigned to
@@ -809,10 +806,10 @@ class TokenClass(object):
         :rtype: list
         """
         return self.token.get_realms()
-        
+
     def get_serial(self):
         return self.token.serial
-    
+
     def get_tokentype(self):
         return self.token.tokentype
 
@@ -832,7 +829,6 @@ class TokenClass(object):
     def set_otplen(self, otplen):
         self.token.otplen = int(otplen)
 
-    @check_token_locked
     def get_otplen(self):
         return self.token.otplen
 
@@ -871,7 +867,7 @@ class TokenClass(object):
     def revoke(self):
         """
         This revokes the token.
-        By default it
+        By default, it
         1. sets the revoked-field
         2. set the locked field
         3. disables the token.
@@ -1090,8 +1086,8 @@ class TokenClass(object):
 
     def get_validity_period_end(self):
         """
-        returns the end of validity period (if set)
-        if not set, "" is returned.
+        Returns the end of validity period (if set).
+        If it is not set, "" is returned.
 
         :return: the end of the validity period
         :rtype: str
@@ -1156,6 +1152,7 @@ class TokenClass(object):
 
             self.add_tokeninfo("validity_period_start", d.strftime(DATE_FORMAT))
 
+    @check_token_locked
     def set_next_pin_change(self, diff=None, password=False):
         """
         Sets the timestamp for the next_pin_change. Provide a
@@ -1258,8 +1255,8 @@ class TokenClass(object):
         """
         This function checks the count_auth and the count_auth_success.
         If the counters are less or equal than the maximum allowed counters
-        it returns True. Otherwise False.
-        
+        it returns True. Otherwise, False.
+
         :return: success if the counter is less than max
         :rtype: bool
         """
@@ -1370,7 +1367,7 @@ class TokenClass(object):
         checks if the given OTP value is/are values of this very token.
         This is used to autoassign and to determine the serial number of
         a token.
-        
+
         :param otp: the OTP value
         :param window: The look ahead window
         :type window: int
@@ -1451,13 +1448,13 @@ class TokenClass(object):
     def get_init_detail(self, params=None, user=None):
         """
         to complete the token initialization, the response of the initialization
-        should be build by this token specific method.
+        should be built by this token specific method.
         This method is called from api/token after the token is enrolled
 
         get_init_detail returns additional information after an admin/init
         like the QR code of an HOTP/TOTP token.
         Can be anything else.
-        
+
         :param params: The request params during token creation token/init
         :type params: dict
         :param user: the user, token owner
@@ -1795,7 +1792,7 @@ class TokenClass(object):
 
     @classmethod
     def _get_default_settings(cls, g, role="user", username=None, userrealm=None,
-                                      adminuser=None, adminrealm=None):
+                              adminuser=None, adminrealm=None):
         """
         Internal function that can be called either during enrollment via /token/init or during
         enrollment via validate/check.
@@ -1818,7 +1815,7 @@ class TokenClass(object):
         :type last_auth: basestring
         :return: bool
         """
-        # per default we return True
+        # By default, we return True
         res = True
         # The tdelta in the policy
         tdelta = parse_timedelta(last_auth)
@@ -1852,20 +1849,20 @@ class TokenClass(object):
     def generate_symmetric_key(self, server_component, client_component,
                                options=None):
         """
-        This method generates a symmetric key, from a server component and a 
-        client component. 
+        This method generates a symmetric key, from a server component and a
+        client component.
         This key generation could be based on HMAC, KDF or even Diffie-Hellman.
-        
-        The basic key-generation is simply replacing the last n byte of the 
+
+        The basic key-generation is simply replacing the last n byte of the
         server component with bytes of the client component.
-                
+
         :param server_component: The component usually generated by privacyIDEA.
                                  This is a hex string
         :type server_component: str
         :param client_component: The component usually generated by the
             client (e.g. smartphone). This is a hex string.
         :type client_component: str
-        :param options: 
+        :param options:
         :return: the new generated key as hex string
         :rtype: str
         """
@@ -1912,7 +1909,7 @@ class TokenClass(object):
 
         return params
 
-    def prepare_verify_enrollment(self):
+    def prepare_verify_enrollment(self, options=None):
         """
         This is called, if the token should be enrolled in a way, that the user
         needs to provide a proof, that the server can verify, that the token

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -321,10 +321,11 @@ class HotpTokenClass(TokenClass):
 
         Do we really always need an otpkey?
         the otpKey is handled in the parent class
+
         :param param: dict of initialization parameters
         :type param: dict
-
-        :return: nothing
+        :param reset_failcount: reset the failcount
+        :type reset_failcount: bool
         """
         # In case am Immutable MultiDict:
         upd_param = {}
@@ -382,6 +383,7 @@ class HotpTokenClass(TokenClass):
     def _calc_otp(self, counter):
         """
         Helper function to calculate the OTP value for the given counter
+
         :param counter: The OTP counter
         :return: OTP value as string
         """
@@ -480,7 +482,6 @@ class HotpTokenClass(TokenClass):
         Check if the OTP values was previously used.
 
         :param otp:
-        :param window:
         :return:
         """
         counter = int(self.get_otp_count())
@@ -517,7 +518,7 @@ class HotpTokenClass(TokenClass):
 
         # if _autosync is not enabled
         if autosync is False:
-            log.debug("end. _autosync is not enabled : res {0!r}".format((res)))
+            log.debug("end. _autosync is not enabled : res {0!r}".format(res))
             return res
 
         info = self.get_tokeninfo()
@@ -589,7 +590,7 @@ class HotpTokenClass(TokenClass):
         counter = hmac2Otp.checkOtp(otp1, syncWindow)
 
         if counter == -1:
-            log.debug("exit. First counter (-1) not found  ret: {0!r}".format((ret)))
+            log.debug("exit. First counter (-1) not found  ret: {0!r}".format(ret))
             return ret
 
         nextOtp = hmac2Otp.generate(counter + 1)
@@ -602,7 +603,7 @@ class HotpTokenClass(TokenClass):
         ret = True
         self.inc_otp_counter(counter + 1, reset=True)
 
-        log.debug("end. resync was successful: ret: {0!r}".format((ret)))
+        log.debug("end. resync was successful: ret: {0!r}".format(ret))
         return ret
 
     @staticmethod
@@ -616,7 +617,7 @@ class HotpTokenClass(TokenClass):
         try:
             timeOut = int(get_from_config("AutoResyncTimeout", 5 * 60))
         except Exception as ex:
-            log.warning("AutoResyncTimeout: value error {0!r} - reset to 5*60".format((ex)))
+            log.warning("AutoResyncTimeout: value error {0!r} - reset to 5*60".format(ex))
             timeOut = 5 * 60
 
         return timeOut
@@ -626,7 +627,7 @@ class HotpTokenClass(TokenClass):
         """
         return the next otp value
 
-        :param curTime: Not Used in HOTP
+        :param current_time: Not Used in HOTP
         :return: next otp value and PIN if possible
         :rtype: tuple
         """
@@ -707,6 +708,7 @@ class HotpTokenClass(TokenClass):
         with these values.
 
         The returned dictionary is added to the parameters of the API call.
+
         :param g: context object, see documentation of ``Match``
         :param params: The call parameters
         :type params: dict
@@ -798,7 +800,7 @@ class HotpTokenClass(TokenClass):
             params["counter"] = int(l[4].strip())
         return params
 
-    def prepare_verify_enrollment(self):
+    def prepare_verify_enrollment(self, options=None):
         """
         This is called, if the token should be enrolled in a way, that the user
         needs to provide a proof, that the server can verify, that the token

--- a/privacyidea/lib/tokens/indexedsecrettoken.py
+++ b/privacyidea/lib/tokens/indexedsecrettoken.py
@@ -339,7 +339,7 @@ class IndexedSecretTokenClass(TokenClass):
 
         return False
 
-    def prepare_verify_enrollment(self):
+    def prepare_verify_enrollment(self, options=None):
         """
         This is called, if the token should be enrolled in a way, that the user
         needs to provide a proof, that the server can verify, that the token
@@ -350,7 +350,7 @@ class IndexedSecretTokenClass(TokenClass):
 
         :return: A dictionary with information that is needed to trigger the verification.
         """
-        _, return_message, transaction_id, reply_dict = self.create_challenge()
+        _, return_message, transaction_id, reply_dict = self.create_challenge(options=options)
         return {"message": return_message}
 
     def verify_enrollment(self, verify):

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -2573,7 +2573,7 @@ class SMTPServer(MethodsMixin, db.Model):
     This table can store configurations for SMTP servers.
     Each entry represents an SMTP server.
     EMail Token, SMS SMTP Gateways or Notifications like PIN handlers are
-    supposed to use a reference to to a server definition.
+    supposed to use a reference to a server definition.
     Each Machine Resolver can have multiple configuration entries.
     The config entries are referenced by the id of the machine resolver
     """

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1,15 +1,15 @@
 from .base import MyApiTestCase, PWFILE2
 import json
-import os
 import datetime
 import codecs
 from mock import mock
+import requests
 from privacyidea.lib.policy import (set_policy, delete_policy, SCOPE, ACTION,
                                     enable_policy,
                                     PolicyClass)
 from privacyidea.lib.token import (get_tokens, init_token, remove_token,
                                    get_tokens_from_serial_or_user, enable_token,
-                                   check_serial_pass, get_realms_of_token,
+                                   check_serial_pass,
                                    assign_token, token_exist, add_tokeninfo)
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.realm import set_realm
@@ -20,17 +20,18 @@ from urllib.parse import urlencode, quote
 from privacyidea.lib.tokenclass import DATE_FORMAT
 from privacyidea.lib.tokenclass import ROLLOUTSTATE
 from privacyidea.lib.tokens.hotptoken import VERIFY_ENROLLMENT_MESSAGE
+from privacyidea.lib.tokens.smstoken import SMSACTION
 from privacyidea.lib.config import set_privacyidea_config, delete_privacyidea_config
 from dateutil.tz import tzlocal
 from privacyidea.lib import _
 import os
 import unittest
-import mock
 from privacyidea.lib.caconnectors.baseca import AvailableCAConnectors
 from privacyidea.lib.caconnectors.msca import MSCAConnector
 from .mscamock import CAServiceMock
 from privacyidea.lib.caconnectors.msca import ATTR as MS_ATTR
-from privacyidea.lib.token import init_token
+from privacyidea.lib.smsprovider.SMSProvider import (set_smsgateway,
+                                                     delete_smsgateway)
 
 # Mock for certificate from MSCA
 MY_CA_NAME = "192.168.47.11"
@@ -165,11 +166,11 @@ class API000TokenAdminRealmList(MyApiTestCase):
         self.setUp_user_realm2()
 
         # create tokens
-        t = init_token({"otpkey": self.otpkey},
-                       tokenrealms=[self.realm1])
+        init_token({"otpkey": self.otpkey},
+                   tokenrealms=[self.realm1])
 
-        t = init_token({"otpkey": self.otpkey},
-                       tokenrealms=[self.realm2])
+        init_token({"otpkey": self.otpkey},
+                   tokenrealms=[self.realm2])
 
     def test_01_test_two_tokens(self):
         with self.app.test_request_context('/token/',
@@ -396,6 +397,7 @@ class API000TokenAdminRealmList(MyApiTestCase):
         remove_token(t1.token.serial)
         delete_policy("pol-reso1")
 
+
 class APIAttestationTestCase(MyApiTestCase):
 
     def test_00_realms_and_ca(self):
@@ -403,18 +405,18 @@ class APIAttestationTestCase(MyApiTestCase):
         self.setUp_user_realms()
         cwd = os.getcwd()
         # setup ca connector
-        r = save_caconnector({"cakey": CAKEY,
-                              "cacert": CACERT,
-                              "type": "local",
-                              "caconnector": "localCA",
-                              "openssl.cnf": OPENSSLCNF,
-                              "CSRDir": "",
-                              "CertificateDir": "",
-                              "WorkingDir": cwd + "/" + WORKINGDIR})
+        save_caconnector({"cakey": CAKEY,
+                          "cacert": CACERT,
+                          "type": "local",
+                          "caconnector": "localCA",
+                          "openssl.cnf": OPENSSLCNF,
+                          "CSRDir": "",
+                          "CertificateDir": "",
+                          "WorkingDir": cwd + "/" + WORKINGDIR})
 
     def test_01_enroll_certificate(self):
         # Enroll a certificate without a policy
-        from .test_lib_tokens_certificate import YUBIKEY_CSR, BOGUS_ATTESTATION, YUBIKEY_ATTEST, ACTION
+        from .test_lib_tokens_certificate import YUBIKEY_CSR, BOGUS_ATTESTATION, YUBIKEY_ATTEST
 
         # A bogus attestation certificate will fail!
         with self.app.test_request_context('/token/init',
@@ -568,15 +570,14 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             count = result.get("value").get("count")
-            next = result.get("value").get("next")
+            next_tokens = result.get("value").get("next")
             prev = result.get("value").get("prev")
             self.assertTrue(result.get("status"), result)
             self.assertGreaterEqual(len(tokenlist), 1, tokenlist)
             self.assertGreaterEqual(count, 1, result)
-            self.assertTrue(next is None, next)
+            self.assertTrue(next_tokens is None, next_tokens)
             self.assertTrue(prev is None, prev)
             token0 = tokenlist[0]
             self.assertTrue(token0.get("username") == "", token0)
@@ -596,7 +597,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             # NO token assigned, yet
             self.assertGreaterEqual(len(tokenlist), 0, "{0!s}".format(tokenlist))
@@ -610,7 +610,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             self.assertTrue(len(tokenlist) == 1, len(tokenlist))
 
@@ -626,7 +625,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             # NO token assigned, yet
             self.assertTrue(len(tokenlist) == 1, "{0!s}".format(tokenlist))
@@ -640,7 +638,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             self.assertTrue(len(tokenlist) == 1, len(tokenlist))
             token0 = tokenlist[0]
@@ -653,7 +650,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             self.assertTrue(len(tokenlist) == 2, len(tokenlist))
 
@@ -664,13 +660,12 @@ class APITokenTestCase(MyApiTestCase):
                                            method='GET',
                                            query_string=urlencode({
                                                "assigned": False,
-                                           "infokey": "tokenkind",
-                                           "infovalue": "hardware"}),
+                                               "infokey": "tokenkind",
+                                               "infovalue": "hardware"}),
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             self.assertEqual(len(tokenlist), 0)
 
@@ -686,7 +681,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             self.assertEqual(len(tokenlist), 1)
 
@@ -706,13 +700,12 @@ class APITokenTestCase(MyApiTestCase):
 
     def test_03_list_tokens_in_one_realm(self):
         for serial in ["S1", "S2", "S3", "S4"]:
-             with self.app.test_request_context('/token/init',
-                                                method='POST',
-                                                data={"type": "hotp",
-                                                      "otpkey": self.otpkey,
-                                                      "serial": serial},
-                                                headers={'Authorization':
-                                                             self.at}):
+            with self.app.test_request_context('/token/init',
+                                               method='POST',
+                                               data={"type": "hotp",
+                                                     "otpkey": self.otpkey,
+                                                     "serial": serial},
+                                               headers={'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
 
@@ -723,8 +716,7 @@ class APITokenTestCase(MyApiTestCase):
                                                      "otpkey": self.otpkey,
                                                      "serial": serial,
                                                      "realm": self.realm1},
-                                               headers={'Authorization':
-                                                            self.at}):
+                                               headers={'Authorization': self.at}):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
 
@@ -735,15 +727,12 @@ class APITokenTestCase(MyApiTestCase):
                                                "tokenrealm": self.realm1}),
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
-            self.assertTrue(res.status_code == 200, res)
+            self.assertEqual(res.status_code, 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             count = result.get("value").get("count")
-            next = result.get("value").get("next")
-            prev = result.get("value").get("prev")
-            self.assertTrue(len(tokenlist) == 2, res.data)
-            self.assertTrue(count == 2, count)
+            self.assertEqual(len(tokenlist), 2, result)
+            self.assertEqual(count, 2, result)
 
         # list tokens, that look a bit like realm1
         search_realm = self.realm1[:-1] + "*"
@@ -755,11 +744,8 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             tokenlist = result.get("value").get("tokens")
             count = result.get("value").get("count")
-            next = result.get("value").get("next")
-            prev = result.get("value").get("prev")
             self.assertTrue(len(tokenlist) == 2, res.data)
             self.assertTrue(count == 2, count)
 
@@ -799,8 +785,7 @@ class APITokenTestCase(MyApiTestCase):
         # Now the user tries to assign a foreign token
         with self.app.test_request_context('/auth',
                                            method='POST',
-                                           data={"username":
-                                                     "selfservice@realm1",
+                                           data={"username": "selfservice@realm1",
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
@@ -988,8 +973,7 @@ class APITokenTestCase(MyApiTestCase):
         # test the failcount
         with self.app.test_request_context('/token/',
                                            method='GET',
-                                           query_string=urlencode({"serial":
-                                                                       serial}),
+                                           query_string=urlencode({"serial": serial}),
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
@@ -1037,10 +1021,10 @@ class APITokenTestCase(MyApiTestCase):
 
         # Resync does not work with NON-consecutive values
         with self.app.test_request_context('/token/resync/Resync01',
-                                            method="POST",
-                                            data={"otp1": 287082,
-                                                  "otp2": 969429},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"otp1": 287082,
+                                                 "otp2": 969429},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1060,11 +1044,11 @@ class APITokenTestCase(MyApiTestCase):
 
         # Successful resync with consecutive values
         with self.app.test_request_context('/token/resync',
-                                            method="POST",
-                                            data={"serial": "Resync01",
-                                                  "otp1": 359152,
-                                                  "otp2": 969429},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"serial": "Resync01",
+                                                 "otp1": 359152,
+                                                 "otp2": 969429},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1084,9 +1068,9 @@ class APITokenTestCase(MyApiTestCase):
 
         # Get the OTP token and inspect the counter
         with self.app.test_request_context('/token/',
-                                            method="GET",
-                                            query_string=urlencode({"serial": "Resync01"}),
-                                            headers={'Authorization': self.at}):
+                                           method="GET",
+                                           query_string=urlencode({"serial": "Resync01"}),
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1097,8 +1081,7 @@ class APITokenTestCase(MyApiTestCase):
         # Authenticate a user
         with self.app.test_request_context('/auth',
                                            method='POST',
-                                           data={"username":
-                                                     "selfservice@realm1",
+                                           data={"username": "selfservice@realm1",
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
@@ -1109,12 +1092,11 @@ class APITokenTestCase(MyApiTestCase):
 
         # The user fails to resync the token, since it does not belong to him
         with self.app.test_request_context('/token/resync',
-                                            method="POST",
-                                            data={"serial": "Resync01",
-                                                  "otp1": 254676,
-                                                  "otp2": 287922},
-                                            headers={'Authorization':
-                                                         self.at_user}):
+                                           method="POST",
+                                           data={"serial": "Resync01",
+                                                 "otp1": 254676,
+                                                 "otp2": 287922},
+                                           headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
             result = res.json.get("result")
@@ -1122,10 +1104,10 @@ class APITokenTestCase(MyApiTestCase):
 
         # assign the token to the user selfservice@realm1.
         with self.app.test_request_context('/token/assign',
-                                            method="POST",
-                                            data={"serial": "Resync01",
-                                                  "user": "selfservice@realm1"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"serial": "Resync01",
+                                                 "user": "selfservice@realm1"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1133,26 +1115,24 @@ class APITokenTestCase(MyApiTestCase):
 
         # let the user resync the token
         with self.app.test_request_context('/token/resync',
-                                            method="POST",
-                                            data={"serial": "Resync01",
-                                                  "otp1": 254676,
-                                                  "otp2": 287922},
-                                            headers={'Authorization':
-                                                         self.at_user}):
+                                           method="POST",
+                                           data={"serial": "Resync01",
+                                                 "otp1": 254676,
+                                                 "otp2": 287922},
+                                           headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result.get("value") is True, result)
 
-
     def test_08_setpin(self):
         self._create_temp_token("PToken")
         # Set one PIN of the token
         with self.app.test_request_context('/token/setpin',
-                                            method="POST",
-                                            data={"serial": "PToken",
-                                                  "userpin": "test"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"serial": "PToken",
+                                                 "userpin": "test"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1160,10 +1140,10 @@ class APITokenTestCase(MyApiTestCase):
 
         # Set both PINs of the token
         with self.app.test_request_context('/token/setpin/PToken',
-                                            method="POST",
-                                            data={"userpin": "test",
-                                                  "sopin": "topsecret"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"userpin": "test",
+                                                 "sopin": "topsecret"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1171,9 +1151,9 @@ class APITokenTestCase(MyApiTestCase):
 
         # set a pin
         with self.app.test_request_context('/token/setpin/PToken',
-                                            method="POST",
-                                            data={"otppin": "test"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"otppin": "test"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1181,9 +1161,9 @@ class APITokenTestCase(MyApiTestCase):
 
         # set an empty pin
         with self.app.test_request_context('/token/setpin/PToken',
-                                            method="POST",
-                                            data={"otppin": ""},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"otppin": ""},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1193,31 +1173,30 @@ class APITokenTestCase(MyApiTestCase):
         self._create_temp_token("SET001")
         # Set some things
         with self.app.test_request_context('/token/setpin',
-                                            method="POST",
-                                            data={"serial": "SET001",
-                                                  "otppin": "test"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"serial": "SET001",
+                                                 "otppin": "test"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result.get("value") == 1, result)
 
-
         # Set all other values
         with self.app.test_request_context('/token/set/SET001',
-                                            method="POST",
-                                            data={"count_auth_max": 17,
-                                                  "count_auth_success_max": 8,
-                                                  "hashlib": "sha2",
-                                                  "count_window": 11,
-                                                  "sync_window": 999,
-                                                  "max_failcount": 15,
-                                                  "description": "Some Token",
-                                                  "validity_period_start":
-                                                      "2014-05-22T22:00+0200",
-                                                  "validity_period_end":
-                                                      "2014-05-22T23:00+0200"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"count_auth_max": 17,
+                                                 "count_auth_success_max": 8,
+                                                 "hashlib": "sha2",
+                                                 "count_window": 11,
+                                                 "sync_window": 999,
+                                                 "max_failcount": 15,
+                                                 "description": "Some Token",
+                                                 "validity_period_start":
+                                                     "2014-05-22T22:00+0200",
+                                                 "validity_period_end":
+                                                     "2014-05-22T23:00+0200"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1268,9 +1247,9 @@ class APITokenTestCase(MyApiTestCase):
         self._create_temp_token("REALM001")
 
         with self.app.test_request_context('/token/realm/REALM001',
-                                            method="POST",
-                                            data={"realms": "realm1, realm2"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"realms": "realm1, realm2"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1278,9 +1257,9 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(value is True, result)
 
         with self.app.test_request_context('/token/',
-                                            method="GET",
-                                            query_string=urlencode({"serial": "REALM001"}),
-                                            headers={'Authorization': self.at}):
+                                           method="GET",
+                                           query_string=urlencode({"serial": "REALM001"}),
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1293,12 +1272,12 @@ class APITokenTestCase(MyApiTestCase):
         set_policy("dumm01", scope=SCOPE.USER, action=ACTION.DISABLE)
         # Load OATH CSV
         with self.app.test_request_context('/token/load/import.oath',
-                                            method="POST",
-                                            data={"type": "oathcsv",
-                                                  "tokenrealms": self.realm1,
-                                                  "file": (IMPORTFILE,
-                                                           "import.oath")},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"type": "oathcsv",
+                                                 "tokenrealms": self.realm1,
+                                                 "file": (IMPORTFILE,
+                                                          "import.oath")},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1325,12 +1304,12 @@ class APITokenTestCase(MyApiTestCase):
 
         # Load yubico.csv
         with self.app.test_request_context('/token/load/yubico.csv',
-                                            method="POST",
-                                            data={"type": "yubikeycsv",
-                                                  "tokenrealms": self.realm1,
-                                                  "file": (YUBICOFILE,
-                                                           "yubico.csv")},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"type": "yubikeycsv",
+                                                 "tokenrealms": self.realm1,
+                                                 "file": (YUBICOFILE,
+                                                          "yubico.csv")},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1345,11 +1324,11 @@ class APITokenTestCase(MyApiTestCase):
 
         # Try to load empty file
         with self.app.test_request_context('/token/load/empty.oath',
-                                            method="POST",
-                                            data={"type": "oathcsv",
-                                                  "file": (IMPORTFILE2,
-                                                           "empty.oath")},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"type": "oathcsv",
+                                                 "file": (IMPORTFILE2,
+                                                          "empty.oath")},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
         # check for a failed audit entry
@@ -1358,22 +1337,22 @@ class APITokenTestCase(MyApiTestCase):
 
         # Try to load unknown file type
         with self.app.test_request_context('/token/load/import.oath',
-                                            method="POST",
-                                            data={"type": "unknown",
-                                                  "file": (IMPORTFILE,
-                                                           "import.oath")},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"type": "unknown",
+                                                 "file": (IMPORTFILE,
+                                                          "import.oath")},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
 
         # Load PSKC file, encrypted PSK
         with self.app.test_request_context('/token/load/pskc-aes.xml',
-                                            method="POST",
-                                            data={"type": "pskc",
-                                                  "psk": PSK_HEX,
-                                                  "file": (IMPORTPSKC,
-                                                           "pskc-aes.xml")},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"type": "pskc",
+                                                 "psk": PSK_HEX,
+                                                 "file": (IMPORTPSKC,
+                                                          "pskc-aes.xml")},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1382,12 +1361,12 @@ class APITokenTestCase(MyApiTestCase):
 
         # Load PSKC file, encrypted Password
         with self.app.test_request_context('/token/load/pskc-password.xml',
-                                            method="POST",
-                                            data={"type": "pskc",
-                                                  "password": "qwerty",
-                                                  "file": (IMPORTPSKC_PASS,
-                                                           "pskc-password.xml")},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"type": "pskc",
+                                                 "password": "qwerty",
+                                                 "file": (IMPORTPSKC_PASS,
+                                                          "pskc-password.xml")},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1397,19 +1376,19 @@ class APITokenTestCase(MyApiTestCase):
     def test_11_load_tokens_tokenhandler(self):
 
         # create a new event to disable tokens after import
-        r = set_event("token_disable", ["token_load"], "Token",
-                      "disable", position="post")
+        set_event("token_disable", ["token_load"], "Token",
+                  "disable", position="post")
         events = EventConfiguration()
         event_id = [event['id'] for event in events.events if event['name'] == 'token_disable'][0]
 
         # Load yubico.csv
         with self.app.test_request_context('/token/load/yubico.csv',
-                                            method="POST",
-                                            data={"type": "yubikeycsv",
-                                                  "tokenrealms": self.realm1,
-                                                  "file": (YUBICOFILE_LONG,
-                                                           "yubico.csv")},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"type": "yubikeycsv",
+                                                 "tokenrealms": self.realm1,
+                                                 "file": (YUBICOFILE_LONG,
+                                                          "yubico.csv")},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1495,11 +1474,11 @@ class APITokenTestCase(MyApiTestCase):
         self._create_temp_token("FROM001")
         self._create_temp_token("TO001")
         with self.app.test_request_context('/token/assign',
-                                            method="POST",
-                                            data={"serial": "FROM001",
-                                                  "user": "cornelius",
-                                                  "realm": self.realm1},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"serial": "FROM001",
+                                                 "user": "cornelius",
+                                                 "realm": self.realm1},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1507,10 +1486,10 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(value is True, result)
 
         with self.app.test_request_context('/token/setpin',
-                                            method="POST",
-                                            data={"serial": "FROM001",
-                                                  "otppin": "test"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"serial": "FROM001",
+                                                 "otppin": "test"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1519,10 +1498,10 @@ class APITokenTestCase(MyApiTestCase):
 
         # copy the PIN
         with self.app.test_request_context('/token/copypin',
-                                            method="POST",
-                                            data={"from": "FROM001",
-                                                  "to": "TO001"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"from": "FROM001",
+                                                 "to": "TO001"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1531,10 +1510,10 @@ class APITokenTestCase(MyApiTestCase):
 
         # copy the user
         with self.app.test_request_context('/token/copyuser',
-                                            method="POST",
-                                            data={"from": "FROM001",
-                                                  "to": "TO001"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"from": "FROM001",
+                                                 "to": "TO001"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1555,18 +1534,18 @@ class APITokenTestCase(MyApiTestCase):
         # call lost token for a token, that is not assigned.
         # THis will create an exception
         with self.app.test_request_context('/token/lost/LOST001',
-                                            method="POST",
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 400, res)
 
         # assign the token
         with self.app.test_request_context('/token/assign',
-                                            method="POST",
-                                            data={"serial": "LOST001",
-                                                  "user": "cornelius",
-                                                  "realm": self.realm1},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"serial": "LOST001",
+                                                 "user": "cornelius",
+                                                 "realm": self.realm1},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1574,8 +1553,8 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(value is True, result)
 
         with self.app.test_request_context('/token/lost/LOST001',
-                                            method="POST",
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1635,7 +1614,6 @@ class APITokenTestCase(MyApiTestCase):
             result = res.json.get("result")
             value = result.get("value")
             self.assertEqual(value.get("serial"), None)
-
 
         # Will not find an assigned token
         with self.app.test_request_context('/token/getserial/413789'
@@ -1711,7 +1689,6 @@ class APITokenTestCase(MyApiTestCase):
                 self.assertTrue(res.status_code == 200, res)
                 result = res.json.get("result")
                 self.assertTrue(result.get("value"))
-                detail = res.json.get("detail")
 
             token = get_tokens(serial="totp{0!s}".format(timestep))[0]
             self.assertEqual(token.timestep, int(timestep))
@@ -1720,14 +1697,14 @@ class APITokenTestCase(MyApiTestCase):
         self.setUp_user_realms()
         cwd = os.getcwd()
         # setup ca connector
-        r = save_caconnector({"cakey": CAKEY,
-                              "cacert": CACERT,
-                              "type": "local",
-                              "caconnector": "localCA",
-                              "openssl.cnf": OPENSSLCNF,
-                              "CSRDir": "",
-                              "CertificateDir": "",
-                              "WorkingDir": cwd + "/" + WORKINGDIR})
+        save_caconnector({"cakey": CAKEY,
+                          "cacert": CACERT,
+                          "type": "local",
+                          "caconnector": "localCA",
+                          "openssl.cnf": OPENSSLCNF,
+                          "CSRDir": "",
+                          "CertificateDir": "",
+                          "WorkingDir": cwd + "/" + WORKINGDIR})
 
         # Enroll a certificate token with a CSR
         with self.app.test_request_context('/token/init',
@@ -1789,7 +1766,6 @@ class APITokenTestCase(MyApiTestCase):
 
         delete_policy("pol1")
 
-
     def test_18_revoke_token(self):
         self._create_temp_token("RevToken")
 
@@ -1813,7 +1789,7 @@ class APITokenTestCase(MyApiTestCase):
 
     def test_19_get_challenges(self):
         set_policy("chalresp", scope=SCOPE.AUTHZ,
-        action="{0!s}=hotp".format(ACTION.CHALLENGERESPONSE))
+                   action="{0!s}=hotp".format(ACTION.CHALLENGERESPONSE))
         token = init_token({"genkey": 1, "serial": "CHAL1", "pin": "pin"})
         serial = token.token.serial
         r = check_serial_pass(serial, "pin")
@@ -1857,9 +1833,9 @@ class APITokenTestCase(MyApiTestCase):
             value = result.get("value")
             self.assertEqual(value.get("count"), 0)
 
-        # create a second challenge and a third cahllenge
-        r = check_serial_pass(serial, "pin")
-        r = check_serial_pass(serial, "pin")
+        # create a second challenge and a third challenge
+        check_serial_pass(serial, "pin")
+        check_serial_pass(serial, "pin")
         transaction_ids = []
         with self.app.test_request_context('/token/challenges/',
                                            method='GET',
@@ -1871,14 +1847,14 @@ class APITokenTestCase(MyApiTestCase):
             self.assertEqual(value.get("count"), 3)
             challenges = value.get("challenges")
             for challenge in challenges:
-                # Fill the list of all transaction_ids
+                # Fill the list with all transaction_ids
                 transaction_ids.append(challenge.get("transaction_id"))
 
         # Now we only ask for the first transation id. This should return only ONE challenge
         with self.app.test_request_context('/token/challenges/',
-                                            data={"transaction_id": transaction_ids[0]},
-                                            method='GET',
-                                            headers={'Authorization': self.at}):
+                                           data={"transaction_id": transaction_ids[0]},
+                                           method='GET',
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -1970,8 +1946,8 @@ class APITokenTestCase(MyApiTestCase):
                    user="testadmin",
                    realm="testrealm"
                    )
-        r = init_token({"type": "SPASS", "serial": "SP001"},
-                       user=User("cornelius", self.realm1))
+        init_token({"type": "SPASS", "serial": "SP001"},
+                   user=User("cornelius", self.realm1))
 
         # Now testadmin tries to delete a token from realm1, which he can not
         #  access.
@@ -2009,8 +1985,7 @@ class APITokenTestCase(MyApiTestCase):
         # If the administrator sets a PIN of the user, the next_pin_change
         # must also be created!
 
-        token = init_token({"serial": "SP001", "type": "spass", "pin":
-            "123456"})
+        token = init_token({"serial": "SP001", "type": "spass", "pin": "123456"})
         ti = token.get_tokeninfo("next_pin_change")
         self.assertEqual(ti, None)
         # Now we set the PIN
@@ -2036,17 +2011,17 @@ class APITokenTestCase(MyApiTestCase):
         self._create_temp_token("INF001")
         # Set two tokeninfo values
         with self.app.test_request_context('/token/info/INF001/key1',
-                                            method="POST",
-                                            data={"value": "value 1"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"value": "value 1"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result.get("value"), result)
         with self.app.test_request_context('/token/info/INF001/key2',
-                                            method="POST",
-                                            data={"value": "value 2"},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"value": "value 2"},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -2066,16 +2041,13 @@ class APITokenTestCase(MyApiTestCase):
 
             tokeninfo = token.get("info")
             test_dict = {'key1': 'value 1', 'key2': 'value 2'}
-            try:
-                self.assertTrue(test_dict.viewitems() <= tokeninfo.viewitems())
-            except AttributeError:
-                self.assertTrue(test_dict.items() <= tokeninfo.items())
+            self.assertLessEqual(test_dict.items(), tokeninfo.items())
 
         # Overwrite an existing tokeninfo value
         with self.app.test_request_context('/token/info/INF001/key1',
-                                            method="POST",
-                                            data={"value": 'value 1 new'},
-                                            headers={'Authorization': self.at}):
+                                           method="POST",
+                                           data={"value": 'value 1 new'},
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -2095,24 +2067,21 @@ class APITokenTestCase(MyApiTestCase):
 
             tokeninfo = token.get("info")
             test_dict = {'key1': 'value 1 new', 'key2': 'value 2'}
-            try:
-                self.assertTrue(test_dict.viewitems() <= tokeninfo.viewitems())
-            except AttributeError:
-                self.assertTrue(test_dict.items() <= tokeninfo.items())
+            self.assertLessEqual(test_dict.items(), tokeninfo.items())
 
         # Delete an existing tokeninfo value
         with self.app.test_request_context('/token/info/INF001/key1',
                                            method="DELETE",
                                            headers={'Authorization': self.at}):
-           res = self.app.full_dispatch_request()
-           self.assertTrue(res.status_code == 200, res)
-           result = res.json.get("result")
-           self.assertTrue(result.get("value"), result)
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            result = res.json.get("result")
+            self.assertTrue(result.get("value"), result)
 
         # Delete a non-existing tokeninfo value
         with self.app.test_request_context('/token/info/INF001/key1',
-                                            method="DELETE",
-                                            headers={'Authorization': self.at}):
+                                           method="DELETE",
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -2120,8 +2089,8 @@ class APITokenTestCase(MyApiTestCase):
 
         # Try to delete with an unknown serial
         with self.app.test_request_context('/token/info/UNKNOWN/key1',
-                                            method="DELETE",
-                                            headers={'Authorization': self.at}):
+                                           method="DELETE",
+                                           headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 404)
             result = res.json.get("result")
@@ -2141,10 +2110,7 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(value.get("count") == 1, result)
 
             tokeninfo = token.get("info")
-            try:
-                self.assertTrue({'key2': 'value 2'}.viewitems() <= tokeninfo.viewitems())
-            except AttributeError:
-                self.assertTrue({'key2': 'value 2'}.items() <= tokeninfo.items())
+            self.assertLessEqual({'key2': 'value 2'}.items(), tokeninfo.items())
             self.assertNotIn('key1', tokeninfo)
 
     def test_25_user_init_defaults(self):
@@ -2221,8 +2187,7 @@ class APITokenTestCase(MyApiTestCase):
                                                "genkey": 1,
                                                "user": "selfservice",
                                                "realm": "realm1"},
-                                           headers={'Authorization':
-                                                        self.at_user}):
+                                           headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -2245,8 +2210,7 @@ class APITokenTestCase(MyApiTestCase):
                                                "genkey": 1,
                                                "user": "selfservice",
                                                "realm": "realm1"},
-                                           headers={'Authorization':
-                                                        self.at_user}):
+                                           headers={'Authorization': self.at_user}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
@@ -2456,7 +2420,6 @@ class APITokenTestCase(MyApiTestCase):
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
-            result = res.json.get("result")
             detail = res.json.get("detail")
             self.assertEqual(10, len(detail.get("pin")))
 
@@ -2594,8 +2557,8 @@ class APITokenTestCase(MyApiTestCase):
             result = res.json.get("result")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
-            self.assertEqual(detail.get("rollout_state"), ROLLOUTSTATE.VERIFYPENDING)
-            self.assertEqual(detail.get("verify").get("message"), VERIFY_ENROLLMENT_MESSAGE)
+            self.assertEqual(detail.get("rollout_state"), ROLLOUTSTATE.VERIFYPENDING, detail)
+            self.assertEqual(detail.get("verify").get("message"), VERIFY_ENROLLMENT_MESSAGE, detail)
             serial = detail.get("serial")
             tokenobj_list = get_tokens(serial=serial)
             # Check the token rollout state
@@ -2636,7 +2599,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             tokenobj_list = get_tokens(serial=serial)
@@ -2647,9 +2609,16 @@ class APITokenTestCase(MyApiTestCase):
         delete_policy("verify_toks2")
         delete_policy("require_description")
 
-    def test_41_init_verify_email_token(self):
+    @mock.patch('privacyidea.lib.smtpserver.smtplib.SMTP', autospec=True)
+    def test_41_init_verify_email_token(self, smtp_mock):
+        smtp_inst = smtp_mock.return_value
+        smtp_inst.sendmail.return_value = {"user@example.com": (200, 'OK')}
+
         set_policy("verify_toks1", scope=SCOPE.ENROLL, action="{0!s}=email".format(ACTION.VERIFY_ENROLLMENT))
+        set_policy("email_challenge_text", scope=SCOPE.AUTH,
+                   action=f"email_{ACTION.CHALLENGETEXT}=ENTER EMAIL TOKEN")
         # Enroll an email token
+        # TODO: Check mock mailserver for correct email subject and text
         with self.app.test_request_context('/token/init',
                                            method='POST',
                                            data={"otpkey": self.otpkey,
@@ -2663,7 +2632,7 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             self.assertEqual(detail.get("rollout_state"), ROLLOUTSTATE.VERIFYPENDING)
-            self.assertEqual(detail.get("verify").get("message"), VERIFY_ENROLLMENT_MESSAGE)
+            self.assertEqual(detail.get("verify").get("message"), "ENTER EMAIL TOKEN", detail)
             serial = detail.get("serial")
             tokenobj_list = get_tokens(serial=serial)
             # Check the token rollout state
@@ -2679,7 +2648,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             tokenobj_list = get_tokens(serial=serial)
@@ -2687,10 +2655,34 @@ class APITokenTestCase(MyApiTestCase):
             self.assertEqual(ROLLOUTSTATE.ENROLLED, tokenobj_list[0].token.rollout_state)
 
         delete_policy("verify_toks1")
+        delete_policy("email_challenge_text")
+        remove_token(serial=serial)
 
-    def test_42_init_verify_sms_token(self):
-        set_policy("verify_toks1", scope=SCOPE.ENROLL, action="{0!s}=sms".format(ACTION.VERIFY_ENROLLMENT))
-        # Enroll an email token
+    @mock.patch("privacyidea.lib.smsprovider.HttpSMSProvider.requests",
+                autospec=True)
+    def test_42_init_verify_sms_token(self, req_mock):
+        resp_mock = mock.MagicMock(spec=requests.Response)
+        resp_mock.status_code = 200
+        req_mock.post.return_value = resp_mock
+
+        smsgw_id = "mySMSGW"
+        set_smsgateway(
+            smsgw_id,
+            "privacyidea.lib.smsprovider.HttpSMSProvider.HttpSMSProvider",
+            description="test",
+            options={"HTTP_METHOD": "POST",
+                     "URL": "sms.example.com",
+                     "text": "{otp}",
+                     "phone": "{phone}"})
+
+        set_privacyidea_config("sms.identifier", smsgw_id)
+        set_policy("verify_toks1", scope=SCOPE.ENROLL,
+                   action="{0!s}=sms".format(ACTION.VERIFY_ENROLLMENT))
+        sms_text = "YOUR SMS TOKEN: {otp}"
+        set_policy(name="smstext", scope=SCOPE.AUTH,
+                   action=f"{SMSACTION.SMSTEXT}={sms_text}")
+
+        # Enroll an SMS token
         with self.app.test_request_context('/token/init',
                                            method='POST',
                                            data={"otpkey": self.otpkey,
@@ -2704,7 +2696,12 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             self.assertEqual(detail.get("rollout_state"), ROLLOUTSTATE.VERIFYPENDING)
-            self.assertEqual(detail.get("verify").get("message"), VERIFY_ENROLLMENT_MESSAGE)
+            # Without a challenge-text policy we get the default challenge message for SMS tokens
+            self.assertEqual("Enter the OTP from the SMS:", detail.get("verify").get("message"), detail)
+            calls = req_mock.post.mock_calls
+            self.assertEqual("sms.example.com", calls[0][1][0], calls)
+            # check that we sent the correct SMS text (via policy)
+            self.assertIn("YOUR SMS TOKEN:", calls[0][2]['data']['text'], calls[0][2])
             serial = detail.get("serial")
             tokenobj_list = get_tokens(serial=serial)
             # Check the token rollout state
@@ -2720,7 +2717,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             tokenobj_list = get_tokens(serial=serial)
@@ -2728,6 +2724,8 @@ class APITokenTestCase(MyApiTestCase):
             self.assertEqual(ROLLOUTSTATE.ENROLLED, tokenobj_list[0].token.rollout_state)
 
         delete_policy("verify_toks1")
+        delete_policy("smstext")
+        delete_smsgateway(smsgw_id)
 
     def test_43_init_verify_index_token(self):
         set_policy("verify_toks1", scope=SCOPE.ENROLL, action="{0!s}=indexedsecret".format(ACTION.VERIFY_ENROLLMENT))
@@ -2771,7 +2769,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             tokenobj_list = get_tokens(serial=serial)
@@ -2843,7 +2840,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             self.assertTrue(result.get("status"), result)
             self.assertTrue(result.get("value"), result)
             tokenobj_list = get_tokens(serial=serial)
@@ -2913,7 +2909,6 @@ class APITokenTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             self.assertTrue(result.get("status"), result)
             self.assertTrue(result.get("value"), result)
             tokenobj_list = get_tokens(serial=serial)
@@ -2985,7 +2980,7 @@ class API00TokenPerformance(MyApiTestCase):
         toks = get_tokens(serial_wildcard="perf*")
         self.assertEqual(len(toks), self.token_count)
 
-        for i in range(0,10):
+        for i in range(0, 10):
             init_token({"genkey": 1, "serial": "TOK{0!s:0>3}".format(i)})
         toks = get_tokens(serial_wildcard="TOK*")
         self.assertEqual(len(toks), 10)
@@ -3216,11 +3211,9 @@ class API00TokenPerformance(MyApiTestCase):
             self.assertEqual(result.get("error").get("code"), 1017)
             self.assertEqual(result.get("error").get("message"), "ERR1017: No unique token to copy to found")
 
-
-
         # Try to mark wildcard token as lost
         # Just to be clear, all tokens are assigned to the user cornelius
-        for i in range(0,self.token_count):
+        for i in range(0, self.token_count):
             assign_token("perf{0!s:0>3}".format(i), User("cornelius", self.realm1))
 
         with self.app.test_request_context('/token/lost/perf*',
@@ -3234,7 +3227,7 @@ class API00TokenPerformance(MyApiTestCase):
             self.assertFalse(result["status"])
 
         # unassign tokens again
-        for i in range(0,self.token_count):
+        for i in range(0, self.token_count):
             unassign_token("perf{0!s:0>3}".format(i))
 
         # Try to set tokeninfo
@@ -3263,7 +3256,7 @@ class API00TokenPerformance(MyApiTestCase):
             self.assertFalse(result["status"])
 
 
-class APIDetermine_User_from_Serial_for_Policies(MyApiTestCase):
+class APIDetermineUserFromSerialForPolicies(MyApiTestCase):
     """
     This Testclass verifies if a request, that only contains a serial will also
     honour policies, that are configured for users, if the serial is assigned to such a user.
@@ -3277,7 +3270,7 @@ class APIDetermine_User_from_Serial_for_Policies(MyApiTestCase):
         serial = "SPASS001"
         polname = "disabletokens"
 
-        t = init_token({"type": "spass", "serial": serial}, user=User("cornelius", self.realm1))
+        init_token({"type": "spass", "serial": serial}, user=User("cornelius", self.realm1))
 
         # We are using the "testadmin"
         with self.app.test_request_context('/token/disable',
@@ -3339,7 +3332,6 @@ class APIRolloutState(MyApiTestCase):
 
         r = init_token({"genkey": 1})
         self.assertEqual(r.rollout_state, "")
-        serial2 = r.token.serial
 
         # There are two tokens enrolled
         with self.app.test_request_context('/token/',


### PR DESCRIPTION
- This also makes the `emailtext` and `emailsubject` actions available for email tokens during verify.
- The `challenge_text` action or the token specific challenge message will be returned to the client instead of the generic message.
- The tokens available for verification during enrollment can now be chosen with a multi-select element in the UI.
- Added the token-locked check to more `set` functions and removed it for `get_otplen` to avoid an error during export.
- Fixed some spellings, removed unused code and fixed some formatting

Closes #3971