### PR TITLE
auth max fail

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+Version 3.12dev2, 2025-07-16
+
+  Fixes:
+  * 'max_auth_fail' and 'max_auth_success' are also applied to local admins and evaluated before checking the password (#4340)
+
 Version 3.12dev1, 2025-07-09
 
   Features:

--- a/Changelog
+++ b/Changelog
@@ -1,9 +1,9 @@
-Version 3.12dev2, 2025-07-16
+Version 3.12dev1, 2025-07-16
 
   Fixes:
   * 'max_auth_fail' and 'max_auth_success' are also applied to local admins and evaluated before checking the password (#4340)
 
-Version 3.12dev1, 2025-07-09
+Version 3.12dev0, 2025-07-09
 
   Features:
   * Entra ID and Keycloak resolver (#4217)

--- a/doc/policies/authorization.rst
+++ b/doc/policies/authorization.rst
@@ -217,6 +217,9 @@ invalidated.
 
 Allowed time specifiers are *s* (second), *m* (minute) and *h* (hour).
 
+This policy applies to ``/auth`` and ``/validate/check`` and holds for both admins and users. The policy is
+evaluated before checking the password or OTP value.
+
 .. note:: This policy depends on reading the audit log. If you use a
    non-readable audit log like :ref:`logger_audit` this policy will not
    work.
@@ -238,6 +241,9 @@ Specify the value like ``2/1m`` meaning 2 failed authentication requests per min
 failed authentications were performed the authentication request is discarded. The used OTP value is invalidated.
 
 Allowed time specifiers are *s* (second), *m* (minute) and *h* (hour).
+
+This policy applies to ``/auth`` and ``/validate/check`` and holds for both admins and users. The policy is
+evaluated before checking the password or OTP value.
 
 .. note:: This policy depends on reading the audit log. If you use a non-readable audit log like :ref:`logger_audit`
     this policy will not work.

--- a/doc/policies/authorization.rst
+++ b/doc/policies/authorization.rst
@@ -228,25 +228,19 @@ auth_max_fail
 
 type: ``string``
 
-Here you can specify how many failed authentication requests a user is
-allowed to perform during a given time.
+Here you can specify how many failed authentication requests a user is allowed to perform during a given time.
 
-If this value is exceeded, authentication is not possible anymore. The user
-will have to wait.
+If this value is exceeded, authentication is not possible anymore. The user will have to wait.
 
-If this policy is not defined, the normal behaviour of the failcounter
-applies. (see :term:`failcount`)
+If this policy is not defined, the normal behaviour of the failcounter applies. (see :term:`failcount`)
 
-Specify the value like ``2/1m`` meaning 2 successful authentication requests
-per minute. If during the last 5 minutes 2 successful authentications were
-performed the authentication request is discarded. The used OTP value is
-invalidated.
+Specify the value like ``2/1m`` meaning 2 failed authentication requests per minute. If during the last 5 minutes 2
+failed authentications were performed the authentication request is discarded. The used OTP value is invalidated.
 
 Allowed time specifiers are *s* (second), *m* (minute) and *h* (hour).
 
-.. note:: This policy depends on reading the audit log. If you use a
-   non-readable audit log like :ref:`logger_audit` this policy will not
-   work.
+.. note:: This policy depends on reading the audit log. If you use a non-readable audit log like :ref:`logger_audit`
+    this policy will not work.
 
 last_auth
 ~~~~~~~~~

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -69,7 +69,7 @@ from privacyidea.api.lib.postpolicy import (postpolicy, add_user_detail_to_respo
 from privacyidea.api.lib.prepolicy import (is_remote_user_allowed, prepolicy,
                                            pushtoken_disable_wait, webauthntoken_authz, webauthntoken_request,
                                            fido2_auth, increase_failcounter_on_challenge,
-                                           jwt_validity, disabled_token_types)
+                                           jwt_validity, disabled_token_types, auth_timelimit)
 from privacyidea.api.lib.utils import (send_result, get_all_params,
                                        verify_auth_token, getParam, get_optional, get_required)
 from privacyidea.lib.utils import get_client_ip, hexlify_and_unicode, to_unicode, get_plugin_info_from_useragent
@@ -129,6 +129,7 @@ def before_request():
 
 
 @jwtauth.route('', methods=['POST'])
+@prepolicy(auth_timelimit, request=request)
 @prepolicy(increase_failcounter_on_challenge, request=request)
 @prepolicy(pushtoken_disable_wait, request)
 @prepolicy(webauthntoken_request, request=request)

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -71,8 +71,10 @@ from privacyidea.lib import _
 from privacyidea.lib.container import find_container_by_serial, get_container_realms
 from privacyidea.lib.containers.container_info import CHALLENGE_TTL, REGISTRATION_TTL, SERVER_URL
 from privacyidea.lib.error import (PolicyError, RegistrationError,
-                                   TokenAdminError, ResourceNotFoundError)
+                                   TokenAdminError, ResourceNotFoundError, AuthError)
 from flask import g, current_app, Request
+
+from privacyidea.lib.policies.policy_helper import check_max_auth_fail, check_max_auth_success
 from privacyidea.lib.policy import SCOPE, ACTION, REMOTE_USER
 from privacyidea.lib.policy import Match, check_pin
 from privacyidea.lib.tokens.passkeytoken import PasskeyTokenClass
@@ -85,7 +87,7 @@ from privacyidea.lib.utils import (parse_timedelta, is_true,
                                    get_module_class,
                                    determine_logged_in_userparams, parse_string_to_dict)
 from privacyidea.lib.crypto import generate_password
-from privacyidea.lib.auth import ROLE
+from privacyidea.lib.auth import ROLE, get_db_admin
 from privacyidea.api.lib.utils import getParam, attestation_certificate_allowed, is_fqdn
 from privacyidea.api.lib.policyhelper import (get_init_tokenlabel_parameters,
                                               get_pushtoken_add_config,
@@ -94,7 +96,7 @@ from privacyidea.api.lib.policyhelper import (get_init_tokenlabel_parameters,
                                               UserAttributes,
                                               get_container_user_attributes)
 from privacyidea.lib.clientapplication import save_clientapplication
-from privacyidea.lib.config import (get_token_class)
+from privacyidea.lib.config import (get_token_class, get_superuser_realms)
 from privacyidea.lib.tokenclass import ROLLOUTSTATE
 from privacyidea.lib.tokens.certificatetoken import ACTION as CERTIFICATE_ACTION
 from privacyidea.lib.token import get_one_token
@@ -2310,7 +2312,7 @@ def webauthntoken_allowed(request, action):
         # TODO: trust_path can be a certificate chain. All certificates in the
         #  path should be considered
         attestation_cert = trust_path[0] if trust_path else None
-        allowed_certs_pols = Match\
+        allowed_certs_pols = Match \
             .user(g,
                   scope=SCOPE.ENROLL,
                   action=FIDO2PolicyAction.REQ,
@@ -2700,11 +2702,51 @@ def disabled_token_types(request, action):
     :return: True
     """
     disabled = Match.user(g, scope=SCOPE.AUTH, action=ACTION.DISABLED_TOKEN_TYPES,
-                             user_object=request.User if hasattr(request, 'User') else None).action_values(unique=False)
+                          user_object=request.User if hasattr(request, 'User') else None).action_values(unique=False)
 
     if disabled:
         request.all_data[ACTION.DISABLED_TOKEN_TYPES] = list(disabled)
     else:
         request.all_data[ACTION.DISABLED_TOKEN_TYPES] = []
+
+    return True
+
+
+def auth_timelimit(request, action):
+    """
+    This decorator retrieves the auth timelimit from the policies and adds it to the request data.
+    The auth timelimit is used to limit the time a user has to complete the authentication process.
+
+    :param request: The request object
+    :param action: The action parameter is not used in this decorator
+    :return: True
+    """
+    if not hasattr(request, 'User') or not request.User:
+        return False
+
+    user = request.User
+    # check if the user is an admin
+    admin_realms = get_superuser_realms()
+    local_admin = get_db_admin(user.login)
+    if local_admin:
+        # local admin
+        user = User(login=local_admin.username)
+        user_search_dict = {"user": user.login}
+    elif user.realm and user.realm.lower() in admin_realms:
+        # external admin
+        user_search_dict = {"administrator": user.login, "realm": user.realm}
+    else:
+        # normal user
+        user_search_dict = {"user": user.login, "realm": user.realm}
+
+    # Check policies
+    result, reply_dict = check_max_auth_fail(user, user_search_dict, check_validate_check=not local_admin)
+    if result:
+        if local_admin:
+            user_search_dict = {"administrator": local_admin.username}
+        result, reply_dict = check_max_auth_success(user, user_search_dict, check_validate_check=not local_admin)
+
+    if not result:
+        raise AuthError(_("Authentication failure. Account is temporary locked!"), details=reply_dict)
 
     return True

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -96,7 +96,7 @@ from privacyidea.api.lib.policyhelper import (get_init_tokenlabel_parameters,
                                               UserAttributes,
                                               get_container_user_attributes)
 from privacyidea.lib.clientapplication import save_clientapplication
-from privacyidea.lib.config import (get_token_class, get_superuser_realms)
+from privacyidea.lib.config import get_token_class
 from privacyidea.lib.tokenclass import ROLLOUTSTATE
 from privacyidea.lib.tokens.certificatetoken import ACTION as CERTIFICATE_ACTION
 from privacyidea.lib.token import get_one_token
@@ -2719,7 +2719,7 @@ def auth_timelimit(request, action):
 
     user = request.User
     # check if the user is an admin
-    admin_realms = get_superuser_realms()
+    admin_realms = [x.lower() for x in current_app.config.get("SUPERUSER_REALM", [])]
     local_admin = get_db_admin(user.login)
     if local_admin:
         # local admin

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -2740,6 +2740,6 @@ def auth_timelimit(request, action):
         result, reply_dict = check_max_auth_success(user, user_search_dict, check_validate_check=not local_admin)
 
     if not result:
-        raise AuthError(_("Authentication failure. Account is temporary locked!"), details=reply_dict)
+        raise AuthError(_("Authentication failure. The account has exceeded the authentication time limit!"), details=reply_dict)
 
     return True

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -2312,20 +2312,13 @@ def webauthntoken_allowed(request, action):
         # TODO: trust_path can be a certificate chain. All certificates in the
         #  path should be considered
         attestation_cert = trust_path[0] if trust_path else None
-        allowed_certs_pols = Match \
-            .user(g,
-                  scope=SCOPE.ENROLL,
-                  action=FIDO2PolicyAction.REQ,
-                  user_object=request.User if hasattr(request, 'User') else None) \
-            .action_values(unique=False)
+        allowed_certs_pols = Match.user(g, scope=SCOPE.ENROLL, action=FIDO2PolicyAction.REQ,
+                                        user_object=request.User if hasattr(request, 'User')
+                                        else None).action_values(unique=False)
 
-        allowed_aaguids_pols = Match \
-            .user(g,
-                  scope=SCOPE.ENROLL,
-                  action=FIDO2PolicyAction.AUTHENTICATOR_SELECTION_LIST,
-                  user_object=request.User if hasattr(request, 'User') else None) \
-            .action_values(unique=False,
-                           allow_white_space_in_action=True)
+        allowed_aaguids_pols = Match.user(g, scope=SCOPE.ENROLL, action=FIDO2PolicyAction.AUTHENTICATOR_SELECTION_LIST,
+                                          user_object=request.User if hasattr(request, 'User')
+                                          else None).action_values(unique=False, allow_white_space_in_action=True)
         allowed_aaguids = set(
             aaguid
             for allowed_aaguid_pol in allowed_aaguids_pols

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -239,9 +239,15 @@ class Audit(AuditBase):
                             column = to_isodate(column)
                         search_value = search_value.replace('*', '%')
                         if '%' in search_value:
-                            conditions.append(column.like(search_value))
+                            if search_value.startswith("!"):
+                                conditions.append(column.notlike(search_value[1:]))
+                            else:
+                                conditions.append(column.like(search_value))
                         else:
-                            conditions.append(column == search_value)
+                            if search_value.startswith("!"):
+                                conditions.append(column != search_value[1:])
+                            else:
+                                conditions.append(column == search_value)
                 except Exception as exx:
                     # The search_key was no search key but some
                     # bullshit stuff in the param

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -1141,11 +1141,3 @@ def get_multichallenge_enrollable_types() -> list[str]:
 
         this.config["pi_multichallenge_enrollable_types"] = enrollable_types
     return this.config["pi_multichallenge_enrollable_types"]
-
-
-def get_superuser_realms() -> list[str]:
-    """
-    Returns a list of all realms which are configured as superuser/admin realms. The names are in lowercase.
-    """
-    superuser_realms = [x.lower() for x in this.config.get("SUPERUSER_REALM", [])]
-    return superuser_realms

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -1141,3 +1141,11 @@ def get_multichallenge_enrollable_types() -> list[str]:
 
         this.config["pi_multichallenge_enrollable_types"] = enrollable_types
     return this.config["pi_multichallenge_enrollable_types"]
+
+
+def get_superuser_realms() -> list[str]:
+    """
+    Returns a list of all realms which are configured as superuser/admin realms. The names are in lowercase.
+    """
+    superuser_realms = [x.lower() for x in this.config.get("SUPERUSER_REALM", [])]
+    return superuser_realms

--- a/privacyidea/lib/policies/policy_helper.py
+++ b/privacyidea/lib/policies/policy_helper.py
@@ -26,6 +26,7 @@ from privacyidea.lib.utils import parse_timelimit, AUTH_RESPONSE
 
 log = logging.getLogger(__name__)
 
+
 def check_max_auth_fail(user: User, user_search_dict: dict, check_validate_check: bool = True):
     """
     Check if the maximum number of authentication failures is reached.
@@ -43,8 +44,9 @@ def check_max_auth_fail(user: User, user_search_dict: dict, check_validate_check
     fail_count = 0
     if check_validate_check:
         # Local admins can not authenticate at validate/check, no need to search the audit log for it
-        search_dict = {"action": "%/validate/check", "authentication": f"!{AUTH_RESPONSE.CHALLENGE}"}
-        search_dict.update(user_search_dict)
+        # at validate/check users and admins are not distinguished: always search for user
+        search_dict = {"action": "%/validate/check", "authentication": f"!{AUTH_RESPONSE.CHALLENGE}",
+                       "user": user.login, "realm": user_search_dict.get("realm", "%")}
         fail_count = g.audit_object.get_count(search_dict, success=False, timedelta=time_delta)
         log.debug(f"Checking users timelimit {list(max_fail_dict)[0]}: {fail_count} failed authentications with "
                   "/validate/check")

--- a/privacyidea/lib/policies/policy_helper.py
+++ b/privacyidea/lib/policies/policy_helper.py
@@ -1,0 +1,100 @@
+# (c) NetKnights GmbH 2025,  https://netknights.it
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: 2025 Jelina Unger <jelina.unger@netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import logging
+
+from flask import g
+
+from privacyidea.lib.policy import Match, SCOPE, ACTION
+from privacyidea.lib.user import User
+from privacyidea.lib.utils import parse_timelimit
+
+log = logging.getLogger(__name__)
+
+def check_max_auth_fail(user: User, user_search_dict: dict, check_validate_check: bool = True):
+    """
+    Check if the maximum number of authentication failures is reached.
+    This function is used to determine if the user should be blocked due to too many failed authentication attempts.
+    """
+    result = True
+    reply_dict = {}
+    max_fail_dict = Match.user(g, scope=SCOPE.AUTHZ, action=ACTION.AUTHMAXFAIL,
+                               user_object=user).action_values(unique=True, write_to_audit_log=False)
+
+    if len(max_fail_dict) != 1:
+        return result, reply_dict
+
+    policy_count, time_delta = parse_timelimit(list(max_fail_dict)[0])
+    fail_count = 0
+    if check_validate_check:
+        # Local admins can not authenticate at validate/check, no need to search the audit log for it
+        search_dict = {"action": "%/validate/check"}
+        search_dict.update(user_search_dict)
+        fail_count = g.audit_object.get_count(search_dict, success=False, timedelta=time_delta)
+        log.debug(f"Checking users timelimit {list(max_fail_dict)[0]}: {fail_count} failed authentications with "
+                  "/validate/check")
+    search_dict = {"action": "%/auth"}
+    search_dict.update(user_search_dict)
+    fail_auth_count = g.audit_object.get_count(search_dict, success=False, timedelta=time_delta)
+    log.debug(f"Checking users timelimit {list(max_fail_dict)[0]}: {fail_auth_count} failed authentications with "
+              "/auth")
+    fail_count += fail_auth_count
+    if fail_count >= policy_count:
+        result = False
+        reply_dict["message"] = f"Only {policy_count} failed authentications per {time_delta} allowed."
+        g.audit_object.add_policy(next(iter(max_fail_dict.values())))
+
+    return result, reply_dict
+
+
+def check_max_auth_success(user: User, user_search_dict: dict, check_validate_check: bool = True):
+    """
+    Check if the maximum number of successful authentication is reached.
+    This function is used to determine if the user should be blocked due to too many successful authentication attempts.
+    """
+    result = True
+    reply_dict = {}
+    # Get policies
+    max_success_dict = Match.user(g, scope=SCOPE.AUTHZ, action=ACTION.AUTHMAXSUCCESS,
+                                  user_object=user).action_values(unique=True, write_to_audit_log=False)
+
+    if len(max_success_dict) != 1:
+        return result, reply_dict
+
+    # Check for maximum successful authentications
+    policy_count, time_delta = parse_timelimit(list(max_success_dict)[0])
+    # Check the successful authentications for this user
+    success_count = 0
+    if check_validate_check:
+        search_dict = {"action": "%/validate/check"}
+        search_dict.update(user_search_dict)
+        success_count = g.audit_object.get_count(search_dict, success=True, timedelta=time_delta)
+        log.debug(f"Checking users timelimit {list(max_success_dict)[0]}: {success_count} successful "
+                  "authentications with /validate/check")
+    search_dict = {"action": "%/auth"}
+    search_dict.update(user_search_dict)
+    success_auth_count = g.audit_object.get_count(search_dict,
+                                                  success=True, timedelta=time_delta)
+    log.debug(f"Checking users timelimit {list(max_success_dict)[0]}: {success_auth_count} successful "
+              "authentications with /auth")
+    success_count += success_auth_count
+    if success_count >= policy_count:
+        result = False
+        reply_dict["message"] = f"Only {policy_count} successful authentications per {time_delta} allowed."
+
+    return result, reply_dict

--- a/privacyidea/lib/policies/policy_helper.py
+++ b/privacyidea/lib/policies/policy_helper.py
@@ -22,7 +22,7 @@ from flask import g
 
 from privacyidea.lib.policy import Match, SCOPE, ACTION
 from privacyidea.lib.user import User
-from privacyidea.lib.utils import parse_timelimit
+from privacyidea.lib.utils import parse_timelimit, AUTH_RESPONSE
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ def check_max_auth_fail(user: User, user_search_dict: dict, check_validate_check
     fail_count = 0
     if check_validate_check:
         # Local admins can not authenticate at validate/check, no need to search the audit log for it
-        search_dict = {"action": "%/validate/check"}
+        search_dict = {"action": "%/validate/check", "authentication": f"!{AUTH_RESPONSE.CHALLENGE}"}
         search_dict.update(user_search_dict)
         fail_count = g.audit_object.get_count(search_dict, success=False, timedelta=time_delta)
         log.debug(f"Checking users timelimit {list(max_fail_dict)[0]}: {fail_count} failed authentications with "

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -361,7 +361,7 @@ def auth_user_timelimit(wrapped_function, user, password, options=None):
         if result:
             result, reply_dict = check_max_auth_success(user, user_search_dict)
 
-    # Only execute wrapped function if auth is temporarily locked for the user
+    # Only execute wrapped function if auth is not temporarily locked for the user
     if result:
         result, reply_dict = wrapped_function(user, password, options)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -76,6 +76,15 @@ class MyTestCase(unittest.TestCase):
         # Create an admin for tests.
         create_db_admin(cls.testadmin, cls.testadminmail, cls.testadminpw)
 
+    def set_default_g_variables(self):
+        # Set values to g to avoid attribute errors in tests
+        self.app_context.g.policy_object = None
+        self.app_context.g.logged_in_user = {}
+        self.app_context.g.audit_object = None
+        self.app_context.g.client_ip = None
+        self.app_context.g.request_headers = None
+        self.app_context.g.serial = None
+
     def tearDown(self):
         # Rollback uncommitted changes to the DB and close the session to
         # avoid breaking following tests due to unfinished transactions

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -191,7 +191,7 @@ class APIAuthTestCase(MyApiTestCase):
         for _ in range(2):
             with self.app.test_request_context('/auth',
                                                method='POST',
-                                               data={"username": "selfservice",
+                                               data={"username": "selfservice@adminrealm",
                                                      "password": "wrong"}):
                 res = self.app.full_dispatch_request()
                 self.assertEqual(res.status_code, 401)
@@ -199,7 +199,7 @@ class APIAuthTestCase(MyApiTestCase):
         # We now cannot authenticate even with the correct PIN
         with self.app.test_request_context('/auth',
                                            method='POST',
-                                           data={"username": "selfservice",
+                                           data={"username": "selfservice@adminrealm",
                                                  "password": "test"}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 401)

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -159,6 +159,123 @@ class APIAuthTestCase(MyApiTestCase):
 
         delete_policy("realmadmin")
 
+    def test_04_auth_timelimit_maxfail(self):
+        # Test with local admin
+        set_policy(name="policy", scope=SCOPE.AUTHZ, action=f"{ACTION.AUTHMAXFAIL}=2/20s")
+        self.app_context.g.audit_object.clear()
+        for _ in range(2):
+            with self.app.test_request_context('/auth',
+                                               method='POST',
+                                               data={"username": self.testadmin,
+                                                     "password": "wrong"}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 401)
+
+        # We now cannot authenticate even with the correct PIN
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": self.testadmin,
+                                                 "password": self.testadminpw}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 401)
+            details = res.json.get("detail")
+            self.assertEqual(details.get("message"),
+                             "Only 2 failed authentications per 0:00:20 allowed.", details)
+
+        # Test with external admin
+        self.setUp_user_realms()
+        (added, failed) = set_realm("adminrealm",[{'name': self.resolvername1}])
+        self.assertTrue(len(failed) == 0)
+        self.assertTrue(len(added) == 1)
+
+        for _ in range(2):
+            with self.app.test_request_context('/auth',
+                                               method='POST',
+                                               data={"username": "selfservice",
+                                                     "password": "wrong"}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 401)
+
+        # We now cannot authenticate even with the correct PIN
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": "selfservice",
+                                                 "password": "test"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 401)
+            details = res.json.get("detail")
+            self.assertEqual(details.get("message"),
+                             "Only 2 failed authentications per 0:00:20 allowed.", details)
+
+        delete_policy("policy")
+        delete_realm("adminrealm")
+
+    def test_05_auth_timelimit_maxsuccess(self):
+        set_policy(name="policy", scope=SCOPE.AUTHZ, action=f"{ACTION.AUTHMAXSUCCESS}=2/20s")
+        self.app_context.g.audit_object.clear()
+        for _ in range(2):
+            with self.app.test_request_context('/auth',
+                                               method='POST',
+                                               data={"username": self.testadmin,
+                                                     "password": self.testadminpw}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 200)
+
+        # We now cannot authenticate even with the correct PIN
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": self.testadmin,
+                                                 "password": self.testadminpw}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 401)
+            details = res.json.get("detail")
+            self.assertEqual(details.get("message"),
+                             "Only 2 successful authentications per 0:00:20 allowed.", details)
+
+        # ... and not with the wrong PIN
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": self.testadmin,
+                                                 "password": "wrong"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 401)
+
+        # Test with external admin
+        self.setUp_user_realms()
+        (added, failed) = set_realm("adminrealm", [{'name': self.resolvername1}])
+        self.assertTrue(len(failed) == 0)
+        self.assertTrue(len(added) == 1)
+
+        for _ in range(2):
+            with self.app.test_request_context('/auth',
+                                               method='POST',
+                                               data={"username": "selfservice",
+                                                     "password": "test"}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 200)
+
+        # We now cannot authenticate even with the correct PIN
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": "selfservice",
+                                                 "password": "test"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 401)
+            details = res.json.get("detail")
+            self.assertEqual(details.get("message"),
+                             "Only 2 successful authentications per 0:00:20 allowed.", details)
+
+        # ... and not with the wrong PIN
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": "selfservice",
+                                                 "password": "wrong"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 401)
+
+        delete_policy("policy")
+        delete_realm("adminrealm")
+
 
 class APIAuthChallengeResponse(MyApiTestCase):
 
@@ -1055,7 +1172,7 @@ class APISelfserviceTestCase(MyApiTestCase):
 
         delete_policy("webui5")
 
-    def test_42_auth_timelimit_maxfail(self):
+    def test_42_auth_timelimit_maxfail_auth(self):
         self.setUp_user_realm2()
         # check that AUTHMAXFAIL also takes effect for /auth with loginmode=privacyIDEA
         user = User("timelimituser", realm=self.realm2)
@@ -1103,6 +1220,7 @@ class APISelfserviceTestCase(MyApiTestCase):
 
         delete_policy("pol_time1")
         delete_policy("pol_loginmode")
+        token.delete_token()
 
     def test_43_auth_timelimit_maxsuccess(self):
         self.setUp_user_realm2()
@@ -1151,6 +1269,137 @@ class APISelfserviceTestCase(MyApiTestCase):
         with self.app.test_request_context('/validate/check',
                                            method='POST',
                                            data={"user": "timelimituser@" + self.realm2,
+                                                 "pass": pin}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            result = res.json.get("result")
+            self.assertTrue(result["status"], result)
+            self.assertFalse(result["value"], result)
+
+        delete_policy("pol_time1")
+        delete_policy("pol_loginmode")
+        token.delete_token()
+
+    def test_44_auth_timelimit_maxfail_challenge_response(self):
+        # check with challenge response token
+        self.setUp_user_realm2()
+        user = User("timelimituser", realm=self.realm2)
+        pin = "spass"
+        # create a token
+        token = init_token({"type": "hotp", "genkey": True, "pin": pin}, user=user)
+        set_policy(name="policy", scope=SCOPE.AUTHZ, action=f"{ACTION.AUTHMAXFAIL}=2/20s")
+        set_policy(name="challenge_response", scope=SCOPE.AUTH, action=f"{ACTION.CHALLENGERESPONSE}=hotp")
+        self.app_context.g.audit_object.clear()
+
+        # only triggering challenges should not count for the policy
+        for _ in range(2):
+            with self.app.test_request_context('/validate/check',
+                                               method='POST',
+                                               data={"user": "timelimituser@" + self.realm2,
+                                                     "pass": pin}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 200)
+                result = res.json.get("result")
+                self.assertTrue(result["status"], result)
+                self.assertFalse(result["value"], result)
+                self.assertEqual(result.get("authentication"), "CHALLENGE")
+                detail = res.json.get("detail")
+                transaction_id = detail.get("transaction_id")
+
+        # Answering the last challenge should work
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "timelimituser@" + self.realm2,
+                                                 "pass": token.get_otp()[2],
+                                                 "transaction_id": transaction_id}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            result = res.json.get("result")
+            self.assertTrue(result["status"], result)
+            self.assertTrue(result["value"], result)
+
+        # Trigger new challenge
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "timelimituser@" + self.realm2,
+                                                 "pass": pin}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            result = res.json.get("result")
+            self.assertTrue(result["status"], result)
+            self.assertFalse(result["value"], result)
+            self.assertEqual(result.get("authentication"), "CHALLENGE")
+            detail = res.json.get("detail")
+            transaction_id = detail.get("transaction_id")
+
+        # Sending wrong OTP values will block the authentication
+        for i in range(2):
+            with self.app.test_request_context('/validate/check',
+                                               method='POST',
+                                               data={"user": "timelimituser@" + self.realm2,
+                                                     "pass": "123",
+                                                     "transaction_id": transaction_id}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 200)
+                result = res.json.get("result")
+                self.assertTrue(result["status"], result)
+                self.assertFalse(result["value"], result)
+                message = res.json.get("detail").get("message")
+                self.assertEqual("Response did not match the challenge.", message)
+
+        # Now sending correct OTP value also fails
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "timelimituser@" + self.realm2,
+                                                 "pass": token.get_otp()[2],
+                                                 "transaction_id": transaction_id}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200)
+            result = res.json.get("result")
+            self.assertTrue(result["status"], result)
+            self.assertFalse(result["value"], result)
+            message = res.json.get("detail").get("message")
+            self.assertEqual("Only 2 failed authentications per 0:00:20 allowed.", message)
+
+        delete_policy("policy")
+        delete_policy("challenge_response")
+
+    def test_45_auth_timelimit_maxfail_non_existing_user(self):
+        # Test that the policy also works for non-existing users
+        self.setUp_user_realm2()
+        pin = "spass"
+
+        set_policy(name="pol_time1",
+                   scope=SCOPE.AUTHZ,
+                   action="{0!s}=2/20s".format(ACTION.AUTHMAXFAIL))
+        set_policy(name="pol_loginmode",
+                   scope=SCOPE.WEBUI,
+                   action="{}={}".format(ACTION.LOGINMODE, LOGINMODE.PRIVACYIDEA))
+        for _ in range(2):
+            with self.app.test_request_context('/auth',
+                                               method='POST',
+                                               data={"username": "eve",
+                                                     "password": "wrong"}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 401)
+
+        # We now cannot authenticate even with the correct PIN
+        with self.app.test_request_context('/auth',
+                                           method='POST',
+                                           data={"username": "eve",
+                                                 "password": pin}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 401)
+            details = res.json.get("detail")
+            self.assertEqual(details.get("message"),
+                             "Only 2 failed authentications per 0:00:20 allowed.",
+                             details)
+
+        # and even /validate/check does not work
+        # (since it counts /auth *and* /validate/check )
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "eve",
                                                  "pass": pin}):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -1086,7 +1086,7 @@ class APISelfserviceTestCase(MyApiTestCase):
             self.assertEqual(res.status_code, 401)
             details = res.json.get("detail")
             self.assertEqual(details.get("message"),
-                             "Only 2 failed authentications per 0:00:20",
+                             "Only 2 failed authentications per 0:00:20 allowed.",
                              details)
 
         # and even /validate/check does not work
@@ -1135,7 +1135,7 @@ class APISelfserviceTestCase(MyApiTestCase):
             self.assertEqual(res.status_code, 401)
             details = res.json.get("detail")
             self.assertEqual(details.get("message"),
-                             "Only 2 successful authentications per 0:00:20",
+                             "Only 2 successful authentications per 0:00:20 allowed.",
                              details)
 
         # ... and not with the wrong PIN

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1848,7 +1848,7 @@ class ValidateAPITestCase(MyApiTestCase):
             self.assertEqual(result.get("value"), False)
             details = res.json.get("detail")
             self.assertEqual(details.get("message"),
-                             "Only 2 failed authentications per 0:00:20")
+                             "Only 2 failed authentications per 0:00:20 allowed.")
 
         delete_policy("pol_time1")
         remove_token(token.token.serial)

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -165,6 +165,11 @@ class AuditTestCase(MyTestCase):
                                      success=False)
             self.assertEqual(r, 2)
 
+            # get failed authentication
+            r = self.Audit.get_count({"action": "/validate/check", "authentication": "!CHAL%"},
+                                     success=False)
+            self.assertEqual(r, 2)
+
             # get one authentication during the last second
             r = self.Audit.get_count({"action": "/validate/check"}, success=True,
                                      timedelta=datetime.timedelta(seconds=1))

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -14,6 +14,7 @@ from privacyidea.lib.audit import getAudit, search
 from privacyidea.lib.auditmodules.containeraudit import Audit as ContainerAudit
 from privacyidea.lib.auditmodules.loggeraudit import Audit as LoggerAudit
 from privacyidea.lib.auditmodules.sqlaudit import column_length
+from privacyidea.lib.utils import AUTH_RESPONSE
 from .base import MyTestCase, OverrideConfigTestCase
 from testfixtures import log_capture
 
@@ -117,7 +118,15 @@ class AuditTestCase(MyTestCase):
                         "success": True})
         self.Audit.finalize_log()
 
-        self.Audit.log({"action": "/validate/check",
+        self.Audit.log({"action": "/validate/check", "authentication": AUTH_RESPONSE.REJECT,
+                        "success": False})
+        self.Audit.finalize_log()
+
+        self.Audit.log({"action": "/validate/check", "authentication": AUTH_RESPONSE.DECLINED,
+                        "success": False})
+        self.Audit.finalize_log()
+
+        self.Audit.log({"action": "/validate/check", "authentication": AUTH_RESPONSE.CHALLENGE,
                         "success": False})
         self.Audit.finalize_log()
 
@@ -140,11 +149,21 @@ class AuditTestCase(MyTestCase):
 
             # get 4 authentications
             r = self.Audit.get_count({"action": "/validate/check"})
-            self.assertEqual(r, 4)
+            self.assertEqual(r, 6)
 
             # get one failed authentication
             r = self.Audit.get_count({"action": "/validate/check"}, success=False)
+            self.assertEqual(r, 3)
+
+            # get one challenge authentication
+            r = self.Audit.get_count({"action": "/validate/check", "authentication": AUTH_RESPONSE.CHALLENGE},
+                                     success=False)
             self.assertEqual(r, 1)
+
+            # get failed authentication
+            r = self.Audit.get_count({"action": "/validate/check", "authentication": f"!{AUTH_RESPONSE.CHALLENGE}"},
+                                     success=False)
+            self.assertEqual(r, 2)
 
             # get one authentication during the last second
             r = self.Audit.get_count({"action": "/validate/check"}, success=True,

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -243,10 +243,10 @@ class LibPolicyTestCase(MyTestCase):
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
                    action=ACTION.PASSTHRU)
-        g = FakeFlaskG()
-        g.policy_object = PolicyClass()
-        g.audit_object = FakeAudit()
-        options = {"g": g}
+        self.set_default_g_variables()
+        self.app_context.g.policy_object = PolicyClass()
+        self.app_context.g.audit_object = FakeAudit()
+        options = {"g": self.app_context.g}
         rv = auth_user_passthru(check_user_pass, user, passw,
                                 options=options)
         self.assertTrue(rv[0])
@@ -257,10 +257,10 @@ class LibPolicyTestCase(MyTestCase):
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
                    action="{0!s}=userstore".format(ACTION.PASSTHRU))
-        g = FakeFlaskG()
-        g.policy_object = PolicyClass()
-        g.audit_object = FakeAudit()
-        options = {"g": g}
+        self.set_default_g_variables()
+        self.app_context.g.policy_object = PolicyClass()
+        self.app_context.g.audit_object = FakeAudit()
+        options = {"g": self.app_context.g}
         rv = auth_user_passthru(check_user_pass, user, passw, options=options)
         self.assertTrue(rv[0])
         self.assertEqual(rv[1].get("message"), "against userstore due to 'pol1'")
@@ -273,10 +273,10 @@ class LibPolicyTestCase(MyTestCase):
         r = add_radius("radiusconfig1", "1.2.3.4", "testing123", dictionary=DICT_FILE)
         self.assertTrue(r > 0)
 
-        g = FakeFlaskG()
-        g.policy_object = PolicyClass()
-        g.audit_object = FakeAudit()
-        options = {"g": g}
+        self.set_default_g_variables()
+        self.app_context.g.policy_object = PolicyClass()
+        self.app_context.g.audit_object = FakeAudit()
+        options = {"g": self.app_context.g}
         rv = auth_user_passthru(check_user_pass, user, passw, options=options)
         self.assertTrue(rv[0])
         self.assertEqual(rv[1].get("message"),
@@ -288,13 +288,13 @@ class LibPolicyTestCase(MyTestCase):
         init_token({"serial": "PTHRU",
                     "type": "spass", "pin": "Hallo"},
                    user=user)
-        rv = auth_user_passthru(check_user_pass, user, passw,
-                                options=options)
+        rv = auth_user_passthru(check_user_pass, user, passw, options=options)
         self.assertFalse(rv[0])
         self.assertEqual(rv[1].get("message"), "wrong otp pin")
 
         remove_token("PTHRU")
         delete_policy("pol1")
+        self.set_default_g_variables()
 
     def test_07_login_mode(self):
         # a realm: cornelius@r1: PW: test

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -28,6 +28,7 @@ from privacyidea.lib.resolver import save_resolver, delete_resolver
 from privacyidea.lib.token import (init_token, remove_token, check_user_pass,
                                    get_tokens)
 from privacyidea.lib.user import User
+from privacyidea.lib.utils import AUTH_RESPONSE
 from privacyidea.models import AuthCache
 from . import radiusmock
 from .base import MyTestCase, FakeFlaskG, FakeAudit
@@ -984,6 +985,8 @@ class LibPolicyTestCase(MyTestCase):
                                                  "user": user.login,
                                                  "realm": user.realm,
                                                  "resolver": user.resolver})
+            if endpoint == "/validate/check":
+                self.app_context.g.audit_object.log({"authentication": AUTH_RESPONSE.REJECT})
             self.app_context.g.audit_object.finalize_log()
 
         # Number of failed audits reached
@@ -1044,6 +1047,8 @@ class LibPolicyTestCase(MyTestCase):
                                                  "user": user.login,
                                                  "realm": user.realm,
                                                  "resolver": user.resolver})
+            if endpoint == "/validate/check":
+                self.app_context.g.audit_object.log({"authentication": AUTH_RESPONSE.REJECT})
             self.app_context.g.audit_object.finalize_log()
         # Policy for failed authentications is checked first
         success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, pin, options=options)

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 
 from flask import g
 
+from privacyidea.lib.audit import getAudit
 from privacyidea.lib.authcache import delete_from_cache, _hash_password
 from privacyidea.lib.error import UserError, PolicyError
 from privacyidea.lib.policy import (set_policy, delete_policy,
@@ -20,7 +21,7 @@ from privacyidea.lib.policydecorators import (auth_otppin,
                                               auth_user_has_no_token,
                                               login_mode, config_lost_token,
                                               auth_cache,
-                                              auth_lastauth, reset_all_user_tokens)
+                                              auth_lastauth, reset_all_user_tokens, auth_user_timelimit)
 from privacyidea.lib.radiusserver import add_radius
 from privacyidea.lib.realm import set_realm, delete_realm
 from privacyidea.lib.resolver import save_resolver, delete_resolver
@@ -675,10 +676,10 @@ class LibPolicyTestCase(MyTestCase):
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
                    action="{0!s}=userstore".format(ACTION.PASSTHRU))
-        g = FakeFlaskG()
-        g.policy_object = PolicyClass()
-        g.audit_object = FakeAudit()
-        options = {"g": g}
+        self.set_default_g_variables()
+        self.app_context.g.policy_object = PolicyClass()
+        self.app_context.g.audit_object = FakeAudit()
+        options = {"g": self.app_context.g}
         rv = auth_user_passthru(check_user_pass, user, passw,
                                 options=options)
         self.assertTrue(rv[0])
@@ -693,10 +694,10 @@ class LibPolicyTestCase(MyTestCase):
         r = add_radius("radiusconfig1", "1.2.3.4", "testing123",
                        dictionary=DICT_FILE)
         self.assertTrue(r > 0)
-        g = FakeFlaskG()
-        g.policy_object = PolicyClass()
-        g.audit_object = FakeAudit()
-        options = {"g": g}
+        self.set_default_g_variables()
+        self.app_context.g.policy_object = PolicyClass()
+        self.app_context.g.audit_object = FakeAudit()
+        options = {"g": self.app_context.g}
 
         # They will conflict, because they use the same priority
         with self.assertRaises(PolicyError):
@@ -738,9 +739,7 @@ class LibPolicyTestCase(MyTestCase):
         # Now assign a token to the user. If the user has a token and the
         # passthru policy is set, the user must not be able to authenticate
         # with his userstore password.
-        init_token({"serial": "PTHRU",
-                    "type": "spass", "pin": "Hallo"},
-                   user=user)
+        init_token({"serial": "PTHRU", "type": "spass", "pin": "Hallo"}, user=user)
         rv = auth_user_passthru(check_user_pass, user, passw,
                                 options=options)
         self.assertFalse(rv[0])
@@ -749,6 +748,7 @@ class LibPolicyTestCase(MyTestCase):
         remove_token("PTHRU")
         delete_policy("pol1")
         delete_policy("pol2")
+        self.set_default_g_variables()
 
     def test_14_otppin_priority(self):
         my_user = User("cornelius", realm="r1")
@@ -953,3 +953,108 @@ class LibPolicyTestCase(MyTestCase):
         delete_policy("hotp_cr")
         user.delete()
         remove_token(token.token.serial)
+
+    def test_18_auth_user_timelimit_max_fail(self):
+        self.setUp_user_realm2()
+        user = User("timelimituser", realm=self.realm2)
+        pin = "spass"
+
+        set_policy(name="policy", scope=SCOPE.AUTHZ, action=f"{ACTION.AUTHMAXFAIL}=2/20s")
+
+        def mock_check_user_pass(user_obj, password, options=None):
+            if password == pin:
+                return True, {}
+            return False, {"message": "wrong otp pin"}
+
+        self.set_default_g_variables()
+        self.app_context.g.policy_object = PolicyClass()
+        self.app_context.g.audit_object = getAudit(self.app.config)
+        options = {"g": self.app_context.g}
+
+        # No failed audit entries: should authenticate
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, pin, options=options)
+        self.assertTrue(success)
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, "wrong", options=options)
+        self.assertFalse(success)
+
+        # Write failed authentication entries to audit log
+        for endpoint in ["/auth", "/validate/check"]:
+            self.app_context.g.audit_object.log({"success": False,
+                                                 "action": f"POST {endpoint}",
+                                                 "user": user.login,
+                                                 "realm": user.realm,
+                                                 "resolver": user.resolver})
+            self.app_context.g.audit_object.finalize_log()
+
+        # Number of failed audits reached
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, pin, options=options)
+        self.assertFalse(success)
+        self.assertEqual("Only 2 failed authentications per 0:00:20 allowed.", reply_dict.get("message"))
+
+        # Deleting policy: authentication allowed
+        delete_policy("policy")
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, pin, options=options)
+        self.assertTrue(success)
+
+        self.app_context.g.audit_object.clear()
+        self.set_default_g_variables()
+
+    def test_19_auth_user_timelimit_max_success(self):
+        self.setUp_user_realm2()
+        user = User("timelimituser", realm=self.realm2)
+        pin = "spass"
+
+        set_policy(name="policy", scope=SCOPE.AUTHZ, action=f"{ACTION.AUTHMAXSUCCESS}=2/20s")
+
+        def mock_check_user_pass(user_obj, password, options=None):
+            if password == pin:
+                return True, {}
+            return False, {"message": "wrong otp pin"}
+
+        self.set_default_g_variables()
+        self.app_context.g.policy_object = PolicyClass()
+        self.app_context.g.audit_object = getAudit(self.app.config)
+        options = {"g": self.app_context.g}
+
+        # No success audit entries: should authenticate
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, pin, options=options)
+        self.assertTrue(success)
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, "wrong", options=options)
+        self.assertFalse(success)
+
+        # Write success authentication entries to audit log
+        for endpoint in ["/auth", "/validate/check"]:
+            self.app_context.g.audit_object.log({"success": True,
+                                                 "action": f"POST {endpoint}",
+                                                 "user": user.login,
+                                                 "realm": user.realm,
+                                                 "resolver": user.resolver})
+            self.app_context.g.audit_object.finalize_log()
+
+        # Number of successful audits reached
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, pin, options=options)
+        self.assertFalse(success)
+        self.assertEqual("Only 2 successful authentications per 0:00:20 allowed.", reply_dict.get("message"))
+
+        # Write failed authentication entries to audit log
+        set_policy(name="policy_failed", scope=SCOPE.AUTHZ, action=f"{ACTION.AUTHMAXFAIL}=2/20s")
+        for endpoint in ["/auth", "/validate/check"]:
+            self.app_context.g.audit_object.log({"success": False,
+                                                 "action": f"POST {endpoint}",
+                                                 "user": user.login,
+                                                 "realm": user.realm,
+                                                 "resolver": user.resolver})
+            self.app_context.g.audit_object.finalize_log()
+        # Policy for failed authentications is checked first
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, pin, options=options)
+        self.assertFalse(success)
+        self.assertEqual("Only 2 failed authentications per 0:00:20 allowed.", reply_dict.get("message"))
+
+        # Deleting policy: authentication allowed
+        delete_policy("policy")
+        delete_policy("policy_failed")
+        success, reply_dict = auth_user_timelimit(mock_check_user_pass, user, pin, options=options)
+        self.assertTrue(success)
+
+        self.app_context.g.audit_object.clear()
+        self.set_default_g_variables()

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -2380,10 +2380,10 @@ class TestMultipleUserToken(MyTestCase):
         # To test whether the password caching works, we need to set the otppin policy to userstore
         set_policy("otppin", scope=SCOPE.AUTH, action=f"{ACTION.OTPPIN}=userstore")
 
-        g = FakeFlaskG()
-        g.policy_object = PolicyClass()
-        g.audit_object = FakeAudit()
-        options = {"g": g}
+        self.set_default_g_variables()
+        self.app_context.g.policy_object = PolicyClass()
+        self.app_context.g.audit_object = FakeAudit()
+        options = {"g": self.app_context.g}
 
         logging.getLogger('privacyidea.lib.user').setLevel(logging.DEBUG)
 
@@ -2594,3 +2594,4 @@ class TestMultipleUserToken(MyTestCase):
         delete_policy("force_chalresp")
         remove_token("s1")
         remove_token("s2")
+        self.set_default_g_variables()


### PR DESCRIPTION
* apply `auth_max_fail` and `auth_max_success` also to the `/auth` endpoint
* change to prepolicy 
* Extend audit filter to also filter for non equal values 
* exclude challenge requests from failed auth count