### PR TITLE
force server generate

### DIFF
--- a/doc/policies/admin.rst
+++ b/doc/policies/admin.rst
@@ -846,6 +846,19 @@ Possible values are *6* or *8*, default is *6*.
 
 .. versionadded:: 3.2
 
+.. _admin_policy_force-server-generate:
+
+hotp-, totp-, daypassword-, applspec- and motp_force_server_generate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+type: ``bool``
+
+Enforce the key generation on the server. Even if an otp key is passed, the server will generate a new key.
+
+In the web UI, a corresponding input field for the key is disabled/hidden.
+
+Default value is *false*.
+
 totp_timestep
 ~~~~~~~~~~~~~
 

--- a/doc/policies/user.rst
+++ b/doc/policies/user.rst
@@ -332,14 +332,15 @@ Possible values are *6* or *8*, default is *6*.
 .. _hotp-force-server-generate:
 .. _totp-force-server-generate:
 
-hotp_force_server_generate and totp_force_server_generate
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+hotp-, totp-, daypassword-, applspec- and motp_force_server_generate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 type: ``bool``
 
-Enforce the key generation on the server.
-A corresponding input field for the key data will be disabled/hidden
-in the web UI.
+Enforce the key generation on the server. Even if an otp key is passed, the server will generate a new key.
+
+In the web UI, a corresponding input field for the key is disabled/hidden.
+
 Default value is *false*.
 
 .. _totp-timestep:

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -325,6 +325,7 @@ def get_before_request_config():
     g.client_ip = get_client_ip(request, get_from_config(SYSCONF.OVERRIDECLIENT))
     # Save the HTTP header in the localproxy object
     g.request_headers = request.headers
+    g.policies = {}
 
 
 def before_request():

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1605,7 +1605,7 @@ def check_token_init(request=None, action=None):
     return True
 
 
-def force_server_generate_key(request=None, action=None):
+def force_server_generate_key(request: Request, action=None):
     """
     Checks if for the given token type a policy to force the server to generate the key is set.
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1617,8 +1617,7 @@ def force_server_generate_key(request: Request, action=None):
     tokentype = params.get("type", "HOTP")
     action = f"{tokentype.lower()}_{ACTION.FORCE_SERVER_GENERATE}"
     force_genkey = Match.admin_or_user(g, action=action, user_obj=request.User).allowed()
-    if force_genkey:
-        g.policies[action] = True
+    g.policies[action] = force_genkey
 
     return True
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -1605,6 +1605,24 @@ def check_token_init(request=None, action=None):
     return True
 
 
+def force_server_generate_key(request=None, action=None):
+    """
+    Checks if for the given token type a policy to force the server to generate the key is set.
+
+    :param request:
+    :param action:
+    :return: True
+    """
+    params = request.all_data
+    tokentype = params.get("type", "HOTP")
+    action = f"{tokentype.lower()}_{ACTION.FORCE_SERVER_GENERATE}"
+    force_genkey = Match.admin_or_user(g, action=action, user_obj=request.User).allowed()
+    if force_genkey:
+        g.policies[action] = True
+
+    return True
+
+
 def check_external(request=None, action="init"):
     """
     This decorator is a hook to an external check function, that is called
@@ -2740,6 +2758,7 @@ def auth_timelimit(request, action):
         result, reply_dict = check_max_auth_success(user, user_search_dict, check_validate_check=not local_admin)
 
     if not result:
-        raise AuthError(_("Authentication failure. The account has exceeded the authentication time limit!"), details=reply_dict)
+        raise AuthError(_("Authentication failure. The account has exceeded the authentication time limit!"),
+                        details=reply_dict)
 
     return True

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -105,7 +105,8 @@ from privacyidea.api.lib.prepolicy import (prepolicy, check_base_action, check_t
                                            webauthntoken_request, required_piv_attestation,
                                            hide_tokeninfo, init_ca_connector, init_ca_template,
                                            init_subject_components, require_description,
-                                           check_container_action, check_user_params, check_token_list_action)
+                                           check_container_action, check_user_params, check_token_list_action,
+                                           force_server_generate_key)
 from privacyidea.api.lib.postpolicy import (save_pin_change, check_verify_enrollment,
                                             postpolicy)
 from privacyidea.lib.event import event
@@ -158,6 +159,7 @@ To see how to authenticate read :ref:`rest_auth`.
 @prepolicy(fido2_enroll, request)
 @prepolicy(required_piv_attestation, request)
 @prepolicy(verify_enrollment, request)
+@prepolicy(force_server_generate_key, request)
 @postpolicy(save_pin_change, request)
 @event("token_init", request, g)
 @postpolicy(check_verify_enrollment, request)
@@ -296,7 +298,8 @@ def init():
     authentication.
     """
     response_details = {}
-    param = request.all_data
+    param = request.all_data.copy()
+    param.update(g.get("policies", {}))
 
     user = request.User
     token = init_token(param, user)

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -300,7 +300,7 @@ def init():
     """
     response_details = {}
     param = request.all_data.copy()
-    param.update(g.get("policies", {}))
+    param["policies"] = g.get("policies", {})
 
     user = request.User
     token = init_token(param, user)

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -451,6 +451,7 @@ class ACTION(object):
     CLIENT_MODE_PER_USER = "client_mode_per_user"
     HIDE_CONTAINER_INFO = "hide_container_info"
     DISABLED_TOKEN_TYPES = "disabled_token_types"
+    FORCE_SERVER_GENERATE = "force_server_generate"
 
 
 class TYPE(object):

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -611,7 +611,7 @@ class TokenClass(object):
             raise ParameterError('[ParameterError] You may either specify '
                                  'genkey or otpkey, but not both!', id=344)
 
-        if otpKey is None and genkey:
+        if otpKey is None and genkey and not verify:
             otpKey = self._genOtpKey_(key_size)
 
         # otpKey still None?? - raise the exception, if an otpkey is required, and we are not in verify state

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -84,6 +84,7 @@ from datetime import datetime, timedelta, timezone
 
 from dateutil.parser import parse as parse_date_string, ParserError
 from dateutil.tz import tzlocal, tzutc
+from flask_babel import lazy_gettext
 
 from privacyidea.lib import _
 from privacyidea.lib.crypto import (encryptPassword, decryptPassword,
@@ -165,6 +166,8 @@ class TokenClass(object):
     client_mode = CLIENTMODE.INTERACTIVE
     # If the token provides means that the user has to prove/verify that the token was successfully enrolled.
     can_verify_enrollment = False
+
+    desc_key_gen = lazy_gettext("Force the key to be generated on the server.")
 
     @log_with(log)
     def __init__(self, db_token):

--- a/privacyidea/lib/tokens/applicationspecificpasswordtoken.py
+++ b/privacyidea/lib/tokens/applicationspecificpasswordtoken.py
@@ -79,6 +79,14 @@ class ApplicationSpecificPasswordTokenClass(PasswordTokenClass):
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
                'policy': {
+                   SCOPE.ADMIN: {
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
+                                                      'desc': ApplicationSpecificPasswordTokenClass.desc_key_gen}
+                   },
+                   SCOPE.USER: {
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
+                                                      'desc': ApplicationSpecificPasswordTokenClass.desc_key_gen}
+                   },
                    SCOPE.ENROLL: {
                        ACTION.MAXTOKENUSER: {
                            'type': 'int',

--- a/privacyidea/lib/tokens/daypasswordtoken.py
+++ b/privacyidea/lib/tokens/daypasswordtoken.py
@@ -97,8 +97,8 @@ class DayPasswordTokenClass(TotpTokenClass):
                        'otplen': {'type': 'int',
                                   'value': [6, 8],
                                   'desc': DayPasswordTokenClass.desc_otp_len},
-                       'force_server_generate': {'type': 'bool',
-                                                 'desc': DayPasswordTokenClass.desc_key_gen}
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
+                                                      'desc': DayPasswordTokenClass.desc_key_gen}
                    },
                    SCOPE.ADMIN: {
                        'timestep': {'type': 'str',
@@ -111,8 +111,8 @@ class DayPasswordTokenClass(TotpTokenClass):
                        'otplen': {'type': 'int',
                                   'value': [6, 8],
                                   'desc': DayPasswordTokenClass.desc_otp_len},
-                       'force_server_generate': {'type': 'bool',
-                                                 'desc': DayPasswordTokenClass.desc_key_gen}
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
+                                                      'desc': DayPasswordTokenClass.desc_key_gen}
                    },
                    SCOPE.ENROLL: {
                        ACTION.FORCE_APP_PIN: {

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -362,7 +362,7 @@ class HotpTokenClass(TokenClass):
         if force_genkey or not otp_key:
             upd_param["genkey"] = True
         genkey = is_true(upd_param.get("genkey"))
-        if genkey and otp_key:
+        if genkey and otp_key is not None:
             # The Base TokenClass does not allow otpkey and genkey at the
             # same time
             del upd_param['otpkey']

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -97,7 +97,6 @@ class HotpTokenClass(TokenClass):
     desc_hash_func = lazy_gettext('Specify the hashing function to be used. '
                                   'Can be SHA1, SHA256 or SHA512.')
     desc_otp_len = lazy_gettext('Specify the OTP length to be used. Can be 6 or 8 digits.')
-    desc_key_gen = lazy_gettext("Force the key to be generated on the server.")
     desc_two_step_user = lazy_gettext('Specify whether users are allowed or forced to use '
                                       'two-step enrollment.')
     desc_two_step_admin = lazy_gettext('Specify whether admins are allowed or forced to '
@@ -353,7 +352,7 @@ class HotpTokenClass(TokenClass):
 
         # check if the key_size is provided
         # if not, we could derive it from the hashlib
-        key_size = upd_param.get('key_size') or upd_param.get('keysize')
+        key_size = upd_param.get('keysize')
         if key_size is None:
             upd_param['keysize'] = keylen.get(hashlibStr)
 

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -183,7 +183,7 @@ class HotpTokenClass(TokenClass):
                        'hotp_otplen': {'type': 'int',
                                        'value': [6, 8],
                                        'desc': HotpTokenClass.desc_otp_len},
-                       'hotp_force_server_generate': {
+                       ACTION.FORCE_SERVER_GENERATE: {
                            'type': 'bool',
                            'desc': HotpTokenClass.desc_key_gen},
                        'hotp_2step': {'type': 'str',
@@ -201,7 +201,9 @@ class HotpTokenClass(TokenClass):
                                        'desc': HotpTokenClass.desc_otp_len},
                        'hotp_2step': {'type': 'str',
                                       'value': ['allow', 'force'],
-                                      'desc': HotpTokenClass.desc_two_step_admin}
+                                      'desc': HotpTokenClass.desc_two_step_admin},
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
+                                                      'desc': HotpTokenClass.desc_key_gen}
                    }
                }
                }

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -353,14 +353,16 @@ class HotpTokenClass(TokenClass):
 
         # check if the key_size is provided
         # if not, we could derive it from the hashlib
-        key_size = getParam(upd_param, 'key_size', optional) \
-                   or getParam(upd_param, 'keysize', optional)
+        key_size = upd_param.get('key_size') or upd_param.get('keysize')
         if key_size is None:
             upd_param['keysize'] = keylen.get(hashlibStr)
 
-        otpKey = getParam(upd_param, "otpkey", optional)
-        genkey = is_true(getParam(upd_param, "genkey", optional))
-        if genkey and otpKey:
+        otp_key = upd_param.get("otpkey")
+        force_genkey = param.get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}")
+        if force_genkey or not otp_key:
+            upd_param["genkey"] = True
+        genkey = is_true(upd_param.get("genkey"))
+        if genkey and otp_key:
             # The Base TokenClass does not allow otpkey and genkey at the
             # same time
             del upd_param['otpkey']

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -357,7 +357,7 @@ class HotpTokenClass(TokenClass):
             upd_param['keysize'] = keylen.get(hashlibStr)
 
         otp_key = upd_param.get("otpkey")
-        force_genkey = param.get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}")
+        force_genkey = param.get("policies", {}).get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}", False)
         if force_genkey or not otp_key:
             upd_param["genkey"] = True
         genkey = is_true(upd_param.get("genkey"))

--- a/privacyidea/lib/tokens/motptoken.py
+++ b/privacyidea/lib/tokens/motptoken.py
@@ -58,7 +58,6 @@ log = logging.getLogger(__name__)
 
 
 class MotpTokenClass(TokenClass):
-
     desc_key_gen = lazy_gettext("Force the key to be generated on the server.")
 
     @staticmethod
@@ -163,7 +162,7 @@ class MotpTokenClass(TokenClass):
                                                   "value": motp_url,
                                                   "img": create_img(motp_url)
                                                   }
-                except Exception as ex:   # pragma: no cover
+                except Exception as ex:  # pragma: no cover
                     log.debug("{0!s}".format(traceback.format_exc()))
                     log.error('failed to set motp url: {0!r}'.format(ex))
 
@@ -180,7 +179,11 @@ class MotpTokenClass(TokenClass):
         :return: nothing
         """
         if self.hKeyRequired is True:
-            genkey = is_true(getParam(param, "genkey", optional))
+            otp_key = param.get("otpkey")
+            force_genkey = param.get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}")
+            if force_genkey or not otp_key:
+                param["genkey"] = True
+            genkey = is_true(param.get("genkey"))
             if not param.get('keysize'):
                 param['keysize'] = 16
             if genkey:

--- a/privacyidea/lib/tokens/motptoken.py
+++ b/privacyidea/lib/tokens/motptoken.py
@@ -37,6 +37,8 @@ described in motp.sourceforge.net.
 
 The code is tested in tests/test_lib_tokens_motp
 """
+from flask_babel import lazy_gettext
+
 from .mOTP import mTimeOtp
 from privacyidea.lib.apps import create_motp_url
 from privacyidea.lib.tokenclass import TokenClass
@@ -56,6 +58,8 @@ log = logging.getLogger(__name__)
 
 
 class MotpTokenClass(TokenClass):
+
+    desc_key_gen = lazy_gettext("Force the key to be generated on the server.")
 
     @staticmethod
     def get_class_type():
@@ -96,6 +100,14 @@ class MotpTokenClass(TokenClass):
                # This tokentype is enrollable in the UI for...
                'ui_enroll': ["admin", "user"],
                'policy': {
+                   SCOPE.ADMIN: {
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
+                                                      'desc': MotpTokenClass.desc_key_gen}
+                   },
+                   SCOPE.USER: {
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
+                                                      'desc': MotpTokenClass.desc_key_gen}
+                   },
                    SCOPE.ENROLL: {
                        ACTION.MAXTOKENUSER: {
                            'type': 'int',

--- a/privacyidea/lib/tokens/motptoken.py
+++ b/privacyidea/lib/tokens/motptoken.py
@@ -58,7 +58,6 @@ log = logging.getLogger(__name__)
 
 
 class MotpTokenClass(TokenClass):
-    desc_key_gen = lazy_gettext("Force the key to be generated on the server.")
 
     @staticmethod
     def get_class_type():
@@ -178,23 +177,22 @@ class MotpTokenClass(TokenClass):
 
         :return: nothing
         """
-        if self.hKeyRequired is True:
-            otp_key = param.get("otpkey")
-            force_genkey = param.get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}")
-            if force_genkey or not otp_key:
-                param["genkey"] = True
-            genkey = is_true(param.get("genkey"))
-            if not param.get('keysize'):
-                param['keysize'] = 16
-            if genkey:
-                otpKey = generate_otpkey(param['keysize'])
-                del param['genkey']
-            else:
-                # genkey not set: check otpkey is given
-                # this will raise an exception if otpkey is not present
-                otpKey = getParam(param, "otpkey", required)
+        otp_key = param.get("otpkey")
+        force_genkey = param.get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}")
+        if force_genkey or not otp_key:
+            param["genkey"] = True
+        genkey = is_true(param.get("genkey"))
+        if not param.get('keysize'):
+            param['keysize'] = 16
+        if genkey:
+            otpKey = generate_otpkey(param['keysize'])
+            del param['genkey']
+        else:
+            # genkey not set: check otpkey is given
+            # this will raise an exception if otpkey is not present
+            otpKey = getParam(param, "otpkey", required)
 
-            param['otpkey'] = otpKey
+        param['otpkey'] = otpKey
 
         # motp token specific
         mOTPPin = getParam(param, "motppin", required)

--- a/privacyidea/lib/tokens/motptoken.py
+++ b/privacyidea/lib/tokens/motptoken.py
@@ -178,7 +178,7 @@ class MotpTokenClass(TokenClass):
         :return: nothing
         """
         otp_key = param.get("otpkey")
-        force_genkey = param.get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}")
+        force_genkey = param.get("policies", {}).get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}", False)
         if force_genkey or not otp_key:
             param["genkey"] = True
         genkey = is_true(param.get("genkey"))

--- a/privacyidea/lib/tokens/passwordtoken.py
+++ b/privacyidea/lib/tokens/passwordtoken.py
@@ -152,7 +152,7 @@ class PasswordTokenClass(TokenClass):
         :return: None
         """
         otp_key = param.get("otpkey")
-        force_genkey = param.get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}")
+        force_genkey = param.get("policies", {}).get(f"{self.get_tokentype()}_{ACTION.FORCE_SERVER_GENERATE}", False)
         if force_genkey or not otp_key:
             param["genkey"] = True
         genkey = is_true(param.get("genkey"))

--- a/privacyidea/lib/tokens/passwordtoken.py
+++ b/privacyidea/lib/tokens/passwordtoken.py
@@ -50,7 +50,6 @@ class PasswordTokenClass(TokenClass):
     password_detail_key = "password"  # nosec B105 # key name
     default_length = DEFAULT_LENGTH
     default_contents = DEFAULT_CONTENTS
-    desc_key_gen = lazy_gettext("Force the key to be generated on the server.")
 
     class SecretPassword(object):
 

--- a/privacyidea/lib/tokens/passwordtoken.py
+++ b/privacyidea/lib/tokens/passwordtoken.py
@@ -18,6 +18,8 @@ This file contains the definition of the password token class
 
 import logging
 
+from flask_babel import lazy_gettext
+
 from privacyidea.lib.crypto import zerome, safe_compare
 from privacyidea.lib.utils import to_unicode
 from privacyidea.lib.tokenclass import TokenClass
@@ -49,6 +51,7 @@ class PasswordTokenClass(TokenClass):
     password_detail_key = "password"  # nosec B105 # key name
     default_length = DEFAULT_LENGTH
     default_contents = DEFAULT_CONTENTS
+    desc_key_gen = lazy_gettext("Force the key to be generated on the server.")
 
     class SecretPassword(object):
 

--- a/privacyidea/lib/tokens/passwordtoken.py
+++ b/privacyidea/lib/tokens/passwordtoken.py
@@ -175,8 +175,8 @@ class PasswordTokenClass(TokenClass):
             else:
                 contents = self.otp_contents
             param["otpkey"] = _generate_pin_from_policy(contents, size=int(size))
-        if otp_key:
-            param["otplen"] = len(otp_key)
+        if "otpkey" in param:
+            param["otplen"] = len(param.get("otpkey"))
         TokenClass.update(self, param)
 
     @log_with(log, log_entry=False)

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -120,7 +120,7 @@ class TotpTokenClass(HotpTokenClass):
                        'totp_otplen': {'type': 'int',
                                        'value': [6, 8],
                                        'desc': TotpTokenClass.desc_otp_len},
-                       'totp_force_server_generate': {'type': 'bool',
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
                                                       'desc': TotpTokenClass.desc_key_gen},
                        '2step': {'type': 'str',
                                  'value': ['allow', 'force'],
@@ -138,6 +138,8 @@ class TotpTokenClass(HotpTokenClass):
                        'totp_otplen': {'type': 'int',
                                        'value': [6, 8],
                                        'desc': TotpTokenClass.desc_otp_len},
+                       ACTION.FORCE_SERVER_GENERATE: {'type': 'bool',
+                                                      'desc': TotpTokenClass.desc_key_gen},
                        '2step': {'type': 'str',
                                  'value': ['allow', 'force'],
                                  'desc': TotpTokenClass.desc_two_step_admin}

--- a/privacyidea/static/components/token/views/token.enroll.applspec.html
+++ b/privacyidea/static/components/token/views/token.enroll.applspec.html
@@ -6,7 +6,7 @@
 <h4 translate>Token data</h4>
 
 <div class="form-group">
-    <div ng-hide=False>
+    <div ng-hide=checkRight('applspec_force_server_generate')>
         <input type="checkbox" ng-model="form.genkey"
                name="generate" id="generate">
         <label for="generate" translate>Generate the static password on the Server</label>

--- a/privacyidea/static/components/token/views/token.enroll.motp.html
+++ b/privacyidea/static/components/token/views/token.enroll.motp.html
@@ -1,14 +1,16 @@
 <p class="help-block" translate>
-The mOTP token is a time based OTP token for mobile devices.
+    The mOTP token is a time based OTP token for mobile devices.
     You can
     have the server generate the secret and scan the QR code.
 </p>
 
 <h4 translate>Token data</h4>
 <div class="form-group">
-    <input type="checkbox" ng-model="form.genkey"
-           name="generate" id="generate">
-    <label for="generate" translate>Generate OTP Key on the Server</label>
+    <div ng-hide="checkRight('motp_force_server_generate')">
+        <input type="checkbox" ng-model="form.genkey"
+               name="generate" id="generate">
+        <label for="generate" translate>Generate OTP Key on the Server</label>
+    </div>
 
     <div ng-show="form.genkey">
         <p class="help-block" translate>

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -4829,13 +4829,13 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         # Policy is not set
         g.policies = {}
         force_server_generate_key(request)
-        self.assertNotIn(f"hotp_{ACTION.FORCE_SERVER_GENERATE}", g.policies)
+        self.assertFalse(g.policies.get(f"hotp_{ACTION.FORCE_SERVER_GENERATE}"))
 
         # Set policy for different token type
         g.policies = {}
         set_policy("totp_genkey", scope=SCOPE.USER, action=f"totp_{ACTION.FORCE_SERVER_GENERATE}")
         force_server_generate_key(request)
-        self.assertNotIn(f"hotp_{ACTION.FORCE_SERVER_GENERATE}", g.policies)
+        self.assertFalse(g.policies.get(f"hotp_{ACTION.FORCE_SERVER_GENERATE}"))
         self.assertNotIn(f"totp_{ACTION.FORCE_SERVER_GENERATE}", g.policies)
 
         # Set policy for hotp
@@ -4875,7 +4875,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         g.policies = {}
         request.all_data = {"type": "spass"}
         force_server_generate_key(request)
-        self.assertNotIn(f"spass_{ACTION.FORCE_SERVER_GENERATE}", g.policies)
+        self.assertFalse(g.policies.get(f"spass_{ACTION.FORCE_SERVER_GENERATE}"))
         self.assertNotIn(f"hotp_{ACTION.FORCE_SERVER_GENERATE}", g.policies)
         self.assertNotIn(f"totp_{ACTION.FORCE_SERVER_GENERATE}", g.policies)
         self.assertNotIn(f"motp_{ACTION.FORCE_SERVER_GENERATE}", g.policies)
@@ -4902,7 +4902,7 @@ class PrePolicyDecoratorTestCase(MyApiTestCase):
         # Policy is not set
         g.policies = {}
         force_server_generate_key(request)
-        self.assertNotIn(f"hotp_{ACTION.FORCE_SERVER_GENERATE}", g.policies)
+        self.assertFalse(g.policies.get(f"hotp_{ACTION.FORCE_SERVER_GENERATE}"))
 
         # Set policy for hotp
         g.policies = {}

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -497,8 +497,8 @@ class API000TokenAdminRealmList(MyApiTestCase):
         container.remove_user(User(login="hans", realm=self.realm1))
         container.add_user(User(login="corny", realm=self.realm3))
         result = self.request_assert_200("/token/init", {"type": "hotp", "genkey": True, "user": "hans",
-                                                "realm": self.realm1, "container_serial": container_serial},
-                                self.at, "POST")
+                                                         "realm": self.realm1, "container_serial": container_serial},
+                                         self.at, "POST")
         self.assertIsNone(find_container_for_token(result["detail"]["serial"]))
 
         # no container owner but token_owner
@@ -619,14 +619,6 @@ class APITokenTestCase(MyApiTestCase):
         with self.app.test_request_context('/token/init',
                                            method='POST',
                                            data={"type": "hmac"},
-                                           headers={'Authorization': self.at}):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(400, res.status_code, res)
-
-        # missing parameter otpkey
-        with self.app.test_request_context('/token/init',
-                                           method='POST',
-                                           data={"type": "hotp"},
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()
             self.assertEqual(400, res.status_code, res)
@@ -1216,6 +1208,8 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(result.get("value") == 1, result)
 
     def test_07_resync(self):
+        set_policy("enroll", scope=SCOPE.ADMIN, action=["enrollHOTP", ACTION.RESYNC, ACTION.AUDIT, ACTION.TOKENLIST,
+                                                        ACTION.ASSIGN])
 
         with self.app.test_request_context('/token/init', method="POST",
                                            data={"serial": "Resync01",
@@ -1346,6 +1340,8 @@ class APITokenTestCase(MyApiTestCase):
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
             self.assertTrue(result.get("value") is True, result)
+
+        delete_policy("enroll")
 
     def test_08_setpin(self):
         self._create_temp_token("PToken")
@@ -2778,11 +2774,11 @@ class APITokenTestCase(MyApiTestCase):
             remaining, 1,
             f"challenge-cache contains {remaining} rows")
 
-
     def test_40_init_verify_hotp_token(self):
         set_policy("verify_toks1", scope=SCOPE.ENROLL, action="{0!s}=hotp top".format(ACTION.VERIFY_ENROLLMENT))
         set_policy("verify_toks2", scope=SCOPE.ENROLL, action="{0!s}=HOTP email".format(ACTION.VERIFY_ENROLLMENT))
         set_policy("require_description", scope=SCOPE.ENROLL, action="{0!s}=hotp".format(ACTION.REQUIRE_DESCRIPTION))
+        set_policy("enroll", scope=SCOPE.ADMIN, action=["enrollHOTP"])
         # Enroll an HOTP token
         with self.app.test_request_context('/token/init',
                                            method='POST',
@@ -2856,6 +2852,7 @@ class APITokenTestCase(MyApiTestCase):
         delete_policy("verify_toks1")
         delete_policy("verify_toks2")
         delete_policy("require_description")
+        delete_policy("enroll")
 
     @mock.patch('privacyidea.lib.smtpserver.smtplib.SMTP', autospec=True)
     def test_41_init_verify_email_token(self, smtp_mock):
@@ -2865,6 +2862,7 @@ class APITokenTestCase(MyApiTestCase):
         set_policy("verify_toks1", scope=SCOPE.ENROLL, action="{0!s}=email".format(ACTION.VERIFY_ENROLLMENT))
         set_policy("email_challenge_text", scope=SCOPE.AUTH,
                    action=f"email_{ACTION.CHALLENGETEXT}=ENTER EMAIL TOKEN")
+        set_policy("enroll", scope=SCOPE.ADMIN, action=["enrollEMAIL"])
         # Enroll an email token
         # TODO: Check mock mailserver for correct email subject and text
         with self.app.test_request_context('/token/init',
@@ -2905,6 +2903,7 @@ class APITokenTestCase(MyApiTestCase):
         delete_policy("verify_toks1")
         delete_policy("email_challenge_text")
         remove_token(serial=serial)
+        delete_policy("enroll")
 
     @mock.patch("privacyidea.lib.smsprovider.HttpSMSProvider.requests",
                 autospec=True)
@@ -2929,6 +2928,7 @@ class APITokenTestCase(MyApiTestCase):
         sms_text = "YOUR SMS TOKEN: {otp}"
         set_policy(name="smstext", scope=SCOPE.AUTH,
                    action=f"{SMSACTION.SMSTEXT}={sms_text}")
+        set_policy("enroll", scope=SCOPE.ADMIN, action=["enrollSMS"])
 
         # Enroll an SMS token
         with self.app.test_request_context('/token/init',
@@ -2974,6 +2974,7 @@ class APITokenTestCase(MyApiTestCase):
         delete_policy("verify_toks1")
         delete_policy("smstext")
         delete_smsgateway(smsgw_id)
+        delete_policy("enroll")
 
     def test_43_init_verify_index_token(self):
         set_policy("verify_toks1", scope=SCOPE.ENROLL, action="{0!s}=indexedsecret".format(ACTION.VERIFY_ENROLLMENT))
@@ -3350,7 +3351,6 @@ class APITokenTestCase(MyApiTestCase):
             remove_token(serial)
         delete_policy("applspec_genkey")
         delete_policy("enroll")
-
 
 
 class API00TokenPerformance(MyApiTestCase):

--- a/tests/test_api_validate_webauthn.py
+++ b/tests/test_api_validate_webauthn.py
@@ -335,6 +335,8 @@ class WebAuthn(MyApiTestCase):
         remove_token(webauthn_serial)
 
     def test_20_authenticate_other_token(self):
+        set_policy("enroll", scope=SCOPE.ADMIN, action=["enrollWEBAUTHN", "enrollHOTP", ACTION.ENROLLPIN,
+                                                        ACTION.TRIGGERCHALLENGE])
         # Ensure that a not readily enrolled WebAuthn token does not disturb the usage
         # of an HOTP token with challenge response.
         # First enrollment step
@@ -435,6 +437,7 @@ class WebAuthn(MyApiTestCase):
             self.assertTrue(result.get("value"))
 
         delete_policy("trigpol")
+        delete_policy("enroll")
         remove_token("hotpX1")
         remove_token(self.serial)
 

--- a/tests/test_lib_tokens_daplug.py
+++ b/tests/test_lib_tokens_daplug.py
@@ -397,11 +397,10 @@ class DaplugTokenTestCase(MyTestCase):
     def test_17_update_token(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()
         token = DaplugTokenClass(db_token)
-        # Failed update: genkey wrong
-        self.assertRaises(Exception,
-                          token.update,
-                          {"description": "new desc",
-                           "genkey": "17"})
+        # Wrong genkey is replaced with genkey=True
+        token.update({"description": "new desc",
+                      "genkey": "17"})
+        self.assertEqual("new desc", token.token.description)
         # genkey and otpkey used at the same time
         token.update({"otpkey": self.otpkey,
                       "genkey": "1"})
@@ -426,8 +425,9 @@ class DaplugTokenTestCase(MyTestCase):
         self.assertTrue(token.token.pin_hash.startswith("@@"),
                         token.token.pin_hash)
 
-        # update token without otpkey raises an error
-        self.assertRaises(Exception, token.update, {"description": "test"})
+        # update token without otpkey generates one
+        token.update({"description": "test"})
+        self.assertEqual("test", token.token.description)
 
     def test_18_challenges(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()

--- a/tests/test_lib_tokens_daypassword.py
+++ b/tests/test_lib_tokens_daypassword.py
@@ -353,11 +353,10 @@ class DayPasswordTokenTestCase(MyTestCase):
     def test_17_update_token(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()
         token = DayPasswordTokenClass(db_token)
-        # Failed update: genkey wrong
-        self.assertRaises(Exception,
-                          token.update,
-                          {"description": "new desc",
-                           "genkey": "17"})
+        # Wrong genkey is replaced with genkey=True
+        token.update({"description": "new desc",
+                      "genkey": "17"})
+        self.assertEqual("new desc", token.token.description)
         # genkey and otpkey used at the same time
         token.update({"otpkey": self.otpkey,
                       "genkey": "1"})
@@ -381,8 +380,9 @@ class DayPasswordTokenTestCase(MyTestCase):
         self.assertTrue(token.token.pin_hash.startswith("@@"),
                         token.token.pin_hash)
 
-        # update token without otpkey raises an error
-        self.assertRaises(Exception, token.update, {"description": "test"})
+        # update token without otpkey generates one
+        token.update({"description": "test"})
+        self.assertEqual("test", token.token.description)
 
         # update time settings
         db_token = Token.query.filter_by(serial=self.serial1).first()

--- a/tests/test_lib_tokens_hotp.py
+++ b/tests/test_lib_tokens_hotp.py
@@ -410,11 +410,10 @@ class HOTPTokenTestCase(MyTestCase):
     def test_17_update_token(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()
         token = HotpTokenClass(db_token)
-        # Failed update: genkey wrong
-        self.assertRaises(Exception,
-                          token.update,
-                          {"description": "new desc",
+        # Wrong genkey is replaced with genkey=True
+        token.update({"description": "new desc",
                            "genkey": "17"})
+        self.assertEqual("new desc", token.token.description)
         # genkey and otpkey used at the same time
         token.update({"otpkey": self.otpkey,
                       "genkey": "1"})
@@ -439,8 +438,9 @@ class HOTPTokenTestCase(MyTestCase):
         self.assertTrue(token.token.pin_hash.startswith("@@"),
                         token.token.pin_hash)
 
-        # update token without otpkey raises an error
-        self.assertRaises(Exception, token.update, {"description": "test"})
+        # update token without otpkey generates one
+        token.update({"description": "test"})
+        self.assertEqual("test", token.token.description)
 
     def test_18_challenges(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()

--- a/tests/test_lib_tokens_totp.py
+++ b/tests/test_lib_tokens_totp.py
@@ -372,11 +372,10 @@ class TOTPTokenTestCase(MyTestCase):
     def test_17_update_token(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()
         token = TotpTokenClass(db_token)
-        # Failed update: genkey wrong
-        self.assertRaises(Exception,
-                          token.update,
-                          {"description": "new desc",
-                           "genkey": "17"})
+        # Wrong genkey is replaced with genkey=True
+        token.update({"description": "new desc",
+                      "genkey": "17"})
+        self.assertEqual("new desc", token.token.description)
         # genkey and otpkey used at the same time
         token.update({"otpkey": self.otpkey,
                       "genkey": "1"})
@@ -400,8 +399,9 @@ class TOTPTokenTestCase(MyTestCase):
         self.assertTrue(token.token.pin_hash.startswith("@@"),
                         token.token.pin_hash)
 
-        # update token without otpkey raises an error
-        self.assertRaises(Exception, token.update, {"description": "test"})
+        # update token without otpkey generates one
+        token.update({"description": "test"})
+        self.assertEqual("test", token.token.description)
 
         # update time settings
         db_token = Token.query.filter_by(serial=self.serial1).first()


### PR DESCRIPTION
closes #4410

if `otpkey` and `genkey` are not provided, `genkey` is set to `True` instead of raising a `ParameterError`