### PR TITLE
Fix failing install with Python 3.8

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,6 +40,8 @@ jobs:
       matrix:
         # current supported Python versions
         python-version: ['3.9', '3.10', '3.11', '3.12']
+        include:
+          - python-version: ${{ github.event_name == 'pull_request' && contains(github.base_ref, 'branch-3.11') && '3.8' || '3.12' }}
 
     steps:
     - uses: actions/checkout@v3

--- a/privacyidea/lib/auditmodules/base.py
+++ b/privacyidea/lib/auditmodules/base.py
@@ -158,7 +158,7 @@ class Audit(object):  # pragma: no cover
         return bool(self.audit_data and "action" in self.audit_data)
 
     @log_with(log)
-    def log(self, param: dict[str, str]):
+    def log(self, param):
         """
         This method is used to log the data.
         During a request this method can be called several times to fill the
@@ -199,7 +199,7 @@ class Audit(object):  # pragma: no cover
         """
         if "policies" not in self.audit_data:
             self.audit_data["policies"] = []
-        if type(policyname) == list:
+        if isinstance(policyname, list):
             for p in policyname:
                 self.audit_data["policies"].append(p)
         else:

--- a/privacyidea/lib/auditmodules/containeraudit.py
+++ b/privacyidea/lib/auditmodules/containeraudit.py
@@ -60,7 +60,7 @@ class Audit(AuditBase):
     def has_data(self):
         return any([x.has_data for x in self.write_modules])
 
-    def log(self, param: dict[str, str]):
+    def log(self, param):
         """
         Call the log method for all writeable modules
         """


### PR DESCRIPTION
Remove the type hints for dictionaries which are not available in Python 3.8.
Add a matrix workflow to include testing with Python 3.8 if the pull request is on branch 3.11