### PR TITLE
fix for container

### DIFF
--- a/privacyidea/api/container.py
+++ b/privacyidea/api/container.py
@@ -169,10 +169,11 @@ def unassign(container_serial):
 def init():
     """
     Create a new container.
+    Raises an EnrollmentError if an invalid type or an already existing serial is provided.
 
     :jsonparam description: Description for the container
     :jsonparam type: Type of the container. If the type is unknown, an error will be returned
-    :jsonparam serial: Optional serial
+    :jsonparam container_serial: Optional unique serial (not case-sensitive)
     :jsonparam user: Optional username to assign the container to. Requires realm param to be present as well.
     :jsonparam realm: Optional realm to assign the container to. Requires user param to be present as well.
     :jsonparam template: The template to create the container from (dictionary), optional

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -497,6 +497,7 @@ def list_api():
 def assign_api():
     """
     Assign a token to a user.
+    It also adds the user's realm to the token realms. Existing token realms are preserved.
 
     :jsonparam serial: The token, which should be assigned to a user
     :jsonparam user: The username of the user

--- a/privacyidea/lib/container.py
+++ b/privacyidea/lib/container.py
@@ -30,8 +30,9 @@ from privacyidea.api.lib.utils import send_result
 from privacyidea.lib.challenge import delete_challenges
 from privacyidea.lib.config import get_from_config
 from privacyidea.lib.containerclass import TokenContainerClass
+from privacyidea.lib.containers.container_info import PI_INTERNAL, TokenContainerInfoData
 from privacyidea.lib.containertemplate.containertemplatebase import ContainerTemplateBase
-from privacyidea.lib.error import ResourceNotFoundError, ParameterError, EnrollmentError, UserError
+from privacyidea.lib.error import ResourceNotFoundError, ParameterError, EnrollmentError, UserError, PolicyError
 from privacyidea.lib.log import log_with
 from privacyidea.lib.machine import is_offline_token
 from privacyidea.lib.token import (get_tokens_from_serial_or_user, get_tokens,
@@ -147,7 +148,10 @@ def find_container_by_serial(serial: str) -> TokenContainerClass:
     :return: container object
     :rtype: privacyidea.lib.containerclass.TokenContainerClass
     """
-    db_container = TokenContainer.query.filter(func.upper(TokenContainer.serial) == serial.upper()).first()
+    if serial:
+        db_container = TokenContainer.query.filter(func.upper(TokenContainer.serial) == serial.upper()).first()
+    else:
+        db_container = None
     if not db_container:
         raise ResourceNotFoundError(f"Unable to find container with serial {serial}.")
 
@@ -697,6 +701,8 @@ def remove_multiple_tokens_from_container(container_serial: str, token_serials: 
 def add_container_info(serial: str, ikey: str, ivalue) -> bool:
     """
     Add the given info to the container with the given serial.
+    If the key already exists, the value is updated. However, if the entry is of type PI_INTERNAL, the value can not be
+    modified.
 
     :param serial: The serial of the container
     :param ikey: The info key
@@ -705,21 +711,40 @@ def add_container_info(serial: str, ikey: str, ivalue) -> bool:
     """
     container = find_container_by_serial(serial)
 
-    container.add_container_info(ikey, ivalue)
+    # Check if key already exists and if it is an internal key
+    internal_keys = container.get_internal_info_keys()
+    if ikey in internal_keys:
+        raise PolicyError(f"The key {ikey} is an internal entry and can not be modified.")
+
+    container.update_container_info([TokenContainerInfoData(key=ikey, value=ivalue)])
     return True
 
 
-def set_container_info(serial, info: dict) -> bool:
+def set_container_info(serial, info: dict) -> dict[str, bool]:
     """
     Set the given info to the container with the given serial.
+    Keys of type PI_INTERNAL can not be modified and will be ignored.
 
     :param serial: The serial of the container
     :param info: The info dictionary in the format {key: value}
-    :returns: True on success
+    :returns: Dictionary with the success state for each info key
     """
     container = find_container_by_serial(serial)
-    container.set_container_info(info)
-    return True
+    result = {}
+
+    # Remove internal keys from the info dictionary, they can not be modified by the user
+    internal_keys = container.get_internal_info_keys()
+    not_internal_info = {}
+    for key, value in info.items():
+        if key not in internal_keys:
+            not_internal_info[key] = value
+            result[key] = True
+        else:
+            result[key] = False
+            log.warning(f"The key {key} is an internal entry and can not be modified.")
+
+    container.set_container_info(not_internal_info)
+    return result
 
 
 def get_container_info_dict(serial: str, ikey: str = None) -> dict[str, Union[str, None]]:
@@ -745,6 +770,7 @@ def get_container_info_dict(serial: str, ikey: str = None) -> dict[str, Union[st
 def delete_container_info(serial: str, ikey: str = None) -> dict[str, bool]:
     """
     Delete the info of the given key or all infos if no key is given.
+    Internal infos are not deleted
 
     :param serial: The serial of the container
     :param ikey: The info key or None to delete all info keys
@@ -752,7 +778,7 @@ def delete_container_info(serial: str, ikey: str = None) -> dict[str, bool]:
     """
     container = find_container_by_serial(serial)
 
-    res = container.delete_container_info(ikey)
+    res = container.delete_container_info(ikey, keep_internal=True)
     return res
 
 
@@ -941,6 +967,7 @@ def create_container_dict(container_list: list[TokenContainerClass], no_token: b
                             ...
                         }],
                     "info": {"hash_algorithm": "SHA256", ...},
+                    "internal_info_keys": ["hash_algorithm"],
                     "realms": ["realm1", "realm2"],
                     "template": "template1"
                 }, ...
@@ -1015,11 +1042,13 @@ def finalize_registration(container_serial: str, params: dict) -> dict:
         for key, value in container_info.items():
             if key.find("rollover_") == 0:
                 original_key = key.replace("rollover_", "")
-                container.add_container_info(original_key, value)
-                container.delete_container_info(key)
+                container.update_container_info(
+                    [TokenContainerInfoData(key=original_key, value=value, info_type=PI_INTERNAL)])
+                container.delete_container_info(key, keep_internal=False)
 
         finalize_container_rollover(container)
-        container.add_container_info("registration_state", "rollover_completed")
+        container.update_container_info(
+            [TokenContainerInfoData(key="registration_state", value="rollover_completed", info_type=PI_INTERNAL)])
 
     return res
 
@@ -1059,7 +1088,7 @@ def finalize_container_rollover(container: TokenContainerClass):
 
 
 def init_container_rollover(container: TokenContainerClass, server_url: str, challenge_ttl: int, registration_ttl: int,
-                            ssl_verify: str, params: dict) -> dict:
+                            ssl_verify: bool, params: dict) -> dict:
     """
     Initializes the rollover of a container.
     First the response to the challenge is validated. If it is valid, the registration is initialized.
@@ -1085,8 +1114,10 @@ def init_container_rollover(container: TokenContainerClass, server_url: str, cha
     res = container.init_registration(server_url, registration_scope, registration_ttl, ssl_verify, params)
 
     # Set registration state
-    container.update_container_info({"registration_state": "rollover", "rollover_server_url": server_url,
-                                     "rollover_challenge_ttl": challenge_ttl})
+    info = [TokenContainerInfoData(key="registration_state", value="rollover", info_type=PI_INTERNAL),
+            TokenContainerInfoData(key="rollover_server_url", value=server_url, info_type=PI_INTERNAL),
+            TokenContainerInfoData(key="rollover_challenge_ttl", value=str(challenge_ttl), info_type=PI_INTERNAL)]
+    container.update_container_info(info)
 
     return res
 

--- a/privacyidea/lib/containers/container_info.py
+++ b/privacyidea/lib/containers/container_info.py
@@ -1,0 +1,37 @@
+# (c) NetKnights GmbH 2025,  https://netknights.it
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: 2025 Jelina Unger <jelina.unger@netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from dataclasses import dataclass
+
+PI_INTERNAL = "pi_internal"
+
+@dataclass
+class TokenContainerInfoData:
+    """
+    Dataclass for token container info
+    """
+    key: str
+    value: str
+    type: str
+    description: str
+
+    def __init__(self, key: str, value: str, info_type: str = None, description: str = None):
+        self.key = key
+        self.value = value
+        self.type = info_type
+        self.description = description

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -337,7 +337,8 @@ def _create_token_query(tokentype=None, token_type_list=None, realm=None, assign
             sql_query = (sql_query.outerjoin(TokenContainerToken)
                          .filter(TokenContainerToken.container_id.is_(None)))
         else:
-            container = TokenContainer.query.filter(TokenContainer.serial == container_serial).first()
+            container = TokenContainer.query.filter(
+                func.upper(TokenContainer.serial) == container_serial.upper()).first()
             if container is None:
                 raise privacyIDEAError(_(f"No container with the serial {container_serial} exists."))
             token_container_token = TokenContainerToken.query.filter(

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -243,7 +243,7 @@ class TokenClass(object):
                        user_id=uid, resolver=resolvername,
                        realmname=user.realm).save()
         # set the tokenrealm
-        self.set_realms([user.realm])
+        self.set_realms([user.realm], add=True)
 
     def add_tokengroup(self, tokengroup=None, tokengroup_id=None):
         """

--- a/tests/test_api_container.py
+++ b/tests/test_api_container.py
@@ -10,6 +10,7 @@ from privacyidea.lib.applications.offline import MachineApplication, REFILLTOKEN
 from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib.container import (create_container_template, get_template_obj, delete_container_by_serial,
                                        get_container_realms)
+from privacyidea.lib.containers.container_info import PI_INTERNAL, TokenContainerInfoData
 from privacyidea.lib.containers.smartphone import SmartphoneOptions
 from privacyidea.lib.crypto import generate_keypair_ecc, decrypt_aes
 from privacyidea.lib.container import (init_container, find_container_by_serial, add_token_to_container, assign_user,
@@ -559,7 +560,8 @@ class APIContainerAuthorizationUser(APIContainerAuthorization):
     def test_24_user_container_rollover_allowed(self):
         container_serial = self.create_container_for_user("smartphone")
         container = find_container_by_serial(container_serial)
-        container.add_container_info("registration_state", "registered")
+        container.update_container_info(
+            [TokenContainerInfoData(key="registration_state", value="registered", info_type=PI_INTERNAL)])
         set_policy("policy", scope=SCOPE.USER,
                    action={ACTION.CONTAINER_ROLLOVER: True})
         set_policy("container_policy", scope=SCOPE.CONTAINER, action={ACTION.PI_SERVER_URL: "https://test"})
@@ -573,7 +575,8 @@ class APIContainerAuthorizationUser(APIContainerAuthorization):
         # User has no CONTAINER_ROLLOVER rights
         container_serial = self.create_container_for_user("smartphone")
         container = find_container_by_serial(container_serial)
-        container.add_container_info("registration_state", "registered")
+        container.update_container_info(
+            [TokenContainerInfoData(key="registration_state", value="registered", info_type=PI_INTERNAL)])
         set_policy("container_policy", scope=SCOPE.CONTAINER, action={ACTION.PI_SERVER_URL: "https://test"})
         set_policy("policy", scope=SCOPE.USER,
                    action={ACTION.CONTAINER_REGISTER: True})
@@ -964,7 +967,8 @@ class APIContainerAuthorizationAdmin(APIContainerAuthorization):
     def test_27_admin_container_rollover_allowed(self):
         container_serial = self.create_container_for_user("smartphone")
         container = find_container_by_serial(container_serial)
-        container.add_container_info("registration_state", "registered")
+        container.update_container_info(
+            [TokenContainerInfoData(key="registration_state", value="registered", info_type=PI_INTERNAL)])
         set_policy("policy", scope=SCOPE.ADMIN,
                    action={ACTION.CONTAINER_ROLLOVER: True})
         set_policy("container_policy", scope=SCOPE.CONTAINER, action={ACTION.PI_SERVER_URL: "https://test"})
@@ -978,7 +982,8 @@ class APIContainerAuthorizationAdmin(APIContainerAuthorization):
         # Admin has no CONTAINER_ROLLOVER rights
         container_serial = self.create_container_for_user("smartphone")
         container = find_container_by_serial(container_serial)
-        container.add_container_info("registration_state", "registered")
+        container.update_container_info(
+            [TokenContainerInfoData("registration_state", "registered", info_type=PI_INTERNAL)])
         set_policy("container_policy", scope=SCOPE.CONTAINER, action={ACTION.PI_SERVER_URL: "https://test"})
         set_policy("policy", scope=SCOPE.ADMIN,
                    action={ACTION.CONTAINER_REGISTER: True})
@@ -1073,6 +1078,48 @@ class APIContainerAuthorizationAdmin(APIContainerAuthorization):
         template = get_template_obj(template_params["name"])
         template.delete()
 
+        delete_policy("policy")
+
+    def test_38_admin_set_container_info_allowed(self):
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO)
+        container_serial = self.create_container_for_user("smartphone")
+        self.request_assert_success(f"/container/{container_serial}/info/test", {"value": "1234"}, self.at,
+                                    method='POST')
+        delete_policy("policy")
+
+    def test_39_admin_set_container_info_denied(self):
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_DELETE)
+        container_serial = self.create_container_for_user("smartphone")
+        self.request_denied_assert_403(f"/container/{container_serial}/info/test", {"value": "1234"}, self.at,
+                                       method='POST')
+        delete_policy("policy")
+
+        # Modify container info is allowed, but internal info can not be modified
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO)
+        container_serial = self.create_container_for_user("smartphone")
+        container = find_container_by_serial(container_serial)
+        container.update_container_info(
+            [TokenContainerInfoData(key="public_server_key", value="123456789", info_type=PI_INTERNAL)])
+        self.request_denied_assert_403(f"/container/{container_serial}/info/public_server_key",
+                                       {"value": "1234"}, self.at, method='POST')
+        delete_policy("policy")
+
+    def test_40_admin_delete_container_info_allowed(self):
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO)
+        container_serial = self.create_container_for_user("smartphone")
+        container = find_container_by_serial(container_serial)
+        container.update_container_info([TokenContainerInfoData(key="test", value="1234")])
+        self.request_assert_success(f"/container/{container_serial}/info/delete/test", {}, self.at,
+                                    method="DELETE")
+        delete_policy("policy")
+
+    def test_41_admin_delete_container_info_denied(self):
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_DELETE)
+        container_serial = self.create_container_for_user("smartphone")
+        container = find_container_by_serial(container_serial)
+        container.update_container_info([TokenContainerInfoData(key="test", value="1234")])
+        self.request_denied_assert_403(f"/container/{container_serial}/info/delete/test", {}, self.at,
+                                       method="DELETE")
         delete_policy("policy")
 
 
@@ -1705,7 +1752,8 @@ class APIContainerAuthorizationHelpdesk(APIContainerAuthorization):
     def test_24_helpdesk_container_rollover_allowed(self):
         container_serial = self.create_container_for_user("smartphone")
         container = find_container_by_serial(container_serial)
-        container.add_container_info("registration_state", "registered")
+        container.update_container_info(
+            [TokenContainerInfoData(key="registration_state", value="registered", info_type=PI_INTERNAL)])
         set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_ROLLOVER, realm=self.realm1)
         set_policy("container_policy", scope=SCOPE.CONTAINER, action={ACTION.PI_SERVER_URL: "https://test"})
         data = {"container_serial": container_serial, "rollover": True}
@@ -1718,7 +1766,8 @@ class APIContainerAuthorizationHelpdesk(APIContainerAuthorization):
         # Helpdesk has no CONTAINER_ROLLOVER rights for the realm of the container
         container_serial = self.create_container_for_user("smartphone")
         container = find_container_by_serial(container_serial)
-        container.add_container_info("registration_state", "registered")
+        container.update_container_info(
+            [TokenContainerInfoData(key="registration_state", value="registered", info_type=PI_INTERNAL)])
         set_policy("container_policy", scope=SCOPE.CONTAINER, action={ACTION.PI_SERVER_URL: "https://test"})
         set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_REGISTER, realm=self.realm2)
         data = {"container_serial": container_serial, "rollover": True}
@@ -1865,6 +1914,121 @@ class APIContainerAuthorizationHelpdesk(APIContainerAuthorization):
         template = get_template_obj(template_params["name"])
         template.delete()
 
+        delete_policy("policy")
+
+    def test_30_helpdesk_set_container_info_allowed(self):
+        self.setUp_user_realm2()
+        # policy for realms
+        container_serial = init_container({"type": "generic", "realm": self.realm1})["container_serial"]
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, realm=[self.realm1, self.realm2])
+        self.request_assert_success(f"/container/{container_serial}/info/test", {"value": "1234"}, self.at,
+                                    method='POST')
+        delete_policy("policy")
+
+        # policy for resolver
+        container_serial = self.create_container_for_user()
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, resolver=self.resolvername1)
+        self.request_assert_success(f"/container/{container_serial}/info/test", {"value": "1234"}, self.at,
+                                    method='POST')
+        delete_policy("policy")
+
+        # policy for user
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, user="selfservice",
+                   realm=self.realm1, resolver=self.resolvername1)
+        self.request_assert_success(f"/container/{container_serial}/info/test", {"value": "1234"}, self.at,
+                                    method='POST')
+        delete_policy("policy")
+
+    def test_31_helpdesk_set_container_info_denied(self):
+        self.setUp_user_realm3()
+        c_serial_user = self.create_container_for_user()
+        c_serial_no_user = init_container({"type": "generic"})["container_serial"]
+
+        # policy for a realm
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, realm=self.realm3)
+        self.request_denied_assert_403(f"/container/{c_serial_user}/info/test", {"value": "1234"}, self.at,
+                                       method='POST')
+        self.request_denied_assert_403(f"/container/{c_serial_no_user}/info/test", {"value": "1234"}, self.at,
+                                       method='POST')
+        delete_policy("policy")
+
+        # policy for a resolver
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, resolver=self.resolvername3)
+        self.request_denied_assert_403(f"/container/{c_serial_user}/info/test", {"value": "1234"}, self.at,
+                                       method='POST')
+        self.request_denied_assert_403(f"/container/{c_serial_no_user}/info/test", {"value": "1234"}, self.at,
+                                       method='POST')
+        delete_policy("policy")
+
+        # policy for a user
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, user="hans", realm=self.realm1,
+                   resolver=self.resolvername1)
+        self.request_denied_assert_403(f"/container/{c_serial_user}/info/test", {"value": "1234"}, self.at,
+                                       method='POST')
+        self.request_denied_assert_403(f"/container/{c_serial_no_user}/info/test", {"value": "1234"}, self.at,
+                                       method='POST')
+        delete_policy("policy")
+
+    def test_32_helpdesk_delete_container_info_allowed(self):
+        self.setUp_user_realm2()
+        # policy for realms
+        container_serial = init_container({"type": "generic", "realm": self.realm1})["container_serial"]
+        container = find_container_by_serial(container_serial)
+        container.update_container_info([TokenContainerInfoData(key="test", value="1234")])
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, realm=[self.realm1, self.realm2])
+        self.request_assert_success(f"/container/{container_serial}/info/delete/test", {}, self.at,
+                                    method="DELETE")
+        delete_policy("policy")
+
+        # policy for resolver
+        container_serial = self.create_container_for_user()
+        container = find_container_by_serial(container_serial)
+        container.update_container_info([TokenContainerInfoData(key="test", value="1234")])
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, resolver=self.resolvername1)
+        self.request_assert_success(f"/container/{container_serial}/info/delete/test", {}, self.at,
+                                    method="DELETE")
+        delete_policy("policy")
+
+        # policy for user
+        container.update_container_info([TokenContainerInfoData(key="test", value="1234")])
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, user="selfservice",
+                   realm=self.realm1, resolver=self.resolvername1)
+        self.request_assert_success(f"/container/{container_serial}/info/delete/test", {}, self.at,
+                                    method="DELETE")
+        delete_policy("policy")
+
+    def test_33_helpdesk_delete_container_info_denied(self):
+        self.setUp_user_realm3()
+        c_serial_user = self.create_container_for_user()
+        container_user = find_container_by_serial(c_serial_user)
+        container_user.update_container_info([TokenContainerInfoData(key="test", value="1234")])
+        c_serial_no_user = init_container({"type": "generic"})["container_serial"]
+        container_no_user = find_container_by_serial(c_serial_no_user)
+        container_no_user.update_container_info([TokenContainerInfoData(key="test", value="1234")])
+
+        # policy for a realm
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, realm=self.realm3)
+        self.request_denied_assert_403(f"/container/{c_serial_user}/info/delete/test", {}, self.at,
+                                       method="DELETE")
+        self.request_denied_assert_403(f"/container/{c_serial_no_user}/info/delete/test", {}, self.at,
+                                       method="DELETE")
+        delete_policy("policy")
+
+        # policy for a resolver
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, resolver=self.resolvername3)
+        self.request_denied_assert_403(f"/container/{c_serial_user}/info/delete/test", {}, self.at,
+                                       method="DELETE")
+        self.request_denied_assert_403(f"/container/{c_serial_no_user}/info/delete/test", {}, self.at,
+                                       method="DELETE")
+        delete_policy("policy")
+
+        # policy for a user
+        set_policy("policy", scope=SCOPE.ADMIN, action=ACTION.CONTAINER_INFO, user="hans", realm=self.realm1,
+                   resolver=self.resolvername1)
+        self.request_denied_assert_403(f"/container/{c_serial_user}/info/delete/test", {}, self.at,
+                                       method="DELETE")
+        self.request_denied_assert_403(f"/container/{c_serial_no_user}/info/delete/test", {}, self.at,
+                                       method="DELETE")
         delete_policy("policy")
 
 
@@ -2316,7 +2480,7 @@ class APIContainer(APIContainerTest):
         self.setUp_user_realm2()
         container.set_realms([self.realm2], add=True)
         # Add info
-        container.add_container_info("key1", "value1")
+        container.update_container_info([TokenContainerInfoData(key="key1", value="value1")])
 
         # Filter for type
         result = self.request_assert_success('/container/',
@@ -2380,6 +2544,29 @@ class APIContainer(APIContainerTest):
                                              {"token_serial": "non-existing", "pagesize": 15},
                                              self.at, 'GET')
         self.assertEqual(result["result"]["value"]["count"], 0)
+
+    def test_23_delete_container_info_success(self):
+        # Arrange
+        container_serial = init_container({"type": "generic", "description": "test container"})["container_serial"]
+        container = find_container_by_serial(container_serial)
+        container.update_container_info([TokenContainerInfoData(key="test", value="1234")])
+
+        # Delete info
+        self.request_assert_success(f"/container/{container_serial}/info/delete/test",
+                                    {}, self.at, "DELETE")
+
+    def test_24_delete_container_info_fail(self):
+        # Arrange
+        container_serial = init_container({"type": "generic", "description": "test container"})["container_serial"]
+        container = find_container_by_serial(container_serial)
+        container.update_container_info([TokenContainerInfoData(key="test", value="1234"),
+                                         TokenContainerInfoData(key="internal_test", value="abcd",
+                                                                info_type=PI_INTERNAL)])
+
+        # Try to delete internal key
+        result = self.request_assert_success(f"/container/{container_serial}/info/delete/internal_test",
+                                             {}, self.at, "DELETE")
+        self.assertFalse(result["result"]["value"])
 
 
 @dataclass
@@ -4511,7 +4698,8 @@ class APIContainerSynchronization(APIContainerTest):
         registration = self.register_smartphone_success()
         mock_smph = registration.mock_smph
         smartphone = find_container_by_serial(mock_smph.container_serial)
-        smartphone.add_container_info("registration_state", "rollover_completed")
+        smartphone.update_container_info(
+            [TokenContainerInfoData(key="registration_state", value="rollover_completed", info_type=PI_INTERNAL)])
 
         # tokens
         server_token = init_token({"genkey": "1", "type": "hotp", "otplen": 8, "hashlib": "sha256"})

--- a/tests/test_lib_events.py
+++ b/tests/test_lib_events.py
@@ -13,6 +13,7 @@ from mock import patch
 
 from privacyidea.lib.container import (init_container, find_container_by_serial, get_all_containers,
                                        delete_container_by_serial, add_token_to_container, create_endpoint_url)
+from privacyidea.lib.containers.container_info import TokenContainerInfoData, PI_INTERNAL
 from privacyidea.lib.eventhandler.containerhandler import (ContainerEventHandler, ACTION_TYPE as C_ACTION_TYPE)
 from privacyidea.lib.eventhandler.customuserattributeshandler import (CustomUserAttributesHandler,
                                                                       ACTION_TYPE as CUAH_ACTION_TYPE,
@@ -968,7 +969,7 @@ class BaseEventHandlerTestCase(MyTestCase):
         options["handler_def"] = {"conditions": {CONDITION.CONTAINER_INFO: "challenge_ttl > 5"}}
 
         # condition not match: no info
-        container.delete_container_info("challenge_ttl")
+        container.delete_container_info("challenge_ttl", keep_internal=False)
         r = event_handler.check_condition(options)
         self.assertFalse(r)
 
@@ -2002,7 +2003,8 @@ class ContainerEventTestCase(MyTestCase):
         scope = create_endpoint_url(server_url, "container/register/finalize")
         init_result = smartphone.init_registration(server_url, scope, registration_ttl=100, ssl_verify="True",
                                                    params={})
-        smartphone.add_container_info("server_url", server_url)
+        smartphone.update_container_info(
+            [TokenContainerInfoData(key="server_url", value=server_url, info_type=PI_INTERNAL)])
         mock_smph = MockSmartphone()
         params = mock_smph.register_finalize(init_result["nonce"],
                                              init_result["time_stamp"],

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -14,7 +14,7 @@ getToken....
 """
 import logging
 from testfixtures import LogCapture
-from privacyidea.lib.container import init_container, add_token_to_container
+from privacyidea.lib.container import init_container, add_token_to_container, find_container_by_serial
 from .base import MyTestCase, FakeAudit, FakeFlaskG
 from privacyidea.lib.user import (User)
 from privacyidea.lib.tokenclass import (TokenClass, TOKENKIND,
@@ -1015,6 +1015,17 @@ class TokenTestCase(MyTestCase):
         self.assertNotIn(token.get_serial(), token_serials)
         for token in tokens_pag["tokens"]:
             self.assertEqual("", token["container_serial"])
+
+        # filter for container serial in lower cases
+        container_serial = init_container({"type": "generic", "container_serial": "CONT0001"})["container_serial"]
+        token_in_container = init_token({"genkey": True, "type": "hotp"})
+        container = find_container_by_serial(container_serial)
+        container.add_token(token_in_container)
+        tokens = get_tokens_paginate(container_serial="cont0001")["tokens"]
+        self.assertEqual(1, len(tokens))
+        self.assertEqual(token_in_container.get_serial(), tokens[0]["serial"])
+        container.delete()
+        token_in_container.delete_token()
 
     def test_42_sort_tokens(self):
         # return pagination

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -440,15 +440,16 @@ class TokenTestCase(MyTestCase):
         remove_token(serial)
 
     def test_18_assign_token(self):
+        self.setUp_user_realm2()
         serial = "ASSTOKEN"
-        user = User("cornelius", resolver=self.resolvername1,
-                    realm=self.realm1)
-        tokenobject = init_token({"serial": serial,
-                                  "otpkey": "1234567890123456"})
+        user = User("cornelius", resolver=self.resolvername1, realm=self.realm1)
+        token = init_token({"serial": serial, "otpkey": "1234567890123456"}, tokenrealms=[self.realm2])
+        self.assertSetEqual({self.realm2}, set(token.get_realms()))
 
         r = assign_token(serial, user, pin="1234")
         self.assertTrue(r)
-        self.assertEqual(tokenobject.token.first_owner.user_id, "1000")
+        self.assertEqual(token.token.first_owner.user_id, "1000")
+        self.assertSetEqual({self.realm2, self.realm1}, set(token.get_realms()))
 
         # token already assigned...
         self.assertRaises(TokenAdminError, assign_token, serial,
@@ -457,7 +458,7 @@ class TokenTestCase(MyTestCase):
         # unassign token
         r = unassign_token(serial)
         self.assertTrue(r)
-        self.assertEqual(tokenobject.token.first_owner, None)
+        self.assertEqual(token.token.first_owner, None)
 
         remove_token(serial)
         # assign or unassign a token, that does not exist

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -21,6 +21,7 @@ from privacyidea.lib.container import (delete_container_by_id, find_container_by
                                        finalize_registration, finalize_container_rollover, init_container_rollover)
 from privacyidea.lib.container import get_container_classes, unregister
 from privacyidea.lib.containerclass import TokenContainerClass
+from privacyidea.lib.containers.container_info import TokenContainerInfoData, PI_INTERNAL
 from privacyidea.lib.containers.smartphone import SmartphoneOptions, SmartphoneContainer
 from privacyidea.lib.containers.yubikey import YubikeyContainer
 from privacyidea.lib.containertemplate.containertemplatebase import ContainerTemplateBase
@@ -29,7 +30,7 @@ from privacyidea.lib.containertemplate.yubikeytemplate import YubikeyContainerTe
 from privacyidea.lib.crypto import (geturandom, generate_keypair_ecc, ecc_key_pair_to_b64url_str, sign_ecc,
                                     decryptPassword, KeyPair)
 from privacyidea.lib.error import (ResourceNotFoundError, ParameterError, EnrollmentError, UserError,
-                                   TokenAdminError, ContainerInvalidChallenge, ContainerNotRegistered)
+                                   TokenAdminError, ContainerInvalidChallenge, ContainerNotRegistered, PolicyError)
 from privacyidea.lib.token import init_token, remove_token
 from privacyidea.lib.user import User
 from privacyidea.models import TokenContainer, Token, TokenContainerTemplate
@@ -449,13 +450,19 @@ class TokenContainerManagementTestCase(MyTestCase):
         container_info = get_container_info_dict(container_serial)
         self.assertEqual("", container_info["key"])
 
+        # Try to modify internal info raises exception
+        container = find_container_by_serial(container_serial)
+        container.update_container_info(
+            [TokenContainerInfoData(key="public_server_key", value="123456789", info_type=PI_INTERNAL)])
+        self.assertRaises(PolicyError, add_container_info, container_serial, "public_server_key", "000000000")
+
     def test_23_set_container_info(self):
         # Arrange
         container_serial = init_container({"type": "generic", "description": "add container info"})["container_serial"]
 
         # Set container info
         res = set_container_info(container_serial, {"key1": "value1"})
-        self.assertTrue(res)
+        self.assertTrue(res["key1"])
         container_info = get_container_info_dict(container_serial)
         self.assertEqual("value1", container_info["key1"])
         container_info = get_container_info_dict(container_serial, ikey="key1")
@@ -463,7 +470,7 @@ class TokenContainerManagementTestCase(MyTestCase):
 
         # Set second info overwrites first info
         res = set_container_info(container_serial, {"key2": "value2"})
-        self.assertTrue(res)
+        self.assertTrue(res["key2"])
         container_info = get_container_info_dict(container_serial)
         self.assertEqual("value2", container_info["key2"])
         self.assertNotIn("key1", container_info.keys())
@@ -471,22 +478,27 @@ class TokenContainerManagementTestCase(MyTestCase):
         self.assertIsNone(container_info["key1"])
 
         # Pass no info only deletes old entries
-        res = set_container_info(container_serial, None)
-        self.assertTrue(res)
+        res = set_container_info(container_serial, {})
+        self.assertDictEqual({}, res)
         container_info = get_container_info_dict(container_serial)
         self.assertEqual(0, len(container_info))
 
         # Pass no value
         res = set_container_info(container_serial, {"key": None})
-        self.assertTrue(res)
+        self.assertTrue(res["key"])
         container_info = get_container_info_dict(container_serial)
         self.assertEqual("", container_info["key"])
 
-        # Pass no key only deletes old entries
-        res = set_container_info(container_serial, {None: "value"})
-        self.assertTrue(res)
+        # Try to set internal info
+        container = find_container_by_serial(container_serial)
+        container.update_container_info(
+            [TokenContainerInfoData(key="public_server_key", value="123456", info_type=PI_INTERNAL)])
+        res = set_container_info(container_serial, {"public_server_key": "0000", "key": "value"})
+        self.assertFalse(res["public_server_key"])
+        self.assertTrue(res["key"])
         container_info = get_container_info_dict(container_serial)
-        self.assertEqual(0, len(container_info))
+        self.assertEqual("123456", container_info["public_server_key"])
+        self.assertEqual("value", container_info["key"])
 
     def test_24_delete_container_info(self):
         # Arrange
@@ -498,7 +510,7 @@ class TokenContainerManagementTestCase(MyTestCase):
 
         # Delete non-existing key
         res = delete_container_info(container_serial, "non_existing_key")
-        self.assertEqual(0, len(res))
+        self.assertFalse(res["non_existing_key"])
         container_info = get_container_info_dict(container_serial)
         self.assertEqual(3, len(container_info))
 
@@ -515,6 +527,14 @@ class TokenContainerManagementTestCase(MyTestCase):
         self.assertTrue(res["key3"])
         container_info = get_container_info_dict(container_serial)
         self.assertEqual(0, len(container_info))
+
+        # Try to delete internal info key
+        container.update_container_info(
+            [TokenContainerInfoData(key="public_server_key", value="123456789", info_type=PI_INTERNAL)])
+        res = delete_container_info(container_serial, "public_server_key")
+        self.assertDictEqual({"public_server_key": False}, res)
+        res = delete_container_info(container_serial)
+        self.assertDictEqual({"public_server_key": False}, res)
 
     def test_25_set_description(self):
         # Arrange
@@ -924,22 +944,24 @@ class TokenContainerManagementTestCase(MyTestCase):
         container = find_container_by_serial(container_serial)
 
         # Set initial info fields
-        container.update_container_info({"key1": "abc", "key2": "123"})
+        info = [TokenContainerInfoData(key="key1", value="abc"), TokenContainerInfoData(key="key2", value="123")]
+        container.update_container_info(info)
         container_info = get_container_info_dict(container_serial)
         self.assertEqual("abc", container_info["key1"])
         self.assertEqual("123", container_info["key2"])
         self.assertEqual(2, len(container_info))
 
         # Update info fields
-        container.update_container_info({"key2": "456", "key3": "xyz"})
+        info = [TokenContainerInfoData(key="key2", value="456"), TokenContainerInfoData(key="key3", value="xyz")]
+        container.update_container_info(info)
         container_info = get_container_info_dict(container_serial)
         self.assertEqual("abc", container_info["key1"])
         self.assertEqual("456", container_info["key2"])
         self.assertEqual("xyz", container_info["key3"])
         self.assertEqual(3, len(container_info))
 
-        # Pass empty dict
-        container.update_container_info({})
+        # Pass empty list
+        container.update_container_info([])
         container_info = get_container_info_dict(container_serial)
         self.assertEqual(3, len(container_info))
 
@@ -1129,8 +1151,9 @@ class TokenContainerSynchronization(MyTestCase):
             params.update(passphrase_params)
 
         # Prepare
-        result = smartphone.init_registration(server_url, scope, registration_ttl=100, ssl_verify="True", params=params)
-        smartphone.add_container_info("server_url", server_url)
+        result = smartphone.init_registration(server_url, scope, registration_ttl=100, ssl_verify=True, params=params)
+        smartphone.update_container_info(
+            [TokenContainerInfoData(key="server_url", value=server_url, info_type=PI_INTERNAL)])
 
         # Check result entries
         result_entries = result.keys()
@@ -1594,7 +1617,6 @@ class TokenContainerSynchronization(MyTestCase):
     def test_18_container_rollover(self):
         mock_smph = self.test_03_register_smartphone_success()
         smartphone = find_container_by_serial(mock_smph.container_serial)
-        smartphone.add_container_info("allow_client_rollover", "True")
 
         # Create Challenge for rollover
         scope = "https://pi.net/container/rollover"
@@ -1633,7 +1655,6 @@ class TokenContainerSynchronization(MyTestCase):
     def test_19_container_rollover_with_tokens(self):
         mock_smph = self.test_03_register_smartphone_success()
         smartphone = find_container_by_serial(mock_smph.container_serial)
-        smartphone.add_container_info("allow_client_rollover", "True")
 
         # Add tokens
         hotp = init_token({"genkey": "1", "type": "hotp", "otplen": 8, "hashlib": "sha256"})
@@ -1696,7 +1717,6 @@ class TokenContainerSynchronization(MyTestCase):
     def test_20_container_rollover_aborted(self):
         mock_smph = self.test_03_register_smartphone_success()
         smartphone = find_container_by_serial(mock_smph.container_serial)
-        smartphone.add_container_info("allow_client_rollover", "True")
 
         # Add tokens
         hotp = init_token({"genkey": "1", "type": "hotp", "otplen": 8, "hashlib": "sha256"})
@@ -1731,7 +1751,8 @@ class TokenContainerSynchronization(MyTestCase):
 
         # Registration
         mock_smph = self.test_03_register_smartphone_success(smartphone_serial)
-        smartphone.add_container_info("initially_synchronized", "False")
+        smartphone.update_container_info(
+            [TokenContainerInfoData(key="initially_synchronized", value="False", info_type=PI_INTERNAL)])
 
         # tokens
         hotp_token = init_token({"genkey": "1", "type": "hotp"})

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -88,6 +88,10 @@ class TokenContainerManagementTestCase(MyTestCase):
         # Empty container type raises exception
         self.assertRaises(EnrollmentError, init_container, {})
 
+        # create container with existing serial
+        serial = init_container({"type": "generic"})["container_serial"]
+        self.assertRaises(EnrollmentError, init_container, {"type": "generic", "container_serial": serial})
+
     def test_03_create_container_wrong_user_parameters(self):
         # Init container with user: User shall not be assigned (realm required)
         serial = init_container({"type": "Generic", "user": "hans"})["container_serial"]
@@ -125,6 +129,13 @@ class TokenContainerManagementTestCase(MyTestCase):
         self.assertTrue(res)
         # Check if token is added to container
         smartphone = find_container_by_serial(self.smartphone_serial)
+        tokens = smartphone.get_tokens()
+        self.assertEqual(1, len(tokens))
+        self.assertIn(self.totp_serial_smph, tokens[0].get_serial())
+
+        # Try to add the same token again to the container
+        res = add_token_to_container(self.smartphone_serial, self.totp_serial_smph)
+        self.assertFalse(res)
         tokens = smartphone.get_tokens()
         self.assertEqual(1, len(tokens))
         self.assertIn(self.totp_serial_smph, tokens[0].get_serial())
@@ -297,9 +308,14 @@ class TokenContainerManagementTestCase(MyTestCase):
         self.assertRaises(ResourceNotFoundError, find_container_by_serial, None)
 
     def test_18_find_container_success(self):
-        # Find by serial
-        serial = init_container({"type": "generic", "description": "find container"})["container_serial"]
-        container = find_container_by_serial(serial)
+        serial = "CONT0001"
+        init_container({"type": "generic", "container_serial": serial})
+        # Find by serial exact
+        container = find_container_by_serial("CONT0001")
+        self.assertEqual(serial, container.serial)
+
+        # find by serial in lower cases
+        container = find_container_by_serial("cont0001")
         self.assertEqual(serial, container.serial)
 
         # Find by ID
@@ -614,19 +630,34 @@ class TokenContainerManagementTestCase(MyTestCase):
             container.delete()
 
         # Arrange
-        types = ["Smartphone", "generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
+        types = ["generic", "Yubikey", "Smartphone", "generic", "Yubikey"]
         self.setUp_user_realms()
         self.setUp_user_realm2()
-        realms = ["realm1", "realm2", "realm1", "realm2", "realm1", "realm1"]
-        container_serials = []
-        for t, r in zip(types, realms):
+        realms = ["realm2", "realm1", "realm2", "realm1", "realm1"]
+        container_serials = ["SMPH0001"]
+        init_container(
+            {"type": "smartphone", "description": "test container", "realm": "realm1", "container_serial": "SMPH0001"})
+        for t, r, serial in zip(types, realms, container_serials):
             serial = init_container({"type": t, "description": "test container", "realm": r})["container_serial"]
             container_serials.append(serial)
 
-        # Filter for container serial
-        container_data = get_all_containers(serial=container_serials[3], pagesize=15)
+        # Filter for exact container serial
+        container_data = get_all_containers(serial=container_serials[0], pagesize=15)
         self.assertEqual(1, container_data["count"])
-        self.assertEqual(container_data["containers"][0].serial, container_serials[3])
+        self.assertEqual(container_serials[0], container_data["containers"][0].serial)
+
+        # Filter for container serial in lower cases
+        container_data = get_all_containers(serial="smph0001", pagesize=15)
+        self.assertEqual(1, container_data["count"])
+        self.assertEqual("SMPH0001", container_data["containers"][0].serial)
+
+        # Filter for container serial stored as lower cases in db
+        init_container(
+            {"type": "generic", "description": "test container", "realm": "realm2", "container_serial": "cont0001"})
+        container_data = get_all_containers(serial="CONT0001", pagesize=15)
+        self.assertEqual(1, container_data["count"])
+        self.assertEqual("cont0001", container_data["containers"][0].serial)
+        find_container_by_serial("cont0001").delete()
 
         # Filter for non-existing serial
         container_data = get_all_containers(serial="non_existing_serial")


### PR DESCRIPTION
* container_serial not case-sensitive in queries
*  Assign user to token: Not remove other token realms
* Mark container info for internal use to avoid that users can modify and delete it
* Added endpoint to delete container info

Related to #3950 and #4102