### PR TITLE
Remove aria-hidden for dialogs if they are displayed

### DIFF
--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -828,9 +828,10 @@ myApp.controller("PasswdResolverController", ["$scope", "ConfigFactory",
             /* If we have a resolvername, we do an Edit
              and we need to fill all the $scope.params */
             ConfigFactory.getResolver($scope.resolvername, function (data) {
-                var resolver = data.result.value[$scope.resolvername];
+                const resolver = data.result.value[$scope.resolvername];
                 $scope.params = resolver.data;
                 $scope.params.type = 'passwdresolver';
+                $scope.params.fileName = resolver.data.fileName || resolver.data.filename;
             });
         }
 

--- a/privacyidea/static/components/config/views/config.events.details.html
+++ b/privacyidea/static/components/config/views/config.events.details.html
@@ -14,7 +14,7 @@
         Enable
     </button>
     <button class="btn btn-danger"
-            aria-details="{{ 'Do you really want to delete this event?' | translate }}"
+            data-confirmation-text="{{ 'Do you really want to delete this event?' | translate }}"
             ng-click="confirmDelete(delEvent, eventid)">
         <span class="glyphicon glyphicon-trash"></span>
         <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.events.details.html
+++ b/privacyidea/static/components/config/views/config.events.details.html
@@ -14,7 +14,7 @@
         Enable
     </button>
     <button class="btn btn-danger"
-            aria-label="{{ 'Do you really want to delete this event?' | translate }}"
+            aria-details="{{ 'Do you really want to delete this event?' | translate }}"
             ng-click="confirmDelete(delEvent, eventid)">
         <span class="glyphicon glyphicon-trash"></span>
         <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.events.list.html
+++ b/privacyidea/static/components/config/views/config.events.list.html
@@ -78,7 +78,7 @@
             <td>
                 <button class="btn btn-danger"
                         ng-show="checkRight('eventhandling_write')"
-                        aria-details="{{ 'Do you really want to delete this event?' | translate }}"
+                        data-confirmation-text="{{ 'Do you really want to delete this event?' | translate }}"
                         ng-click="confirmDelete(delEvent, event.id)">
                         <span class="glyphicon glyphicon-trash"></span>
                         <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.events.list.html
+++ b/privacyidea/static/components/config/views/config.events.list.html
@@ -78,7 +78,7 @@
             <td>
                 <button class="btn btn-danger"
                         ng-show="checkRight('eventhandling_write')"
-                        aria-label="{{ 'Do you really want to delete this event?' | translate }}"
+                        aria-details="{{ 'Do you really want to delete this event?' | translate }}"
                         ng-click="confirmDelete(delEvent, event.id)">
                         <span class="glyphicon glyphicon-trash"></span>
                         <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.mresolvers.list.html
+++ b/privacyidea/static/components/config/views/config.mresolvers.list.html
@@ -22,7 +22,7 @@
                         translate>Edit</button>
                 <button class="btn btn-sm btn-danger"
                         ng-show="checkRight('mresolverdelete')"
-                        aria-details="{{ 'Do you really want to delete this machine resolver?' | translate }}"
+                        data-confirmation-text="{{ 'Do you really want to delete this machine resolver?' | translate }}"
                         ng-click="confirmDelete(delResolver, resolver.resolvername)">
                     <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span></button>

--- a/privacyidea/static/components/config/views/config.mresolvers.list.html
+++ b/privacyidea/static/components/config/views/config.mresolvers.list.html
@@ -22,7 +22,7 @@
                         translate>Edit</button>
                 <button class="btn btn-sm btn-danger"
                         ng-show="checkRight('mresolverdelete')"
-                        aria-label="{{ 'Do you really want to delete this machine resolver?' | translate }}"
+                        aria-details="{{ 'Do you really want to delete this machine resolver?' | translate }}"
                         ng-click="confirmDelete(delResolver, resolver.resolvername)">
                     <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span></button>

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -14,7 +14,7 @@
         Enable
     </button>
     <button class="btn btn-danger"
-            aria-label="{{ 'Do you really want to delete this periodic task?' | translate }}"
+            aria-details="{{ 'Do you really want to delete this periodic task?' | translate }}"
             ng-click="confirmDelete(delPeriodicTask, ptaskid)">
         <span class="glyphicon glyphicon-trash"></span>
         <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.periodictasks.details.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.details.html
@@ -14,7 +14,7 @@
         Enable
     </button>
     <button class="btn btn-danger"
-            aria-details="{{ 'Do you really want to delete this periodic task?' | translate }}"
+            data-confirmation-text="{{ 'Do you really want to delete this periodic task?' | translate }}"
             ng-click="confirmDelete(delPeriodicTask, ptaskid)">
         <span class="glyphicon glyphicon-trash"></span>
         <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.periodictasks.list.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.list.html
@@ -49,7 +49,7 @@
             <td>
                 <button class="btn btn-danger"
                         ng-show="checkRight('periodictask_write')"
-                        aria-details="{{ 'Do you really want to delete this periodic task?' | translate }}"
+                        data-confirmation-text="{{ 'Do you really want to delete this periodic task?' | translate }}"
                         ng-click="confirmDelete(delPeriodicTask, ptask.id)">
                         <span class="glyphicon glyphicon-trash"></span>
                         <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.periodictasks.list.html
+++ b/privacyidea/static/components/config/views/config.periodictasks.list.html
@@ -49,7 +49,7 @@
             <td>
                 <button class="btn btn-danger"
                         ng-show="checkRight('periodictask_write')"
-                        aria-label="{{ 'Do you really want to delete this periodic task?' | translate }}"
+                        aria-details="{{ 'Do you really want to delete this periodic task?' | translate }}"
                         ng-click="confirmDelete(delPeriodicTask, ptask.id)">
                         <span class="glyphicon glyphicon-trash"></span>
                         <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.policies.details.html
+++ b/privacyidea/static/components/config/views/config.policies.details.html
@@ -138,7 +138,7 @@
                 Enable
             </button>
             <button class="btn btn-danger"
-                    aria-label="{{ 'Do you really want to delete this policy?' | translate }}"
+                    aria-details="{{ 'Do you really want to delete this policy?' | translate }}"
                     ng-click="confirmDelete(delPolicy, existingPolicyname)">
                 <span class="glyphicon glyphicon-trash"></span>
                 <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.policies.details.html
+++ b/privacyidea/static/components/config/views/config.policies.details.html
@@ -138,7 +138,7 @@
                 Enable
             </button>
             <button class="btn btn-danger"
-                    aria-details="{{ 'Do you really want to delete this policy?' | translate }}"
+                    data-confirmation-text="{{ 'Do you really want to delete this policy?' | translate }}"
                     ng-click="confirmDelete(delPolicy, existingPolicyname)">
                 <span class="glyphicon glyphicon-trash"></span>
                 <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.policies.list.html
+++ b/privacyidea/static/components/config/views/config.policies.list.html
@@ -73,7 +73,7 @@
             <td>
                 <button class="btn btn-danger"
                         ng-show="checkRight('policydelete')"
-                        aria-label='{{ "Do you really want to delete this policy?" |  translate }}'
+                        aria-details='{{ "Do you really want to delete this policy?" |  translate }}'
                         ng-click="confirmDelete(delPolicy, policy.name)">
                         <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.policies.list.html
+++ b/privacyidea/static/components/config/views/config.policies.list.html
@@ -73,7 +73,7 @@
             <td>
                 <button class="btn btn-danger"
                         ng-show="checkRight('policydelete')"
-                        aria-details='{{ "Do you really want to delete this policy?" |  translate }}'
+                        data-confirmation-text='{{ "Do you really want to delete this policy?" |  translate }}'
                         ng-click="confirmDelete(delPolicy, policy.name)">
                         <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.resolvers.list.html
+++ b/privacyidea/static/components/config/views/config.resolvers.list.html
@@ -21,7 +21,7 @@
                         translate>Edit</button>
                 <button class="btn btn-sm btn-danger"
                         ng-show="checkRight('resolverdelete')"
-                        aria-details="{{ 'Do you really want to delete this resolver?' | translate }}"
+                        data-confirmation-text="{{ 'Do you really want to delete this resolver?' | translate }}"
                         ng-click="confirmDelete(delResolver, resolver.resolvername)">
                     <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.resolvers.list.html
+++ b/privacyidea/static/components/config/views/config.resolvers.list.html
@@ -21,7 +21,7 @@
                         translate>Edit</button>
                 <button class="btn btn-sm btn-danger"
                         ng-show="checkRight('resolverdelete')"
-                        aria-label="{{ 'Do you really want to delete this resolver?' | translate }}"
+                        aria-details="{{ 'Do you really want to delete this resolver?' | translate }}"
                         ng-click="confirmDelete(delResolver, resolver.resolvername)">
                     <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.serviceid.list.html
+++ b/privacyidea/static/components/config/views/config.serviceid.list.html
@@ -26,7 +26,7 @@ To view attached tokens go to <a ui-sref="token.applications">token applications
             <td>
                 <button class="btn btn-danger"
                         ng-show="checkRight('serviceid_delete')"
-                        aria-details="{{ 'Do you really want to delete this service ID?' | translate }}"
+                        data-confirmation-text="{{ 'Do you really want to delete this service ID?' | translate }}"
                         ng-click="confirmDelete(delServiceid, servicename)">
                         <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/config.serviceid.list.html
+++ b/privacyidea/static/components/config/views/config.serviceid.list.html
@@ -26,6 +26,7 @@ To view attached tokens go to <a ui-sref="token.applications">token applications
             <td>
                 <button class="btn btn-danger"
                         ng-show="checkRight('serviceid_delete')"
+                        aria-details="{{ 'Do you really want to delete this service ID?' | translate }}"
                         ng-click="confirmDelete(delServiceid, servicename)">
                         <span class="glyphicon glyphicon-trash"></span>
                     <span translate>Delete</span>

--- a/privacyidea/static/components/config/views/dialog.confirm_delete.html
+++ b/privacyidea/static/components/config/views/dialog.confirm_delete.html
@@ -2,8 +2,7 @@
     <!-- Modal -->
     <div class="modal fade" id="dialogConfirmDelete" tabindex="-1"
          role="dialog"
-         aria-labelledby="myModalConfirm"
-         aria-hidden="true">
+         aria-labelledby="myModalConfirm">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">

--- a/privacyidea/static/components/dialogs/views/dialog.about.html
+++ b/privacyidea/static/components/dialogs/views/dialog.about.html
@@ -1,8 +1,7 @@
     <!-- Modal -->
     <div class="modal fade" id="dialogAbout" tabindex="-1"
          role="dialog"
-         aria-labelledby="myModalDialog"
-         aria-hidden="true">
+         aria-labelledby="myModalDialog">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">

--- a/privacyidea/static/components/dialogs/views/dialog.autocreate_realm.html
+++ b/privacyidea/static/components/dialogs/views/dialog.autocreate_realm.html
@@ -2,8 +2,7 @@
 <!-- Modal -->
 <div class="modal fade" id="dialogAutoCreateRealm" tabindex="-1"
      role="dialog"
-     aria-labelledby="myModalLabel"
-     aria-hidden="true">
+     aria-labelledby="myModalLabel">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/privacyidea/static/components/dialogs/views/dialog.lock.html
+++ b/privacyidea/static/components/dialogs/views/dialog.lock.html
@@ -2,8 +2,7 @@
 <div class="modal fade lock-dialog" id="dialogLock" tabindex="-1"
      role="dialog"
      data-backdrop="static" data-keyboard="false"
-     aria-labelledby="myModalLock"
-     aria-hidden="true">
+     aria-labelledby="myModalLock">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/privacyidea/static/components/dialogs/views/dialog.no.token.html
+++ b/privacyidea/static/components/dialogs/views/dialog.no.token.html
@@ -7,7 +7,7 @@
      ng-show="dialogNoToken == true"
      data-backdrop="static" data-keyboard="false"
      aria-labelledby="myModalNoToken"
-     aria-hidden="true">
+     aria-hidden="{{ dialogNoToken == false }}">
     <div class="modal-dialog">
 
         <div class="modal-content">

--- a/privacyidea/static/components/dialogs/views/dialog.welcome.html
+++ b/privacyidea/static/components/dialogs/views/dialog.welcome.html
@@ -5,8 +5,8 @@
      ng-show="welcomeStep < 5"
      data-backdrop="static" data-keyboard="false"
      aria-labelledby="myModalLabel"
-     aria-hidden="true">
-    <div class="modal-dialog">
+     aria-hidden="{{ welcomeStep >= 5 }}">
+    <div class="modal-dialog" aria-live="polite">
 
         <div class="modal-content" ng-show="welcomeStep === 0">
             <div class="modal-header">
@@ -61,7 +61,7 @@
                     You do not have to worry about end-of-life.
                 </p>
                 <p>
-                    <b>Using open source is not about spending no money, but is is about full control you get over
+                    <b>Using open source is not about spending no money, but it is about full control you get over
                         your own system! Forever!</b>
                 </p>
             </div>

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -671,7 +671,7 @@ angular.module("privacyideaApp")
             };
 
             $scope.createDefaultRealm = function () {
-                const resolver_params = {type: "passwdresolver", filename: "/etc/passwd"};
+                const resolver_params = {type: "passwdresolver", fileName: "/etc/passwd"};
                 const realm_params = {resolvers: "deflocal"};
                 ConfigFactory.setResolver("deflocal",
                     resolver_params,

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -99,7 +99,7 @@ angular.module("privacyideaApp")
 
             $scope.confirmDelete = function (delete_function, identifier) {
                 $scope.confirmDeleteObj = {
-                    question: document.activeElement.getAttribute('aria-label'),
+                    question: document.activeElement.getAttribute('aria-details'),
                     identifier: identifier,
                     delete_function: delete_function
                 };

--- a/privacyidea/static/components/login/controllers/loginControllers.js
+++ b/privacyidea/static/components/login/controllers/loginControllers.js
@@ -99,7 +99,7 @@ angular.module("privacyideaApp")
 
             $scope.confirmDelete = function (delete_function, identifier) {
                 $scope.confirmDeleteObj = {
-                    question: document.activeElement.getAttribute('aria-details'),
+                    question: document.activeElement.getAttribute('data-confirmation-text'),
                     identifier: identifier,
                     delete_function: delete_function
                 };

--- a/privacyidea/static/components/token/views/dialog.ask_token_delete.html
+++ b/privacyidea/static/components/token/views/dialog.ask_token_delete.html
@@ -2,8 +2,7 @@
     <!-- Modal -->
     <div class="modal fade" id="dialogTokenDelete" tabindex="-1"
          role="dialog"
-         aria-labelledby="myModalLabel"
-         aria-hidden="true">
+         aria-labelledby="myModalLabel">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">

--- a/privacyidea/static/components/user/views/dialog.ask_user_delete.html
+++ b/privacyidea/static/components/user/views/dialog.ask_user_delete.html
@@ -2,8 +2,7 @@
 <!-- Modal -->
 <div class="modal fade" id="dialogUserDelete" tabindex="-1"
      role="dialog"
-     aria-labelledby="myModalLabel"
-     aria-hidden="true">
+     aria-labelledby="myModalLabel">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
closes #2224

* use `data-*` attribute to store the delete confirmation text instead of aria attributes
* Fix to correctly fill the fileName in the password resolver and use the correct attribute name in the autocreate realm function