### PR TITLE
 Adding a warning about the use of commas in the email and sms text.

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -245,6 +245,8 @@ an HTML file.
 .. note:: If a message text is supplied directly, the email is sent as plain text.
    If the email template is read from a file, a HTML-only email is sent instead.
 
+.. note:: In the code, commas separated different policy actions. This is why a comma in a policy action-value cannot be used.
+
 emailsubject
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Some users add ¨,"in the email or sms text. Or as commas separated different policy actions, the code interprets them.  This is why a comma in a policy action-value cannot be used.