### PR TITLE
fix two references in the documentation

### DIFF
--- a/doc/overview/index.rst
+++ b/doc/overview/index.rst
@@ -72,11 +72,11 @@ to consider the following aspects:
   of possibilities to design automatation and **processes** like
   enrollment, revocation, leaving users and more. You will identify
   processes that are mandatory and others might not be relevant for you.
-  You can use again :ref:`policies` and :ref:`event_handler`s to implement these.
+  You can use again :ref:`policies` and :ref:`eventhandler` to implement these.
 
 * Authentication data is important. Plan your **backup** and **recovery**
   of your privacyIDEA system. You can use the database level but
-  also need to take a closer look at the :ref`:`pimanage`.
+  also need to take a closer look at :ref:`the pi-manage script <pimanage>`.
 
 * Think about update- and **upgrade**-processes. Both for privacyIDEA
   and for the OS.


### PR DESCRIPTION
In [the current documentation](https://privacyidea.readthedocs.io/en/v3.10/overview/index.html), two references do not resolve. This commit sets it to the correct references:
- https://github.com/privacyidea/privacyidea/blob/master/doc/installation/system/pi-manage.rst?plain=1#L1
- https://github.com/privacyidea/privacyidea/blob/master/doc/eventhandler/index.rst?plain=1#L3

Marking it as a draft since I can't get the current master to build the documentation and test it.