### PR TITLE
add check for pem to csr parsing

### DIFF
--- a/privacyidea/lib/tokens/certificatetoken.py
+++ b/privacyidea/lib/tokens/certificatetoken.py
@@ -440,6 +440,11 @@ class CertificateTokenClass(TokenClass):
         if request:
             if not spkac:
                 # We only do the whole attestation checking in case we have no SPKAC
+                request = request.replace("\n", "")
+                if not request.startswith("-----BEGIN CERTIFICATE REQUEST-----"):
+                    request = "-----BEGIN CERTIFICATE REQUEST-----" + request
+                if not request.endswith("-----END CERTIFICATE REQUEST-----"):
+                    request = request + "-----END CERTIFICATE REQUEST-----"
                 request_csr = load_pem_x509_csr(to_byte_string(request), default_backend())
                 if not request_csr.is_signature_valid:
                     raise privacyIDEAError("request has invalid signature.")

--- a/privacyidea/lib/tokens/certificatetoken.py
+++ b/privacyidea/lib/tokens/certificatetoken.py
@@ -33,6 +33,8 @@ The code is tested in test_lib_tokens_certificate.py.
 
 import logging
 
+from cryptography.hazmat.primitives import serialization
+
 from privacyidea.lib.utils import to_unicode, b64encode_and_unicode, to_byte_string
 from privacyidea.lib.tokenclass import TokenClass, ROLLOUTSTATE
 from privacyidea.lib.log import log_with
@@ -446,6 +448,8 @@ class CertificateTokenClass(TokenClass):
                 if not request.endswith("-----END CERTIFICATE REQUEST-----"):
                     request = request + "-----END CERTIFICATE REQUEST-----"
                 request_csr = load_pem_x509_csr(to_byte_string(request), default_backend())
+                # Restore the request string with newlines
+                request = request_csr.public_bytes(encoding=serialization.Encoding.PEM).decode('utf-8')
                 if not request_csr.is_signature_valid:
                     raise privacyIDEAError("request has invalid signature.")
                 # If a request is sent, we can have an attestation certificate
@@ -471,6 +475,7 @@ class CertificateTokenClass(TokenClass):
                         log.warning("Failed to verify certificate chain of attestation certificate.")
                         if verify_attestation:
                             raise privacyIDEAError("Failed to verify certificate chain of attestation certificate.")
+
 
             # During the initialization process, we need to create the certificate
             request_id, x509object = cacon.sign_request(request,


### PR DESCRIPTION
This pull request includes changes to the `privacyidea/lib/tokens/certificatetoken.py` file to improve the handling and validation of certificate requests. The most important changes include importing necessary modules, ensuring certificate request strings are properly formatted, and restoring the request string with newlines.

Improvements to certificate request handling:

* [`privacyidea/lib/tokens/certificatetoken.py`](diffhunk://#diff-253f23f51c7dba307fd769ef2d42402b98f5ae44db3e9d4b26c24a816fb20104R36-R37): Imported `serialization` from `cryptography.hazmat.primitives` to support the handling of certificate requests.
* [`privacyidea/lib/tokens/certificatetoken.py`](diffhunk://#diff-253f23f51c7dba307fd769ef2d42402b98f5ae44db3e9d4b26c24a816fb20104R445-R452): Added logic to ensure the certificate request string starts with "-----BEGIN CERTIFICATE REQUEST-----" and ends with "-----END CERTIFICATE REQUEST-----".
* [`privacyidea/lib/tokens/certificatetoken.py`](diffhunk://#diff-253f23f51c7dba307fd769ef2d42402b98f5ae44db3e9d4b26c24a816fb20104R445-R452): Restored the request string with newlines after loading the PEM-encoded CSR.

Codebase simplification:

* [`privacyidea/lib/tokens/certificatetoken.py`](diffhunk://#diff-253f23f51c7dba307fd769ef2d42402b98f5ae44db3e9d4b26c24a816fb20104R479): Removed unnecessary blank line for better readability.