### PR TITLE
Increase audit signature column size

### DIFF
--- a/privacyidea/migrations/versions/056b6642ff5d_.py
+++ b/privacyidea/migrations/versions/056b6642ff5d_.py
@@ -1,0 +1,29 @@
+"""v3.13: Increase audit signature column size to support 4096-bit RSA keys
+
+Revision ID: 056b6642ff5d
+Revises: 1c48d4ffb8c3
+Create Date: 2025-09-15 13:29:06.058342
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '056b6642ff5d'
+down_revision = '1c48d4ffb8c3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('pidea_audit', 'signature',
+                    existing_type=sa.VARCHAR(length=620),
+                    type_=sa.Unicode(length=1100),
+                    existing_nullable=True)
+
+
+def downgrade():
+    op.alter_column('pidea_audit', 'signature',
+                    existing_type=sa.Unicode(length=1100),
+                    type_=sa.VARCHAR(length=620),
+                    existing_nullable=True)

--- a/privacyidea/models/audit.py
+++ b/privacyidea/models/audit.py
@@ -24,7 +24,7 @@ from privacyidea.models import db
 from privacyidea.models.utils import MethodsMixin
 from privacyidea.lib.utils import convert_column_to_unicode
 
-audit_column_length = {"signature": 620,
+audit_column_length = {"signature": 1100,
                        "action": 200,
                        "serial": 40,
                        "token_type": 12,


### PR DESCRIPTION
Increases size limit of the `signature` column from 620 to 1132 characters, so it can hold signatures from up to 4096-bit RSA keys.

The actual number of characters required to store the RSA N-bit signatures are as follows:
2048: 527
3072: 783
4096: 1039

The extra space of 93 characters for the old size limit is kept as-is.

Fixes #4686 