### PR TITLE
Initialise conditions array

### DIFF
--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -152,6 +152,7 @@ myApp.controller("policyDetailsController", ["$scope", "$stateParams",
                     action: data.action || [],
                     resolver: data.resolver || [],
                     adminrealm: data.adminrealm || [],
+                    conditions: data.conditions || [],
                     pinode: []
                 });
             });


### PR DESCRIPTION
When loading a policy template, the conditions array was not properly initialised.

Closes #4383