### PR TITLE
webauthn improvements

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,11 @@
+Version 3.11.3 TBD
+
+Fixes:
+* WebAuthn: sign_count of 0 will result in a successful authentication (#4391)
+* WebAuthn: The WebAuthn Token can validate challenges that were created by /validate/initialize. This can happen when the authenticator does create a passkey anyway and that webauthn token is then used as a passkey (#4400)
+* Fixed a bug that would cause different transaction_ids to be generated when the user has a passkey and /validate/triggerchallenge is used (4399)
+* WebUI: Cancelling WebAuthn enrollment will delete the unfinished token and redirect to the token list (#4402)
+
 Version 3.11.2, 2025-04-25
 
   Fixes:

--- a/privacyidea/lib/fido2/challenge.py
+++ b/privacyidea/lib/fido2/challenge.py
@@ -10,6 +10,8 @@ from privacyidea.lib.error import ResourceNotFoundError, AuthError
 from privacyidea.lib.fido2.config import FIDO2ConfigOptions
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.models import Challenge
+from privacyidea.lib import fido2
+from privacyidea.lib.tokens.passkeytoken import PasskeyTokenClass
 
 log = logging.getLogger(__name__)
 

--- a/privacyidea/lib/fido2/challenge.py
+++ b/privacyidea/lib/fido2/challenge.py
@@ -1,18 +1,17 @@
 from typing import Union
+import logging
 
 from webauthn.helpers import bytes_to_base64url
 
 from privacyidea.api.lib.utils import get_required_one_of, get_optional_one_of, get_required
-from privacyidea.lib import fido2
 from privacyidea.lib.config import get_from_config
 from privacyidea.lib.crypto import geturandom
 from privacyidea.lib.error import ResourceNotFoundError, AuthError
 from privacyidea.lib.fido2.config import FIDO2ConfigOptions
-from privacyidea.lib.token import log
 from privacyidea.lib.tokenclass import TokenClass
-from privacyidea.lib.tokens.passkeytoken import PasskeyTokenClass
 from privacyidea.models import Challenge
 
+log = logging.getLogger(__name__)
 
 def get_fido2_nonce() -> str:
     """

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1550,6 +1550,23 @@ def delete_policy(name):
     """
     return fetch_one_resource(Policy, name=name).delete()
 
+@log_with(log)
+def delete_policies(names: list[str]) -> list[int]:
+    """
+    Delete multiple policies. ResourceNotFoundErrors are suppressed.
+
+    :param names: the names of the policies to be deleted
+    :return: the IDs of the deleted policies
+    :rtype: list[int]
+    """
+    ids = []
+    for name in names:
+        try:
+            ids.append(delete_policy(name))
+        except ResourceNotFoundError:
+            log.warning(f"Policy with name '{name}' does not exist and therefore can not be deleted.")
+            pass
+    return ids
 
 @log_with(log)
 def delete_all_policies():

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1551,7 +1551,7 @@ def delete_policy(name):
     return fetch_one_resource(Policy, name=name).delete()
 
 @log_with(log)
-def delete_policies(names: list[str]) -> list[int]:
+def delete_policies(names):
     """
     Delete multiple policies. ResourceNotFoundErrors are suppressed.
 

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -1550,6 +1550,7 @@ def delete_policy(name):
     """
     return fetch_one_resource(Policy, name=name).delete()
 
+
 @log_with(log)
 def delete_policies(names):
     """
@@ -1567,6 +1568,7 @@ def delete_policies(names):
             log.warning(f"Policy with name '{name}' does not exist and therefore can not be deleted.")
             pass
     return ids
+
 
 @log_with(log)
 def delete_all_policies():

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2632,11 +2632,10 @@ def check_token_list(token_object_list, passw, user=None, options=None, allow_re
                         token_object.reset()
                         token_object.post_success()
 
-                    # clean up all challenges from this and other tokens. I.e.
-                    # all challenges with this very transaction_id!
+                    # Clean up all challenges with this transaction_id
                     transaction_id = options.get("transaction_id") or options.get("state")
                     Challenge.query.filter(Challenge.transaction_id == '' + transaction_id).delete()
-                    # We have one successful authentication, so we bail out
+                    # Authentication is successful, stop here
                     break
 
         if not res and not further_challenge:

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2359,9 +2359,8 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
     for token in token_list:
         # Check if the max auth is succeeded
         if token.check_all(message_list):
-            challenge_created, message, transaction_id, challenge_info = token.create_challenge(
+            challenge_created, message, new_transaction_id, challenge_info = token.create_challenge(
                 transactionid=transaction_id, options=options)
-
             # We need to pass the info if a push token has been triggered, so that require presence can re-use the
             # challenge instead of creating a new one with a different answer
             # Also check the challenge info if the presence answer is returned to pass it on for tag replacement
@@ -2375,6 +2374,8 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
                                              additional_tags=additional_tags)
             message_list.append(message)
             if challenge_created:
+                if new_transaction_id:
+                    transaction_id = new_transaction_id
                 challenge_info = challenge_info or {}
                 challenge_info["transaction_id"] = transaction_id
                 challenge_info["serial"] = token.token.serial

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -1667,7 +1667,8 @@ class TokenClass(object):
 
     def challenge_janitor(self):
         """
-        Just clean up all challenges, for which the expiration has expired.
+        Clean up all challenges for this token, for which the expiration has
+        expired.
 
         :return: None
         """

--- a/privacyidea/lib/tokens/passkeytoken.py
+++ b/privacyidea/lib/tokens/passkeytoken.py
@@ -422,7 +422,7 @@ class PasskeyTokenClass(TokenClass):
             # TODO this vvv is horrible
             return True, message, transaction_id, challenge_details
         else:
-            return False, "", "", {}
+            return False, "", transactionid, {}
 
     @log_with(log)
     def use_for_authentication(self, options):

--- a/privacyidea/lib/tokens/passkeytoken.py
+++ b/privacyidea/lib/tokens/passkeytoken.py
@@ -38,7 +38,6 @@ from webauthn.registration.verify_registration_response import VerifiedRegistrat
 
 from privacyidea.api.lib.utils import get_optional, get_required, get_required_one_of, get_optional_one_of
 from privacyidea.lib import _
-from privacyidea.lib import fido2
 from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib.config import get_from_config
 from privacyidea.lib.decorators import check_token_locked
@@ -47,6 +46,7 @@ from privacyidea.lib.fido2.config import FIDO2ConfigOptions
 from privacyidea.lib.fido2.policy_action import FIDO2PolicyAction, PasskeyAction
 from privacyidea.lib.fido2.token_info import FIDO2TokenInfo
 from privacyidea.lib.fido2.util import hash_credential_id, save_credential_id_hash
+from privacyidea.lib.fido2.challenge import get_fido2_nonce, create_fido2_challenge
 from privacyidea.lib.log import log_with
 from privacyidea.lib.policy import ACTION, SCOPE
 from privacyidea.lib.tokenclass import TokenClass, ROLLOUTSTATE, AUTHENTICATIONMODE, CLIENTMODE
@@ -152,7 +152,7 @@ class PasskeyTokenClass(TokenClass):
 
             response_detail: dict = TokenClass.get_init_detail(self, params, token_user)
             response_detail['rollout_state'] = self.token.rollout_state
-            nonce_base64 = fido2.challenge.get_fido2_nonce()
+            nonce_base64 = get_fido2_nonce()
             challenge_validity: int = int(get_from_config(FIDO2ConfigOptions.CHALLENGE_VALIDITY_TIME,
                                                           get_from_config('DefaultChallengeValidityTime', 120)))
             challenge: Challenge = Challenge(serial=self.token.serial,
@@ -413,8 +413,8 @@ class PasskeyTokenClass(TokenClass):
         if options and PasskeyAction.EnableTriggerByPIN in options and options[PasskeyAction.EnableTriggerByPIN]:
             rp_id = get_required(options, FIDO2PolicyAction.RELYING_PARTY_ID)
             user_verification = get_optional(options, "user_verification", "preferred")
-            challenge = fido2.challenge.create_fido2_challenge(rp_id, user_verification=user_verification,
-                                                               transaction_id=transactionid, serial=self.token.serial)
+            challenge = create_fido2_challenge(rp_id, user_verification=user_verification,
+                                               transaction_id=transactionid, serial=self.token.serial)
             message = challenge["message"]
             transaction_id = challenge["transaction_id"]
             challenge_details = {"challenge": challenge["challenge"], "rpId": rp_id,

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -18,11 +18,11 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 import binascii
 import logging
 
 from cryptography import x509
+from webauthn.helpers import bytes_to_base64url
 
 from privacyidea.api.lib.utils import (attestation_certificate_allowed, get_required_one_of,
                                        get_optional_one_of, get_optional, get_required)
@@ -1181,7 +1181,24 @@ class WebAuthnTokenClass(TokenClass):
                 raise ValueError("When performing WebAuthn authorization, options must contain user")
 
             uv_req = get_optional(options, FIDO2PolicyAction.USER_VERIFICATION_REQUIREMENT)
-            challenge = binascii.unhexlify(get_required(options, "challenge"))
+            # Check if challenge is base64 encoded to be able to use login via passkey with webauthn
+            challenge = get_required(options, "challenge")
+            challenge: str = challenge.replace("=", "")
+            challenge_decoded = None
+            if len(challenge) % 2 == 0:
+                try:
+                    challenge_decoded = binascii.unhexlify(challenge)
+                    challenge_decoded = webauthn_b64_encode(challenge_decoded)
+                except Exception as ex:
+                    log.warning(f"Challenge {get_required(options, 'challenge')} is not hex encoded. {ex}. Attempting"
+                                f" to decode it as base64.")
+            if not challenge_decoded:
+                try:
+                    challenge_decoded = bytes_to_base64url(challenge.encode("utf-8"))
+                except Exception as ex:
+                    log.warning(f"Challenge {get_required(options, 'challenge')} is not base64url encoded. {ex}.")
+                    raise AuthenticationRejectedException('Challenge is not hex or base64url encoded.')
+
             http_origin = get_required(options, "HTTP_ORIGIN")
             if not http_origin:
                 raise AuthenticationRejectedException('HTTP Origin header missing.')
@@ -1204,13 +1221,13 @@ class WebAuthnTokenClass(TokenClass):
                             if assertion_client_extensions
                             else None
                     },
-                    challenge=webauthn_b64_encode(challenge),
+                    challenge=challenge_decoded,
                     origin=http_origin,
                     allow_credentials=[user.credential_id],
                     uv_required=uv_req
                 ).verify())
-            except AuthenticationRejectedException as e:
-                log.warning(f"Checking response for token {self.token.serial} failed. {e}")
+            except Exception as ex:
+                log.warning(f"Checking response for token {self.token.serial} failed. {ex}")
                 return -1
 
             # Save the credential_id hash to an extra table to be able to find the token faster
@@ -1222,7 +1239,9 @@ class WebAuthnTokenClass(TokenClass):
                                                            credential_id_hash=credential_id_hash)
                 token_cred_id_hash.save()
 
-            return self.get_otp_count()
+            sign_count = self.get_otp_count()
+            # TODO returning int is not good
+            return sign_count if sign_count > 0 else 1
 
         else:
             # Not all necessary data provided.

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -1196,7 +1196,7 @@ class WebAuthnTokenClass(TokenClass):
                     challenge_decoded = bytes_to_base64url(challenge.encode("utf-8"))
                 except Exception as ex:
                     log.warning(f"Challenge {get_required(options, 'challenge')} is not base64url encoded. {ex}.")
-                    raise AuthenticationRejectedException('Challenge is not hex or base64url encoded.')
+                    raise AuthenticationRejectedException('Challenge is neither hex nor base64url encoded.')
 
             http_origin = get_required(options, "HTTP_ORIGIN")
             if not http_origin:

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -1182,8 +1182,7 @@ class WebAuthnTokenClass(TokenClass):
 
             uv_req = get_optional(options, FIDO2PolicyAction.USER_VERIFICATION_REQUIREMENT)
             # Check if challenge is base64 encoded to be able to use login via passkey with webauthn
-            challenge = get_required(options, "challenge")
-            challenge: str = challenge.replace("=", "")
+            challenge = get_required(options, "challenge").rstrip("=")
             challenge_decoded = None
             if len(challenge) % 2 == 0:
                 try:

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -987,15 +987,15 @@ class WebAuthnTokenClass(TokenClass):
             }
 
             if credential_options.get("authenticatorSelection"):
-               register_request["authenticatorSelection"] = credential_options["authenticatorSelection"]
+                register_request["authenticatorSelection"] = credential_options["authenticatorSelection"]
             if credential_options.get("timeout"):
-               register_request["timeout"] = credential_options["timeout"]
+                register_request["timeout"] = credential_options["timeout"]
             if credential_options.get("attestation"):
-               register_request["attestation"] = credential_options["attestation"]
+                register_request["attestation"] = credential_options["attestation"]
             if (credential_options.get("extensions") or {}).get("authnSel"):
-               register_request["authenticatorSelectionList"] = credential_options["extensions"]["authnSel"]
+                register_request["authenticatorSelectionList"] = credential_options["extensions"]["authnSel"]
             if credential_options.get("excludeCredentials"):
-               register_request["excludeCredentials"] = credential_options.get("excludeCredentials")
+                register_request["excludeCredentials"] = credential_options.get("excludeCredentials")
 
             response_detail["webAuthnRegisterRequest"] = register_request
 
@@ -1187,11 +1187,10 @@ class WebAuthnTokenClass(TokenClass):
             challenge_decoded = None
             if len(challenge) % 2 == 0:
                 try:
-                    challenge_decoded = binascii.unhexlify(challenge)
-                    challenge_decoded = webauthn_b64_encode(challenge_decoded)
+                    challenge_decoded = webauthn_b64_encode(binascii.unhexlify(challenge))
                 except Exception as ex:
-                    log.warning(f"Challenge {get_required(options, 'challenge')} is not hex encoded. {ex}. Attempting"
-                                f" to decode it as base64.")
+                    log.warning(f"Challenge {get_required(options, 'challenge')} is not hex encoded. {ex}. "
+                                f"Attempting to decode it as base64url.")
             if not challenge_decoded:
                 try:
                     challenge_decoded = bytes_to_base64url(challenge.encode("utf-8"))

--- a/privacyidea/static/components/login/factories/webauthn.js
+++ b/privacyidea/static/components/login/factories/webauthn.js
@@ -36,7 +36,7 @@ angular
                 domExceptionErrorMessage
             ) {
                 return {
-                    register_request: function(registerRequest, callback) {
+                    register_request: function(registerRequest, callback, error_callback) {
                         if (!pi_webauthn) {
                             inform.add(
                                 gettextCatalog.getString(
@@ -62,6 +62,7 @@ angular
                                         ttl: 5000
                                     }
                                 );
+                                error_callback(e);
                             });
                     },
                     sign_request: function(data, signRequests, username, transactionid, login_callback) {

--- a/privacyidea/static/components/token/controllers/tokenControllers.js
+++ b/privacyidea/static/components/token/controllers/tokenControllers.js
@@ -667,7 +667,7 @@ myApp.controller("tokenEnrollController", ["$scope", "TokenFactory", "$timeout",
                         token.subject
                             = (response.detail.u2fRegisterResponse || response.detail.webAuthnRegisterResponse).subject;
                         token.vendor = token.subject.split(" ")[0];
-                        console.log(token);
+                        //console.log(token);
                     });
             });
             $scope.click_wait = true;

--- a/tests/test_api_validate_webauthn.py
+++ b/tests/test_api_validate_webauthn.py
@@ -437,7 +437,7 @@ class WebAuthn(MyApiTestCase):
         remove_token("hotpX1")
         remove_token(self.serial)
 
-    def _enroll_webauthn(self, serial: str, client_data: str, reg_data: str, mock_nonce: str):
+    def _enroll_webauthn(self, serial, client_data, reg_data, mock_nonce):
         # First enrollment step
         with self.app.test_request_context('/token/init',
                                            method='POST',
@@ -471,7 +471,7 @@ class WebAuthn(MyApiTestCase):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
 
-    def _authenticate_webauthn(self, data: dict):
+    def _authenticate_webauthn(self, data):
         with self.app.test_request_context('/validate/check', method='POST', data=data,
                                            headers={"Origin": "https://kc.fritz.box:8443"}):
             res = self.app.full_dispatch_request()
@@ -480,7 +480,7 @@ class WebAuthn(MyApiTestCase):
             self.assertTrue(res.json.get("result").get("value"))
             self.assertEqual("ACCEPT", res.json.get("result").get("authentication"))
 
-    def _change_challenge_nonce(self, transaction_id: str, new_nonce: str, serial: Union[str, None] = None):
+    def _change_challenge_nonce(self, transaction_id, new_nonce, serial = None):
         from privacyidea.lib.challenge import get_challenges
         challenge = get_challenges(serial=serial, transaction_id=transaction_id)[0]
         if not challenge:

--- a/tests/test_api_validate_webauthn.py
+++ b/tests/test_api_validate_webauthn.py
@@ -1,17 +1,19 @@
+from typing import Union
+
 from mock.mock import patch
 from webauthn.helpers import bytes_to_base64url
 
-from .base import MyApiTestCase
-from privacyidea.models import TokenCredentialIdHash, TokenInfo
 from privacyidea.lib.fido2.util import hash_credential_id
 from privacyidea.lib.machine import attach_token, detach_token
-from privacyidea.lib.policy import SCOPE, ACTION, set_policy, delete_policy
+from privacyidea.lib.policy import SCOPE, ACTION, set_policy, delete_policy, delete_policies
 from privacyidea.lib.token import (get_tokens, init_token, remove_token,
                                    get_one_token)
 from privacyidea.lib.tokenclass import ROLLOUTSTATE
 from privacyidea.lib.tokens.webauthn import webauthn_b64_decode
 from privacyidea.lib.user import User
 from privacyidea.lib.utils import hexlify_and_unicode
+from privacyidea.models import TokenCredentialIdHash, TokenInfo
+from .base import MyApiTestCase
 
 
 class WebAuthn(MyApiTestCase):
@@ -306,7 +308,7 @@ class WebAuthn(MyApiTestCase):
         token_info_entry.delete()
 
         # For WebAuthn token, the userHandle is the serial
-        user_handle = bytes_to_base64url(webauthn_serial.encode("utf-8"))
+        user_handle = bytes_to_base64url(webauthn_serial.encode())
         data = {
             "authenticatordata": "1kwVsywYDmugu2qhEi7LiS8tgyaE5XqILRqvKXkZ-1oBAAAACA",
             "clientdata": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiWjFvc0hYVl9rYm1FMEpnNVMyemtCV1VLSTNaTzZVWU8t"
@@ -435,20 +437,7 @@ class WebAuthn(MyApiTestCase):
         remove_token("hotpX1")
         remove_token(self.serial)
 
-    def test_30_sign_count_zero(self):
-        """
-        Some authenticators do not return a real sign count, but instead 0. This is allowed by the spec and should not
-        cause any problems. https://w3c.github.io/webauthn/#sctn-sign-counter
-        This test uses data recorded from using a passkey on a Macbook.
-        """
-        delete_policy("wan1")
-        delete_policy("wan2")
-        set_policy("wan1", scope=SCOPE.ENROLL, action="webauthn_relying_party_id=fritz.box")
-        set_policy("wan2", scope=SCOPE.ENROLL, action="webauthn_relying_party_name=fritz box")
-        # Required for Macbook passkey to work because of no or unsupported attestation format
-        set_policy("wan3", scope=SCOPE.ENROLL,
-                   action="webauthn_authenticator_attestation_level=none, webauthn_authenticator_attestation_form=none")
-        serial = "WAN00023620"
+    def _enroll_webauthn(self, serial: str, client_data: str, reg_data: str, mock_nonce: str):
         # First enrollment step
         with self.app.test_request_context('/token/init',
                                            method='POST',
@@ -466,21 +455,7 @@ class WebAuthn(MyApiTestCase):
             self.assertEqual("Please confirm with your WebAuthn token", webauthn_request.get("message"))
             transaction_id = webauthn_request.get("transaction_id")
 
-            # Update the nonce in the challenge database.
-            from privacyidea.lib.challenge import get_challenges
-            recorded_nonce = "q6RYoDdiC8YUCqBas4MMx2663kKdZdYV1q8PJTzmNkE"
-            recorded_nonce_hex = hexlify_and_unicode(webauthn_b64_decode(recorded_nonce))
-            chal = get_challenges(serial=serial, transaction_id=transaction_id)[0]
-            chal.challenge = recorded_nonce_hex
-            chal.save()
-
-            client_data = ("eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoicTZSWW9EZGlDOFlVQ3FCYXM0TU14MjY2M2tLZFp"
-                           "kWVYxcThQSlR6bU5rRSIsIm9yaWdpbiI6Imh0dHBzOi8vcGkuZnJpdHouYm94OjUwMDAiLCJjcm9zc09yaWdpbiI6Zm"
-                           "Fsc2V9")
-            reg_data = (
-                "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViY1kwVsywYDmugu2qhEi7LiS8tgyaE5XqILRqvKXkZ-1pdAAAAAAAAAAA"
-                "AAAAAAAAAAAAAAAAAFKv96-pAxzqutsqg657wFMw3JxY5pQECAyYgASFYIPsVTkUsjPCSLoBk2Yj1zEp8626I-_LobjfOI"
-                "aOdrTlfIlggSXIdmqO_aLKz71Qr-Xg3zMYabPYmUWtT3RsKyjZpTww")
+            self._change_challenge_nonce(transaction_id, mock_nonce, serial)
 
             # Second enrollment step
             with self.app.test_request_context('/token/init',
@@ -496,53 +471,136 @@ class WebAuthn(MyApiTestCase):
                 res = self.app.full_dispatch_request()
                 self.assertTrue(res.status_code == 200, res)
 
-            # Authenticate
-            with self.app.test_request_context('/validate/check',
-                                               method='POST',
-                                               data={"user": self.username,
-                                                     "pass": self.pin},
-                                               headers={"Origin": "https://kc.fritz.box:8443"}):
-                res = self.app.full_dispatch_request()
-                self.assertEqual(200, res.status_code)
-                data = res.json
-                self.assertTrue("transaction_id" in data.get("detail"))
-                transaction_id = data.get("detail").get("transaction_id")
-                self.assertEqual(serial, data.get("detail").get("serial"))
-                self.assertEqual("CHALLENGE", data.get("result").get("authentication"))
+    def _authenticate_webauthn(self, data: dict):
+        with self.app.test_request_context('/validate/check', method='POST', data=data,
+                                           headers={"Origin": "https://kc.fritz.box:8443"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"))
+            self.assertTrue(res.json.get("result").get("value"))
+            self.assertEqual("ACCEPT", res.json.get("result").get("authentication"))
 
-            # Update the nonce in the challenge database.
-            from privacyidea.lib.challenge import get_challenges
-            recorded_nonce = "V9nbUxzEAyXkt1KzMHYQv6Wky78FNE9911xCo3akjUQ"
-            recorded_nonce_hex = hexlify_and_unicode(webauthn_b64_decode(recorded_nonce))
-            chal = get_challenges(serial=serial, transaction_id=transaction_id)[0]
-            chal.challenge = recorded_nonce_hex
-            chal.save()
+    def _change_challenge_nonce(self, transaction_id: str, new_nonce: str, serial: Union[str, None] = None):
+        from privacyidea.lib.challenge import get_challenges
+        challenge = get_challenges(serial=serial, transaction_id=transaction_id)[0]
+        if not challenge:
+            self.fail("No challenge found")
+        challenge.challenge = new_nonce
+        challenge.save()
 
-            user_handle = bytes_to_base64url(serial.encode("utf-8"))
-            data = {
-                "authenticatordata": "1kwVsywYDmugu2qhEi7LiS8tgyaE5XqILRqvKXkZ-1odAAAAAA",
-                "clientdata": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiVjluYlV4ekVBeVhrdDFLek1IWVF2NldreTc4Rk5F"
-                              "OTkxMXhDbzNha2pVUSIsIm9yaWdpbiI6Imh0dHBzOi8va2MuZnJpdHouYm94Ojg0NDMiLCJjcm9zc09yaWdpbiI6"
-                              "ZmFsc2V9",
-                "credentialid": "q_3r6kDHOq62yqDrnvAUzDcnFjk",
-                "signaturedata": "MEUCIDeFbUlK_Clq2q2gUy1RqDRciMTpx2Ww7AEUwXysZaWfAiEAkvMWut17A5IiEWCO7CAOKMFZ44zIMNdBy"
-                                 "bGXfhujL_0",
-                "transaction_id": transaction_id,
-                "userHandle": user_handle,
-                "username": self.username
-            }
-            with self.app.test_request_context('/validate/check', method='POST', data=data,
-                                               headers={"Origin": "https://kc.fritz.box:8443"}):
-                res = self.app.full_dispatch_request()
-                self.assertEqual(200, res.status_code, res)
-                j = res.json
-                self.assertTrue(j.get("result").get("status"))
-                self.assertTrue(j.get("result").get("value"))
-                self.assertEqual("ACCEPT", j.get("result").get("authentication"))
-            delete_policy("wan1")
-            delete_policy("wan2")
-            delete_policy("wan3")
-            remove_token(serial=serial)
+    def test_30_sign_count_zero(self):
+        """
+        Some authenticators do not return a real sign count, but instead 0. This is allowed by the spec and should not
+        cause any problems. https://w3c.github.io/webauthn/#sctn-sign-counter
+        This test uses data recorded from using a passkey on a Macbook.
+        """
+        delete_policies(["wan1", "wan2"])
+        set_policy("wan1", scope=SCOPE.ENROLL, action="webauthn_relying_party_id=fritz.box")
+        set_policy("wan2", scope=SCOPE.ENROLL, action="webauthn_relying_party_name=fritz box")
+        # Required for Macbook passkey to work because of no or unsupported attestation format
+        set_policy("wan3", scope=SCOPE.ENROLL,
+                   action="webauthn_authenticator_attestation_level=none, webauthn_authenticator_attestation_form=none")
+        serial = "WAN00023620"
+
+        mock_nonce = hexlify_and_unicode(webauthn_b64_decode("q6RYoDdiC8YUCqBas4MMx2663kKdZdYV1q8PJTzmNkE"))
+        client_data = ("eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoicTZSWW9EZGlDOFlVQ3FCYXM0TU14MjY2M2tLZFp"
+                       "kWVYxcThQSlR6bU5rRSIsIm9yaWdpbiI6Imh0dHBzOi8vcGkuZnJpdHouYm94OjUwMDAiLCJjcm9zc09yaWdpbiI6Zm"
+                       "Fsc2V9")
+        reg_data = (
+            "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViY1kwVsywYDmugu2qhEi7LiS8tgyaE5XqILRqvKXkZ-1pdAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAFKv96-pAxzqutsqg657wFMw3JxY5pQECAyYgASFYIPsVTkUsjPCSLoBk2Yj1zEp8626I-_LobjfOI"
+            "aOdrTlfIlggSXIdmqO_aLKz71Qr-Xg3zMYabPYmUWtT3RsKyjZpTww")
+        self._enroll_webauthn(serial, client_data, reg_data, mock_nonce)
+
+        # Trigger the authentication
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": self.username,
+                                                 "pass": self.pin},
+                                           headers={"Origin": "https://kc.fritz.box:8443"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code)
+            data = res.json
+            self.assertTrue("transaction_id" in data.get("detail"))
+            transaction_id = data.get("detail").get("transaction_id")
+            self.assertEqual(serial, data.get("detail").get("serial"))
+            self.assertEqual("CHALLENGE", data.get("result").get("authentication"))
+
+        # Update the nonce in the challenge database. The nonce is converted to hex.
+        mock_nonce = hexlify_and_unicode(webauthn_b64_decode("V9nbUxzEAyXkt1KzMHYQv6Wky78FNE9911xCo3akjUQ"))
+        self._change_challenge_nonce(transaction_id, mock_nonce, serial)
+
+        user_handle = bytes_to_base64url(serial.encode())
+        data = {
+            "authenticatordata": "1kwVsywYDmugu2qhEi7LiS8tgyaE5XqILRqvKXkZ-1odAAAAAA",
+            "clientdata": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiVjluYlV4ekVBeVhrdDFLek1IWVF2NldreTc4Rk5F"
+                          "OTkxMXhDbzNha2pVUSIsIm9yaWdpbiI6Imh0dHBzOi8va2MuZnJpdHouYm94Ojg0NDMiLCJjcm9zc09yaWdpbiI6"
+                          "ZmFsc2V9",
+            "credentialid": "q_3r6kDHOq62yqDrnvAUzDcnFjk",
+            "signaturedata": "MEUCIDeFbUlK_Clq2q2gUy1RqDRciMTpx2Ww7AEUwXysZaWfAiEAkvMWut17A5IiEWCO7CAOKMFZ44zIMNdBy"
+                             "bGXfhujL_0",
+            "transaction_id": transaction_id,
+            "userHandle": user_handle,
+            "username": self.username
+        }
+        self._authenticate_webauthn(data)
+
+        delete_policies(["wan1", "wan2", "wan3"])
+        remove_token(serial=serial)
+
+    def test_31_webauthn_passkey_login(self):
+        """
+        If a WebAuthn token is enrolled as a passkey, because the authenticator just always creates passkeys,
+        the WebAuthn token can be used with the passkey login. The difference is the encoding of the challenge, which is
+        base64url for passkey and hex for WebAuthn.
+        This test makes sure the WebAuthnTokenClass can validate challenges that were encoded in base64url.
+        """
+        delete_policies(["wan1", "wan2"])
+        set_policy("wan1", scope=SCOPE.ENROLL, action="webauthn_relying_party_id=fritz.box")
+        set_policy("wan2", scope=SCOPE.ENROLL, action="webauthn_relying_party_name=fritz box")
+        # Required for Macbook passkey to work because of no or unsupported attestation format
+        set_policy("wan3", scope=SCOPE.ENROLL,
+                   action="webauthn_authenticator_attestation_level=none, webauthn_authenticator_attestation_form=none")
+        serial = "WAN00037300"
+        mock_nonce = hexlify_and_unicode(webauthn_b64_decode("u2UUrVcqwF4tlKaZH7nfLM2V0wWZ-1-RPCF1rwsmhEo"))
+        reg_data = ("o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViY1kwVsywYDmugu2qhEi7LiS8tgyaE5XqILRqvKXkZ-1pdAAAAAAAAAAAAAA"
+                    "AAAAAAAAAAAAAAFKyhLhHxRLvrqQY8OFUfwMDp5x5rpQECAyYgASFYIJohLFYLJp3Gk7h8oy5M9rjaGsyiffu1HU9plGWySuv-"
+                    "Ilgg4bJtPzLqiwWEZWIKIrNFkIoYT8SRwa4bCxUB2OFlba4")
+        client_data = ("eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoidTJVVXJWY3F3RjR0bEthWkg3bmZMTTJWMHdXWi0xLVJ"
+                       "QQ0YxcndzbWhFbyIsIm9yaWdpbiI6Imh0dHBzOi8vcGkuZnJpdHouYm94OjUwMDAiLCJjcm9zc09yaWdpbiI6ZmFsc2V9")
+        self._enroll_webauthn(serial, client_data, reg_data, mock_nonce)
+
+        # Trigger
+        with self.app.test_request_context('/validate/initialize',
+                                           method='POST',
+                                           data={"type": "passkey"},
+                                           headers={"Origin": "https://kc.fritz.box:8443"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code)
+            data = res.json
+            self.assertTrue("transaction_id" in data.get("detail"))
+            transaction_id = data.get("detail").get("transaction_id")
+            self.assertEqual("CHALLENGE", data.get("result").get("authentication"))
+
+        # Update the nonce in the challenge database. The nonce is base64url encoded for passkey challenges.
+        self._change_challenge_nonce(transaction_id, "0Bw6Kfs-i5-rqYvgykgQFpVD8jXYshoDeqKjOn_4x1c")
+        data = {
+            "userHandle": "V0FOMDAwMzczMDA=",
+            "transaction_id": transaction_id,
+            "credential_id": "rKEuEfFEu-upBjw4VR_AwOnnHms",
+            "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTUVKM05rdG1jeTFwTlMxeWNWbDJaM2xyWjFGR2NG"
+                              "WkVPR3BZV1hOb2IwUmxjVXRxVDI1Zk5IZ3hZdyIsIm9yaWdpbiI6Imh0dHBzOi8va2MuZnJpdHouYm94Ojg0NDMi"
+                              "LCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+            "signature": "MEYCIQCxSkkSc0wMwUdyfZq2sRnBQa2AuBbgz8I/B51wN0TiNQIhAIZplnq87VrRfHcJZBZvk0xuR5nVfg2YGVKoabiuH"
+                         "Vcm",
+            "authenticatorData": "1kwVsywYDmugu2qhEi7LiS8tgyaE5XqILRqvKXkZ+1odAAAAAA=="
+        }
+
+        # Authenticate
+        self._authenticate_webauthn(data)
+
+        delete_policies(["wan1", "wan2", "wan3"])
+        remove_token(serial=serial)
 
 
 class WebAuthnOfflineTestCase(MyApiTestCase):

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1670,7 +1670,7 @@ class PolicyTestCase(MyTestCase):
         set_policy("wan2", scope=SCOPE.ENROLL, action="webauthn_relying_party_name=fritz box")
         policies = Policy.query.filter_by().all()
         self.assertEqual(2, len(policies), policies)
-        # Delete those and one that does not exist inbetween, which will NOT raise an error and still remove the
+        # Delete those and one that does not exist in between, which will NOT raise an error and still remove the
         # other 2, indicated by the returned ids
         deleted_ids = delete_policies(["wan1", "wan3", "wan2"])
         self.assertEqual(2, len(deleted_ids), deleted_ids)


### PR DESCRIPTION
* WebAuthn: sign_count of 0 will result in a successful authentication (#4391)
* WebAuthn: The WebAuthn Token can validate challenges that were created by /validate/initialize. This can happen when the authenticator does create a passkey anyway and that webauthn token is then used as a passkey (#4400)
* Fixed a bug that would cause different transaction_ids to be generated when the user has a passkey and /validate/triggerchallenge is used (4399)
* WebUI: Cancelling WebAuthn enrollment will delete the unfinished token and redirect to the token list (#4402)