### PR TITLE
Issue warning on mismatching number of presence options

### DIFF
--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -476,7 +476,7 @@ class PushTokenClass(TokenClass):
                                          'Does only apply if <em>{0!s}</em> is set.').format(
                                    PUSH_ACTION.REQUIRE_PRESENCE),
                                'group': 'PUSH',
-                               'value': PushPresenceOptions._member_names_,
+                               'value': [x for x in PushPresenceOptions.__members__],
                            },
                            PUSH_ACTION.PRESENCE_CUSTOM_OPTIONS: {
                                'type': 'str',
@@ -1042,8 +1042,11 @@ class PushTokenClass(TokenClass):
                     options) or DEFAULT_NUMBER_OF_PRESENCE_OPTIONS)
                 num_option = (num_option if num_option in ALLOWED_NUMBER_OF_OPTIONS
                               else DEFAULT_NUMBER_OF_PRESENCE_OPTIONS)
-                num_option = (num_option if num_option < len(available_presence_options)
-                              else len(available_presence_options))
+                if num_option > len(available_presence_options):
+                    log.warning(f"The required number of presence options exceeds "
+                                f"the number of available presence options ({num_option} "
+                                f"!= {len(available_presence_options)})")
+                    num_option = len(available_presence_options)
                 current_presence_options = random.sample(available_presence_options,
                                                          num_option)
                 correct_presence_option = secrets.choice(current_presence_options)

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import json
+import logging
 import time
 from base64 import b32decode, b32encode
 from datetime import datetime, timedelta, timezone
 from threading import Timer
+from testfixtures import LogCapture
 
 import mock
 import responses
@@ -37,7 +39,8 @@ from privacyidea.lib.tokens.pushtoken import (PushTokenClass, PUSH_ACTION,
                                               PUBLIC_KEY_SMARTPHONE, PRIVATE_KEY_SERVER,
                                               PUBLIC_KEY_SERVER, AVAILABLE_PRESENCE_OPTIONS_ALPHABETIC,
                                               AVAILABLE_PRESENCE_OPTIONS_NUMERIC,
-                                              PushAllowPolling, POLLING_ALLOWED, POLL_ONLY)
+                                              PushAllowPolling, POLLING_ALLOWED, POLL_ONLY,
+                                              PushPresenceOptions)
 from privacyidea.lib.user import (User)
 from privacyidea.lib.utils import to_bytes, b32encode_and_unicode, to_unicode, AUTH_RESPONSE
 from privacyidea.models import Token, Challenge
@@ -124,6 +127,9 @@ class PushTokenTestCase(MyTestCase):
         class_prefix = token.get_class_prefix()
         self.assertEqual(class_prefix, "PIPU")
         self.assertEqual(token.get_class_type(), "push")
+        self.assertEqual([x for x in PushPresenceOptions.__members__],
+                         token.get_class_info(key="policy")[SCOPE.AUTH][PUSH_ACTION.PRESENCE_OPTIONS]["value"],
+                         token.get_class_info())
 
         # Test to do the 2nd step, although the token is not yet in clientwait
         self.assertRaises(ParameterError, token.update, {"otpkey": "1234", "pubkey": "1234", "serial": self.serial1})
@@ -597,15 +603,6 @@ class PushTokenTestCase(MyTestCase):
             'firebase_token': {
                 FB_CONFIG_VALS[FirebaseConfig.JSON_CONFIG]: _create_credential_mock()}}
         self.app.config.setdefault('_app_local_store', {}).update(cached_fbtoken)
-        # We mock the ServiceAccountCredentials, since we can not directly contact the Google API
-        with mock.patch('privacyidea.lib.smsprovider.FirebaseProvider.service_account'
-                        '.Credentials.from_service_account_file') as mySA:
-            # add responses, to simulate the communication to firebase
-            responses.add(responses.POST, 'https://fcm.googleapis.com/v1/projects'
-                                          '/test-123456/messages:send',
-                          body="""{}""",
-                          content_type="application/json")
-
         # set PIN
         tokenobj.set_pin("pushpin")
         tokenobj.add_user(User("cornelius", self.realm1))
@@ -1112,7 +1109,7 @@ class PushTokenTestCase(MyTestCase):
         set_policy("push_config", scope=SCOPE.ENROLL,
                    action=f"{PUSH_ACTION.FIREBASE_CONFIG}={self.firebase_config_name}")
         set_policy("push_numeric", scope=SCOPE.AUTH,
-                   action=f"{PUSH_ACTION.PRESENCE_OPTIONS}=NUMERIC")
+                   action=f"{PUSH_ACTION.PRESENCE_OPTIONS}={PushPresenceOptions.NUMERIC.name}")
         # Create push token
         token_object = self._create_push_token()
 
@@ -1221,7 +1218,8 @@ class PushTokenTestCase(MyTestCase):
     @responses.activate
     def test_06d_api_auth_presence_custom(self):
         self.setUp_user_realms()
-        custom_presence_options = "0A:1B:2C:3D:4E:5F:6G:7H:8I:9J"
+        # Only define 8 custom options to test the allowed number of options
+        custom_presence_options = "0A:1B:2C:3D:4E:5F:6G:7H"
         custom_options_list = custom_presence_options.split(":")
         # create FireBase Service and policies
         set_smsgateway(self.firebase_config_name,
@@ -1230,9 +1228,11 @@ class PushTokenTestCase(MyTestCase):
         set_policy("push_config", scope=SCOPE.ENROLL,
                    action=f"{PUSH_ACTION.FIREBASE_CONFIG}={self.firebase_config_name}")
         set_policy("push_custom", scope=SCOPE.AUTH,
-                   action=f"{PUSH_ACTION.PRESENCE_OPTIONS}=CUSTOM")
+                   action=f"{PUSH_ACTION.PRESENCE_OPTIONS}={PushPresenceOptions.CUSTOM.name}")
         set_policy("push_custom_options", scope=SCOPE.AUTH,
                    action=f"{PUSH_ACTION.PRESENCE_CUSTOM_OPTIONS}={custom_presence_options}")
+        set_policy("push_presence_num_opts", scope=SCOPE.AUTH,
+                   action=f"{PUSH_ACTION.PRESENCE_NUM_OPTIONS}=9")
         # create push token
         token = self._create_push_token()
 
@@ -1240,7 +1240,7 @@ class PushTokenTestCase(MyTestCase):
         token.set_pin("pushpin")
         token.add_user(User("cornelius", self.realm1))
 
-        # Set a loginmode policy
+        # Set a login mode policy
         set_policy("webui", scope=SCOPE.WEBUI,
                    action=f"{PolicyAction.LOGINMODE}={LOGINMODE.PRIVACYIDEA}")
         # Set a policy to require presence
@@ -1254,33 +1254,38 @@ class PushTokenTestCase(MyTestCase):
             responses.add(responses.POST, 'https://fcm.googleapis.com/v1/projects/test-123456/messages:send',
                           body="""{}""",
                           content_type="application/json")
+            with LogCapture(level=logging.WARNING) as lc:
+                with self.app.test_request_context('/auth',
+                                                   method='POST',
+                                                   data={"username": "cornelius",
+                                                         "realm": self.realm1,
+                                                         # this will be overwritten by pushtoken_disable_wait
+                                                         PUSH_ACTION.WAIT: "10",
+                                                         "password": "pushpin"}):
+                    res = self.app.full_dispatch_request()
+                    self.assertEqual(res.status_code, 200)
+                    # Get the challenge from the database
 
-            with self.app.test_request_context('/auth',
-                                               method='POST',
-                                               data={"username": "cornelius",
-                                                     "realm": self.realm1,
-                                                     # this will be overwritten by pushtoken_disable_wait
-                                                     PUSH_ACTION.WAIT: "10",
-                                                     "password": "pushpin"}):
-                res = self.app.full_dispatch_request()
-                self.assertEqual(res.status_code, 200)
-                # Get the challenge from the database
-
-                json_response = res.json
-                self.assertFalse(json_response.get("result").get("value"))
-                self.assertTrue(json_response.get("result").get("status"))
-                self.assertEqual(json_response["result"]["authentication"],
-                                 AUTH_RESPONSE.CHALLENGE, res.json)
-                self.assertEqual(json_response.get("detail").get("serial"), token.token.serial)
-                self.assertIn("transaction_id", json_response.get("detail"))
-                transaction_id = json_response.get("detail").get("transaction_id")
-                challenges = get_challenges(serial=token.token.serial, transaction_id=transaction_id)
-                challenge = challenges[0]
-                nonce = challenge.challenge
-                # The correct answer is always appended to the available options
-                presence_answer = challenge.get_data().split(',').pop()
-                challenge_text = DEFAULT_CHALLENGE_TEXT + f" Please press: {presence_answer}"
-                self.assertEqual(json_response.get("detail").get("message"), challenge_text)
+                    json_response = res.json
+                    self.assertFalse(json_response.get("result").get("value"))
+                    self.assertTrue(json_response.get("result").get("status"))
+                    self.assertEqual(json_response["result"]["authentication"],
+                                     AUTH_RESPONSE.CHALLENGE, res.json)
+                    self.assertEqual(json_response.get("detail").get("serial"), token.token.serial)
+                    self.assertIn("transaction_id", json_response.get("detail"))
+                    transaction_id = json_response.get("detail").get("transaction_id")
+                    challenges = get_challenges(serial=token.token.serial, transaction_id=transaction_id)
+                    challenge = challenges[0]
+                    nonce = challenge.challenge
+                    # Check the number of given options
+                    self.assertEqual(9, len(challenge.get_data().split(",")))
+                    # The correct answer is always appended to the available options
+                    presence_answer = challenge.get_data().split(',').pop()
+                    challenge_text = DEFAULT_CHALLENGE_TEXT + f" Please press: {presence_answer}"
+                    self.assertEqual(json_response.get("detail").get("message"), challenge_text)
+                    lc.check_present(("privacyidea.lib.tokens.pushtoken", "WARNING",
+                                      "The required number of presence options exceeds "
+                                      "the number of available presence options (9 != 8)"))
 
         self.assertIsNotNone(presence_answer)
         self.assertIn(presence_answer, custom_options_list)
@@ -1329,7 +1334,12 @@ class PushTokenTestCase(MyTestCase):
 
         remove_token(token.get_serial())
         delete_policy("webui")
+        delete_policy("push_config")
         delete_policy("push_require_presence")
+        delete_policy("push_custom")
+        delete_policy("push_custom_options")
+        delete_policy("push_presence_num_opts")
+        delete_smsgateway(self.firebase_config_name)
 
     def test_06e_require_presence_text_replace(self):
         # Set a loginmode policy


### PR DESCRIPTION
If the number of required options exceeds the number of available options a warning is issued and the number of required options is set to the number of available options.

Working on #4702