### PR TITLE
Fix deleting offline token with options

### DIFF
--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -292,9 +292,8 @@ class Token(MethodsMixin, db.Model):
         db.session.query(TokenOwner) \
             .filter(TokenOwner.token_id == self.id) \
             .delete()
-        db.session.query(MachineToken) \
-            .filter(MachineToken.token_id == self.id) \
-            .delete()
+        for mt in db.session.execute(db.select(MachineToken).filter(MachineToken.token_id == self.id)).scalars():
+            mt.delete()
         db.session.query(Challenge) \
             .filter(Challenge.serial == self.serial) \
             .delete()

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -6,7 +6,6 @@ import passlib
 
 from privacyidea.lib.user import User
 from .base import MyApiTestCase
-import json
 from privacyidea.lib.token import init_token, get_tokens, remove_token
 from privacyidea.lib.machine import attach_token, detach_token, ANY_MACHINE, NO_RESOLVER
 from privacyidea.lib.policy import (set_policy, delete_policy, ACTION, SCOPE)
@@ -238,7 +237,6 @@ class APIMachinesTestCase(MyApiTestCase):
 
     def test_04_set_options_by_mtid(self):
         serial = "S1"
-        mtid = 0
         # current number of attached applications.
         token_obj = get_tokens(serial=serial)[0]
         num_applications = len(token_obj.token.machine_list)
@@ -582,7 +580,7 @@ class APIMachinesTestCase(MyApiTestCase):
                              "93235fc7d1d444d0ec014ea9eafcc44fc65b73eb")
 
     def test_12_auth_items_offline(self):
-        #create HOTP token for offline usage
+        # Create HOTP token for offline usage
         self.setUp_user_realms()
         token_obj = init_token({"serial": self.serial4, "type": "hotp",
                                 "otpkey": OTPKEY,
@@ -611,13 +609,13 @@ class APIMachinesTestCase(MyApiTestCase):
             response = offline_auth_item.get("response")
             self.assertEqual(len(response), 17)
             self.assertEqual(token_obj.token.count, 17)
-            self.assertTrue(passlib.hash.\
+            self.assertTrue(passlib.hash.
                             pbkdf2_sha512.verify("755224",
                                                  response.get('0')))
 
-        self.assertEqual(token_obj.check_otp('187581'), -1) # count = 16
+        self.assertEqual(token_obj.check_otp('187581'), -1)  # count = 16
         with self.app.test_request_context(
-                '/validate/check?user=cornelius&pass=test447589', # count = 17
+                '/validate/check?user=cornelius&pass=test447589',  # count = 17
                 environ_base={'REMOTE_ADDR': '192.168.0.1'},
                 method='GET'):
             res = self.app.full_dispatch_request()
@@ -631,15 +629,15 @@ class APIMachinesTestCase(MyApiTestCase):
             # check, if we got 17 otp values
             response = offline_auth_item.get("response")
             self.assertEqual(len(response), 17)
-            self.assertEqual(token_obj.token.count, 35) # 17 + 17 + 1, because we consumed 447589
+            self.assertEqual(token_obj.token.count, 35)  # 17 + 17 + 1, because we consumed 447589
             self.assertTrue(passlib.hash.
-                            pbkdf2_sha512.verify("test903435", # count = 18
+                            pbkdf2_sha512.verify("test903435",  # count = 18
                                                  response.get('18')))
             self.assertTrue(passlib.hash.
-                            pbkdf2_sha512.verify("test749439", # count = 34
+                            pbkdf2_sha512.verify("test749439",  # count = 34
                                                  response.get('34')))
-        self.assertEqual(token_obj.check_otp('747439'), -1) # count = 34
-        self.assertEqual(token_obj.check_otp('037211'), 35) # count = 35
+        self.assertEqual(token_obj.check_otp('747439'), -1)  # count = 34
+        self.assertEqual(token_obj.check_otp('037211'), 35)  # count = 35
 
     def test_20_detach_ssh_key_any_token(self):
         # we could also attach an SSH key to "any machine".
@@ -766,3 +764,46 @@ class APIMachinesTestCase(MyApiTestCase):
         token_obj = get_tokens(serial=serial)[0]
         self.assertEqual(len(token_obj.token.machine_list), 0)
         remove_token(serial)
+
+    def test_35_delete_offline_token(self):
+        # Delete an offline token with machine token options (Issue #4136)
+        serial = "hotp01"
+        tok = init_token({"type": "hotp", "otpkey": self.otpkey, "serial": serial})
+        # Mark this token as "offline"
+        with self.app.test_request_context('/machine/token',
+                                           method='POST',
+                                           data={"machineid": 0,
+                                                 "serial": serial,
+                                                 "application": "offline",
+                                                 "rounds": 25,
+                                                 "count": 15,
+                                                 "resolver": ""},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code)
+            result = res.json.get("result")
+            self.assertTrue(result["status"])
+            self.assertGreaterEqual(result["value"], 1, result)
+
+        # Check if the options were set.
+        with self.app.test_request_context('/machine/token', method="GET",
+                                           query_string={"serial": serial},
+                                           headers={"Authorization": self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code)
+            result = res.json.get("result")
+            self.assertEqual("offline", result["value"][0]["application"], result)
+            self.assertEqual("15", result["value"][0]["options"]["count"], result)
+            self.assertEqual("25", result["value"][0]["options"]["rounds"], result)
+
+        # Delete the token
+        with self.app.test_request_context(f"/token/{serial}", method="DELETE",
+                                           headers={"Authorization": self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code)
+            result = res.json.get("result")
+            self.assertTrue(result["status"])
+            self.assertEqual(1, result["value"], result)
+
+        # Check that the token was deleted
+        self.assertFalse(get_tokens(serial=serial))

--- a/tests/test_api_machines_serviceid.py
+++ b/tests/test_api_machines_serviceid.py
@@ -2,14 +2,8 @@
 This testcase is used to test the REST API  in api/machines.py
 to fetch machine information and to attach token to machines
 """
-import passlib
-
-from privacyidea.lib.user import User
 from .base import MyApiTestCase
-import json
-from privacyidea.lib.token import init_token, get_tokens, remove_token
-from privacyidea.lib.machine import attach_token, detach_token, ANY_MACHINE, NO_RESOLVER
-from privacyidea.lib.policy import (set_policy, delete_policy, ACTION, SCOPE)
+from privacyidea.lib.token import init_token
 
 HOSTSFILE = "tests/testdata/hosts"
 
@@ -66,7 +60,6 @@ class APIMachinesServiceIDTestCase(MyApiTestCase):
             result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
-            mtid = result.get("value")
 
         # Attach S1 to mailserver
         with self.app.test_request_context('/machine/token',
@@ -81,7 +74,6 @@ class APIMachinesServiceIDTestCase(MyApiTestCase):
             result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
-            mtid = result.get("value")
 
         # Attach S2 to mailserver
         with self.app.test_request_context('/machine/token',
@@ -96,7 +88,6 @@ class APIMachinesServiceIDTestCase(MyApiTestCase):
             result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
-            mtid = result.get("value")
 
     def test_03_get_service_ids(self):
         # Get all machinetokens
@@ -202,7 +193,6 @@ class APIMachinesServiceIDTestCase(MyApiTestCase):
             result = res.json.get("result")
             self.assertEqual(result["status"], True)
             self.assertTrue(result["value"] >= 1)
-            mtid = result.get("value")
 
         # Get token for service_id self.serviceID2 and the application=ssh and the user=root
         with self.app.test_request_context(

--- a/tests/test_api_offline_no_token.py
+++ b/tests/test_api_offline_no_token.py
@@ -7,7 +7,7 @@ from privacyidea.lib.machine import attach_token
 
 class OfflinePassNoTokenTestCase(MyApiTestCase):
     """
-    Ensure that an user with no tokens do not receive any offline values
+    Ensure that a user with no tokens do not receive any offline values
     https://github.com/privacyidea/privacyidea/issues/3333
     """
 


### PR DESCRIPTION
Deleting a token with an offline application and options set (like "rounds" and "count") failed due to a simplified call to SQLs DELETE. Deleting each MachineToken explicitly when deleting an offline token fixes this behaviour.

Fixes #4136