### PR TITLE
Remove unsupported Python 3.8 from tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         # current supported Python versions
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/doc/installation/pip.rst
+++ b/doc/installation/pip.rst
@@ -9,7 +9,7 @@ You can install privacyidea usually on any Linux distribution in a python
 virtual environment. This way you keep all privacyIDEA code in one defined
 subdirectory.
 
-privacyIDEA currently runs with Python 3.8 to 3.10. Other
+privacyIDEA currently runs with Python 3.9 to 3.12. Other
 versions either do not work or are not tested.
 
 You first need to install a package for creating a python `virtual environment

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,6 @@ setup(
                  " Systems Administration :: Authentication/Directory",
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.9',
                  'Programming Language :: Python :: 3.10',
                  'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Python 3.8 is end of life (https://devguide.python.org/versions/).