### PR TITLE
Improve file handling in `sign_response` test

### DIFF
--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -4072,9 +4072,10 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
                "id": 1}
         resp = jsonify(res)
         from privacyidea.lib.crypto import Sign
-        sign_object = Sign(private_key=None,
-                           public_key=open("tests/testdata/public.pem", 'rb').read())
-
+        with open("tests/testdata/public.pem", 'rb') as f:
+            public_key = f.read()
+        sign_object = Sign(private_key=None, public_key=public_key)
+        
         # check that we don't sign if 'PI_NO_RESPONSE_SIGN' is set
         current_app.config['PI_NO_RESPONSE_SIGN'] = True
         new_response = sign_response(req, resp)

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -4075,7 +4075,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         with open("tests/testdata/public.pem", 'rb') as f:
             public_key = f.read()
         sign_object = Sign(private_key=None, public_key=public_key)
-        
+
         # check that we don't sign if 'PI_NO_RESPONSE_SIGN' is set
         current_app.config['PI_NO_RESPONSE_SIGN'] = True
         new_response = sign_response(req, resp)


### PR DESCRIPTION
This pull request addresses an issue with file handling in the test_07_sign_response. The current implementation uses `open()` without properly closing the file, which could potentially lead to resource leaks.

Changes made:

Replace the direct open() call with a with statement to ensure proper file closure.
Improve code readability and adhere to Python best practices for file handling.

Before:
```python
sign_object = Sign(private_key=None, public_key=open("tests/testdata/public.pem", 'rb').read())
```

After:
```python
with open("tests/testdata/public.pem", 'rb') as f:
    public_key = f.read()
sign_object = Sign(private_key=None, public_key=public_key)
```

Motivation:
While Python's garbage collector will eventually close the file when the file object is no longer referenced, it's generally considered good practice to explicitly close files or use a context manager to ensure they're closed promptly and also avoid resource leaks..

