### PR TITLE
fix backup restoration on mysql databases

### DIFF
--- a/privacyidea/cli/pimanage/backup.py
+++ b/privacyidea/cli/pimanage/backup.py
@@ -211,7 +211,7 @@ def backup_restore(backup_file):
             cmd.extend(['-P', str(parsed_sqluri.port)])
         cmd.extend(['-B', shlex.quote(database)])
         with open(sqlfile, "r") as sql_file:
-            p = subprocess.run(cmd, input=sql_file.read())
+            p = subprocess.run(cmd, input=sql_file.read(), text=True)
             if p.returncode == 0:
                 os.unlink(sqlfile)
     else:


### PR DESCRIPTION
Currently, restoration for mysql-type databases fails with this error: `TypeError: a bytes-like object is required, not 'str'`.
This is due to `.read()` returning a string, but input expecting a bytes-like object as default. To get `.run()` to accept a string for input, the attribute `text` has to be set to True.
I've tested this change on privacyIDEA 3.10.1 via creating a backup, creating a token and then restoring the backup. It successfully vanished :smile:.

### Example
```
$ python3 -c 'import subprocess; subprocess.run(["tee"], input="Hello")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.12/subprocess.py", line 550, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1194, in communicate
    self._stdin_write(input)
  File "/usr/lib/python3.12/subprocess.py", line 1143, in _stdin_write
    self.stdin.write(input)
TypeError: a bytes-like object is required, not 'str'
```
With text=True:
```
$ python3 -c 'import subprocess; subprocess.run(["tee"], input="Hello", text=True)'
Hello
```

### Documentation references
> The input argument is passed to [Popen.communicate()](https://docs.python.org/3.12/library/subprocess.html#subprocess.Popen.communicate) and thus to the subprocess’s stdin. **If used it must be a byte sequence, or a string if encoding or errors is specified or text is true**.

> If encoding or errors are specified, **or text is true**, file objects for stdin, stdout and stderr are opened in text mode using the specified encoding and errors or the [io.TextIOWrapper](https://docs.python.org/3.12/library/io.html#io.TextIOWrapper) default.

https://docs.python.org/3.12/library/subprocess.html#subprocess.run (emphasis mine)