### PR TITLE
Fix display recursive user groups

### DIFF
--- a/privacyidea/static/components/user/controllers/userControllers.js
+++ b/privacyidea/static/components/user/controllers/userControllers.js
@@ -507,7 +507,7 @@ angular.module("privacyideaApp")
                     switch (resolver.type) {
                         case "ldapresolver":
                             userinfo = JSON.parse(resolver.data.USERINFO);
-                            if (resolver.data.recursive_group_search) {
+                            if (resolver.data.recursive_group_search && resolver.data.group_attribute_mapping_key) {
                                 userinfo[resolver.data.group_attribute_mapping_key] = "";
                             }
                             break;


### PR DESCRIPTION
Fix display recursive user groups only for complete definition (avoid showing undefined values)