### PR TITLE
Also hide the enroll token menu for admins

### DIFF
--- a/privacyidea/static/components/token/views/token.html
+++ b/privacyidea/static/components/token/views/token.html
@@ -58,7 +58,7 @@
                         {{ $stateParams.tokenSerial }}</a>
                     </li>
                     <li role="presentation"
-                        ng-show="checkEnroll() || loggedInUser.role === 'admin'"
+                        ng-show="checkEnroll()"
                         ng-class="{active: $state.includes('token.enroll')}">
                         <a ui-sref="token.enroll">
                             <span class="glyphicon glyphicon-edit"></span>


### PR DESCRIPTION
If an admin has no right to enrol any token,
we can also hide the menu.

Closes #4053

