### PR TITLE
Mark 'no_detail_' policies as deprecated

### DIFF
--- a/doc/eventhandler/tokenhandler.rst
+++ b/doc/eventhandler/tokenhandler.rst
@@ -160,10 +160,10 @@ Other tags are ``{client_ip}`` for the client IP address and ``{ua_browser}``
 and ``{ua_string}`` for information on the user agent and ``{username}`` and
 ``{realm}`` for information on the user in the parameters.
 
-.. note:: Some tokens have token specific attributes that are stored in the
-   tokeninfo. The TOTP token type has a ``timeWindow``. The TOTP and the HOTP
-   token store the ``hashlib`` in the tokeninfo, the SMS token stores the
-   ``phone`` number.
+.. note:: Some tokens have token specific required attributes that are stored
+   in the tokeninfo. The TOTP token type has a ``timeStep`` attribute, the TOTP
+   and the HOTP token store the ``hashlib`` attribute in the tokeninfo. the SMS
+   token stores the ``phone`` number.
 
 .. note:: You can use this to set the ``timeWindow`` of a TOTP token for
    :ref:`faq_initial_synchronization`.

--- a/doc/policies/authorization.rst
+++ b/doc/policies/authorization.rst
@@ -144,6 +144,8 @@ the realm in this action.
 
 no_detail_on_success
 ~~~~~~~~~~~~~~~~~~~~
+.. deprecated:: v3.12
+   Please use the :ref:`responsemanglerhandler` to delete the ``detail`` section.
 
 type: ``bool``
 
@@ -158,6 +160,8 @@ this additional information will not be returned.
 
 no_detail_on_fail
 ~~~~~~~~~~~~~~~~~
+.. deprecated:: v3.12
+   This policy breaks :term:`challenge-response <Challenge>` authentication.
 
 type: ``bool``
 

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -2668,13 +2668,15 @@ def get_static_policy_definitions(scope=None):
             ACTION.NODETAILSUCCESS: {
                 'type': 'bool',
                 'desc': _('In case of successful authentication additional '
-                          'no detail information will be returned.'),
+                          'no detail information will be returned.')
+                        + " <em>Deprecated since v3.11</em>",
                 'group': GROUP.SETTING_ACTIONS,
             },
             ACTION.NODETAILFAIL: {
                 'type': 'bool',
                 'desc': _('In case of failed authentication additional '
-                          'no detail information will be returned.'),
+                          'no detail information will be returned.')
+                        + " <em>Deprecated since v3.11</em>",
                 'group': GROUP.SETTING_ACTIONS,
             },
             ACTION.ADDUSERINRESPONSE: {

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -390,8 +390,6 @@ class IdResolver(UserIdResolver):
                                                 auto_referrals=not self.noreferrals,
                                                 start_tls=self.start_tls)
             if not connection.bind():
-                log.info(f"Bind operation failed: {connection.result.get('description')} "
-                         f"({connection.result.get('result')})")
                 raise ResolverError(f"Bind failed with: {connection.result.get('description')} "
                                     f"({connection.result.get('result')})")
             log.debug(f"LDAP bind operation took {connection.usage.elapsed_time}")

--- a/privacyidea/lib/utils/__init__.py
+++ b/privacyidea/lib/utils/__init__.py
@@ -98,7 +98,7 @@ def check_time_in_range(time_range, check_time=None):
     :param time_range: The timerange
     :type time_range: basestring
     :param check_time: The time to check
-    :type check_time: datetime
+    :type check_time: datetime.datetime
     :return: True, if time is within time_range.
     """
     time_match = False

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -43,8 +43,9 @@ from privacyidea.lib.config import get_from_config, SYSCONF, get_privacyidea_nod
 from privacyidea.lib.queue import has_job_queue
 
 DEFAULT_THEME = "/static/contrib/css/bootstrap-theme.css"
-# note: the comment in the following line allows to include it in the docs
-DEFAULT_LANGUAGE_LIST = ['en', 'de', 'nl', 'zh_Hant', 'fr', 'es', 'tr', 'cs', 'it', 'ta', 'pt', 'ru']  #:
+# note: the empty comment in the following line allows to include it in the docs
+DEFAULT_LANGUAGE_LIST = ['en', 'de', 'nl', 'zh_Hant', 'fr', 'es', 'tr', 'cs',
+                         'it', 'ta', 'pt', 'ru', 'uk']  #:
 
 login_blueprint = Blueprint('login_blueprint', __name__)
 


### PR DESCRIPTION
The `no_detail_on_fail` and `no_detail_on_success` will be deprecated in v3.11 since they break challenge-response authentication.

- Add deprecation warning to docs and policy descriptions
- Fix description of required tokeninfo attributes
- Remove duplicate log message in LDAP-resolver
- Add Ukrainian to default language list