### PR TITLE
doc: Use new tags for tokenlabel example

### DIFF
--- a/doc/policies/templates.rst
+++ b/doc/policies/templates.rst
@@ -20,15 +20,15 @@ You may also fork the github repository and commit pull request to improve
 the policy templates. Or you may fork the github repository and use your own
 policy template URL for your policy templates.
 
-A policy templates looks like this::
+A policy template looks like this::
 
    {
     "name": "template_name1",
     "scope": "enrollment",
     "action": {
-               "tokenlabel": "<u>@<r>/<s>",
-               "autoassignment": true
-              }
+      "tokenlabel": "{user}@{realm}/{serial}",
+      "autoassignment": true
+    }
    }
 
 *realms*, *resolver* and *clients* are not used in the templates.


### PR DESCRIPTION
Since version 3.9 <>-style tags are [no longer](https://privacyidea.readthedocs.io/en/v3.9/policies/enrollment.html#tokenlabel) mentioned in the documentation, this updates an example in the documentation to use the new format.

Before:
![grafik](https://github.com/user-attachments/assets/107621c3-602f-47bf-befc-eb122a901f8a)

After:
![grafik](https://github.com/user-attachments/assets/86c6c073-1515-464a-b0d2-b283a8f65741)
