### PR TITLE
Add new WebUI to docker build

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,20 +1,20 @@
 FROM cgr.dev/chainguard/wolfi-base AS builder
 
 ARG PYTHON_VERSION=3.13
+ARG NODEJS_VERSION=22
 
 ARG GUNICORN=23.0.0
 # TODO: we should probably create a different container image for use with postgres
 ARG PSYCOPG2=2.9.10
 
 # TODO: Add build steps for gssapi and PyKCS11
-# TODO: Add build step for new WebUI
 
 # Set environment variables to optimize Python for docker
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 # Install Python, pip, build tools
-RUN apk add --no-cache python-${PYTHON_VERSION} py${PYTHON_VERSION}-pip build-base git
+RUN apk add --no-cache python-${PYTHON_VERSION} py${PYTHON_VERSION}-pip build-base git nodejs-${NODEJS_VERSION} npm
 
 RUN python3 -m venv /opt/privacyidea
 
@@ -35,6 +35,15 @@ COPY ./.git ./.git
 COPY ./deploy/ ./deploy
 COPY ./tools/ ./tools
 COPY ./privacyidea/ ./privacyidea
+
+# Build the new WebUI
+# TODO: This could be done in a separate builder image
+WORKDIR /build/privacyidea/static_new
+RUN npm ci
+RUN npm run-script ng build
+RUN rm -rf node_modules
+
+WORKDIR /build
 
 RUN /opt/privacyidea/bin/pip install --no-cache-dir .
 

--- a/deploy/docker/compose.yaml
+++ b/deploy/docker/compose.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2025 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: CC0-1.0
+
 name: privacyIDEA
 
 services:
@@ -29,10 +32,13 @@ services:
     ports:
       - "8080:8080"
     secrets:
+      # To automatically detect the encryption key, the secret must be named "enckey"
       - enckey
       - secret_key
       - pi_pepper
       - mariadb_password
+      - audit_key_private
+      - audit_key_public
     environment:
       # Construct the database uri from variables/secrets
       PI_DB_PASSWORD_FILE: /run/secrets/mariadb_password
@@ -41,16 +47,18 @@ services:
       PI_DB_NAME: pi
       # Alternatively use SQLALCHEMY_DATABASE_URI or SQLALCHEMY_DATABASE_URI_FILE
 #      SQLALCHEMY_DATABASE_URI: mysql+pymysql://pi:test123@db:3306/pi
+
+      # The encryption key is automatically detected if configured as the "enckey" secret
+      # Alternatively, if the encryption key is mounted elsewhere, set the environment
+      # variable PI_ENCFILE to point to the file.
+
+      # Secrets that can be passed into the container as files:
       SECRET_KEY_FILE: /run/secrets/secret_key
       PI_PEPPER_FILE: /run/secrets/pi_pepper
-      PI_ENCFILE: /run/secrets/enckey
-      # Additional secrets that can be given as files:
-#      PI_AUDIT_KEY_PUBLIC_FILE
-#      PI_AUDIT_KEY_PRIVATE_FILE
-#      SQLALCHEMY_DATABASE_URI_FILE
+
       # To test the setup of the container, set FLASK_DEBUG to "true".
       # Note: This also sets the log-level of privacyIDEA to "DEBUG"
-      FLASK_DEBUG: true
+#      FLASK_DEBUG: true
     env_file:
       # Additional environment variables can be loaded from an .env file
       - ./example.env
@@ -69,3 +77,9 @@ secrets:
   mariadb_password:
     # Create a random password i.e. with "pwgen 20 1 > db_password.txt"
     file: ./db_password.txt
+  # Generate audit key-pair with "openssl genrsa -out audit_key_private.pem 2048"
+  #  and "openssl rsa -in audit_key_private.pem -pubout -out audit_key_public.pem"
+  audit_key_private:
+    file: ./audit_key_private.pem
+  audit_key_public:
+    file: ./audit_key_public.pem

--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -269,9 +269,10 @@ def create_app(config_name="development",
     @app.errorhandler(404)
     def fallback(error):
         if request.path.startswith("/app/v2/"):
+            index_html = app.config.get("PI_INDEX_HTML") or "index.html"
             return send_html(
                 render_template(
-                    "index.html"))
+                    index_html))
         return jsonify(error="Not found"), 404
 
     # Overwrite default config with environment setting

--- a/privacyidea/static_new/angular.json
+++ b/privacyidea/static_new/angular.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "$schema": "node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
@@ -24,9 +24,6 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "localize": [
-              "de"
-            ],
             "allowedCommonJsDependencies": [
               "crypto-js"
             ],

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -69,7 +69,6 @@ def before_request():
     This is executed before the request
     """
     g.policy_object = PolicyClass()
-    g.audit_object = None
     # access_route contains the ip addresses of all clients, hops and proxies.
     g.client_ip = get_client_ip(request, get_from_config(SYSCONF.OVERRIDECLIENT))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ where = ["."]
 include = ["privacyidea*"]
 
 [tool.setuptools.package-data]
-"privacyidea" = ["static/**", "static_new/dist/**"]
+"privacyidea" = ["static/**", "static_new/dist/**", "migrations/**"]
 
 [tool.setuptools.exclude-package-data]
 "privacyidea" = ["static/node_modules/**", "static_new/node_modules/**"]


### PR DESCRIPTION
- Build the new WebUI during the docker container build
- Stop building translation bundles for until we have a better grasp on how to deploy translations with the new WebUI
- Add some more comments to the docker-compose example
- Make the 404 fallback for the new WebUI consider the PI_INDEX_HTML configuration
- Detect some docker secrets automatically and add them to the configuration
- Add the alembic configuration files to the python build