### PR TITLE
fix webauthn user verification

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1806,7 +1806,7 @@ def webauthntoken_request(request, action):
         if WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST in actions:
             allowed_aaguids_pols = Match \
                 .user(g,
-                      scope=scope,
+                      scope=SCOPE.AUTHZ if scope == SCOPE.AUTH else scope,
                       action=WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST,
                       user_object=request.User if hasattr(request, 'User') else None) \
                 .action_values(unique=False,

--- a/privacyidea/lib/tokens/webauthn.py
+++ b/privacyidea/lib/tokens/webauthn.py
@@ -145,7 +145,6 @@ SUPPORTED_ATTESTATION_FORMATS = (
     ATTESTATION_FORMAT.NONE
 )
 
-
 REGISTERED_ATTESTATION_FORMATS = (
     ATTESTATION_FORMAT.PACKED,
     ATTESTATION_FORMAT.TPM,
@@ -240,7 +239,6 @@ ATTESTATION_LEVELS = (
     ATTESTATION_LEVEL.NONE
 )
 
-
 ATTESTATION_REQUIREMENT_LEVEL = {
     ATTESTATION_LEVEL.TRUSTED: {
         'self_attestation_permitted': False,
@@ -255,7 +253,6 @@ ATTESTATION_REQUIREMENT_LEVEL = {
         'none_attestation_permitted': True
     }
 }
-
 
 ATTESTATION_REQUIREMENT_LEVELS = (
     ATTESTATION_REQUIREMENT_LEVEL[ATTESTATION_LEVEL.TRUSTED],
@@ -1349,8 +1346,8 @@ class WebAuthnRegistrationResponse(object):
             if not _verify_authenticator_extensions(auth_data, self.expected_registration_authenticator_extensions):
                 raise RegistrationRejectedException('Unable to verify authenticator extensions.')
             if not _verify_client_extensions(
-                self.registration_response.get('registrationClientExtensions'),
-                self.expected_registration_client_extensions
+                    self.registration_response.get('registrationClientExtensions'),
+                    self.expected_registration_client_extensions
             ):
                 raise RegistrationRejectedException('Unable to verify client extensions.')
 
@@ -1498,7 +1495,7 @@ class WebAuthnAssertionResponse(object):
                  expected_assertion_client_extensions=None,
                  expected_assertion_authenticator_extensions=None):
         """
-        Create a new WebAUthnAssertionResponse object.
+        Create a new WebAuthnAssertionResponse object.
 
         :param webauthn_user: The WebAuthnUser used to create the assertion.
         :type webauthn_user: WebAuthnUser
@@ -1523,14 +1520,11 @@ class WebAuthnAssertionResponse(object):
         self.challenge = challenge
         self.origin = origin
         self.allow_credentials = allow_credentials
-        self.uv_required = uv_required
+        self.uv_required = uv_required or USER_VERIFICATION_LEVEL.PREFERRED
 
-        self.expected_assertion_client_extensions = expected_assertion_client_extensions \
-            if expected_assertion_client_extensions \
-            else DEFAULT_CLIENT_EXTENSIONS
-        self.expected_assertion_authenticator_extensions = expected_assertion_authenticator_extensions \
-            if expected_assertion_authenticator_extensions \
-            else DEFAULT_AUTHENTICATOR_EXTENSIONS
+        self.expected_assertion_client_extensions = expected_assertion_client_extensions or DEFAULT_CLIENT_EXTENSIONS
+        self.expected_assertion_authenticator_extensions = (expected_assertion_authenticator_extensions
+                                                            or DEFAULT_AUTHENTICATOR_EXTENSIONS)
 
         if not isinstance(webauthn_user, WebAuthnUser):
             raise ValueError('Invalid user type.')
@@ -1547,7 +1541,6 @@ class WebAuthnAssertionResponse(object):
         :return: The new sign count of the authenticated credential.
         :rtype: int
         """
-
         try:
             # Step 1.
             #
@@ -1652,7 +1645,8 @@ class WebAuthnAssertionResponse(object):
             #
             # If user verification is required for this assertion, verify that
             # the User Verified bit of the flags in authData is set.
-            if self.uv_required and not AuthenticatorDataFlags(a_data).user_verified:
+            if (self.uv_required == USER_VERIFICATION_LEVEL.REQUIRED
+                    and not AuthenticatorDataFlags(a_data).user_verified):
                 raise RegistrationRejectedException('Malformed request received.')
 
             # Step 14.
@@ -1671,8 +1665,8 @@ class WebAuthnAssertionResponse(object):
             if not _verify_authenticator_extensions(a_data, self.expected_assertion_authenticator_extensions):
                 raise AuthenticationRejectedException('Unable to verify authenticator extensions.')
             if not _verify_client_extensions(
-                self.assertion_response.get('assertionClientExtensions'),
-                self.expected_assertion_client_extensions
+                    self.assertion_response.get('assertionClientExtensions'),
+                    self.expected_assertion_client_extensions
             ):
                 raise AuthenticationRejectedException('Unable to verify client extensions.')
 
@@ -1785,7 +1779,6 @@ def _encode_public_key(public_key):
 
 
 def _load_cose_public_key(key_bytes):
-
     cose_public_key = cbor2.loads(key_bytes)
 
     if COSE_PUBLIC_KEY.ALG not in cose_public_key:
@@ -1970,7 +1963,7 @@ def _verify_client_extensions(client_extensions, expected_client_extensions):
     :rtype: bool
     """
     return not client_extensions \
-           or set(expected_client_extensions.keys()).issuperset(json.loads(client_extensions).keys())
+        or set(expected_client_extensions.keys()).issuperset(json.loads(client_extensions).keys())
 
 
 def _verify_authenticator_extensions(auth_data, expected_authenticator_extensions):

--- a/privacyidea/lib/tokens/webauthn.py
+++ b/privacyidea/lib/tokens/webauthn.py
@@ -1507,8 +1507,8 @@ class WebAuthnAssertionResponse(object):
         :type origin: basestring
         :param allow_credentials: Which existing credentials to allow for the authentication.
         :type allow_credentials: list of basestring
-        :param uv_required: Whether user verification is required.
-        :type uv_required: bool
+        :param uv_required: Whether user verification is required, preferred or discouraged.
+        :type uv_required: USER_VERIFICATION_LEVEL
         :param expected_assertion_client_extensions: A dict whose keys indicate which client extensions are expected.
         :type expected_assertion_client_extensions: dict
         :param expected_assertion_authenticator_extensions: A dict whose keys indicate which auth exts to expect.

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -903,7 +903,8 @@ class WebAuthnTokenClass(TokenClass):
                     uv_required=uv_req == USER_VERIFICATION_LEVEL.REQUIRED
                 ).verify([
                     # TODO: this might get slow when a lot of webauthn tokens are registered
-                    token.decrypt_otpkey() for token in get_tokens(tokentype=self.type) if token.get_serial() != self.get_serial()
+                    token.decrypt_otpkey() for token in get_tokens(tokentype=self.type) if
+                    token.get_serial() != self.get_serial()
                 ])
             except Exception as e:
                 log.warning('Enrollment of {0!s} token failed: '
@@ -1216,6 +1217,31 @@ class WebAuthnTokenClass(TokenClass):
             user_handle = getParam(options, "userhandle", optional)
             assertion_client_extensions = getParam(options, "assertionclientextensions", optional)
 
+            # Check if a whitelist for AAGUIDs exists, and if this device is whitelisted. If not raise a
+            # policy exception.
+            allowed_aaguids = getParam(options, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST, optional)
+            if allowed_aaguids and self.get_tokeninfo(WEBAUTHNINFO.AAGUID) not in allowed_aaguids:
+                log.warning(
+                    "The WebAuthn token {0!s} is not allowed to authenticate due to policy "
+                    "restriction {1!s}".format(self.token.serial, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST))
+                raise PolicyError("The WebAuthn token is not allowed to "
+                                  "authenticate due to a policy restriction.")
+
+            # Check if the attestation certificate is
+            # authorized. If not, we can raise a policy exception.
+            if not attestation_certificate_allowed(
+                    {
+                        "attestation_issuer": self.get_tokeninfo(WEBAUTHNINFO.ATTESTATION_ISSUER),
+                        "attestation_serial": self.get_tokeninfo(WEBAUTHNINFO.ATTESTATION_SERIAL),
+                        "attestation_subject": self.get_tokeninfo(WEBAUTHNINFO.ATTESTATION_SUBJECT)
+                    },
+                    getParam(options, WEBAUTHNACTION.REQ, optional)):
+                log.warning(
+                    "The WebAuthn token {0!s} is not allowed to authenticate "
+                    "due to policy restriction {1!s}".format(self.token.serial, WEBAUTHNACTION.REQ))
+                raise PolicyError("The WebAuthn token is not allowed to "
+                                  "authenticate due to a policy restriction.")
+
             try:
                 user = self._get_webauthn_user(getParam(options, "user", required))
             except ParameterError:
@@ -1236,54 +1262,27 @@ class WebAuthnTokenClass(TokenClass):
                 # All data is parsed and verified. If any errors occur, an exception
                 # will be raised.
                 self.set_otp_count(WebAuthnAssertionResponse(
-                                       webauthn_user=user,
-                                       assertion_response={
-                                           'id': credential_id,
-                                           'userHandle': user_handle,
-                                           'clientData': client_data,
-                                           'authData': authenticator_data,
-                                           'signature': signature_data,
-                                           'assertionClientExtensions':
-                                               webauthn_b64_decode(assertion_client_extensions)
-                                                   if assertion_client_extensions
-                                                   else None
-                                       },
-                                       challenge=webauthn_b64_encode(challenge),
-                                       origin=http_origin,
-                                       allow_credentials=[user.credential_id],
-                                       uv_required=uv_req
-                                   ).verify())
+                    webauthn_user=user,
+                    assertion_response={
+                        'id': credential_id,
+                        'userHandle': user_handle,
+                        'clientData': client_data,
+                        'authData': authenticator_data,
+                        'signature': signature_data,
+                        'assertionClientExtensions':
+                            webauthn_b64_decode(assertion_client_extensions)
+                            if assertion_client_extensions
+                            else None
+                    },
+                    challenge=webauthn_b64_encode(challenge),
+                    origin=http_origin,
+                    allow_credentials=[user.credential_id],
+                    uv_required=uv_req
+                ).verify())
             except AuthenticationRejectedException as e:
                 # The authentication ceremony failed.
                 log.warning("Checking response for token {0!s} failed. {1!s}".format(self.token.serial, e))
                 return -1
-
-            # At this point we can check, if the attestation certificate is
-            # authorized. If not, we can raise a policy exception.
-            if not attestation_certificate_allowed(
-                    {
-                        "attestation_issuer": self.get_tokeninfo(WEBAUTHNINFO.ATTESTATION_ISSUER),
-                        "attestation_serial": self.get_tokeninfo(WEBAUTHNINFO.ATTESTATION_SERIAL),
-                        "attestation_subject": self.get_tokeninfo(WEBAUTHNINFO.ATTESTATION_SUBJECT)
-                    },
-                    getParam(options, WEBAUTHNACTION.REQ, optional)
-            ):
-                log.warning(
-                    "The WebAuthn token {0!s} is not allowed to authenticate "
-                    "due to policy restriction {1!s}".format(self.token.serial, WEBAUTHNACTION.REQ))
-                raise PolicyError("The WebAuthn token is not allowed to "
-                                  "authenticate due to a policy restriction.")
-
-            # Now we need to check, if a whitelist for AAGUIDs exists, and if
-            # so, if this device is whitelisted. If not, we again raise a
-            # policy exception.
-            allowed_aaguids = getParam(options, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST, optional)
-            if allowed_aaguids and self.get_tokeninfo(WEBAUTHNINFO.AAGUID) not in allowed_aaguids:
-                log.warning(
-                    "The WebAuthn token {0!s} is not allowed to authenticate due to policy "
-                    "restriction {1!s}".format(self.token.serial, WEBAUTHNACTION.AUTHENTICATOR_SELECTION_LIST))
-                raise PolicyError("The WebAuthn token is not allowed to "
-                                  "authenticate due to a policy restriction.")
 
             # All clear? Nice!
             return self.get_otp_count()


### PR DESCRIPTION
* The policies for webauthn are now loaded properly on every request with webauthn data
* The SCOPE.AUTHZ policies which previously replaced the proper policies are now loaded additionally, every time (to keep other functionality the same)
* Adjusted order of checks when verifying webauthn assertions to allow early exit
* Added test for enforcing the user verification setting
* Formatting