### PR TITLE
Update GitHub action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: pip
+    directory: /doc
+    schedule:
+      interval: daily
+
+  - package-ecosystem: pip
+    directory: /tests
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /privacyidea/static
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
 
-  - package-ecosystem: pip
-    directory: /
+  - package-ecosystem: "pip"
+    directories:
+      - "/"
+      - "/doc"
+      - "/tests"
     schedule:
-      interval: daily
+      interval: "daily"
 
-  - package-ecosystem: pip
-    directory: /doc
+  - package-ecosystem: "npm"
+    directory: "/privacyidea/static"
     schedule:
-      interval: daily
-
-  - package-ecosystem: pip
-    directory: /tests
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /privacyidea/static
-    schedule:
-      interval: daily
+      interval: "daily"

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -2,7 +2,7 @@
 # This action will run Bandit on your codebase.
 # The results of the scan will be found under the Security tab of your repository.
 
-# https://github.com/marketplace/actions/bandit-scan is ISC licensed, by abirismyname
+# https://github.com/PyCQA/bandit-action
 # https://pypi.org/project/bandit/ is Apache v2.0 licensed, by PyCQA
 
 name: Bandit
@@ -22,25 +22,11 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Bandit Scan
-        uses: shundor/python-bandit-scan@v1.0
+        uses: PyCQA/bandit-action@v1
         with: # optional arguments
-          # exit with 0, even with results found
-          exit_zero: true
-          # GitHub token of the repository (automatically created by GitHub)
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
-          # File or directory to run bandit on
-          path: privacyidea
-          # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
-          # level: # optional, default is UNDEFINED
-          # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
-          # confidence: # optional, default is UNDEFINED
-          # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
-          excluded_paths: ./docs,./tests,./migrations
-          # comma-separated list of test IDs to skip
-          # skips: # optional, default is DEFAULT
-          # path to a .bandit file that supplies command line arguments
-          # ini_path: # optional, default is DEFAULT
+          targets: privacyidea
+          exclude: ./docs,./tests,./migrations

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -18,13 +18,14 @@ on:
 jobs:
   bandit:
     permissions:
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Bandit Scan
         uses: PyCQA/bandit-action@v1
         with: # optional arguments

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -8,12 +8,15 @@
 name: Bandit
 on:
   push:
-    branches: [ "master" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches:
+      - "master"
+      - 'branch-*'
   schedule:
-    - cron: '33 11 * * 6'
+    # Do a nightly run at 23:33 UTC
+    - cron: '33 23 * * *'
+
+permissions: {}
 
 jobs:
   bandit:
@@ -23,11 +26,11 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - name: Bandit Scan
-        uses: PyCQA/bandit-action@v1
+        uses: PyCQA/bandit-action@8a1b30610f61f3f792fe7556e888c9d7dffa52de # v1.0.0
         with: # optional arguments
           targets: privacyidea
           exclude: ./docs,./tests,./migrations

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,12 +2,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches:
+      - "master"
+      - 'branch-*'
   schedule:
-    - cron: '31 10 * * 6'
+    - cron: '31 23 * * *'
+
+permissions: {}
 
 jobs:
   analyze:
@@ -24,12 +26,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
+      # The CodeQL Repo is weird, it is unclear how to tag the actions with a commit
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -25,11 +25,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -40,6 +40,6 @@ jobs:
         # queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,9 +12,8 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
       security-events: write
 
@@ -26,6 +25,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,5 +1,8 @@
 name: codespell
 on: [pull_request]
+
+permissions: {}
+
 jobs:
   reviewdog-codespell:
     permissions:
@@ -9,14 +12,14 @@ jobs:
     name: reviewdog / codespell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - name: Install codespell
         run: |
           python -m pip install -U codespell
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
       - name: Run reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install codespell
         run: |
           python -m pip install -U codespell

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,16 +1,26 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+
 name: 'Dependency Review'
 on: [pull_request]
+
 permissions:
   contents: read
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
-          fail-on-severity: moderate
+          warn-only: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,16 @@
+name: 'Dependency Review'
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/gitlab-trigger.yml
+++ b/.github/workflows/gitlab-trigger.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+# No permissions needed for this action
+permissions: {}
+
 jobs:
   trigger-gitlab:
     runs-on: ubuntu-latest

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,18 +1,24 @@
 name: Greetings
 
-on:
-  issues:
-    types:
-      - opened
+on: [pull_request, issues]
+
+permissions:
+  contents: read
 
 jobs:
   greeting:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write  # for actions/first-interaction to comment on first issue
+      pull-requests: write  # for actions/first-interaction to comment on first PR
     steps:
     - uses: actions/first-interaction@v1
       continue-on-error: true
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'Thank you for filing an issue and sharing your observations or ideas.
-                        Please be sure to provide as much information as possible to help us
-                        to work on this issue.'
+        issue-message: |
+          Thank you for filing an issue and sharing your observations or ideas.
+          Please make sure to provide as much information as possible to help us work on this issue.
+        pr-message: |
+          Thank you for opening a pull-request.
+          Please have a look at our contributing guidelines here: [CONTRIBUTING.md](https://github.com/privacyidea/privacyidea/blob/master/CONTRIBUTING.md)

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,8 +2,7 @@ name: Greetings
 
 on: [pull_request, issues]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   greeting:
@@ -12,7 +11,7 @@ jobs:
       issues: write  # for actions/first-interaction to comment on first issue
       pull-requests: write  # for actions/first-interaction to comment on first PR
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@34f15e814fe48ac9312ccf29db4e74fa767cbab7 # v1.3.0
       continue-on-error: true
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-dist.yml
+++ b/.github/workflows/python-dist.yml
@@ -7,19 +7,25 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-dist:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     name: Build Python sdist and wheel
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 2
+        submodules: "recursive"
+        persist-credentials: false
     - run: mkdir -p dist
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install build environment
       run: >-
         python -m pip install build --user

--- a/.github/workflows/python-dist.yml
+++ b/.github/workflows/python-dist.yml
@@ -12,12 +12,12 @@ jobs:
     name: Build Python sdist and wheel
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - run: mkdir -p dist
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install build environment
@@ -32,13 +32,13 @@ jobs:
         path: dist/*
     - name: Create GitHub pre-release
       id: gh_pre_release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: contains(github.ref_name, 'dev')
       with:
         files: dist/*
         prerelease: True
     - name: Create GitHub release draft
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: steps.gh_pre_release.conclusion == 'skipped'
       with:
         files: dist/*

--- a/.github/workflows/python-dist.yml
+++ b/.github/workflows/python-dist.yml
@@ -17,13 +17,13 @@ jobs:
     name: Build Python sdist and wheel
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         submodules: "recursive"
         persist-credentials: false
     - run: mkdir -p dist
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.12"
     - name: Install build environment
@@ -33,18 +33,18 @@ jobs:
       run: >-
         python -m build --sdist --wheel --outdir dist/
     - name: Upload packages to artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         path: dist/*
     - name: Create GitHub pre-release
       id: gh_pre_release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
       if: contains(github.ref_name, 'dev')
       with:
         files: dist/*
         prerelease: True
     - name: Create GitHub release draft
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
       if: steps.gh_pre_release.conclusion == 'skipped'
       with:
         files: dist/*

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,10 +20,10 @@ jobs:
     outputs:
       run_tests: ${{ steps.changes.outputs.python_test}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: changes
       with:
         filters: .github/filters.yml
@@ -42,18 +42,18 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # clone submodules as well
         submodules: 'recursive'
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip installation
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: pip-cache
       with:
         path: ~/.cache/pip
@@ -79,6 +79,6 @@ jobs:
 
     - name: Codecov upload
       if: ${{ steps.pytest_run.outcome == 'success' }}
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,6 +13,9 @@ on:
       - 'master'
       - 'branch-*'
 
+permissions:
+  contents: read
+
 jobs:
   pre_check:
     name: 'Check for code changes'
@@ -22,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 2
+        persist-credentials: false
     - uses: dorny/paths-filter@v3
       id: changes
       with:
@@ -31,9 +34,11 @@ jobs:
 
   build:
     name: 'Run tests with Python'
+    permissions:
+      checks: write
     needs: pre_check
     if: needs.pre_check.outputs.run_tests == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       # don't cancel running matrix tests when one test fails
       fail-fast: false
@@ -46,7 +51,7 @@ jobs:
       with:
         # clone submodules as well
         submodules: 'recursive'
-
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,10 +23,12 @@ jobs:
     outputs:
       run_tests: ${{ steps.changes.outputs.python_test}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
+        # https://yossarian.net/til/post/actions-checkout-can-leak-github-credentials/
         persist-credentials: false
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      # TODO: replace with github actions internal filter on.push/pull_request.paths
       id: changes
       with:
         filters: .github/filters.yml
@@ -47,18 +49,16 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        # clone submodules as well
-        submodules: 'recursive'
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip installation
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       id: pip-cache
       with:
         path: ~/.cache/pip
@@ -84,6 +84,7 @@ jobs:
 
     - name: Codecov upload
       if: ${{ steps.pytest_run.outcome == 'success' }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
       with:
         files: ./coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@2520132f44b3ed84916048d32e5c7153fc739fe7 # v0.0.3

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ setup(
     version=VERSION,
     description='privacyIDEA: multifactor authentication management system',
     author='privacyidea.org',
-    license='AGPLv3',
     author_email='cornelius@privacyidea.org',
     url='https://www.privacyidea.org',
     keywords='OTP, two factor authentication, management, security',
@@ -147,14 +146,12 @@ setup(
                 ('lib/privacyidea/', ['requirements.txt'])
                 ],
     classifiers=["Framework :: Flask",
-                 "License :: OSI Approved :: "
-                 "GNU Affero General Public License v3",
+                 "License-Expression :: AGPL-3.0-or-later",
                  "Programming Language :: Python",
                  "Development Status :: 5 - Production/Stable",
                  "Topic :: Internet",
                  "Topic :: Security",
-                 "Topic :: System ::"
-                 " Systems Administration :: Authentication/Directory",
+                 "Topic :: System :: Systems Administration :: Authentication/Directory",
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 3',
                  'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
- Pin actions to commit hashes
- Set default and per-job permissions for the GitHub token
- Add dependabot configuration for GitHub actions as well
- Set `persist-credentials` to `false` when using the checkout action
- Add the `dependency-review` actions (Currently warn-only)
- Add zizmore action to check for issues in our GitHub actions

Thanks to @woodruffw, https://github.com/zizmorcore and https://www.stepsecurity.io/