### PR TITLE
basic http resolver shall ignore empty advanced parameters

### DIFF
--- a/privacyidea/lib/resolvers/HTTPResolver.py
+++ b/privacyidea/lib/resolvers/HTTPResolver.py
@@ -601,7 +601,7 @@ class HTTPResolver(UserIdResolver):
                     raise ParameterError(f"Invalid JSON format for headers: {self.headers}")
             else:
                 self.headers = {}
-        if CONFIG_GET_USER_BY_ID not in self.config:
+        if not self.config.get(CONFIG_GET_USER_BY_ID):
             # Basic HTTP Resolver config only contains config for getUserInfo
             self.config_get_user_by_id[ENDPOINT] = get_required(config, ENDPOINT)
             self.config_get_user_by_id[METHOD] = get_required(config, METHOD)

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -1483,6 +1483,16 @@ myApp.controller("HTTPResolverController", ["$scope", "ConfigFactory", "$state",
                     $scope.advancedParams["password"] = $scope.serviceAccount["password"];
                 }
                 serverParams = $scope.advancedParams;
+
+                // Set empty endpoint configs to empty dicts, to indicate that an old config can be removed
+                const endpointConfigNames = ["config_get_user_list", "config_get_user_by_id",
+                    "config_get_user_by_name", "config_user_auth", "config_create_user", "config_edit_user",
+                    "config_delete_user"];
+                angular.forEach(endpointConfigNames, function (configName) {
+                    if ($scope.endpointConfigIsEmpty(serverParams[configName])) {
+                        serverParams[configName] = {};
+                    }
+                })
             } else {
                 serverParams = $scope.params;
             }
@@ -1494,15 +1504,6 @@ myApp.controller("HTTPResolverController", ["$scope", "ConfigFactory", "$state",
                     cleaned_params[key] = value;
                 }
             });
-            // Set empty endpoint configs to empty dicts, to indicate that an old config can be removed
-            const endpointConfigNames = ["config_get_user_list", "config_get_user_by_id",
-                "config_get_user_by_name", "config_user_auth", "config_create_user", "config_edit_user",
-                "config_delete_user"];
-            angular.forEach(endpointConfigNames, function (configName) {
-                if ($scope.endpointConfigIsEmpty(cleaned_params[configName])) {
-                    cleaned_params[configName] = {};
-                }
-            })
 
             return cleaned_params;
         };

--- a/tests/test_lib_resolver_httpresolver.py
+++ b/tests/test_lib_resolver_httpresolver.py
@@ -236,6 +236,13 @@ class HTTPResolverTestCase(MyTestCase):
         self.assertTrue("httpresolver" in r_type)
         r_type = instance.getResolverType()
         self.assertEqual("httpresolver", r_type)
+        self.assertEqual(self.ENDPOINT, instance.config_get_user_by_id.get(ENDPOINT))
+        self.assertEqual(self.METHOD, instance.config_get_user_by_id.get(METHOD))
+        self.assertEqual(self.RESPONSE_MAPPING, instance.config_get_user_by_id.get(RESPONSE_MAPPING))
+        self.assertEqual(self.REQUEST_MAPPING, instance.config_get_user_by_id.get(REQUEST_MAPPING))
+        self.assertEqual(self.HEADERS, instance.config_get_user_by_id.get(HEADERS))
+        self.assertTrue(instance.config_get_user_by_id.get(HAS_ERROR_HANDLER))
+        self.assertEqual(self.ERROR_RESPONSE_MAPPING, instance.config_get_user_by_id.get(ERROR_RESPONSE))
 
         # Minimal config
         params = {
@@ -245,6 +252,22 @@ class HTTPResolverTestCase(MyTestCase):
         }
         instance = HTTPResolver()
         instance.loadConfig(params)
+        self.assertEqual(self.ENDPOINT, instance.config_get_user_by_id.get(ENDPOINT))
+        self.assertEqual(self.METHOD, instance.config_get_user_by_id.get(METHOD))
+        self.assertEqual(self.RESPONSE_MAPPING, instance.config_get_user_by_id.get(RESPONSE_MAPPING))
+
+        # Also pass empty advanced parameters should still take the basic params
+        params = {
+            'endpoint': self.ENDPOINT,
+            'method': self.METHOD,
+            'responseMapping': self.RESPONSE_MAPPING,
+            CONFIG_GET_USER_BY_ID: {}
+        }
+        instance = HTTPResolver()
+        instance.loadConfig(params)
+        self.assertEqual(self.ENDPOINT, instance.config_get_user_by_id.get(ENDPOINT))
+        self.assertEqual(self.METHOD, instance.config_get_user_by_id.get(METHOD))
+        self.assertEqual(self.RESPONSE_MAPPING, instance.config_get_user_by_id.get(RESPONSE_MAPPING))
 
     def test_02_load_basic_config_fails(self):
         resolver = HTTPResolver()


### PR DESCRIPTION
* UI: do not send advanced settings for basic resolver
* server: if advanced settings are empty, check for basic settings