### PR TITLE
Move check for max tokens during enroll

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -862,20 +862,20 @@ def multichallenge_enroll_via_validate(request, response):
     result = content.get("result")
     # Check if the authentication was successful, only then attempt to enroll a new token
     if result.get("value") and result.get("authentication") == AUTH_RESPONSE.ACCEPT:
-        # Check if another policy restricts the token count and exit early if true
-        try:
-            check_max_token_user(request=request)
-            check_max_token_realm(request=request)
-        except PolicyError as e:
-            g.audit_object.log({"success": True, "action_detail": f"{e}"})
-            return response
-
         user = request.User
         if user.login and user.realm:
             enroll_policies = Match.user(g, scope=SCOPE.AUTH, action=ACTION.ENROLL_VIA_MULTICHALLENGE,
                                          user_object=user).action_values(unique=True, write_to_audit_log=False)
             # Check if we have a policy to enroll a token and which type
             if enroll_policies:
+                # First check if another policy restricts the token count and exit early if true
+                try:
+                    check_max_token_user(request=request)
+                    check_max_token_realm(request=request)
+                except PolicyError as e:
+                    g.audit_object.log({"success": True, "action_detail": f"{e}"})
+                    return response
+
                 tokentype = list(enroll_policies)[0]
                 tokentype = tokentype.lower()
                 # Check if the user already has a token of the type that should be enrolled

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -6069,7 +6069,27 @@ class MultiChallengeEnrollTest(MyApiTestCase):
         user = User("hans", "realm1")
         spass = "12"
         token1 = init_token({"type": "spass", "pin": spass}, user)
-        self.assertTrue(token1.get_serial())
+        self.assertTrue(token1.get_serial().startswith("PISP"))
+        # Check that we do not have a failed audit entry if the policy is set
+        set_policy("max_token_per_user", scope=SCOPE.ENROLL, action=f"{ACTION.MAXTOKENUSER}=1")
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": user.login, "realm": user.realm, "pass": spass}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"))
+            self.assertTrue(res.json.get("result").get("value"))
+            self.assertEqual(res.json.get("result").get("authentication"), "ACCEPT")
+            self.assertNotIn("transaction_id", res.json.get("detail"))
+            self.assertNotIn("multi_challenge", res.json.get("detail"))
+        # Check that we have the proper log message (action_detail) in the audit
+        audit_entry = self.find_most_recent_audit_entry(action='POST /validate/check')
+        self.assertIsNotNone(audit_entry)
+        self.assertFalse(audit_entry["action_detail"], audit_entry)
+        self.assertEqual(audit_entry["authentication"], AUTH_RESPONSE.ACCEPT, audit_entry)
+        self.assertEqual(audit_entry["success"], 1, audit_entry)
+        delete_policy("max_token_per_user")
+
         set_policy("enroll_via_multichallenge", scope=SCOPE.AUTH,
                    action=f"{ACTION.ENROLL_VIA_MULTICHALLENGE}=hotp")
 


### PR DESCRIPTION
When enrolling token via the `/validate/check` endpoint (`enroll_via_multichallenge` policy) check for max token policies only when the `enroll_via_multichallenge` is active.

Closes: #4377 