### PR TITLE
Remove space on double-click and copy before regtoken on Firefox

### DIFF
--- a/privacyidea/static/components/token/views/token.enrolled.registration.html
+++ b/privacyidea/static/components/token/views/token.enrolled.registration.html
@@ -9,7 +9,7 @@
                         </span>
                     </div>
                 </uib-accordion-heading>
-                {{ enrolledToken.registrationcode }}
+		<div>{{ enrolledToken.registrationcode }}</div>
             </div>
         </uib-accordion>
 


### PR DESCRIPTION
When the registration token is double-clicked and copied, a space is added to the front of string in the clipboard, leading to " TOKEN" instead of "TOKEN". When copied blindly (e.g. during testing), this causes an invalid token and possibly confusion. See this in action:
[firefox_extra_space.webm](https://github.com/user-attachments/assets/cabb2732-19d0-4970-8867-3bd74ffc6217)
As an easy solution, I just wrapped the string in a div. Tested on 3.9.3 (by changing the file on the server, not only the dev tools :smile:).

This space is not appearing in Chromium (checked on Firefox 130.0.1 and Chromium 129.0.6668.58).