### PR TITLE
Design of the unassign button

### DIFF
--- a/privacyidea/static/components/token/views/token.containerdetails.html
+++ b/privacyidea/static/components/token/views/token.containerdetails.html
@@ -408,7 +408,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                         <span class="glyphicon glyphicon-remove"></span>
                         <span translate>Remove</span>
                     </button>
-                    <button class="btn btn-transparent btn-sm btn-danger btn-sm" ng-click="deleteOneToken(token.serial, true)"
+                    <button class="btn btn-transparent btn-sm btn-danger" ng-click="deleteOneToken(token.serial, true)"
                             ng-disabled="!checkRight('delete')"
                             ng-hide="(!checkRight('delete') && hide_buttons) || showDialog[token.serial]">
                         <span class="glyphicon glyphicon-trash"></span>

--- a/privacyidea/static/components/token/views/token.containerdetails.html
+++ b/privacyidea/static/components/token/views/token.containerdetails.html
@@ -304,13 +304,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <th>
                 <div ng-show="loggedInUser.isAdmin">
                     <button ng-click="removeAllTokens(token.serial)"
-                            class="btn btn-transparent btn-danger btn-header"
+                            class="btn btn-transparent btn-danger btn-header btn-sm"
                             ng-hide="showDialogAll"
                             ng-disabled="!checkRight('container_remove_token') || getAllTokenSerials().length === 0">
                         <span class="glyphicon glyphicon-remove"></span>
                         <span translate>Remove All</span>
                     </button>
-                    <button class="btn btn-transparent btn-danger btn-header" ng-click="showDialogAll=true"
+                    <button class="btn btn-transparent btn-danger btn-header btn-sm" ng-click="showDialogAll=true"
                             ng-disabled="!checkRight('delete') || getAllTokenSerials().length === 0"
                             ng-hide="(!checkRight('delete') && hide_buttons) || showDialogAll">
                         <span class="glyphicon glyphicon-trash"></span>
@@ -401,14 +401,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             </td>
             <td>
                 <fieldset ng-disabled="!token.tokentype">
-                    <button class="btn btn-transparent btn-danger"
+                    <button class="btn btn-transparent btn-danger btn-sm"
                             ng-hide="showDialog[token.serial]"
                             ng-disabled="!checkRight('container_remove_token')"
                             ng-click="removeOneToken(token.serial)">
                         <span class="glyphicon glyphicon-remove"></span>
                         <span translate>Remove</span>
                     </button>
-                    <button class="btn btn-transparent btn-danger" ng-click="deleteOneToken(token.serial, true)"
+                    <button class="btn btn-transparent btn-sm btn-danger btn-sm" ng-click="deleteOneToken(token.serial, true)"
                             ng-disabled="!checkRight('delete')"
                             ng-hide="(!checkRight('delete') && hide_buttons) || showDialog[token.serial]">
                         <span class="glyphicon glyphicon-trash"></span>
@@ -613,7 +613,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 </td>
                 <td>
                     <button ng-click="addToken(token_add.serial)"
-                            class="btn btn-transparent btn-primary"
+                            class="btn btn-transparent btn-sm btn-primary"
                             ng-disabled="token_add.container_serial===containerSerial || !checkRight('container_add_token')"
                             ng-hide="(token_add.container_serial===containerSerial || !checkRight('container_add_token')) && hide_buttons">
                         <span class="glyphicon glyphicon-plus"></span>

--- a/privacyidea/static/components/token/views/token.containerdetails.html
+++ b/privacyidea/static/components/token/views/token.containerdetails.html
@@ -304,7 +304,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <th>
                 <div ng-show="loggedInUser.isAdmin">
                     <button ng-click="removeAllTokens(token.serial)"
-                            class="btn btn-transparent btn-danger btn-header btn-sm"
+                            class="btn btn-transparent btn-warning btn-header btn-sm"
                             ng-hide="showDialogAll"
                             ng-disabled="!checkRight('container_remove_token') || getAllTokenSerials().length === 0">
                         <span class="glyphicon glyphicon-remove"></span>
@@ -318,7 +318,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     </button>
                     <span ng-show="showDialogAll" translate> Delete all tokens?</span><br>
                     <button class="btn btn-danger" ng-click="deleteAllTokens(getContainer)"
-                            ng-show="showDialogAll">
+                            ng-show="showDialogAll && checkRight('delete')">
                         <span class="glyphicon glyphicon-trash"></span>
                         <span translate>Delete</span>
                     </button>
@@ -401,7 +401,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             </td>
             <td>
                 <fieldset ng-disabled="!token.tokentype">
-                    <button class="btn btn-transparent btn-danger btn-sm"
+                    <button class="btn btn-transparent btn-warning btn-sm"
                             ng-hide="showDialog[token.serial]"
                             ng-disabled="!checkRight('container_remove_token')"
                             ng-click="removeOneToken(token.serial)">
@@ -417,7 +417,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     <span ng-show="showDialog[token.serial]" translate> Delete this token? </span>
                     <button class="btn btn-danger"
                             ng-click="deleteOneToken(token.serial, false)"
-                            ng-show="showDialog[token.serial] && checkRight('delete') && !hide_buttons"
+                            ng-show="showDialog[token.serial] && checkRight('delete')"
                             ng-disabled="!checkRight('delete')">
                         <span class="glyphicon glyphicon-trash"></span>
                         <span translate>Delete</span>

--- a/privacyidea/static/components/user/views/user.details.html
+++ b/privacyidea/static/components/user/views/user.details.html
@@ -209,11 +209,11 @@
                 </td>
                 <td>
                     <fieldset ng-disabled="!token.tokentype">
-                        <button class="btn btn-transparent btn-danger"
+                        <button class="btn btn-transparent btn-warning"
                                 ng-hide="showDialog[token.serial]"
                                 ng-disabled="!checkRight('unassign')"
                                 ng-click="unassign(token.serial)">
-                            <span class="glyphicon glyphicon-remove"></span>
+                            <span class="glyphicon glyphicon-resize-full" translate></span>
                             <span translate>Unassign</span>
                         </button>
                         <button class="btn btn-transparent btn-danger" ng-click="deleteToken(token.serial, true)"

--- a/privacyidea/static/css/generic.css
+++ b/privacyidea/static/css/generic.css
@@ -27,8 +27,6 @@
     color: #000000;
     background-color: transparent;
     border-color: #ddd;
-    padding: 0.2em 0.6em 0.3em;
-    font-size: 90%;
 }
 
 .btn-transparent.disabled:hover,


### PR DESCRIPTION
* Changed design of the unassign button in the user details view: Same size as other buttons, unassign icon and orange color 
* Removed size from the `btn-transparent` class and use bootstrap class `btn-sm` to reduce the button size in the container details view

closes #4089