### PR TITLE
Add pattern for local admins in the pi.cfg

### DIFF
--- a/deploy/pi.cfg
+++ b/deploy/pi.cfg
@@ -1,6 +1,6 @@
 import logging
 # The realm, where users are allowed to login as administrators
-# The pattern (?#...) is a regexp for an empty string, that 
+# The pattern (?#...) is a regex for an empty string, that 
 # corresponds with the local admins, which actually have an empty realm.
 SUPERUSER_REALM = ['super', '(?#local admins)']
 # Your database

--- a/deploy/pi.cfg
+++ b/deploy/pi.cfg
@@ -1,6 +1,8 @@
 import logging
 # The realm, where users are allowed to login as administrators
-SUPERUSER_REALM = ['super']
+# The pattern (?#...) is a regexp for an empty string, that 
+# corresponds with the local admins, which actually have an empty realm.
+SUPERUSER_REALM = ['super', '(?#local admins)']
 # Your database
 SQLALCHEMY_DATABASE_URI = 'sqlite:////home/cornelius/src/privacyidea/data.sqlite'
 # This is used to encrypt the auth_token


### PR DESCRIPTION
We often see, that installations are missing a policy for local admins.
So I would like to add it as default to the pi.cfg.