### PR TITLE
Add version information to export data

### DIFF
--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -299,7 +299,7 @@ def get_resolver_class(resolver_type):
 def get_resolver_type(resolvername):
     """
     return the type of a resolvername
-    
+
     :param resolvername: THe name of the resolver
     :return: The type of the resolver
     :rtype: string
@@ -381,6 +381,11 @@ def import_resolver(data, name=None):
     #  doesn't check the input) or "loadConfig()" (which also doesn't check the
     #  parameter, at least for LDAP/SQL-resolver).
     log.debug('Import resolver config: {0!s}'.format(data))
+
+    # Check for old style export type where resolvers were given as a list
+    if isinstance(data, list):
+        data = {x.get("resolvername"): x for x in data}
+
     for res_name, res_data in data.items():
         if name and name != res_name:
             continue

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,12 +1,13 @@
+"""Base test configuration to set up/teardown tests."""
 import unittest
 import mock
 from sqlalchemy.orm.session import close_all_sessions
 
 from privacyidea.app import create_app
 from privacyidea.config import TestingConfig
-from privacyidea.models import db, save_config_timestamp, NodeName
-from privacyidea.lib.resolver import (save_resolver)
-from privacyidea.lib.realm import (set_realm)
+from privacyidea.models import db, save_config_timestamp
+from privacyidea.lib.resolver import save_resolver
+from privacyidea.lib.realm import set_realm
 from privacyidea.lib.user import User
 from privacyidea.lib.auth import create_db_admin
 from privacyidea.lib.auditmodules.base import Audit

--- a/tests/cli/base.py
+++ b/tests/cli/base.py
@@ -1,21 +1,21 @@
-# SPDX-FileCopyrightText: (C) 2023 Paul Lettich <paul.lettich@netknights.it>
+# (c) NetKnights GmbH 2024,  https://netknights.it
 #
-# SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# Info: https://privacyidea.org
-#
-# This code is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# as published by the Free Software Foundation; either
 # version 3 of the License, or any later version.
 #
 # This code is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
 #
 # You should have received a copy of the GNU Affero General Public
-# License along with this program. If not, see <http://www.gnu.org/licenses/>.
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: 2024 Paul Lettich <paul.lettich@netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 import unittest
 from sqlalchemy.orm.session import close_all_sessions

--- a/tests/cli/test_cli_pimanage.py
+++ b/tests/cli/test_cli_pimanage.py
@@ -1,24 +1,31 @@
-# SPDX-FileCopyrightText: (C) 2023 Paul Lettich <paul.lettich@netknights.it>
+# (c) NetKnights GmbH 2024,  https://netknights.it
 #
-# SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# Info: https://privacyidea.org
-#
-# This code is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# as published by the Free Software Foundation; either
 # version 3 of the License, or any later version.
 #
 # This code is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
 #
 # You should have received a copy of the GNU Affero General Public
-# License along with this program. If not, see <http://www.gnu.org/licenses/>.
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: 2024 Paul Lettich <paul.lettich@netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
+import pytest
+from sqlalchemy.orm.session import close_all_sessions
+
+from privacyidea.app import create_app
+from privacyidea.models import db
 from privacyidea.cli.pimanage import cli as pi_manage
-from privacyidea.lib.resolver import save_resolver, delete_resolver
+from privacyidea.lib.lifecycle import call_finalizers
+from privacyidea.lib.resolver import (save_resolver, delete_resolver,
+                                      get_resolver_list)
 from .base import CliTestCase
 from ..base import PWFILE
 
@@ -145,3 +152,64 @@ class PIManageTokenTestCase(CliTestCase):
         result = runner.invoke(pi_manage, ["token"])
         self.assertIn("Commands to manage token in privacyIDEA", result.output, result)
         self.assertIn("Import tokens from a file", result.output, result)
+
+
+@pytest.fixture(scope="function")
+def create_user_resolver(app):
+    """Create a user resolver"""
+    with app.app_context():
+        save_resolver({"resolver": "testresolver",
+                       "type": "passwdresolver",
+                       "fileName": "tests/testdata/passwords"})
+
+
+@pytest.fixture(scope="class")
+def app():
+    """Create and configure app instance for testing"""
+    app = create_app(config_name="testing", config_file="", silent=True)
+    with app.app_context():
+        db.create_all()
+
+    yield app
+
+    with app.app_context():
+        call_finalizers()
+        close_all_sessions()
+        db.drop_all()
+        db.engine.dispose()
+
+
+class TestPIManageConfigImportExport:
+    """Test import/export functions of pi-manage"""
+
+    @pytest.mark.usefixtures("create_user_resolver")
+    def test_pimanage_config_import_export(self, app, tmp_path):
+        # Unfortunately capturing stdout/stderr doesn't work with pytest and the
+        # cli_runner, so we need to write the output to a file
+        outfile = tmp_path / "outfile.txt"
+        runner = app.test_cli_runner()
+        result = runner.invoke(pi_manage, ["config", "export", "-o", outfile])
+        assert not result.exception
+        out_text = outfile.read_text()
+        assert "testresolver" in out_text
+        assert "privacyIDEA_version" in out_text
+        assert "periodictask" in out_text
+
+        # Export only resolver configuration
+        result = runner.invoke(pi_manage, ["config", "export", "-t", "resolver", "-o", outfile])
+        assert not result.exception
+        out_text = outfile.read_text()
+        assert "testresolver" in out_text
+        assert "privacyIDEA_version" in out_text
+        assert "periodictask" not in out_text
+
+        # Import the exported resolver
+        with app.app_context():
+            delete_resolver("testresolver")
+            res_dict = get_resolver_list()
+            assert "testresolver" not in res_dict
+        result = runner.invoke(pi_manage, ["config", "import", "-i", outfile])
+        assert not result.exception
+        with app.app_context():
+            res_dict = get_resolver_list()
+            assert "testresolver" in res_dict


### PR DESCRIPTION
When exporting data via `pi-manage config export` and additional entry with the current privacyIDEA version is added.
During import through `pi-manage config import` it is checked whether the version information is present and if it matches the current version. If not, a warning is printed to check the resulting configuration in privacyIDEA.
Also added some error handling during import and introduces some pytest style testing with fixtures.

Closes #4055