### PR TITLE
explain tokentype on pre token_init

### DIFF
--- a/doc/eventhandler/index.rst
+++ b/doc/eventhandler/index.rst
@@ -344,7 +344,9 @@ The resolver of the token, for which this event should apply.
 The action is only triggered if the token in this event is of the given type.
 This way the administrator can design workflows for enrolling and re-enrolling
 tokens. E.g. the tokentype can be a registration token and the registration
-code can be easily and automatically sent to the user.
+code can be easily and automatically sent to the user. If the token does not
+exist yet (like with a pre-event handler for token_init), this condition gets
+ignored.
 
 **user_token_number**
 


### PR DESCRIPTION
The documentation does not explicitly mention that the token has to exist for this condition to not get ignored. This can lead to unexpected behaviour as in #4153.
This add a short sentence in the documentation to explain this limitation.