### PR TITLE
Avoid KeyError when searching for user in SQLResolver

### DIFF
--- a/privacyidea/lib/resolvers/HTTPResolver.py
+++ b/privacyidea/lib/resolvers/HTTPResolver.py
@@ -131,7 +131,7 @@ class HTTPResolver(UserIdResolver):
         """
         return self._getUser(userid)
 
-    def getUserList(self, searchDict=None):
+    def getUserList(self, search_dict=None):
         """
         Since it is an HTTP resolver,
         users are not stored in the database

--- a/privacyidea/lib/resolvers/PasswdIdResolver.py
+++ b/privacyidea/lib/resolvers/PasswdIdResolver.py
@@ -44,7 +44,7 @@ import logging
 import crypt
 import codecs
 
-from privacyidea.lib.utils import to_bytes, convert_column_to_unicode
+from privacyidea.lib.utils import convert_column_to_unicode
 from .UserIdResolver import UserIdResolver
 
 log = logging.getLogger(__name__)
@@ -286,11 +286,11 @@ class IdResolver (UserIdResolver):
 
         return self.searchFields
 
-    def getUserList(self, searchDict=None):
+    def getUserList(self, search_dict=None):
         """
         get a list of all users matching the search criteria of the searchdict
 
-        :param searchDict: dict of search expressions
+        :param search_dict: dict of search expressions
         """
         ret = []
 
@@ -299,13 +299,13 @@ class IdResolver (UserIdResolver):
             line = self.descDict[l]
             ok = True
 
-            for search in searchDict:
+            for search in search_dict:
 
                 if search not in self.searchFields:
                     ok = False
                     break
 
-                pattern = searchDict[search]
+                pattern = search_dict[search]
 
                 log.debug("searching for %s:%s", search, pattern)
 

--- a/privacyidea/lib/resolvers/SCIMIdResolver.py
+++ b/privacyidea/lib/resolvers/SCIMIdResolver.py
@@ -134,7 +134,7 @@ class IdResolver (UserIdResolver):
         # It seems that the userName is the userId
         return convert_column_to_unicode(loginName)
 
-    def getUserList(self, searchDict=None):
+    def getUserList(self, search_dict=None):
         """
         Return the list of users
         """
@@ -144,8 +144,7 @@ class IdResolver (UserIdResolver):
         res = {}
         if self.access_token:
             res = self._search_users(self.resource_server,
-                                                 self.access_token,
-                                                 "")
+                                     self.access_token)
 
         for user in res.get("Resources"):
             ret_user = self._fill_user_schema_1_0(user)
@@ -218,18 +217,18 @@ class IdResolver (UserIdResolver):
     def testconnection(cls, param):
         """
         This function lets you test the to be saved SCIM connection.
-              
+
         :param param: A dictionary with all necessary parameter to test the
                         connection.
         :type param: dict
         :return: Tuple of success and a description
         :rtype: (bool, string)
-        
+
         Parameters are: Authserver, Resourceserver, Client, Secret, Mapping
         """
         desc = None
         success = False
-               
+
         try:
             access_token = cls.get_access_token(str(param.get("Authserver")),
                                                 param.get("Client"),
@@ -243,7 +242,7 @@ class IdResolver (UserIdResolver):
             log.error("Failed to retrieve users: {0!s}".format(exx))
             log.debug("{0!s}".format(traceback.format_exc()))
             desc = "failed to retrieve users: {0!s}".format(exx)
-            
+
         return success, desc
 
     @staticmethod
@@ -264,7 +263,7 @@ class IdResolver (UserIdResolver):
         j_content = yaml.safe_load(resp.content)
 
         return j_content
-    
+
     @staticmethod
     def _get_user(resource_server, access_token, userid):
         """

--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -390,6 +390,8 @@ class IdResolver (UserIdResolver):
         :param search_dict: A dictionary with search parameters
         :type search_dict: dict
         :return: list of users, where each user is a dictionary
+        :raises ParameterError: when the search key does not exist in the
+          mapping or database
         """
         users = []
         conditions = []
@@ -398,7 +400,7 @@ class IdResolver (UserIdResolver):
         # Check if all the search keys are available in the mapping
         broken_keys = list(filter(lambda x: x not in self.map.keys(), search_dict.keys()))
         if broken_keys:
-            log.error(f"Could not find search key ({broken_keys})in "
+            log.error(f"Could not find search key ({broken_keys}) in "
                       f"the column mapping keys ({list(self.map.keys())}).")
             raise ParameterError(f"Search parameter ({broken_keys}) not available in mapping.")
         for key, value in search_dict.items():

--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -45,6 +45,8 @@ from privacyidea.lib.pooling import get_engine
 from privacyidea.lib.lifecycle import register_finalizer
 from privacyidea.lib.utils import (is_true, censor_connect_string,
                                    convert_column_to_unicode)
+from privacyidea.lib.error import ParameterError
+
 from passlib.context import CryptContext
 from passlib.utils import h64
 from passlib.utils.compat import uascii_to_str
@@ -383,21 +385,31 @@ class IdResolver (UserIdResolver):
 
         return user
 
-    def getUserList(self, searchDict=None):
+    def getUserList(self, search_dict=None):
         """
-        :param searchDict: A dictionary with search parameters
-        :type searchDict: dict
+        :param search_dict: A dictionary with search parameters
+        :type search_dict: dict
         :return: list of users, where each user is a dictionary
         """
         users = []
         conditions = []
-        if searchDict is None:
-            searchDict = {}
-        for key in searchDict.keys():
+        if search_dict is None:
+            search_dict = {}
+        # Check if all the search keys are available in the mapping
+        broken_keys = list(filter(lambda x: x not in self.map.keys(), search_dict.keys()))
+        if broken_keys:
+            log.error(f"Could not find search key ({broken_keys})in "
+                      f"the column mapping keys ({list(self.map.keys())}).")
+            raise ParameterError(f"Search parameter ({broken_keys}) not available in mapping.")
+        for key, value in search_dict.items():
             column = self.map.get(key)
-            value = searchDict.get(key)
             value = value.replace("*", "%")
-            conditions.append(self.TABLE.columns[column].like(value))
+            if column in self.TABLE.columns:
+                conditions.append(self.TABLE.columns[column].like(value))
+            else:
+                log.error(f"Mapped column ('{column}') is not available in the database "
+                          f"table '{self.table}' ({list(self.TABLE.columns.keys())}).")
+                raise ParameterError(f"Search parameter ({key}) not available in resolver.")
 
         conditions = self._append_where_filter(conditions, self.TABLE,
                                                self.where)
@@ -619,7 +631,7 @@ class IdResolver (UserIdResolver):
             desc = "Found {0:d} users.".format(num)
         except Exception as e:
             log.warning(f"Failed to retrieve users: {e!r}")
-            desc = f"Failed to retrieve users."
+            desc = "Failed to retrieve users."
         finally:
             # We do not want any leftover DB connection, so we first need to close
             # the session such that the DB connection gets returned to the pool (it

--- a/privacyidea/lib/resolvers/UserIdResolver.py
+++ b/privacyidea/lib/resolvers/UserIdResolver.py
@@ -153,21 +153,21 @@ class UserIdResolver(object):
         """
         return {}
 
-    def getUserList(self, searchDict=None):
+    def getUserList(self, search_dict=None):
         """
         This function finds the user objects,
         that have the term 'value' in the user object field 'key'
 
-        :param searchDict:  dict with key values of user attributes -
+        :param search_dict:  dict with key values of user attributes -
                     the key may be something like 'loginname' or 'email'
                     the value is a regular expression.
-        :type searchDict: dict
+        :type search_dict: dict
 
         :return: list of dictionaries (each dictionary contains a
                  user object) or an empty string if no object is found.
         :rtype: list of dicts
         """
-        searchDict = searchDict or {}
+        search_dict = search_dict or {}
         return [{}]
 
     def getResolverId(self):

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -762,7 +762,7 @@ def get_user_list(param=None, user=None, custom_attributes=False):
             # Continue if we couldn't find a resolver with the given name
             if not y:
                 continue
-            log.debug(f"With this search dictionary: {search_dict!r}")
+            log.debug("With this search dictionary: %r", search_dict)
             ulist = y.getUserList(search_dict)
             # Add resolvername to the list
             realm_id = get_realm_id(param_realm or user_realm)

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -379,7 +379,7 @@ class User(object):
         if phone_type in userinfo:
             phone = userinfo[phone_type]
             log.debug("got user phone {0!r} of type {1!r}".format(phone, phone_type))
-            if type(phone) == list and index is not None:
+            if isinstance(phone, list) and index is not None:
                 if len(phone) > index:
                     return phone[index]
                 else:
@@ -702,7 +702,7 @@ def get_user_list(param=None, user=None, custom_attributes=False):
     """
     users = []
     resolvers = []
-    searchDict = {"username": "*"}
+    search_dict = {"username": "*"}
     param = param or {}
 
     # we have to recreate a new searchdict without the realm key
@@ -711,16 +711,16 @@ def get_user_list(param=None, user=None, custom_attributes=False):
         lval = param[key]
         if key in ["realm", "resolver", "user", "username"]:
             continue
-        searchDict[key] = lval
+        search_dict[key] = lval
         log.debug("Parameter key:{0!r}={1!r}".format(key, lval))
 
     # update searchdict depending on existence of 'user' or 'username' in param
     # Since 'user' takes precedence over 'username' we have to check the order
     if 'username' in param:
-        searchDict['username'] = param['username']
+        search_dict['username'] = param['username']
     if 'user' in param:
-        searchDict['username'] = param['user']
-    log.debug('Changed search key to username: %s.', searchDict['username'])
+        search_dict['username'] = param['user']
+    log.debug('Changed search key to username: %s.', search_dict['username'])
 
     # determine which scope we want to show
     param_resolver = getParam(param, "resolver")
@@ -759,8 +759,11 @@ def get_user_list(param=None, user=None, custom_attributes=False):
         try:
             log.debug("Check for resolver class: {0!r}".format(resolver_name))
             y = get_resolver_object(resolver_name)
-            log.debug("with this search dictionary: {0!r} ".format(searchDict))
-            ulist = y.getUserList(searchDict)
+            # Continue if we couldn't find a resolver with the given name
+            if not y:
+                continue
+            log.debug(f"With this search dictionary: {search_dict!r}")
+            ulist = y.getUserList(search_dict)
             # Add resolvername to the list
             realm_id = get_realm_id(param_realm or user_realm)
             for ue in ulist:
@@ -779,8 +782,8 @@ def get_user_list(param=None, user=None, custom_attributes=False):
             log.debug("{0!s}".format(traceback.format_exc()))
             raise exx
 
-        except Exception as ex:  # pragma: no cover
-            log.error(f"Unable to get user list: {ex}")
+        except Exception as ex:
+            log.error(f"Unable to get user list for resolver '{resolver_name}': {ex}")
             log.debug("{0!s}".format(traceback.format_exc()))
             continue
 

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -226,7 +226,7 @@ class SQLResolverTestCase(MyTestCase):
         with LogCapture(level=logging.ERROR) as lc:
             self.assertRaises(ParameterError, y.getUserList, {"unknown": "parameter"})
             lc.check_present(("privacyidea.lib.resolvers.SQLIdResolver", "ERROR",
-                              f"Could not find search key (['unknown'])in the "
+                              f"Could not find search key (['unknown']) in the "
                               f"column mapping keys ({list(y.map.keys())})."))
 
         # Test a correct map entry with a missing column in the db

--- a/tests/test_lib_user.py
+++ b/tests/test_lib_user.py
@@ -572,6 +572,16 @@ class UserTestCase(MyTestCase):
                          "realm='sqlrealm', resolver='SQL1')",
                          user_repr, user_repr)
 
+        # Test with not existing search filter
+        with LogCapture(level=logging.ERROR) as lc:
+            userlist = get_user_list({"realm": "sqlrealm",
+                                      "unknown": "parameter",
+                                      "resolver": "SQL1"})
+            self.assertTrue(len(userlist) == 0, userlist)
+            lc.check_present(("privacyidea.lib.user", "ERROR",
+                              "Unable to get user list for resolver 'SQL1': ERR905: "
+                              "Search parameter (['unknown']) not available in mapping."))
+
     @ldap3mock.activate
     def test_18_user_with_several_phones(self):
         ldap3mock.setLDAPDirectory(LDAPDirectory_small)


### PR DESCRIPTION
When the column-to-keyword mapping in the SQLIdResolver is wrong, the search for a user results in a 500 error (The authentication flow is not affected by this!).
We check the given keywords if the exist in the mapping and if the requested columns do exist in the user table in the db. Currently this only results in an error message in the privacyIDEA log since there could be multiple resolvers to check.

Closes #4461