### PR TITLE
add spacing in token.enroll.html, fix container directive

### DIFF
--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -595,18 +595,9 @@ myApp.directive("selectOrCreateContainer", ["instanceUrl", "versioningSuffixProv
                 }
 
                 scope.setDefaultSerialSelection = function () {
-                    if (!scope.containerSerial || scope.containerSerial === "createnew") {
+                    if (!scope.containerSerial) {
                         scope.containerSerial = "none";
                     }
-                    /*
-                    if (!scope.containerSerial || scope.containerSerial === "createnew") {
-                        if (AuthFactory.checkRight("container_create")) {
-                            scope.containerSerial = "createnew";
-                        } else {
-                            scope.containerSerial = "none";
-                        }
-                    }
-                    */
                 }
 
                 // Set the default to creating a new container/the first container if there is containerSerial set from outer scope

--- a/privacyidea/static/components/directives/views/directive.selectorcreatecontainer.html
+++ b/privacyidea/static/components/directives/views/directive.selectorcreatecontainer.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-    <div>
+    <div class="form-group">
         <select class="form-control"
                 id="containerSelect"
                 ng-disabled="disableSelection"
@@ -9,7 +9,8 @@
         </select>
     </div>
     <!-- New container creation -->
-    <div ng-show="containerSerial == 'createnew'">
+    <div class="form-group"
+         ng-show="containerSerial == 'createnew'">
         <!-- Type -->
         <label for="containerType" translate>New container type</label>
         <select class="form-control"
@@ -21,9 +22,8 @@
         <div class="form-group">
             <span translate>Supported Token Types</span>: {{ newContainer.token_types }}
         </div>
-        <br>
         <!-- Description -->
-        <label for="description" translate>Description</label>
+        <label for="description" translate>Description of the container</label>
         <input type="text" class="form-control" id="description"
                autocomplete="new-password"
                placeholder="{{ 'Some nice words...'|translate }}"

--- a/privacyidea/static/components/token/views/token.enroll.html
+++ b/privacyidea/static/components/token/views/token.enroll.html
@@ -44,6 +44,7 @@
 
         <!-- User Assignment -->
         <div ng-if="loggedInUser.role == 'admin' && $state.includes('token.rollover') == false">
+            <hr class="horizontal-line-invisible"/>
             <h4 translate>Assign token to user</h4>
 
             <div assign-user new-user-object="newUser" realms="realms" enable-set-pin=true></div>
@@ -71,10 +72,13 @@
 
         <!-- ============ Container ====================== -->
         <div ng-show="checkRight('container_add_token') && checkRight('container_list')">
-            <h4 translate>Assign Container</h4>
+            <hr class="horizontal-line-invisible"/>
+            <h4 translate>Assign the token to a container</h4>
             <div select-or-create-container container-serial="containerSerial"
                  disable-selection="tokenIsInContainer"
-                 enable-user-assignment="newUser.user" user-name="newUser.user" user-realm="newUser.realm"
+                 enable-user-assignment=true
+                 check-user-assignment=true
+                 user-name="newUser.user" user-realm="newUser.realm"
                  token-types="[form.type]">
             </div>
             <div class="text-center" ng-show="showAddToContainer && !tokenIsInContainer">

--- a/privacyidea/static/css/generic.css
+++ b/privacyidea/static/css/generic.css
@@ -38,6 +38,15 @@ fieldset[disabled] .btn-transparent.focus {
   background-color: transparent;
   border-color: #ddd;
 }
+
 .btn-header {
   font-weight: bold;
+}
+
+.horizontal-line-invisible {
+    width: 95%;
+    height: 5px;
+    line-height: 80%;
+    border-top: 1px rgba(72, 112, 150, 0) solid;
+    margin: 12px;
 }


### PR DESCRIPTION
* Added some spacing to the token enroll page to visibly divide the 3 sections: Token info, user and container.
* Set the default of the container selection to "no container" so that the controls are hidden at first
* Fixed the assign user to container checkbox to be shown when a user is selected when enrolling a token