### PR TITLE
Write policies only once to the audit

### DIFF
--- a/privacyidea/lib/auditmodules/base.py
+++ b/privacyidea/lib/auditmodules/base.py
@@ -53,6 +53,8 @@ storage.
 
 import logging
 import traceback
+from typing import Union
+
 from privacyidea.lib.log import log_with
 import datetime
 
@@ -195,20 +197,21 @@ class Audit(object):  # pragma: no cover
                     self.audit_data[k] += ","
                 self.audit_data[k] += v
 
-    def add_policy(self, policyname):
+    def add_policy(self, policy_names: Union[set, list, str]):
         """
-        This method adds a triggered policyname to the list of triggered policies.
+        This method adds triggered policy names to the list of triggered policies.
 
-        :param policyname: A string or a list of strings as policynames
+        :param policy_names: A set, list or single policy name(s)
         :return:
         """
-        if "policies" not in self.audit_data:
-            self.audit_data["policies"] = []
-        if isinstance(policyname, list):
-            for p in policyname:
-                self.audit_data["policies"].append(p)
-        else:
-            self.audit_data["policies"].append(policyname)
+        audit_policies = set(self.audit_data.get('policies', []))
+        if isinstance(policy_names, str):
+            audit_policies.add(policy_names)
+        elif isinstance(policy_names, list):
+            policy_names = set(policy_names)
+        if isinstance(policy_names, set):
+            audit_policies.update(policy_names)
+        self.audit_data["policies"] = list(audit_policies)
 
     def finalize_log(self):
         """

--- a/privacyidea/lib/auditmodules/containeraudit.py
+++ b/privacyidea/lib/auditmodules/containeraudit.py
@@ -31,6 +31,8 @@ You also have to provide the configuration parameters for the referenced audit m
 """
 
 import logging
+from typing import Union
+
 from privacyidea.lib.auditmodules.base import (Audit as AuditBase)
 from privacyidea.lib.utils import get_module_class
 
@@ -74,12 +76,12 @@ class Audit(AuditBase):
         for module in self.write_modules:
             module.add_to_log(param, add_with_comma)
 
-    def add_policy(self, policyname):
+    def add_policy(self, policy_names: Union[set, list, str]):
         """
         Call the add_policy method for all writeable modules
         """
         for module in self.write_modules:
-            module.add_policy(policyname)
+            module.add_policy(policy_names)
 
     def search(self, search_dict, page_size=15, page=1, sortorder="asc",
                timelimit=None):

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -706,8 +706,10 @@ class PolicyClass(object):
                 [p.get('name') for p in reduced_policies]))
 
         if audit_data is not None:
+            audit_data.setdefault("policies", [])
             for p in reduced_policies:
-                audit_data.setdefault("policies", []).append(p.get("name"))
+                if p.get("name") not in audit_data["policies"]:
+                    audit_data["policies"].append(p.get("name"))
 
         return reduced_policies
 
@@ -913,9 +915,11 @@ class PolicyClass(object):
                                                    allow_white_space_in_action=allow_white_space_in_action)
 
         if audit_data is not None:
+            audit_data.setdefault("policies", [])
             for action_value, policy_names in policy_values.items():
                 for p_name in policy_names:
-                    audit_data.setdefault("policies", []).append(p_name)
+                    if p_name not in audit_data["policies"]:
+                        audit_data["policies"].append(p_name)
 
         return policy_values
 
@@ -3157,9 +3161,11 @@ class Match(object):
                                                                     allow_white_space_in_action=
                                                                     allow_white_space_in_action)
         if write_to_audit_log:
+            self._g.audit_object.audit_data.setdefault("policies", [])
             for action_value, policy_names in action_values.items():
                 for p_name in policy_names:
-                    self._g.audit_object.audit_data.setdefault("policies", []).append(p_name)
+                    if p_name not in self._g.audit_object.audit_data["policies"]:
+                        self._g.audit_object.audit_data["policies"].append(p_name)
         return action_values
 
     def allowed(self, write_to_audit_log=True):

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -3161,11 +3161,11 @@ class Match(object):
                                                                     allow_white_space_in_action=
                                                                     allow_white_space_in_action)
         if write_to_audit_log:
-            audit_policies = set(self._g.audit_object.audit_data.get("policies", []))
+            audit_policies = set()
             for action_value, policy_names in action_values.items():
                 for p_name in policy_names:
                     audit_policies.add(p_name)
-            self._g.audit_object.audit_data["policies"] = list(audit_policies)
+            self._g.audit_object.add_policy(audit_policies)
         return action_values
 
     def allowed(self, write_to_audit_log=True):

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -706,10 +706,10 @@ class PolicyClass(object):
                 [p.get('name') for p in reduced_policies]))
 
         if audit_data is not None:
-            audit_data.setdefault("policies", [])
+            audit_policies = set(audit_data.get("policies", []))
             for p in reduced_policies:
-                if p.get("name") not in audit_data["policies"]:
-                    audit_data["policies"].append(p.get("name"))
+                audit_policies.add(p.get("name"))
+            audit_data["policies"] = list(audit_policies)
 
         return reduced_policies
 
@@ -915,11 +915,11 @@ class PolicyClass(object):
                                                    allow_white_space_in_action=allow_white_space_in_action)
 
         if audit_data is not None:
-            audit_data.setdefault("policies", [])
+            audit_policies = set(audit_data.get("policies", []))
             for action_value, policy_names in policy_values.items():
                 for p_name in policy_names:
-                    if p_name not in audit_data["policies"]:
-                        audit_data["policies"].append(p_name)
+                    audit_policies.add(p_name)
+            audit_data["policies"] = list(audit_policies)
 
         return policy_values
 
@@ -3161,11 +3161,11 @@ class Match(object):
                                                                     allow_white_space_in_action=
                                                                     allow_white_space_in_action)
         if write_to_audit_log:
-            self._g.audit_object.audit_data.setdefault("policies", [])
+            audit_policies = set(self._g.audit_object.audit_data.get("policies", []))
             for action_value, policy_names in action_values.items():
                 for p_name in policy_names:
-                    if p_name not in self._g.audit_object.audit_data["policies"]:
-                        self._g.audit_object.audit_data["policies"].append(p_name)
+                    audit_policies.add(p_name)
+            self._g.audit_object.audit_data["policies"] = list(audit_policies)
         return action_values
 
     def allowed(self, write_to_audit_log=True):

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -222,7 +222,7 @@ def auth_user_has_no_token(wrapped_function, user_object, passw,
             # Now we need to check, if the user really has no token.
             token_count = get_tokens(user=user_object, count=True)
             if token_count == 0:
-                g.audit_object.add_policy([p.get("name") for p in pass_no_token])
+                g.audit_object.add_policy({p.get("name") for p in pass_no_token})
                 return True, {"message": f"user has no token, accepted due to '{pass_no_token[0].get('name')}'"}
 
     # If nothing else returned, we return the wrapped function
@@ -250,7 +250,7 @@ def auth_user_does_not_exist(wrapped_function, user_object, passw, options=None)
                                   user_object=user_object).policies(write_to_audit_log=False)
         if not user_object.exist():
             if pass_no_user:
-                g.audit_object.add_policy([p.get("name") for p in pass_no_user])
+                g.audit_object.add_policy({p.get("name") for p in pass_no_user})
                 return True, {"message": f"user does not exist, accepted due to '{pass_no_user[0].get('name')}'"}
             else:
                 raise UserError(f"User {user_object} does not exist.")
@@ -288,7 +288,7 @@ def auth_user_passthru(wrapped_function, user_object, passw, options=None):
             policy_object.check_for_conflicts(pass_thru, "passthru")
             pass_thru_action = pass_thru[0].get("action").get("passthru")
             policy_name = pass_thru[0].get("name")
-            g.audit_object.add_policy([p.get("name") for p in pass_thru])
+            g.audit_object.add_policy({p.get("name") for p in pass_thru})
             if pass_thru_action in ["userstore", True]:
                 # Now we need to check the userstore password
                 if user_object.check_password(passw):

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -535,7 +535,7 @@ class AuthApiTestCase(MyApiTestCase):
         aentry = self.find_most_recent_audit_entry(action='POST /auth')
         self.assertEqual(aentry['action'], 'POST /auth', aentry)
         self.assertEqual(aentry['success'], 0, aentry)
-        self.assertEqual(None, aentry['policies'], aentry)
+        self.assertEqual("", aentry['policies'], aentry)
 
         # check split@sign is working correctly
         set_policy(name="remote", scope=SCOPE.WEBUI, realm=self.realm1,

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -5686,8 +5686,8 @@ class TriggeredPoliciesTestCase(MyApiTestCase):
             self.assertTrue(json_response.get("result").get("status"), res)
             self.assertEqual(json_response.get("result").get("value").get("count"), 1)
             # Both policies have triggered
-            self.assertEqual(json_response.get("result").get("value").get("auditdata")[0].get("policies"),
-                             "otppin,lastauth")
+            audit_policies = json_response.get("result").get("value").get("auditdata")[0].get("policies").split(",")
+            self.assertEqual({"otppin", "lastauth"}, set(audit_policies))
 
         # clean up
         remove_token("triggtoken")

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -1577,6 +1577,7 @@ class PolicyTestCase(MyTestCase):
         g = FakeFlaskG()
         g.client_ip = "127.0.0.1"
         g.audit_object = mock.Mock()
+        g.audit_object.audit_data = {}
         g.policy_object = PolicyClass()
         g.logged_in_user = {"username": "delete_admin", "role": ROLE.ADMIN, "realm": ""}
         pols = Match.admin(g, "delete", None).policies()

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -7,6 +7,7 @@ import dateutil
 import mock
 from werkzeug.datastructures.headers import Headers, EnvironHeaders
 
+from privacyidea.lib.auditmodules.base import Audit
 from privacyidea.lib.container import init_container, find_container_by_serial
 from privacyidea.lib.containers.container_info import RegistrationState
 from privacyidea.lib.policies.conditions import (PolicyConditionClass, ConditionSection,
@@ -3104,7 +3105,7 @@ class PolicyMatchTestCase(MyTestCase):
     def test_01_action_only(self):
         g = FakeFlaskG()
         g.client_ip = "127.0.0.1"
-        g.audit_object = mock.Mock()
+        g.audit_object = Audit()
         g.policy_object = PolicyClass()
 
         g.audit_object.audit_data = {}
@@ -3124,7 +3125,7 @@ class PolicyMatchTestCase(MyTestCase):
         g.audit_object.audit_data = {}
         self.check_names(Match.action_only(g, SCOPE.AUTHZ, PolicyAction.NODETAILSUCCESS).policies(),
                          {})
-        self.assertEqual(g.audit_object.audit_data, {})
+        self.assertEqual([], g.audit_object.audit_data.get("policies", []))
 
         with self.assertRaises(MatchingError):
             Match.action_only(g, SCOPE.ADMIN, "tokenview")
@@ -3154,6 +3155,7 @@ class PolicyMatchTestCase(MyTestCase):
         g = FakeFlaskG()
         g.client_ip = "127.0.0.1"
         g.audit_object = mock.Mock()
+        g.audit_object.audit_data = {}
         g.policy_object = PolicyClass()
 
         class Foobar(User):
@@ -3184,6 +3186,7 @@ class PolicyMatchTestCase(MyTestCase):
         g = FakeFlaskG()
         g.client_ip = "127.0.0.1"
         g.audit_object = mock.Mock()
+        g.audit_object.audit_data = {}
         g.policy_object = PolicyClass()
         g.logged_in_user = {"username": "superroot", "realm": "", "role": ROLE.ADMIN}
 
@@ -3203,6 +3206,7 @@ class PolicyMatchTestCase(MyTestCase):
         g = FakeFlaskG()
         g.client_ip = "127.0.0.1"
         g.audit_object = mock.Mock()
+        g.audit_object.audit_data = {}
         g.policy_object = PolicyClass()
 
         g.logged_in_user = {"username": "superroot", "realm": "", "role": ROLE.ADMIN}


### PR DESCRIPTION
In the audit column `policies`, each policy should appear only once, even if the policy is applied multiple times in the request