### PR TITLE
Fix line numbers in logging decorator

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -332,6 +332,7 @@ def get_auth_token():
         # 1. in local admins
         # 2. in a realm
         # 2a. is an admin realm
+        log.debug(f"Checking remote user: {username}")
         authtype = "remote_user "
         if db_admin_exists(username):
             role = ROLE.ADMIN

--- a/privacyidea/lib/auth.py
+++ b/privacyidea/lib/auth.py
@@ -25,6 +25,7 @@ from privacyidea.lib.token import check_user_pass
 from privacyidea.lib.policydecorators import libpolicy, login_mode
 from privacyidea.lib.crypto import hash_with_pepper, verify_with_pepper
 from privacyidea.lib.utils import fetch_one_resource
+from privacyidea.lib.log import log_with
 import logging
 
 log = logging.getLogger(__name__)
@@ -36,6 +37,7 @@ class ROLE(object):
     VALIDATE = "validate"
 
 
+@log_with(log, hide_args=[1])
 def verify_db_admin(username, password):
     """
     This function is used to verify the username and the password against the

--- a/privacyidea/lib/clientapplication.py
+++ b/privacyidea/lib/clientapplication.py
@@ -25,9 +25,8 @@ The code is tested in tests/test_lib_clientapplication.py.
 
 from sqlalchemy import func
 import logging
-import datetime
 from .log import log_with
-from ..models import ClientApplication, Subscription, db
+from ..models import ClientApplication, db
 from privacyidea.lib.config import get_privacyidea_node
 from netaddr import IPAddress
 

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (C) 2014 NetKnights GmbH <https://netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
 #  2016-04-08 Cornelius Kölbel <cornelius.koelbel@netknights.it>
 #             Avoid consecutive if-statements
 #  2015-12-12 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -488,6 +492,7 @@ def get_token_class(tokentype):
     """
     This takes a token type like "hotp" and returns a class
     like <class privacidea.lib.tokens.hotptoken.HotpTokenClass>
+
     :return: The tokenclass for the given type
     :rtype: tokenclass.TokenClass
     """

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -407,7 +407,7 @@ def decrypt(enc_data, iv, key_id=0):
     return res
 
 
-@log_with(log, log_exit=False)
+@log_with(log, log_exit=False, hide_args=[0])
 def aes_cbc_decrypt(key, iv, enc_data):
     """
     Decrypts the given cipherdata with AES (CBC Mode) using the key/iv.

--- a/privacyidea/lib/log.py
+++ b/privacyidea/lib/log.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (C) 2014 NetKnights GmbH <https://netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
 #  privacyIDEA is a fork of LinOTP
 #  May 08, 2014 Cornelius Kölbel
 #  License:  AGPLv3
@@ -23,10 +27,10 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from logging import Formatter
-import string
 import logging
 import functools
 from copy import deepcopy
+
 log = logging.getLogger(__name__)
 
 
@@ -91,21 +95,17 @@ DOCKER_LOGGING_CONFIG = {
 class SecureFormatter(Formatter):
 
     def format(self, record):
+        if 's_line' in record.__dict__ and '_called' not in record.__dict__:
+            # rotating file handler calls "format" to check for its length before
+            # emitting the actual line
+            record.msg += f" (called from {record.filename}:{record.lineno})"
+            record.lineno = record.__dict__["s_line"]
+            record._called = True
         message = super(SecureFormatter, self).format(record)
-        secured = False
-
-        s = ""
-        for c in message:
-            if c in string.printable:
-                s += c
-            else:
-                s += '.'
-                secured = True
-
-        if secured:
-            s = "!!!Log Entry Secured by SecureFormatter!!! " + s
-
-        return s
+        if not message.isprintable():
+            message = ''.join(map(lambda x: x if x.isprintable() else '.', message))
+            message = "!!Log Entry Secured by SecureFormatter!! " + message
+        return message
 
 
 class log_with(object):
@@ -175,8 +175,7 @@ class log_with(object):
 
             log_args = args
             log_kwds = kwds
-            if self.hide_args or self.hide_kwargs or \
-                    self.hide_args_keywords:
+            if self.hide_args or self.hide_kwargs or self.hide_args_keywords:
                 try:
                     level = self.logger.getEffectiveLevel()
                     # Check if we should not do the password logging.
@@ -200,12 +199,16 @@ class log_with(object):
                     log_args = ()
                     log_kwds = {}
             try:
+                import inspect
+                lno = inspect.getsourcelines(func)[1] + 1
                 if self.log_entry:
                     self.logger.debug(self.ENTRY_MESSAGE.format(
-                        func.__name__, log_args, log_kwds))
+                        func.__name__, log_args, log_kwds),
+                        stacklevel=2, extra={'s_line': lno})
                 else:
                     self.logger.debug(self.ENTRY_MESSAGE.format(
-                        func.__name__, "HIDDEN", "HIDDEN"))
+                        func.__name__, "HIDDEN", "HIDDEN"),
+                        stacklevel=2, extra={'s_line': lno})
             except Exception as exx:
                 self.logger.error(exx)
                 self.logger.error("Error during logging of function {0}! {1}".format(func.__name__, exx))
@@ -213,10 +216,16 @@ class log_with(object):
             f_result = func(*args, **kwds)
 
             try:
+                import inspect
+                lno = inspect.getsourcelines(func)[1] + 1
                 if self.log_exit:
-                    self.logger.debug(self.EXIT_MESSAGE.format(func.__name__, f_result))
+                    self.logger.debug(self.EXIT_MESSAGE.format(
+                        func.__name__, f_result),
+                        stacklevel=2, extra={'s_line': lno})
                 else:
-                    self.logger.debug(self.EXIT_MESSAGE.format(func.__name__, "HIDDEN"))
+                    self.logger.debug(self.EXIT_MESSAGE.format(
+                        func.__name__, "HIDDEN"),
+                        stacklevel=2, extra={'s_line': lno})
             except Exception as exx:
                 self.logger.error("Error during logging of function {0}! {1}".format(func.__name__, exx))
             return f_result

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -433,8 +433,8 @@ def login_mode(wrapped_function, *args, **kwds):
     that the authentication should be performed against privacyIDEA.
 
     :param wrapped_function: Usually the function check_webui_user
-    :param `*args`: arguments user_obj and password
-    :param `**kwds`: keyword arguments like options and !check_otp!
+    :param args: arguments user_obj and password
+    :param kwds: keyword arguments like options and !check_otp!
         kwds["options"] contains the flask g
     :return: calls the original function with the modified "check_otp" argument
     """


### PR DESCRIPTION
The logging decorator did not print the correct line numbers of the wrapped functions, instead the line number of the decorator functions was used.
By inspecting the wrapped function and adding extra data to the log record, we can provide the correct values in the formatter.

This PR also suppresses the output of the compete policies when checking for a match (only the policy name is given.

The SecureFormatter class now works with printable characters (Unicode).