### PR TITLE
Remove passwords from debug log

### DIFF
--- a/privacyidea/lib/tokens/foureyestoken.py
+++ b/privacyidea/lib/tokens/foureyestoken.py
@@ -43,7 +43,7 @@ from privacyidea.lib.error import ParameterError
 from privacyidea.lib.token import check_realm_pass
 from privacyidea.lib.decorators import check_token_locked
 from privacyidea.lib import _
-from privacyidea.lib.policy import ACTION, SCOPE, GROUP, get_action_values_from_options
+from privacyidea.lib.policy import ACTION, SCOPE, GROUP
 from privacyidea.lib.challenge import get_challenges, Challenge
 import json
 import datetime
@@ -287,7 +287,7 @@ class FourEyesTokenClass(TokenClass):
                     break
         return r_success
 
-    @log_with(log)
+    @log_with(log, hide_args=[1])
     @check_token_locked
     def authenticate(self, passw, user=None, options=None):
         """
@@ -450,7 +450,7 @@ class FourEyesTokenClass(TokenClass):
         """
         options = options or {}
         message = ""
-        if type(options.get("data")) == dict:
+        if isinstance(options.get("data"), dict):
             # In the special first chal-resp case we do not have jsonified data, yet. So we need to convert
             options["data"] = json.dumps(options.get("data"))
         used_tokens = json.loads(options.get("data", json.dumps({})))

--- a/privacyidea/lib/tokens/radiustoken.py
+++ b/privacyidea/lib/tokens/radiustoken.py
@@ -354,7 +354,6 @@ class RadiusTokenClass(RemoteTokenClass):
 
         return local_check
 
-    @log_with(log)
     def split_pin_pass(self, passw, user=None, options=None):
         """
         Split the PIN and the OTP value.
@@ -368,7 +367,7 @@ class RadiusTokenClass(RemoteTokenClass):
 
         return res, pin, otpval
 
-    @log_with(log)
+    @log_with(log, hide_args=[1])
     @check_token_locked
     def authenticate(self, passw, user=None, options=None):
         """

--- a/privacyidea/lib/tokens/remotetoken.py
+++ b/privacyidea/lib/tokens/remotetoken.py
@@ -183,7 +183,7 @@ class RemoteTokenClass(TokenClass):
 
         return local_check
 
-    @log_with(log)
+    @log_with(log, hide_args=[1])
     @check_token_locked
     def authenticate(self, passw, user=None, options=None):
         """
@@ -204,7 +204,7 @@ class RemoteTokenClass(TokenClass):
         reply = None
         otpval = passw
 
-        # should we check the pin localy?
+        # should we check the pin locally?
         if self.check_pin_local:
             (_res, pin, otpval) = self.split_pin_pass(passw, user,
                                                       options=options)

--- a/privacyidea/lib/tokens/spasstoken.py
+++ b/privacyidea/lib/tokens/spasstoken.py
@@ -26,9 +26,9 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-__doc__="""This is the implementation of the simple pass token.
+"""This is the implementation of the simple pass token.
 The simple pass token always returns TRUE as far as the checkOTP is concerned.
-Thus a user with a simple pass token can authenticate by just providing the
+Thus, a user with a simple pass token can authenticate by just providing the
 OTP PIN of the token.
 
 This code is tested in tests/test_lib_tokens_spass
@@ -81,8 +81,8 @@ class SpassTokenClass(TokenClass):
         :return: subsection if key exists or user defined
         :rtype: dict
         """
-        res = {'type' :'spass',
-               'title' :'Simple Pass Token',
+        res = {'type': 'spass',
+               'title': 'Simple Pass Token',
                'description': _('SPass: Simple Pass token. Static passwords.'),
                'config': {},
                'user': ['enroll'],
@@ -144,7 +144,7 @@ class SpassTokenClass(TokenClass):
         """
         return 0
 
-    @log_with(log)
+    @log_with(log, hide_args=[1])
     @check_token_locked
     def authenticate(self, passw, user=None, options=None):
         """
@@ -156,4 +156,3 @@ class SpassTokenClass(TokenClass):
         if pin_match is True:
             otp_count = 0
         return pin_match, otp_count, None
-

--- a/tests/test_lib_tokens_spass.py
+++ b/tests/test_lib_tokens_spass.py
@@ -2,6 +2,8 @@
 This test file tests the lib.tokens.spasstoken
 This depends on lib.tokenclass
 """
+import logging
+from testfixtures import LogCapture
 
 from .base import MyTestCase
 from privacyidea.lib.tokens.spasstoken import SpassTokenClass
@@ -14,7 +16,7 @@ class SpassTokenTestCase(MyTestCase):
     serial1 = "ser1"
 
     # add_user, get_user, reset, set_user_identifiers
-    
+
     def test_01_create_token(self):
         db_token = Token(self.serial1, tokentype="spass")
         db_token.save()
@@ -39,8 +41,12 @@ class SpassTokenTestCase(MyTestCase):
 
         # check pin+otp:
         token.set_pin(self.otppin)
-        r = token.authenticate(self.otppin)
-        self.assertTrue(r, r)
+        logging.getLogger('privacyidea.lib.tokens.spasstoken').setLevel(logging.DEBUG)
+        with LogCapture(level=logging.DEBUG) as lc:
+            r = token.authenticate(self.otppin)
+            self.assertTrue(r, r)
+            for log_record in lc.actual():
+                self.assertNotIn(self.otppin, log_record[2], log_record)
 
     def test_03_class_methods(self):
         db_token = Token.query.filter(Token.serial == self.serial1).first()


### PR DESCRIPTION
In some cases a given userstore PIN was logged in debug-mode due to missing filter on the function-entry message logs.