### PR TITLE
Fix secure logging formatter

### DIFF
--- a/privacyidea/lib/log.py
+++ b/privacyidea/lib/log.py
@@ -100,11 +100,12 @@ class SecureFormatter(Formatter):
             record.msg += f" (called from {record.filename}:{record.lineno})"
             record.lineno = record.__dict__["s_line"]
             record._called = True
-        message = super(SecureFormatter, self).format(record)
-        if not message.isprintable():
-            message = ''.join(map(lambda x: x if x.isprintable() else '.', message))
+        # Check for printable characters in output, unicode should be fine
+        if not record.msg.isprintable():
+            message = ''.join(map(lambda x: x if x.isprintable() else '.', record.msg))
             message = "!!Log Entry Secured by SecureFormatter!! " + message
-        return message
+            record.msg = message
+        return super(SecureFormatter, self).format(record)
 
 
 class log_with(object):

--- a/tests/test_lib_config.py
+++ b/tests/test_lib_config.py
@@ -275,7 +275,7 @@ class ConfigTestCase(MyTestCase):
 
     def test_10_enrollable_tokentypes(self):
         # Execute the function twice to ensure the cache works
-        for i in range (2):
+        for i in range(2):
             ttypes = get_multichallenge_enrollable_types()
             self.assertIn("hotp", ttypes)
             self.assertIn("totp", ttypes)
@@ -296,7 +296,6 @@ class ConfigTestCase(MyTestCase):
         validate_email = get_email_validators().get("privacyidea.lib.utils.emailvalidation")
         self.assertTrue(validate_email("valid@email.com"))
         self.assertFalse(validate_email("invalid@email.k"))
-
 
     def test_12_enrollable_token_types(self):
         enrollable_types = get_enrollable_token_types()

--- a/tests/test_lib_logging.py
+++ b/tests/test_lib_logging.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (C) 2025 NetKnights GmbH <https://netknights.it>
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import logging
+import logging.config
+
+from privacyidea.lib.log import DEFAULT_LOGGING_CONFIG
+from privacyidea.lib.utils import parse_date
+
+
+def test_log_formatter(caplog, tmp_path):
+    # Test that the secure formatter filters out potentially harmful characters
+    DEFAULT_LOGGING_CONFIG["handlers"]["file"]["filename"] = tmp_path.joinpath("test.log").as_posix()
+    logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+    caplog.set_level(logging.DEBUG, logger="privacyidea")
+    assert parse_date("2016/\0x052/20") is None
+    assert ("!!Log Entry Secured by SecureFormatter!! Dateformat 2016/.x052/20 "
+            "could not be parsed") == caplog.messages[0]


### PR DESCRIPTION
The secure logging formatter inserted its message in front of the complete log record, not only the log message.
Added some tests for logging.

Closes #4576 