### PR TITLE
Use Argon2 as the default algorithm.

### DIFF
--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -254,9 +254,8 @@ class IdResolver (UserIdResolver):
                              database_pw)
 
         try:
-            # Create a dynamic context that uses the resolver's configured hash type as the default for re-hashing.
-            target_handler_id = hash_type_dict.get(self.password_hash_type.upper())
-            if not target_handler_id:
+            hash_algorithm = hash_type_dict.get(self.password_hash_type.upper())
+            if not hash_algorithm:
                 # This should not happen if config is validated, but as a safeguard:
                 log.error(f"The configured Password_Hash_Type '{self.password_hash_type}' is not a supported handler.")
                 # Fallback to simple verification without re-hashing
@@ -265,7 +264,7 @@ class IdResolver (UserIdResolver):
             else:
                 temp_ctx = CryptContext(
                     schemes=pw_ctx.schemes(),
-                    default=target_handler_id,
+                    default=hash_algorithm,
                     deprecated="auto"
                 )
                 verified, new_hash = temp_ctx.verify_and_update(password, database_pw)

--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -38,7 +38,7 @@ import re
 from privacyidea.lib.resolvers.UserIdResolver import UserIdResolver
 
 from sqlalchemy import (Integer, cast, String, MetaData, Table, and_,
-                        create_engine, select, insert, delete)
+                        create_engine, select, insert, delete, update)
 from sqlalchemy.orm import sessionmaker, scoped_session
 
 import traceback
@@ -56,7 +56,7 @@ from passlib.utils.compat import unicode as pl_unicode
 from passlib.utils import to_unicode
 import passlib.utils.handlers as uh
 import passlib.exc as exc
-from passlib.registry import register_crypt_handler
+from passlib.registry import register_crypt_handler, get_crypt_handler
 from passlib.handlers.ldap_digests import _SaltedBase64DigestHelper
 
 
@@ -130,7 +130,8 @@ register_crypt_handler(ldap_salted_sha256_pi)
 
 
 # The list of supported password hash types for verification (passlib handler)
-pw_ctx = CryptContext(schemes=['phpass',
+pw_ctx = CryptContext(schemes=['argon2',
+                               'phpass',
                                'phpass_drupal',
                                'ldap_salted_sha1',
                                'ldap_salted_sha256_pi',
@@ -144,7 +145,8 @@ pw_ctx = CryptContext(schemes=['phpass',
                                ])
 
 # List of supported password hash types for hash generation (name to passlib handler id)
-hash_type_dict = {"PHPASS": 'phpass',
+hash_type_dict = {"ARGON2ID": 'argon2',
+                  "PHPASS": 'phpass',
                   "SHA": 'ldap_sha1',
                   "SSHA": 'ldap_salted_sha1',
                   "SSHA256": 'ldap_salted_sha256_pi',
@@ -239,10 +241,8 @@ class IdResolver (UserIdResolver):
         :return: True if password matches the saved password hash, False otherwise
         :rtype: bool
         """
-
         res = False
         userinfo = self.getUserInfo(uid)
-
         database_pw = userinfo.get("password", "XXXXXXX")
 
         # remove owncloud hash format identifier (currently only version 1)
@@ -254,11 +254,47 @@ class IdResolver (UserIdResolver):
                              database_pw)
 
         try:
-            res = pw_ctx.verify(password, database_pw)
-        except ValueError as _e:
+            # Create a dynamic context that uses the resolver's configured hash type as the default for re-hashing.
+            target_handler_id = hash_type_dict.get(self.password_hash_type.upper())
+            if not target_handler_id:
+                # This should not happen if config is validated, but as a safeguard:
+                log.error(f"The configured Password_Hash_Type '{self.password_hash_type}' is not a supported handler.")
+                # Fallback to simple verification without re-hashing
+                verified = pw_ctx.verify(password, database_pw)
+                new_hash = None
+            else:
+                temp_ctx = CryptContext(
+                    schemes=pw_ctx.schemes(),
+                    default=target_handler_id,
+                    deprecated="auto"
+                )
+                verified, new_hash = temp_ctx.verify_and_update(password, database_pw)
+
+            log.info(f"Password verification for user {uid}: {verified}, rehash needed: {bool(new_hash)}")
+            if verified:
+                res = True
+                if new_hash:
+                    log.info(f"Re-hashing password for user {uid}")
+                    try:
+                        userid_column = self.map.get("userid")
+                        password_column = self.map.get("password")
+
+                        # Manually create and execute the update statement
+                        # to store the already hashed password.
+                        stmt = (
+                            update(self.TABLE)
+                            .where(self.TABLE.c[userid_column] == uid)
+                            .values({password_column: new_hash})
+                        )
+                        self.session.execute(stmt)
+                        self.session.commit()
+                        log.info(f"Successfully re-hashed password for user {uid}")
+                    except Exception as e:
+                        log.error(f"Failed to save re-hashed password for user {uid}: {e!r}")
+                        self.session.rollback()
+        except (ValueError, exc.UnknownHashError) as _e:
             # if the hash could not be identified / verified, just return False
             pass
-
         return res
 
     def getUserInfo(self, userId):
@@ -467,7 +503,7 @@ class IdResolver (UserIdResolver):
         self.password = config.get('Password', "")
         self.table = config.get('Table', "")
         self._editable = config.get("Editable", False)
-        self.password_hash_type = config.get("Password_Hash_Type", "SSHA256")
+        self.password_hash_type = config.get("Password_Hash_Type", "ARGON2ID")
         usermap = config.get('Map', {})
         self.map = yaml.safe_load(usermap)
         self.reverse_map = {v: k for k, v in self.map.items()}
@@ -759,7 +795,8 @@ def hash_password(password, hashtype):
     """
     hashtype = hashtype.upper()
     try:
-        password = pw_ctx.handler(hash_type_dict[hashtype]).hash(password)
+        handler = get_crypt_handler(hash_type_dict[hashtype])
+        password = handler.hash(password)
     except KeyError as _e:  # pragma: no cover
         raise Exception("Unsupported password hashtype '{0!s}'. "
                         "Use one of {1!s}.".format(hashtype, hash_type_dict.keys()))

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -135,9 +135,8 @@ class AuthorizationPolicyTestCase(MyApiTestCase):
     https://github.com/privacyidea/privacyidea/issues/543
     """
 
-    @ldap3mock.activate
-    def test_00_create_realm(self):
-        ldap3mock.setLDAPDirectory(LDAPDirectory)
+    def setUp(self):
+        super(AuthorizationPolicyTestCase, self).setUp()
         params = {'LDAPURI': 'ldap://localhost',
                   'LDAPBASE': 'o=test',
                   'BINDDN': 'cn=manager,ou=example,o=test',
@@ -154,8 +153,7 @@ class AuthorizationPolicyTestCase(MyApiTestCase):
                   "resolver": "catchall",
                   "type": "ldapresolver"}
 
-        r = save_resolver(params)
-        self.assertTrue(r > 0)
+        save_resolver(params)
 
         params = {'LDAPURI': 'ldap://localhost',
                   'LDAPBASE': 'ou=sales,o=test',
@@ -173,9 +171,15 @@ class AuthorizationPolicyTestCase(MyApiTestCase):
                   "resolver": "sales",
                   "type": "ldapresolver"}
 
-        r = save_resolver(params)
-        self.assertTrue(r > 0)
+        save_resolver(params)
 
+    @ldap3mock.activate
+    def test_00_create_realm(self):
+        """
+        This test verifies that the resolvers created in the setUp method
+        are correctly listed.
+        """
+        ldap3mock.setLDAPDirectory(LDAPDirectory)
         rl = get_resolver_list()
         self.assertTrue("catchall" in rl)
         self.assertTrue("sales" in rl)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -75,7 +75,8 @@ class AppTestCase(unittest.TestCase):
         ], logger.handlers)
 
     def test_02_create_production_app(self):
-        app = create_app(config_name='production')
+        test_config_file = os.path.join(dirname, 'tests', 'testdata', 'test_pi.cfg')
+        app = create_app(config_name='production', config_file=test_config_file)
         dc = config['production']()
         members = inspect.getmembers(dc, lambda a: not (inspect.isroutine(a)))
         conf = [m for m in members if not (m[0].startswith('__') and m[0].endswith('__'))]

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -710,7 +710,7 @@ class SQLResolverTestCase(MyTestCase):
         self.assertTrue(original_hash.startswith("{SSHA256}"))
 
         # 2. Check with wrong password
-        self.assertFalse(y.checkPass(uid, "wrongpassword")),
+        self.assertFalse(y.checkPass(uid, "wrongpassword"))
 
         # 3. Verify the hash has not changed
         new_hash = y.session.execute(

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -530,6 +530,17 @@ class SQLResolverTestCase(MyTestCase):
         self.assertTrue(y.checkPass(uid, "test8"))
         self.assertFalse(y.checkPass(uid, "test"))
 
+        # ARGON2ID
+        parameters["Password_Hash_Type"] = "ARGON2ID"
+        y.loadConfig(parameters)
+        self.assertTrue(y.update_user(uid, {"username": "achmed2",
+                                            "password": "test9"}))
+        stored_password = y.session.execute(
+            y.TABLE.select().where(y.TABLE.c.username == "achmed2")).first().password
+        self.assertTrue(stored_password.startswith("$argon2id$"), stored_password)
+        self.assertTrue(y.checkPass(uid, "test9"))
+        self.assertFalse(y.checkPass(uid, "test"))
+
         # TODO: check unknown hash type
         parameters["Password_Hash_Type"] = "UNKNOWN"
         y.loadConfig(parameters)

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -677,7 +677,7 @@ class SQLResolverTestCase(MyTestCase):
         self.assertTrue(original_hash.startswith("$argon2id$"))
 
         # 2. Check the password
-        self.assertTrue(y.checkPass(uid, "password123")),
+        self.assertTrue(y.checkPass(uid, "password123"))
 
         # 3. Verify the hash has not changed
         new_hash = y.session.execute(

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -200,7 +200,7 @@ class SQLResolverTestCase(MyTestCase):
                     i = 0
                     break
                 if i > 25:
-                    self.fail("Could not delete user {username} with uid {uid}")
+                    self.fail(f"Could not delete user {username} with uid {uid}")
                 y.delete_user(uid)
 
     def test_01_sqlite_resolver(self):

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -739,7 +739,7 @@ class SQLResolverTestCase(MyTestCase):
 
         # 2. Verify checkPass returns False and does not raise an exception
         with LogCapture(level=logging.ERROR) as lc:
-            self.assertFalse(y.checkPass(uid, "password123")),
+            self.assertFalse(y.checkPass(uid, "password123"))
             # No errors should be logged, as this is a graceful failure
             self.assertEqual(len(lc.records), 0)
 

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -649,7 +649,7 @@ class SQLResolverTestCase(MyTestCase):
         self.assertTrue(stored_pw.startswith("{SSHA256}"))
 
         # 2. Check the password, this should trigger the re-hash
-        self.assertTrue(y.checkPass(uid, "password123")),
+        self.assertTrue(y.checkPass(uid, "password123"))
 
         # 3. Verify the new hash is Argon2
         new_stored_pw = y.session.execute(


### PR DESCRIPTION
Refactor the password hashing process to use Argon2 as the default algorithm. Implement re-hashing logic for existing passwords when the algorithm changes.