### PR TITLE
Re-introduce failed user in Audit

### DIFF
--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -117,7 +117,7 @@ from privacyidea.lib.user import get_user_from_param, log_used_user, User
 from privacyidea.lib.utils import get_client_ip, get_plugin_info_from_useragent
 from privacyidea.lib.utils import is_true, get_computer_name_from_user_agent
 from .lib.utils import required
-from .lib.utils import send_result, getParam, get_required, get_optional
+from .lib.utils import send_result, getParam, get_required
 from ..lib.decorators import (check_user_serial_or_cred_id_in_request)
 from ..lib.fido2.policy_action import FIDO2PolicyAction
 from ..lib.framework import get_app_config_value
@@ -161,6 +161,11 @@ def before_request():
                         "action": "{0!s} {1!s}".format(request.method, request.url_rule),
                         "thread_id": "{0!s}".format(threading.current_thread().ident),
                         "info": ""})
+    # Add preliminary user to audit in case we fail with an error
+    g.audit_object.log({
+        "user": request.User.login,
+        "resolver": request.User.resolver,
+        "realm": request.User.realm})
 
 
 @validate_blueprint.route('/offlinerefill', methods=['POST'])

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -2467,6 +2467,10 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertEqual(res.status_code, 400)
             result = res.json.get("result")
             self.assertFalse(result.get("status"))
+        # Check that we have a failed attempt with the username in the audit
+        ae = self.find_most_recent_audit_entry(action='* /validate/radiuscheck')
+        self.assertEqual(0,  ae.get("success"), ae)
+        self.assertEqual("unknown",  ae.get("user"), ae)
 
     def test_29_several_CR_one_locked(self):
         # A user has several CR tokens. One of the tokens is locked.
@@ -4749,7 +4753,8 @@ class AChallengeResponse(MyApiTestCase):
         self.assertEqual(entry["action_detail"], "transaction_id: 123456")
         self.assertEqual(entry["info"], "status: pending")
         self.assertEqual(entry["serial"], None)
-        self.assertEqual(entry["user"], None)
+        # Instead of None the "user" entry is now (v3.11.3) an empty string
+        self.assertEqual(entry["user"], "")
 
         # polling the transaction returns false, because no challenge has been answered
         with self.app.test_request_context("/validate/polltransaction", method="GET",


### PR DESCRIPTION
We add the preliminary user to the audit log when the request starts in case an exception occurs during the request.

Closes #4382