### PR TITLE
Update documentation for v3.11

### DIFF
--- a/doc/audit/index.rst
+++ b/doc/audit/index.rst
@@ -37,6 +37,9 @@ But you can set up a cron job to clean up old audit entries. Since version
 2.19 audit entries can be either cleaned up based on the number of entries or
 based on on the age. Cleaning based on the age takes precedence.
 
+.. versionadded:: 2.22 The ``--chunksize`` parameter allows cleaning up audit
+    entries in chunks to avoid exzessive memory usage.
+
 Cleaning based on the number of entries:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -61,13 +64,14 @@ This will delete all audit entries that are older than one year.
 
 Cleaning based on the config file:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 2.21
 
 Using a config file, you can define different retention times for the audit data.
 E.g. this way you can define, that audit entries about token listings can be deleted after
 one month,
 while the audit information about token creation will only be deleted after ten years.
 
-The config file is a YAML format and looks like this::
+The config file is in a *YAML* format and looks like this::
 
     # DELETE auth requests of nils after 10 days
     - rotate: 10
@@ -114,6 +118,10 @@ You can then add a call like::
 
 in your crontab.
 
+.. note:: The cleaning based on a config file currently does **not** work with
+    the ``--chunksize`` parameter. If the audit-table is too big, consider
+    cleaning based on the age or number of entries first.
+
 
 Access rights
 ~~~~~~~~~~~~~
@@ -134,6 +142,8 @@ Then you can call ``pi-manage`` like this::
 This will read the configuration (only the database URI) from the config file
 ``audit.cfg``.
 
+.. _audit_table_size:
+
 Table size
 ~~~~~~~~~~
 
@@ -142,12 +152,14 @@ column in the database. You should set::
 
    PI_AUDIT_SQL_TRUNCATE = True
 
-in ``pi.cfg``. This will truncate each entry to the defined column length.
+in the :ref:`config file <cfgfile>`. This will truncate each entry to the
+defined column length.
 
-However, if you sill want to fetch more information in the audit log, you can
-increase the column length directly in the database by the usual database means.
+However, if you sill want to add more information to the audit log, you can
+increase the column length directly in the database by the usual database means
+(i.e. :code:`ALTER TABLE pidea_audit MODIFY user varchar(100);` for MariaDB).
 However, privacyIDEA does not know about this and will still truncate the entries
-to the originally defined length.
+to the originally defined lengths.
 
 To avoid this, you need to tell privacyIDEA about the changes.
 In Your :ref:`config file <cfgfile>` add the setting like::
@@ -156,7 +168,8 @@ In Your :ref:`config file <cfgfile>` add the setting like::
                                   "policies": 1000}
 
 which will increase truncation of the user column to 100 and the policies
-column to 1000. Check the database schema for the available columns.
+column to 1000. Check the database schema for the available columns
+here: :class:`privacyidea.models.Audit`.
 
 .. _logger_audit:
 

--- a/doc/installation/centos.rst
+++ b/doc/installation/centos.rst
@@ -82,7 +82,7 @@ privacyIDEA. You can get the latest version tag from the `GitHub release page <h
 .com/privacyidea/privacyidea/releases>`_ or the `PyPI package history <https://pypi
 .org/project/privacyIDEA/#history>`_ (e.g. "3.3.1")::
 
-        (privacyidea)$ export PI_VERSION=3.3.1
+        (privacyidea)$ export PI_VERSION=3.11.3
         (privacyidea)$ pip install -r https://raw.githubusercontent.com/privacyidea/privacyidea/v${PI_VERSION}/requirements.txt
 
 Then just install the targeted privacyIDEA version with::

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -7,7 +7,7 @@ The ways described here to install privacyIDEA are
 
  * the installation via the :ref:`pip_install`, which can be used on
    any Linux distribution and
- * ready made :ref:`install_ubuntu` for Ubuntu 18.04 LTS, 20.04 LTS, 22.04 LTS and 24.04 LTS.
+ * ready made :ref:`install_ubuntu` for Ubuntu 20.04 LTS, 22.04 LTS and 24.04 LTS.
 
 If you want to upgrade please read :ref:`upgrade`.
 

--- a/doc/installation/pip.rst
+++ b/doc/installation/pip.rst
@@ -9,54 +9,58 @@ You can install privacyidea usually on any Linux distribution in a python
 virtual environment. This way you keep all privacyIDEA code in one defined
 subdirectory.
 
-privacyIDEA currently runs with Python 3.9 to 3.12. Other
-versions either do not work or are not tested.
+.. note::
+    privacyIDEA currently runs with Python 3.9 to 3.12. Other
+    versions either do not work or are not tested.
+
+Setting up a virtual environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You first need to install a package for creating a python `virtual environment
 <https://virtualenv.pypa.io/en/stable/>`_.
 
 Now you can setup the virtual environment for privacyIDEA like this::
 
-  virtualenv /opt/privacyidea
+  $ virtualenv /opt/privacyidea
 
-  cd /opt/privacyidea
-  source bin/activate
+  $ cd /opt/privacyidea
+  $ source bin/activate
+  (privacyidea)$
 
 .. note::
     Some distributions still ship Python 2.7 as the system python. If you want
     to use Python 3 you can create the virtual environment like this:
     `virtualenv -p /usr/bin/python3 /opt/privacyidea`
 
-Now you are within the python virtual environment and you can run::
+Now you are within the python virtual environment and you can proceed with the
+:ref:`deterministic installation <pip_deterministic_installation>`.
 
-  pip install privacyidea
-
-in order to install the latest privacyIDEA version from
-`PyPI <https://pypi.org/project/privacyIDEA>`_.
+.. _pip_deterministic_installation:
 
 Deterministic Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The privacyIDEA package contains dependencies with a minimal required version. However, newest
 versions of dependencies are not always tested and might cause problems.
-If you want to achieve a deterministic installation, you can now install the pinned and tested
-versions of the dependencies::
+To achieve a deterministic installation, you must install the pinned and tested
+versions of the dependencies *before* installing privacyIDEA::
 
-  pip install -r lib/privacyidea/requirements.txt
+    (privacyidea)$ pip install -r https://raw.githubusercontent.com/privacyidea/privacyidea/v3.11.3/requirements.txt
 
-It would even be safer to install the pinned dependencies *before* installing privacyIDEA.
-So if you e.g. know that you are going to install version 3.6 you can run::
+Now you can install the required privacyIDEA version from
+`PyPI <https://pypi.org/project/privacyIDEA>`_::
 
-    pip install -r https://raw.githubusercontent.com/privacyidea/privacyidea/v3.6/requirements.txt
-    pip install privacyidea==3.6
+    (privacyidea)$ pip install privacyidea==3.11.3
+
+The requirements are also available after the installation at ``/opt/privacyidea/lib/privacyidea/requirements.txt``.
 
 .. _pip_configuration:
 
 Configuration
-.............
+^^^^^^^^^^^^^
 
 Database
-^^^^^^^^
+........
 
 privacyIDEA makes use of `SQLAlchemy <https://www.sqlalchemy.org>`_ to be able
 to talk to different SQL-based databases. Our best experience is with
@@ -77,7 +81,7 @@ You must then add the database name, user and password to your `pi.cfg`. See
 :ref:`cfgfile` for more information on the configuration.
 
 Setting up privacyIDEA
-^^^^^^^^^^^^^^^^^^^^^^
+......................
 Additionally to the database connection a new ``PI_PEPPER`` and ``SECRET_KEY``
 must be generated in order to secure the installation::
 
@@ -90,26 +94,20 @@ An encryption key for encrypting the secrets in the database and a key for
 signing the :ref:`audit` log is also needed (the following commands should be
 executed inside the virtual environment)::
 
-    pi-manage setup create_enckey  # encryption key for the database
-    pi-manage setup create_audit_keys  # key for verification of audit log entries
+    (privacyidea)$ pi-manage setup create_enckey  # encryption key for the database
+    (privacyidea)$ pi-manage setup create_audit_keys  # key for verification of audit log entries
 
 To create the database tables execute::
 
-    pi-manage setup create_tables
-
-Stamping the database to the current database schema version is important for
-the update process later. Since version 3.10 the database is stamped to the head
-version automatically. For older versions use::
-
-    pi-manage db stamp head -d /opt/privacyidea/lib/privacyidea/migrations/
+    (privacyidea)$ pi-manage setup create_tables
 
 After creating a local administrative user with::
 
-    pi-manage admin add <login>
+    (privacyidea)$ pi-manage admin add <login>
 
 the development server can be started with::
 
-    pi-manage run
+    (privacyidea)$ pi-manage run
 
 .. versionchanged:: 3.10
     To start the development server with an earlier version use ``runserver``. The
@@ -119,7 +117,7 @@ the development server can be started with::
     The development server should not be used for a productive environment.
 
 Webserver
-^^^^^^^^^
+.........
 
 To serve authentication requests and provide the management UI a
 `WSGI <https://wsgi.readthedocs.io/en/latest/index.html>`_ capable webserver

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -188,7 +188,7 @@ database engine. If ``PI_AUDIT_SQL_OPTIONS`` is not set,
 ``SQLALCHEMY_ENGINE_OPTIONS`` will be used.
 
 ``PI_AUDIT_SQL_TRUNCATE = True`` lets you truncate audit entries to the length
-of the database fields.
+of the database fields (See :ref:`Audit table size <audit_table_size>`).
 
 In certain cases when you experiencing problems you may use the parameters
 ``PI_AUDIT_POOL_SIZE`` and ``PI_AUDIT_POOL_RECYCLE``. However, they are only

--- a/doc/installation/ubuntu.rst
+++ b/doc/installation/ubuntu.rst
@@ -9,7 +9,7 @@ Ubuntu Packages
 There are ready made packages for Ubuntu.
 
 For recent releases of privacyIDEA starting from version 3.0 a repository is
-available which provides packages for Ubuntu 18.04 LTS, 20.04 LTS, 22.04 LTS and 24.04 LTS [#ubuntu]_.
+available which provides packages for Ubuntu 20.04 LTS, 22.04 LTS and 24.04 LTS [#ubuntu]_.
 
 .. note:: The packages ``privacyidea-apache2`` and ``privacyidea-nginx`` assume
    that you want to run a privacyIDEA system. These packages deactivate all
@@ -20,10 +20,10 @@ available which provides packages for Ubuntu 18.04 LTS, 20.04 LTS, 22.04 LTS and
 
 Read about the upgrading process in :ref:`upgrade_packaged`.
 
-Installing privacyIDEA 3.0 or higher
-....................................
+Installing privacyIDEA
+......................
 
-Before installing privacyIDEA 3.0 or upgrading to 3.0 you need to add the repository.
+Before installing privacyIDEA you need to add the package repository to the package manager.
 
 .. _add_ubuntu_repository:
 
@@ -51,8 +51,8 @@ On Ubuntu 22.04 LTS and 24.04 LTS you can add the signing key with::
 
    mv NetKnights-Release.asc /etc/apt/trusted.gpg.d/
 
-Now you need to add the repository for your release (either ``bionic/18.04 LTS``,
-``focal/20.04 LTS``, ``jammy/22.04 LTS`` or ``noble/24.04 LTS``)
+Now you need to add the repository for your release (either ``focal/20.04 LTS``,
+``jammy/22.04 LTS`` or ``noble/24.04 LTS``)
 
 You can do this by running the following command on Ubuntu 24.04::
 
@@ -68,8 +68,8 @@ following contents for Ubuntu 24.04::
 
 Change the code name to the running Ubuntu version accordingly.
 
-Installation of privacyIDEA 3.x
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installation of privacyIDEA
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After having added the repositories, run::
 
@@ -109,3 +109,5 @@ For further details see :ref:`rlm_perl`.
     Starting with privacyIDEA 3.5 Ubuntu 20.04 packages are available.
 
     Starting with privacyIDEA 3.8 Ubuntu 22.04 packages are available, Ubuntu 16.04 packages are dropped.
+
+    Starting with privacyIDEA 3.9 Ubuntu 18.04 (bionic) packages are dropped.


### PR DESCRIPTION
- Remove mentions of ubuntu 16.04 and 18.04
- Update version information for the pi-manage audit rotate call
- Add information about audit table size configuration
- Improve formatting for shell commands within virtual environment
- Make the installation with pinned dependencies the default
- Remove information about table stamping