### PR TITLE
Fix YubiKey signature calculation according to Yubico specificiation

### DIFF
--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -90,6 +90,8 @@ def yubico_api_signature(data, api_key):
     r = dict(data)
     if 'h' in r:
         del r['h']
+    if 'ttype' in r:
+        del r['ttype']
     keys = sorted(r.keys())
     data_string = ""
     for key in keys:
@@ -374,7 +376,7 @@ class YubikeyTokenClass(TokenClass):
         :query otp: The OTP from the yubikey in the yubikey mode
         :query nonce: 16-40 bytes of random data
 
-        Optional parameters h, timestamp, sl, timeout are not supported at the
+        Optional parameters timestamp, sl, timeout are not supported at the
         moment.
         """
         id = getParam(request.all_data, "id")


### PR DESCRIPTION
As mentioned in #4306 the signature validation process is currently not working as expected.
[Yubico's specification](https://developers.yubico.com/OTP/Specifications/OTP_validation_protocol.html) is not mentioning any parameter "ttype" and it is also not sent by the requester, but because of this parameter the validation is failing as BAD_SIGNATURE at each request.

Adjusted also the description accordingly.