### PR TITLE
disable trigger with pin, webui adjustments

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -922,3 +922,11 @@ will show you the correct login for your preferred client mode. For example if t
 then your client will automatically show you the login for a webauthn token.
 
 The default list is "interactive webauthn poll u2f".
+
+passkey_trigger_by_pin
+~~~~~~~~~~~~~~~~~~~~~~
+
+type: ``bool``
+
+If this policy is set, the passkey token can be triggered with its PIN. For privacyIDEA plugins, enabling this is not
+recommended. It is advised to use a condition with this policy, for example on the user-agent.

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -876,6 +876,7 @@ def multichallenge_enroll_via_validate(request, response):
                                 content.get("result")["value"] = False
                                 content.get("result")["authentication"] = "CHALLENGE"
                                 detail = content.setdefault("detail", {})
+                                detail["transaction_id"] = init_details["transaction_id"]
                                 detail["transaction_ids"] = [init_details["transaction_id"]]
                                 detail["multi_challenge"] = [init_details]
                                 detail["serial"] = token.token.serial

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -2053,6 +2053,7 @@ def fido2_auth(request, action):
     The following policy values are added:
     - WEBAUTHNACTION.ALLOWED_TRANSPORTS
     - ACTION.CHALLENGETEXT for WebAuthn and Passkey token
+    - PasskeyAction.EnableTriggerByPIN
     """
     user_object = request.User if hasattr(request, "User") else None
     allowed_transports_policies = (Match.user(g,
@@ -2080,6 +2081,13 @@ def fido2_auth(request, action):
     rp_id = get_first_policy_value(FIDO2PolicyAction.RELYING_PARTY_ID, "", scope=SCOPE.ENROLL)
     if rp_id:
         request.all_data[FIDO2PolicyAction.RELYING_PARTY_ID] = rp_id
+
+    passkey_trigger_by_pin = (Match.user(g,
+                                         scope=SCOPE.AUTH,
+                                         action=PasskeyAction.EnableTriggerByPIN,
+                                         user_object=user_object).any())
+    request.all_data[PasskeyAction.EnableTriggerByPIN] = passkey_trigger_by_pin
+    
     return True
 
 
@@ -2612,7 +2620,7 @@ def rss_age(request, action):
     :return: True
     """
     age_list = (Match.user(g, scope=SCOPE.WEBUI, action=ACTION.RSS_AGE,
-                user_object=request.User if hasattr(request, 'User') else None).action_values(unique=True))
+                           user_object=request.User if hasattr(request, 'User') else None).action_values(unique=True))
     # The default age for normal users is 0
     age = 0
     if g.get("logged_in_user", {}).get("role") == ROLE.ADMIN:

--- a/privacyidea/lib/fido2/policy_action.py
+++ b/privacyidea/lib/fido2/policy_action.py
@@ -15,3 +15,4 @@ class FIDO2PolicyAction:
 
 class PasskeyAction:
     AttestationConveyancePreference = "passkey_attestation_conveyance_preference"
+    EnableTriggerByPIN= "passkey_trigger_by_pin"

--- a/privacyidea/lib/tokens/passkeytoken.py
+++ b/privacyidea/lib/tokens/passkeytoken.py
@@ -104,6 +104,12 @@ class PasskeyTokenClass(TokenClass):
                         'desc': _("Alternative challenge message to use when authenticating with a passkey."
                                   "You can also use tags for replacement, "
                                   "check the documentation for more details.")
+                    },
+                    PasskeyAction.EnableTriggerByPIN: {
+                        'type': 'bool',
+                        'desc': _("When enabled, passkey token can be triggered with the PIN. For privacyIDEA plugins, "
+                                  "this is not recommended. It is advised to use a condition, for example on a "
+                                  "user-agent, with this policy."),
                     }
                 },
                 SCOPE.ENROLL: {
@@ -422,8 +428,9 @@ class PasskeyTokenClass(TokenClass):
         """
         This token type is always challenge-response. If the pin matches, a challenge should be created.
         """
-
-        return self.check_pin(passw, user=user, options=options or {})
+        if options and PasskeyAction.EnableTriggerByPIN in options and options[PasskeyAction.EnableTriggerByPIN]:
+            return self.check_pin(passw, user=user, options=options)
+        return False
 
     @check_token_locked
     def authenticate(self, passw, user=None, options=None):

--- a/privacyidea/lib/tokens/passkeytoken.py
+++ b/privacyidea/lib/tokens/passkeytoken.py
@@ -150,7 +150,7 @@ class PasskeyTokenClass(TokenClass):
             rp_name = get_required(params, FIDO2PolicyAction.RELYING_PARTY_NAME)
 
             response_detail: dict = TokenClass.get_init_detail(self, params, token_user)
-
+            response_detail['rollout_state'] = self.token.rollout_state
             nonce_base64 = fido2.challenge.get_fido2_nonce()
             challenge_validity: int = int(get_from_config(FIDO2ConfigOptions.CHALLENGE_VALIDITY_TIME,
                                                           get_from_config('DefaultChallengeValidityTime', 120)))

--- a/privacyidea/lib/tokens/passkeytoken.py
+++ b/privacyidea/lib/tokens/passkeytoken.py
@@ -246,6 +246,7 @@ class PasskeyTokenClass(TokenClass):
 
         if not (attestation and client_data) and not self.token.rollout_state == ROLLOUTSTATE.CLIENTWAIT:
             self.token.rollout_state = ROLLOUTSTATE.CLIENTWAIT
+            self.token.active = False
             # Set the description in the first enrollment step
             if "description" in param:
                 self.set_description(param["description"])
@@ -323,6 +324,7 @@ class PasskeyTokenClass(TokenClass):
                         if attributes:
                             self.set_description(attributes[0].value)
             self.add_tokeninfo_dict(token_info)
+            self.token.active = True
             # Remove the challenge
             challenges[0].delete()
         return response_detail

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -935,7 +935,7 @@ class WebAuthnTokenClass(TokenClass):
             rp_name = get_required(params, FIDO2PolicyAction.RELYING_PARTY_NAME)
 
             response_detail = TokenClass.get_init_detail(self, params, user)
-
+            response_detail['rollout_state'] = self.token.rollout_state
             # To aid with unit testing a fixed nonce may be passed in.
             nonce = self._get_nonce()
             # Create the challenge in the database

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -808,6 +808,7 @@ class WebAuthnTokenClass(TokenClass):
 
         if not (reg_data and client_data):
             self.token.rollout_state = ROLLOUTSTATE.CLIENTWAIT
+            self.token.active = False
             # Set the description in the first enrollment step
             if "description" in param:
                 self.set_description(get_optional(param, "description", default=""))
@@ -898,7 +899,8 @@ class WebAuthnTokenClass(TokenClass):
                 challenge.delete()
             self.challenge_janitor()
             # Reset clientwait rollout_state
-            self.token.rollout_state = ""
+            self.token.rollout_state = ROLLOUTSTATE.ENROLLED
+            self.token.active = True
         else:
             raise ParameterError("regdata and or clientdata provided but token not in clientwait rollout_state.")
 

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -1007,7 +1007,7 @@ class WebAuthnTokenClass(TokenClass):
             self.add_tokeninfo(FIDO2TokenInfo.RELYING_PARTY_NAME,
                                public_key_credential_creation_options["rp"]["name"])
 
-        elif self.token.rollout_state == "":
+        elif self.token.rollout_state in [ROLLOUTSTATE.ENROLLED, ""]:
             # This is the second step of the init request. The registration
             # ceremony has been successfully performed.
             response_detail = {

--- a/privacyidea/static/components/config/views/config.realms.list.html
+++ b/privacyidea/static/components/config/views/config.realms.list.html
@@ -17,8 +17,8 @@
         <thead>
         <tr>
             <th translate>Default</th>
-            <th translate>Realm name</th>
-            <th translate>resolvers</th>
+            <th translate>Realm Name</th>
+            <th translate>Resolvers</th>
             <th></th>
         </tr>
         </thead>
@@ -31,7 +31,7 @@
                     <button class="btn btn-success"
                             ng-hide="realm.default"
                             ng-click="setDefaultRealm(realmName)"
-                            translate>set Default
+                            translate>Set Default
                     </button>
                 </span>
             </td>
@@ -105,7 +105,7 @@
                         <input name="realmname" id="realmname"
                                class="form-control"
                                ng-model="newRealmParams.realmName" required
-                               placeholder="{{ 'new realm'|translate }}"
+                               placeholder="{{ 'New Realm...'|translate }}"
                                ng-pattern="inputNamePatterns.simple.pattern"
                                title="{{ inputNamePatterns.simple.title | translate }}"
                                autofocus/>

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -120,7 +120,7 @@ myApp.directive('assignUser', ["$http", "$rootScope", "userUrl", "AuthFactory", 
             //console.log(scope.realms);
             // If the user is not set, set the default realm selection to the first realm in the list
             scope.$watch('realms', function (newVal, oldVal) {
-                if (newVal && !scope.newUserObject.user) {
+                if (newVal && !scope.newUserObject.user && !scope.newUserObject.realm) {
                     scope.newUserObject.realm = Object.keys(newVal)[0];
                 }
             }, true);

--- a/privacyidea/static/components/directives/views/directive.assigntoken.html
+++ b/privacyidea/static/components/directives/views/directive.assigntoken.html
@@ -3,9 +3,9 @@ This is the directive for assigning tokens to users.
 -->
 <div class="form-group">
     <label for="serial" translate>Serial</label>
-    <input name="serial" type="text" ng-model="newTokenObject.serial"
+    <input name="serial" type="text" ng-model="newTokenObject.serial" id="serial"
            autocomplete="new-password" required
-           placeholder="{{ 'start typing a serial number of a token that is notassigned, yet.'|translate}} "
+           placeholder="{{ 'Start typing a serial number of a token that is not yet assigned'|translate}} "
            ng-keypress="toggleLoadSerials($event.which==13)"
            typeahead-wait-ms="100"
            typeahead-focus-first="false"
@@ -27,7 +27,7 @@ This is the directive for assigning tokens to users.
         also used during assigning and not only during enrolling!
         -->
     <label for="otppin" translate>PIN/Password</label>
-    <input name="otppin" ng-model="newTokenObject.pin"
+    <input name="otppin" ng-model="newTokenObject.pin" id="otppin"
             autocomplete="new-password"
             type=password class="form-control"
             equals="{{pin2}}"

--- a/privacyidea/static/components/login/views/login.html
+++ b/privacyidea/static/components/login/views/login.html
@@ -4,7 +4,7 @@
         <form name="formRemoteUserLogin" class="form-signin" role="form">
             <div class="text-center">
                 <img ng-src="{{ instanceUrl }}/static/css/{{ piLogo }}"
-                     width="90px">
+                     width="90px" alt="">
             </div>
             <h2 class="form-signin-heading" translate>Login as
                 {{ remoteUser }}</h2>
@@ -12,7 +12,7 @@
             <p translate>
                 You are authenticated by the web server as user
                 <b>{{ remoteUser }}</b>.
-                You may login as this user to privacyIDEA without any further
+                You may log in as this user to privacyIDEA without any further
                 credentials.
             </p>
 
@@ -43,7 +43,7 @@
         <div class="container">
             <div class="text-center">
                     <img ng-src="{{ instanceUrl }}/static/css/{{ piLogo }}"
-                         width="90px">
+                         width="90px" alt="">
                 </div>
             <div class="text-center">
                 <h2 ng-hide="piLoginText" class="form-signin-heading" translate>Please sign in</h2>
@@ -79,7 +79,7 @@
                             class="btn btn-primary btn-block" translate>Log In
                     </button>
                     <button ng-click="passkeyLogin()"
-                            class="btn btn-primary btn-block">
+                            class="btn btn-transparent btn-block">
                         Passkey Log In
                     </button>
                     <p class="text-right" ng-show="passwordReset === 'True'">

--- a/privacyidea/static/components/token/controllers/containerControllers.js
+++ b/privacyidea/static/components/token/controllers/containerControllers.js
@@ -656,36 +656,6 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
         $scope.editContainerInfo = false;
         $scope.containerInfoOptions = {};
         $scope.selectedInfoOptions = {};
-        $scope.editInfo = function () {
-            $scope.editContainerInfo = true;
-
-            ContainerFactory.getClassOptions({
-                "only_selectable": true,
-                "container_type": $scope.container.type
-            }, function (data) {
-                $scope.containerInfoOptions = data.result.value[$scope.container.type];
-                angular.forEach($scope.containerInfoOptions, function (values, key) {
-                    let selected = $scope.container.info[key];
-                    if (selected !== undefined) {
-                        $scope.selectedInfoOptions[key] = selected;
-                    } else {
-                        $scope.selectedInfoOptions[key] = values[0];
-                    }
-                });
-
-            });
-        };
-
-        $scope.saveInfo = function () {
-            ContainerFactory.setOptions($scope.containerSerial,
-                {"options": $scope.selectedInfoOptions},
-                function () {
-                    $scope.editContainerInfo = false;
-                    $scope.getContainer();
-                }
-            );
-
-        };
 
         $scope.saveRealms = function () {
             let realmList = "";
@@ -832,6 +802,12 @@ myApp.controller("containerDetailsController", ['$scope', '$http', '$stateParams
             // as we do not assign a user
             ConfigFactory.getRealms(function (data) {
                 $scope.realms = data.result.value;
+                angular.forEach($scope.realms, function (realm, realmname) {
+                    // if there is a default realm, preset the default realm
+                    if (realm.default && !$scope.newUser.realm && !$scope.newUser.user) {
+                        $scope.newUser = {user: "", realm: realmname};
+                    }
+                });
             });
         }
 

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -376,18 +376,17 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
                 $scope.realms = data.result.value;
                 // Set the default realm
                 const size = Object.keys($scope.realms).length;
-                angular.forEach($scope.realms, function (realm, realmname) {
-                    if (size === 1) {
-                        // if there is only one realm, preset it
-                        $scope.newUser = {user: "", realm: realmname};
-                    }
-                    // if there is a default realm, preset the default realm
-                    if (realm.default && !$stateParams.realmname) {
-                        $scope.newUser = {user: "", realm: realmname};
-                        //debug: console.log("tokenEnrollController");
-                        //debug: console.log($scope.newUser);
-                    }
-                });
+                if (size === 1) {
+                    $scope.newUser = {user: "", realm: realmname};
+                } else {
+                    angular.forEach($scope.realms, function (realm, realmname) {
+                        // if there is a default realm, preset the default realm
+                        if (realm.default && !$stateParams.realmname) {
+                            $scope.newUser = {user: "", realm: realmname};
+                        }
+                    });
+                }
+
                 // init the user, if token.enroll was called from the user.details
                 if ($stateParams.realmname) {
                     $scope.newUser.realm = $stateParams.realmname;

--- a/privacyidea/static/components/token/controllers/tokenDetailController.js
+++ b/privacyidea/static/components/token/controllers/tokenDetailController.js
@@ -464,6 +464,12 @@ myApp.controller("tokenDetailController", ['$scope', 'TokenFactory',
             // as we do not assign a token
             ConfigFactory.getRealms(function (data) {
                 $scope.realms = data.result.value;
+                angular.forEach($scope.realms, function (realm, realmname) {
+                    // if there is a default realm, preset the default realm
+                    if (realm.default && !$scope.newUser.realm && !$scope.newUser.user) {
+                        $scope.newUser = {user: "", realm: realmname};
+                    }
+                });
             });
 
             if (AuthFactory.checkRight("tokengroup_list")) {

--- a/privacyidea/static/components/token/views/token.containerdetails.html
+++ b/privacyidea/static/components/token/views/token.containerdetails.html
@@ -197,22 +197,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 </div>
             </td>
             <td>
-                <button class="btn btn-primary"
-                        ng-hide="true || editContainerInfo || (!checkRight('container_set_options') && hide_buttons)"
-                        ng-disabled="!checkRight('container_set_options')"
-                        ng-click="editInfo()"
-                        translate>Edit
-                </button>
-                <button class="btn btn-primary"
-                        ng-show="editContainerInfo"
-                        ng-click="saveInfo()"
-                        translate>Save
-                </button>
-                <button class="btn btn-danger"
-                        ng-show="editContainerInfo"
-                        ng-click="editContainerInfo=false"
-                        translate>Cancel
-                </button>
             </td>
         </tr>
         <tr ng-show="container.info['registration_state'] === 'registered'">
@@ -359,7 +343,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 {{ containerOwner.user_name }}
             </a></td>
             <td>
-                <button id="unassignAdminButton"
+                <button id="unassignUserAdminButton"
                         ng-click="unassignUser()"
                         ng-disabled="!checkRight('container_unassign_user')"
                         ng-hide="!checkRight('container_unassign_user') && hide_buttons"
@@ -375,7 +359,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             </td>
             <td>
                 <button type="button" ng-click="assignUserToAllTokens()"
-                        id="assignButton"
+                        id="assignUserToTokenButton"
                         ng-disabled="!checkRight('assign')"
                         ng-hide="!checkRight('assign') && hide_buttons"
                         class="btn btn-primary">

--- a/privacyidea/static/components/user/views/user.details.html
+++ b/privacyidea/static/components/user/views/user.details.html
@@ -147,11 +147,9 @@
                 <th translate>Serial</th>
                 <th translate>Type</th>
                 <th translate>Active</th>
-                <th translate>Window</th>
                 <th translate>Description</th>
                 <th translate>Failcounter</th>
                 <th translate>Maxfail</th>
-                <th translate>Otplen</th>
                 <th>Container</th>
                 <th ng-if="checkRight('unassign') || checkRight('delete') || !hide_buttons"></th>
             </tr>
@@ -175,7 +173,6 @@
                           translate>disabled
                     </span>
                 </td>
-                <td>{{ token.count_window }}</td>
                 <td>{{ token.description }}</td>
                 <td>
                     <span class="label"
@@ -188,7 +185,6 @@
                     </span>
                 </td>
                 <td>{{ token.maxfail }}</td>
-                <td>{{ token.otplen }}</td>
                 <td>
                     <a ui-sref="token.containerdetails({containerSerial: token.container_serial})"
                        ng-show="checkRight('container_list')">

--- a/tests/test_api_passkey.py
+++ b/tests/test_api_passkey.py
@@ -69,6 +69,8 @@ class PasskeyAPITestBase(MyApiTestCase, PasskeyTestBase):
                 detail = res.json["detail"]
                 self.assertIn("passkey_registration", detail)
                 self.validate_default_passkey_registration(detail["passkey_registration"])
+                self.assertIn("rollout_state", detail)
+                self.assertEqual("clientwait", detail["rollout_state"])
                 passkey_registration = detail["passkey_registration"]
                 # PubKeyCredParams: Via the API, all three key algorithms (from webauthn) are valid by default
                 self.assertEqual(len(passkey_registration["pubKeyCredParams"]), 3)

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -3815,11 +3815,12 @@ class WebAuthn(MyApiTestCase):
             self.assertEqual(200, res.status_code)
             data = res.json
             transaction_id = data.get("detail").get("transaction_id")
+            # The WebAuthn token is disabled because it is not enrolled completely, so there is no data of it
+            # But there is a challenge-response message for the HOTP token
             messages = data.get("detail").get("messages")
-            # There is a working chal resp message for the HOTP token
+            self.assertEqual(1, len(messages))
             self.assertIn("please enter otp: ", messages)
-            # The WebAuthn token died not work, so there is no challenge for this one
-            self.assertIn("Token is not yet enrolled", messages)
+            self.assertEqual(1, len(data.get("detail").get("multi_challenge")))
 
         # Authenticate with HOTP
         with self.app.test_request_context('/validate/check',


### PR DESCRIPTION
* By default, passkeys can not be triggered with the PIN
* There is a new policy to enable that behavior WebUI:
* Passkey login button is transparent so there is always only one main button
* Removed token type specific rows of the token table in the user detail view (otplen, window)
* Adjusted capitalization and typos