### PR TITLE
Disable require_presence when push_wait is active

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,9 @@
+Version 3.12.1
+
+  Fixes:
+  * 'push_require_presence' policy does not work when 'push_wait' is set (#4702)
+  * Show the own audit logs of helpdesk admins (#4637)
+
 Version 3.12, 2025-09-09
 
   Features:

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -651,12 +651,16 @@ The push notification on the smartphone will show several buttons. One is labele
 The user then can confirm the login by pressing this button. All other buttons will decline the
 login request.
 
+If this policy is not set, the PUSH message will simply ask the user if they
+want to log in.
+
+.. important:: This policy is incompatible with the policy :ref:`policy_push_wait`
+   since the correct presence option can not be passed back to the calling client.
+   If the ``push_wait`` policy is also set, ``push_require_presence`` will be disabled.
+
 .. note:: This mechanism allows login scenarios where the user in front of the login window and the
    person owning the smartphone are two different persons. In this case they will have to communicate
    for a successful login.
-
-If this policy is not set, the PUSH message will simply ask the user if they
-want to log in.
 
 .. versionadded:: 3.10
 

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -1,4 +1,6 @@
-#  License:  AGPLv3
+# SPDX-FileCopyrightText: 2019 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
 #  contact:  http://www.privacyidea.org
 #
 #  2019-02-08   Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -25,15 +27,14 @@ and send it back to the authentication endpoint.
 This code is tested in tests/test_lib_tokens_push
 """
 
-import secrets
 from base64 import b32decode
 from binascii import Error as BinasciiError
+from datetime import datetime, timedelta, timezone
+from dateutil.parser import isoparse
+import random
 import string
 from typing import Optional, Union
 from urllib.parse import quote
-from datetime import datetime, timedelta
-from pytz import utc
-from dateutil.parser import isoparse
 import traceback
 
 from privacyidea.api.lib.utils import getParam, get_required
@@ -87,7 +88,7 @@ DELAY = 1.0
 POLL_TIME_WINDOW = 1
 UPDATE_FB_TOKEN_WINDOW = 5
 POLL_ONLY = "poll only"
-AVAILABLE_PRESENCE_OPTIONS_ALPHABETIC = [f"{x}" for x in string.ascii_uppercase]
+AVAILABLE_PRESENCE_OPTIONS_ALPHABETIC = list(string.ascii_uppercase)
 AVAILABLE_PRESENCE_OPTIONS_NUMERIC = [f'{x:02}' for x in range(100)]
 ALLOWED_NUMBER_OF_OPTIONS = [f"{i}" for i in range(2, 11)]
 
@@ -184,26 +185,26 @@ def create_push_token_url(url: Optional[str] = None, ttl: Union[int, str] = 10, 
     return token_url
 
 
-def _get_presence_options(options):
+def _get_presence_options(options) -> list:
     """
     Get the available presence options for the user to confirm the login based on the push policy configurations.
+
     :param options: the request context parameters / data
     :type options: dict
+    :return: The list of available presence characters/numbers
     """
-    push_presence_options = get_action_values_from_options(
+    push_presence_option = get_action_values_from_options(
         SCOPE.AUTH, PUSH_ACTION.PRESENCE_OPTIONS, options) or "ALPHABETIC"
-    push_presence_options = getParam({"presence_options": push_presence_options}, "presence_options",
-                                     allowed_values=["ALPHABETIC", "NUMERIC", "CUSTOM"], default="ALPHABETIC")
-    push_presence_options
-    if push_presence_options == "ALPHABETIC":
-        available_presence_options = list(AVAILABLE_PRESENCE_OPTIONS_ALPHABETIC)
-    elif push_presence_options == "NUMERIC":
+
+    if push_presence_option == "NUMERIC":
         available_presence_options = list(AVAILABLE_PRESENCE_OPTIONS_NUMERIC)
-    elif push_presence_options == "CUSTOM":
+    elif push_presence_option == "CUSTOM":
         custom_presence_options = get_action_values_from_options(
             SCOPE.AUTH, PUSH_ACTION.PRESENCE_CUSTOM_OPTIONS, options)
-        available_presence_options = custom_presence_options.split(
-            ":") or list(AVAILABLE_PRESENCE_OPTIONS_ALPHABETIC)
+        available_presence_options = custom_presence_options.split(":")
+    # Default push_presence_option is "ALPHABETIC":
+    else:
+        available_presence_options = list(AVAILABLE_PRESENCE_OPTIONS_ALPHABETIC)
     return available_presence_options
 
 
@@ -661,15 +662,17 @@ class PushTokenClass(TokenClass):
             ts = isoparse(timestamp)
         except (ValueError, TypeError) as _e:
             log.debug(f'{traceback.format_exc()}')
-            raise privacyIDEAError(f'Could not parse timestamp {timestamp}. '
-                                   'ISO-Format required.')
+            raise privacyIDEAError(f'Could not parse timestamp {timestamp}. ISO-Format required.')
         td = timedelta(minutes=window)
         # We don't know if the passed timestamp is timezone aware. If no
         # timezone is passed, we assume UTC
         if ts.tzinfo:
-            now = datetime.now(utc)
+            # We honor the timezone of the timestamp, ideally it should be UTC
+            now = datetime.now(ts.tzinfo)
         else:
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
+            # We need to add the timezone UTC to the naive timestamp
+            ts = ts.replace(tzinfo=timezone.utc)
         if not (now - td <= ts <= now + td):
             raise privacyIDEAError(f'Timestamp {timestamp} not in valid range.')
 
@@ -736,9 +739,21 @@ class PushTokenClass(TokenClass):
                         else:
                             # Verify the presence_answer. The correct choice is stored as last entry
                             # in the data separated by a comma.
-                            if presence_answer and presence_answer != challenge.get_data().split(",").pop():
+                            # Make sure that the presence_answer is given if it is set in the challenge.
+                            challenge_data = challenge.get_data()
+                            if challenge_data and presence_answer:
+                                if presence_answer != challenge_data.split(",").pop():
+                                    log.debug("Challenge data (%s) does not match "
+                                              "given presence answer (%s)!" % (challenge_data, presence_answer))
+                                    result = False
+                                    # TODO: should we somehow invalidate the challenge by e.g. shuffling the data?
+                                else:
+                                    # Presence answer matches, mark challenge as answered
+                                    challenge.set_otp_status(True)
+                            elif challenge_data and not presence_answer:
+                                log.warning("'push_require_presence' Policy is set but the presence answer "
+                                            "is not present in the smartphone request!")
                                 result = False
-                                # TODO: should we somehow invalidate the challenge by e.g. shuffling the data?
                             else:
                                 challenge.set_otp_status(True)
                         challenge.save()
@@ -994,24 +1009,8 @@ class PushTokenClass(TokenClass):
         data = None
         current_presence_options = None
         reply_dict = {}
-        if is_true(require_presence):
-            if not options["push_triggered"]:
-                # Create a new challenge data
-                current_presence_options = []
-
-                available_presence_options = _get_presence_options(options)
-                num_options = get_action_values_from_options(
-                    SCOPE.AUTH, PUSH_ACTION.PRESENCE_NUM_OPTIONS, options)
-                num_options = getParam({"num_options": num_options}, "num_options",
-                                       allowed_values=ALLOWED_NUMBER_OF_OPTIONS, default="3")
-                for _ in range(int(num_options)):
-                    selected_option = secrets.choice(available_presence_options)
-                    available_presence_options.remove(selected_option)
-                    current_presence_options.append(selected_option)
-                correct_presence_option = secrets.choice(current_presence_options)
-                # The data contains all selected options and the correct option at the end.
-                data = ",".join(current_presence_options + [correct_presence_option])
-            else:
+        if is_true(require_presence) and not options.get(PUSH_ACTION.WAIT):
+            if options.get("push_triggered"):
                 # If the user has more than one token and more than one challenge is created, we need to ensure
                 # that the challenge data for all push token is the same.
                 challenges = get_challenges(transaction_id=transactionid)
@@ -1020,7 +1019,24 @@ class PushTokenClass(TokenClass):
                 split_presence_options = data.split(",")
                 current_presence_options = split_presence_options[:-1]
                 correct_presence_option = split_presence_options[-1]
+            else:
+                # Create a new challenge data
+                current_presence_options = []
+
+                available_presence_options = _get_presence_options(options)
+                num_options = get_action_values_from_options(
+                    SCOPE.AUTH, PUSH_ACTION.PRESENCE_NUM_OPTIONS, options)
+                num_options = getParam({"num_options": num_options}, "num_options",
+                                       allowed_values=ALLOWED_NUMBER_OF_OPTIONS, default="3")
+                current_presence_options = random.sample(available_presence_options,
+                                                         int(num_options))
+                correct_presence_option = random.choice(current_presence_options)
+                # The data contains all selected options and the correct option at the end.
+                data = ",".join(current_presence_options + [correct_presence_option])
             reply_dict.update({"presence_answer": correct_presence_option})
+        elif is_true(require_presence) and options.get(PUSH_ACTION.WAIT):
+            log.warning("Unable to use 'require_presence' policy with 'push_wait'. "
+                        "Disabling 'require_presence' policy!")
         # Initially we assume there is no error from Firebase
         res = True
         fb_identifier = self.get_tokeninfo(PUSH_ACTION.FIREBASE_CONFIG)
@@ -1072,7 +1088,7 @@ class PushTokenClass(TokenClass):
                     raise ValidateError("Failed to submit message to Firebase service.")
         else:
             log.warning(f"The token {self.token.serial} has no tokeninfo {PUSH_ACTION.FIREBASE_CONFIG}. "
-                        "The message could not be sent.")
+                        f"The message could not be sent.")
             message += " " + ERROR_CHALLENGE_TEXT
             if is_true(options.get("exception")):
                 raise ValidateError("The token has no tokeninfo. Can not send via Firebase service.")

--- a/tests/test_api_push_validate.py
+++ b/tests/test_api_push_validate.py
@@ -1,20 +1,31 @@
-from .base import MyApiTestCase
-from privacyidea.lib.user import User
-from privacyidea.lib.token import get_tokens, init_token, remove_token, get_one_token
-from privacyidea.lib.policy import SCOPE, set_policy, delete_policy
-from privacyidea.lib.tokens.pushtoken import PUSH_ACTION, strip_key
-from privacyidea.lib.smsprovider.SMSProvider import set_smsgateway
-from privacyidea.lib.smsprovider.FirebaseProvider import FirebaseConfig
-from cryptography.hazmat.primitives import serialization
+# SPDX-FileCopyrightText: 2020 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from base64 import b32encode
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.backends import default_backend
-from privacyidea.lib.utils import to_bytes, to_unicode
-from cryptography.hazmat.primitives.asymmetric import rsa
+import datetime
+import logging
+
+from testfixtures import LogCapture
+
+from .base import MyApiTestCase
+from privacyidea.lib.user import User
+from privacyidea.lib.token import (get_tokens, init_token, remove_token,
+                                   get_one_token, enable_token)
+from privacyidea.lib.tokenclass import CLIENTMODE, ROLLOUTSTATE
+from privacyidea.lib.policy import SCOPE, set_policy, delete_policy
+from privacyidea.lib.tokens.pushtoken import (PUSH_ACTION, strip_key, POLL_ONLY,
+                                              DEFAULT_CHALLENGE_TEXT)
+from privacyidea.lib.challenge import get_challenges
+from privacyidea.lib.smsprovider.SMSProvider import set_smsgateway
+from privacyidea.lib.smsprovider.FirebaseProvider import FirebaseConfig
+from privacyidea.lib.utils import to_bytes, to_unicode, AUTH_RESPONSE
 from privacyidea.lib.policies.actions import PolicyAction
-from privacyidea.lib.token import enable_token
 from privacyidea.lib.realm import set_realm, set_default_realm
 from privacyidea.lib.resolver import save_resolver
-from privacyidea.lib.tokenclass import CLIENTMODE
 from . import ldap3mock
 
 
@@ -319,13 +330,11 @@ class PushAPITestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200)
             detail = res.json.get("detail")
-            serial = detail.get("serial")
             self.assertEqual(detail.get("rollout_state"), "clientwait")
             self.assertTrue("pushurl" in detail)
             # check that the new URL contains the serial number
             self.assertTrue("&serial=PIPU" in detail.get("pushurl").get("value"))
             self.assertFalse("otpkey" in detail)
-            enrollment_credential = detail.get("enrollment_credential")
 
         # We skip the 2nd step of the enrollment!
         # But we activate the token on purpose!
@@ -504,7 +513,6 @@ class PushAPITestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
             result = res.json.get("result")
-            detail = res.json.get("detail")
             self.assertTrue(result.get("status"))
             self.assertTrue(result.get("value"))
             self.assertEqual(result.get("authentication"), "ACCEPT")
@@ -514,3 +522,248 @@ class PushAPITestCase(MyApiTestCase):
         delete_policy("pol_multienroll")
         delete_policy("pol_push2")
         remove_token(serial)
+
+    def test_15_push_with_require_presence(self):
+        self.setUp_user_realms()
+        # Setup PUSH policies
+        set_policy("push_config", scope=SCOPE.ENROLL,
+                   action="{0!s}={1!s},{2!s}={3!s}".format(
+                       PUSH_ACTION.FIREBASE_CONFIG, POLL_ONLY,
+                       PUSH_ACTION.REGISTRATION_URL, REGISTRATION_URL))
+        # Add the require_presence policy
+        set_policy("push_require_presence", scope=SCOPE.AUTH,
+                   action=f"{PUSH_ACTION.REQUIRE_PRESENCE}=1")
+        # Create push token for user
+        # 1st step
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "push",
+                                                 "pin": "push_pin",
+                                                 "user": "selfservice",
+                                                 "realm": self.realm1,
+                                                 "serial": self.serial_push,
+                                                 "genkey": 1},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            detail = res.json.get("detail")
+            enrollment_credential = detail.get("enrollment_credential")
+
+        # 2nd step: as performed by the smartphone
+        with self.app.test_request_context('/ttype/push',
+                                           method='POST',
+                                           data={"enrollment_credential": enrollment_credential,
+                                                 "serial": self.serial_push,
+                                                 "pubkey": self.smartphone_public_key_pem_urlsafe,
+                                                 "fbtoken": "firebaseT"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"), res.json)
+            self.assertTrue(res.json.get("result").get("value"), res.json)
+            detail = res.json.get("detail")
+            # Now the smartphone gets a public key from the server
+            self.assertIn("public_key", detail, detail)
+            self.assertEqual(ROLLOUTSTATE.ENROLLED, detail.get("rollout_state"), detail)
+
+        #############################################################
+        # Run authentication with push token and without push_wait
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "selfservice",
+                                                 "pass": "push_pin"}):
+            res = self.app.full_dispatch_request()
+            self.assertTrue(res.status_code == 200, res)
+            detail = res.json.get("detail")
+            # Get the challenge data
+            transaction_id = detail.get("transaction_id")
+            challenge_messages = [m.strip() for m in detail.get("message").split(",")]
+            challenge = get_challenges(serial=self.serial_push, transaction_id=transaction_id)[0]
+            # The correct answer is always appended to the available options
+            presence_answer = challenge.get_data().split(',').pop()
+            # Check that we get a presence required message
+            challenge_text = DEFAULT_CHALLENGE_TEXT + f" Please press: {presence_answer}"
+            self.assertTrue(challenge_text in challenge_messages)
+
+        # We do poll only, so we need to poll
+        timestamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+        sign_string = "{serial}|{timestamp}".format(serial=self.serial_push,
+                                                    timestamp=timestamp)
+        sig = self.smartphone_private_key.sign(sign_string.encode('utf8'),
+                                               padding.PKCS1v15(),
+                                               hashes.SHA256())
+        # now check that we receive the challenge when polling
+        with self.app.test_request_context('/ttype/push',
+                                           method='GET',
+                                           query_string={"serial": self.serial_push,
+                                                         "timestamp": timestamp,
+                                                         "signature": b32encode(sig)}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            value = res.json.get("result").get("value")
+            self.assertEqual("Do you want to confirm the login?", value[0].get("question"))
+            nonce = value[0].get("nonce")
+        # Answer the challenge without presence option
+        sign_string = f"{nonce}|{self.serial_push}"
+        sig = self.smartphone_private_key.sign(sign_string.encode('utf8'),
+                                               padding.PKCS1v15(),
+                                               hashes.SHA256())
+        with LogCapture(level=logging.WARNING) as lc:
+            with self.app.test_request_context('/ttype/push',
+                                               method='POST',
+                                               query_string={"serial": self.serial_push,
+                                                             "timestamp": timestamp,
+                                                             "signature": b32encode(sig)}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(200, res.status_code, res)
+                self.assertTrue(res.json.get("result").get("status"), res.json)
+                # This fails since no presence_answer was given
+                self.assertFalse(res.json.get("result").get("value"), res.json)
+                lc.check_present(("privacyidea.lib.tokens.pushtoken", "WARNING",
+                                  "'push_require_presence' Policy is set but the presence "
+                                  "answer is not present in the smartphone request!"))
+        # Finalize authentication fails since the challenge has not been answered
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "selfservice", "pass": "",
+                                                 "transaction_id": transaction_id},
+                                           headers={"user_agent": "privacyidea-cp/2.0"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"), res.json)
+            self.assertFalse(res.json.get("result").get("value"), res.json)
+            self.assertEqual("Response did not match the challenge.",
+                             res.json.get("detail").get("message"), res.json)
+            self.assertEqual(AUTH_RESPONSE.REJECT,
+                             res.json.get("result").get("authentication"), res.json)
+
+        # Answer the Challenge with the wrong presence_answer
+        # Shift the presence answer character one to the right
+        wrong_answer = chr(((ord(presence_answer) + 1 - 65) % 26) + 65)
+        sign_string = f"{nonce}|{self.serial_push}|{wrong_answer}"
+        sig = self.smartphone_private_key.sign(sign_string.encode('utf8'),
+                                               padding.PKCS1v15(),
+                                               hashes.SHA256())
+        with self.app.test_request_context('/ttype/push',
+                                           method='POST',
+                                           query_string={"serial": self.serial_push,
+                                                         "timestamp": timestamp,
+                                                         "presence_answer": wrong_answer,
+                                                         "signature": b32encode(sig)}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"), res.json)
+            # This fails since the wrong presence_answer was given
+            self.assertFalse(res.json.get("result").get("value"), res.json)
+        # Finalize authentication still fails since the wrong answer is given
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "selfservice", "pass": "",
+                                                 "transaction_id": transaction_id},
+                                           headers={"user_agent": "privacyidea-cp/2.0"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"), res.json)
+            self.assertFalse(res.json.get("result").get("value"), res.json)
+            self.assertEqual("Response did not match the challenge.",
+                             res.json.get("detail").get("message"), res.json)
+            self.assertEqual(AUTH_RESPONSE.REJECT,
+                             res.json.get("result").get("authentication"), res.json)
+
+        # Answer the Challenge with the correct answer
+        sign_string = f"{nonce}|{self.serial_push}|{presence_answer}"
+        sig = self.smartphone_private_key.sign(sign_string.encode('utf8'),
+                                               padding.PKCS1v15(),
+                                               hashes.SHA256())
+        with self.app.test_request_context('/ttype/push',
+                                           method='POST',
+                                           query_string={"serial": self.serial_push,
+                                                         "timestamp": timestamp,
+                                                         "presence_answer": presence_answer,
+                                                         "signature": b32encode(sig)}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"), res.json)
+            self.assertTrue(res.json.get("result").get("value"), res.json)
+        # Finalize authentication
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "selfservice", "pass": "",
+                                                 "transaction_id": transaction_id},
+                                           headers={"user_agent": "privacyidea-cp/2.0"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"), res.json)
+            self.assertTrue(res.json.get("result").get("value"), res.json)
+            self.assertEqual(AUTH_RESPONSE.ACCEPT,
+                             res.json.get("result").get("authentication"), res.json)
+
+        remove_token(self.serial_push)
+        delete_policy("push_config")
+        delete_policy("push_require_presence")
+
+    def test_16_push_require_presence_with_push_wait(self):
+        self.setUp_user_realms()
+        # Setup PUSH policies
+        set_policy("pol_push_config", scope=SCOPE.ENROLL,
+                   action="{0!s}={1!s},{2!s}={3!s}".format(
+                       PUSH_ACTION.FIREBASE_CONFIG, POLL_ONLY,
+                       PUSH_ACTION.REGISTRATION_URL, REGISTRATION_URL))
+        # Add the require_presence policy
+        set_policy("pol_push_require_presence", scope=SCOPE.AUTH,
+                   action=f"{PUSH_ACTION.REQUIRE_PRESENCE}=1")
+        # Add the push_wait policy (set timeout to 1 second to avoid blocking the tests)
+        set_policy("pol_push_wait", scope=SCOPE.AUTH,
+                   action=f"{PUSH_ACTION.WAIT}=1")
+        # Create push token for user
+        # 1st step
+        with self.app.test_request_context('/token/init',
+                                           method='POST',
+                                           data={"type": "push",
+                                                 "pin": "push_pin",
+                                                 "user": "selfservice",
+                                                 "realm": self.realm1,
+                                                 "serial": self.serial_push,
+                                                 "genkey": 1},
+                                           headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            detail = res.json.get("detail")
+            enrollment_credential = detail.get("enrollment_credential")
+
+        # 2nd step: as performed by the smartphone
+        with self.app.test_request_context('/ttype/push',
+                                           method='POST',
+                                           data={"enrollment_credential": enrollment_credential,
+                                                 "serial": self.serial_push,
+                                                 "pubkey": self.smartphone_public_key_pem_urlsafe,
+                                                 "fbtoken": "firebaseT"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json.get("result").get("status"), res.json)
+            self.assertTrue(res.json.get("result").get("value"), res.json)
+            detail = res.json.get("detail")
+            # Now the smartphone gets a public key from the server
+            self.assertIn("public_key", detail, detail)
+            self.assertEqual(ROLLOUTSTATE.ENROLLED, detail.get("rollout_state"), detail)
+
+        #############################################################
+        # Run authentication with push token and without push_wait
+        with LogCapture(level=logging.WARNING) as lc:
+            with self.app.test_request_context('/validate/check',
+                                               method='POST',
+                                               data={"user": "selfservice",
+                                                     "pass": "push_pin"}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(200, res.status_code, res)
+                detail = res.json.get("detail")
+                self.assertTrue(res.json.get("result").get("status"), res.json)
+                self.assertFalse(res.json.get("result").get("value"), res.json)
+                self.assertEqual(AUTH_RESPONSE.REJECT,
+                                 res.json.get("result").get("authentication"), res.json)
+                self.assertEqual("wrong otp value", detail.get("message"), detail)
+                lc.check_present(("privacyidea.lib.tokens.pushtoken", "WARNING",
+                                  "Unable to use 'require_presence' policy with 'push_wait'. "
+                                  "Disabling 'require_presence' policy!"))
+
+        remove_token(self.serial_push)
+        delete_policy("pol_push_config")
+        delete_policy("pol_push_require_presence")
+        delete_policy("pol_push_wait")

--- a/tests/test_api_push_validate.py
+++ b/tests/test_api_push_validate.py
@@ -24,8 +24,8 @@ from privacyidea.lib.smsprovider.SMSProvider import set_smsgateway
 from privacyidea.lib.smsprovider.FirebaseProvider import FirebaseConfig
 from privacyidea.lib.utils import to_bytes, to_unicode, AUTH_RESPONSE
 from privacyidea.lib.policies.actions import PolicyAction
-from privacyidea.lib.realm import set_realm, set_default_realm
-from privacyidea.lib.resolver import save_resolver
+from privacyidea.lib.realm import set_realm, set_default_realm, delete_realm
+from privacyidea.lib.resolver import save_resolver, delete_resolver
 from . import ldap3mock
 
 
@@ -522,6 +522,8 @@ class PushAPITestCase(MyApiTestCase):
         delete_policy("pol_multienroll")
         delete_policy("pol_push2")
         remove_token(serial)
+        delete_realm("ldaprealm")
+        delete_resolver("catchall")
 
     def test_15_push_with_require_presence(self):
         self.setUp_user_realms()
@@ -565,7 +567,7 @@ class PushAPITestCase(MyApiTestCase):
             self.assertEqual(ROLLOUTSTATE.ENROLLED, detail.get("rollout_state"), detail)
 
         #############################################################
-        # Run authentication with push token and without push_wait
+        # Run authentication with push token
         with self.app.test_request_context('/validate/check',
                                            method='POST',
                                            data={"user": "selfservice",
@@ -745,7 +747,7 @@ class PushAPITestCase(MyApiTestCase):
             self.assertEqual(ROLLOUTSTATE.ENROLLED, detail.get("rollout_state"), detail)
 
         #############################################################
-        # Run authentication with push token and without push_wait
+        # Run authentication with push token and with push_wait
         with LogCapture(level=logging.WARNING) as lc:
             with self.app.test_request_context('/validate/check',
                                                method='POST',

--- a/tests/test_api_ttype.py
+++ b/tests/test_api_ttype.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2015 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib.framework import get_app_local_store
 from privacyidea.lib.tokenclass import CHALLENGE_SESSION
@@ -18,7 +21,8 @@ from privacyidea.lib.tokens.pushtoken import (PUSH_ACTION,
                                               PUBLIC_KEY_SERVER,
                                               POLL_ONLY)
 from privacyidea.lib.utils import b32encode_and_unicode
-from datetime import datetime
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 from base64 import b32encode, b64encode, b64decode
 from hashlib import sha1
 import hmac
@@ -526,7 +530,8 @@ class TtypePushAPITestCase(MyApiTestCase):
         # Check if the challenge is sent to the smartphone
         # So when we check later, if the challenge is still sent, we can be sure, that the
         # challenge was not answered.
-        timestamp = datetime.utcnow().isoformat()
+        # First we check with a naive timestamp in UTC
+        timestamp = datetime.now(tz=timezone.utc).replace(tzinfo=None).isoformat()
         sign_string = f"{tokenobj.token.serial}|{timestamp}"
         sig = self.smartphone_private_key.sign(sign_string.encode('utf8'),
                                                padding.PKCS1v15(),
@@ -539,8 +544,48 @@ class TtypePushAPITestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, 200, res)
             result = res.json.get("result")
+            self.assertTrue(result.get("status"), result)
             value = result.get("value")
             self.assertEqual(len(value), 1, value)
+            self.assertEqual("Do you want to confirm the login?", value[0].get("question"))
+
+        # Check the challenge again, this time with a timezone-aware timestamp (still UTC)
+        timestamp = datetime.now(tz=timezone.utc).isoformat()
+        sign_string = f"{tokenobj.token.serial}|{timestamp}"
+        sig = self.smartphone_private_key.sign(sign_string.encode('utf8'),
+                                               padding.PKCS1v15(),
+                                               hashes.SHA256())
+        with self.app.test_request_context('/ttype/push',
+                                           method='GET',
+                                           query_string={"serial": tokenobj.token.serial,
+                                                         "timestamp": timestamp,
+                                                         "signature": b32encode(sig)}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200, res)
+            result = res.json.get("result")
+            self.assertTrue(result.get("status"), result)
+            value = result.get("value")
+            self.assertEqual(len(value), 1, value)
+            self.assertEqual("Do you want to confirm the login?", value[0].get("question"))
+
+        # Check the challenge again, this time with a timestamp in a different timezone
+        timestamp = datetime.now(tz=ZoneInfo("America/Los_Angeles")).isoformat()
+        sign_string = f"{tokenobj.token.serial}|{timestamp}"
+        sig = self.smartphone_private_key.sign(sign_string.encode('utf8'),
+                                               padding.PKCS1v15(),
+                                               hashes.SHA256())
+        with self.app.test_request_context('/ttype/push',
+                                           method='GET',
+                                           query_string={"serial": tokenobj.token.serial,
+                                                         "timestamp": timestamp,
+                                                         "signature": b32encode(sig)}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(res.status_code, 200, res)
+            result = res.json.get("result")
+            self.assertTrue(result.get("status"), result)
+            value = result.get("value")
+            self.assertEqual(len(value), 1, value)
+            self.assertEqual("Do you want to confirm the login?", value[0].get("question"))
 
         # Decline the challenge
         challengeobject_list = get_challenges(serial=tokenobj.token.serial,


### PR DESCRIPTION
Since there is no possibility to pass the valid presence question to the
user, the 'require_presence' policy will be disabled in this case and a
warning will be written to the log.

- Also fixed the timestamp check since it was not working as advertised.
- Add documentation entry regarding the require_presence policy together
  with push_wait.
- Change the numbers in the presence options list to integer.

Closes #4702