### PR TITLE
move auth details to log on failed attempts

### DIFF
--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -434,8 +434,9 @@ def get_auth_token():
                 return send_result(False, rid=2, details=details)
 
     if not admin_auth and not user_auth:
+        log.warning(f"User login failed for '{user.login}'. Details: {details}")
         raise AuthError(_("Authentication failure. Wrong credentials"), id=ERROR.AUTHENTICATE_WRONG_CREDENTIALS,
-                        details=details or {})
+                        details={})
     else:
         g.audit_object.log({"success": True})
         request.User = user


### PR DESCRIPTION
Moving details to log for analysis instead of the endpoint result object. By this every attempt on fishing for existing or non existing users will result in the exact same response message.

refs #4684