### PR TITLE
Fixes for token containers

### DIFF
--- a/privacyidea/lib/containers/yubikey.py
+++ b/privacyidea/lib/containers/yubikey.py
@@ -22,7 +22,7 @@ class YubikeyContainer(TokenContainerClass):
         """
         Returns the token types that are supported by the container class.
         """
-        return ["hotp", "certificate", "webauthn"]
+        return ["hotp", "certificate", "webauthn", "yubico", "yubikey"]
 
     @classmethod
     def get_class_prefix(cls):

--- a/privacyidea/static/components/directives/views/directive.selectorcreatecontainer.html
+++ b/privacyidea/static/components/directives/views/directive.selectorcreatecontainer.html
@@ -41,7 +41,7 @@
             <button type="button"
                     ng-click="createContainer()"
                     ng-disabled="checkRight('container_create')"
-                    class="btn btn-primary">
+                    class="btn btn-default">
                 <span translate>Create Container</span>
             </button>
         </div>

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -200,6 +200,7 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
             useIt: false
         };
         $scope.enrolling = false;
+        $scope.containerSerial = $stateParams.containerSerial;
 
         $scope.formInit = {
             tokenTypes: {},  // will be set later with response from server
@@ -496,8 +497,8 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
             $scope.form.validity_period_start = date_object_to_string($scope.form.validity_period_start);
             $scope.form.validity_period_end = date_object_to_string($scope.form.validity_period_end);
 
-            if ($scope.form.container_serial === "createnew" || $scope.form.container_serial === "none") {
-                delete $scope.form.container_serial
+            if ($scope.containerSerial !== "createnew" && $scope.containerSerial !== "none") {
+                $scope.form.container_serial = $scope.containerSerial;
             }
 
             TokenFactory.enroll($scope.newUser,

--- a/privacyidea/static/components/token/views/token.details.html
+++ b/privacyidea/static/components/token/views/token.details.html
@@ -601,14 +601,14 @@
          token-types="[token.tokentype]">
     </div>
     <div class="text-center" ng-show="showAddToContainer && !tokenIsInContainer">
-        <button type="button" class="btn btn-primary"
+        <button type="button" class="btn btn-default"
                 ng-disabled="!checkRight('container_add_token') || containerSerial === 'none'"
                 ng-click="addToContainer()">
             <span translate>Add to Container</span>
         </button>
     </div>
     <div class="text-center" ng-show="tokenIsInContainer">
-        <button type="button" class="btn btn-primary"
+        <button type="button" class="btn btn-default"
                 ng-disabled="!checkRight('container_remove_token')"
                 ng-click="removeFromContainer()">
             <span translate>Remove from Container</span>

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -72,7 +72,7 @@
         <!-- ============ Container ====================== -->
         <div ng-show="checkRight('container_add_token') && checkRight('container_list')">
             <h4 translate>Assign Container</h4>
-            <div select-or-create-container container-serial="form.container_serial"
+            <div select-or-create-container container-serial="containerSerial"
                  disable-selection="tokenIsInContainer"
                  enable-user-assignment="newUser.user" user-name="newUser.user" user-realm="newUser.realm"
                  token-types="[form.type]">

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -599,7 +599,10 @@ class TokenContainerManagementTestCase(MyTestCase):
 
     def test_28_get_all_containers_paginate(self):
         # Removes all previously initialized containers
-        TokenContainer.query.delete()
+        old_test_containers = TokenContainer.query.all()
+        for container in old_test_containers:
+            container.delete()
+
         # Arrange
         types = ["Smartphone", "generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
         self.setUp_user_realms()


### PR DESCRIPTION
Related to #1291

* Delete each container object instead of using the query to delete all containers.
Using the query to delete all containers, does not support cascading (https://docs.sqlalchemy.org/en/20/orm/queryguide/dml.html#important-notes-and-caveats-for-orm-enabled-update-and-delete). Hence, associated table rows are not deleted, causing foreign key errors.

* After enrolling a token, the select-or-create-container directive sets the container serial to the default value if no container was selected. That caused an error when regenerating the QR code. Fixed by using a separate parameter for the directive.

* Add token types 'yubikey' and 'yubico' to the container type 'yubikey'

* Use white buttons for select-or-create-container directive