### PR TITLE
reuse passkey challenge nonce, use json format for challenge data

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -573,8 +573,6 @@ def offline_info(request, response):
                 if auth_items:
                     content["auth_items"] = auth_items
                     response.set_data(json.dumps(content))
-                    # Also update JSON in the response object
-                    response.get_jsons()
             except Exception as exx:
                 log.info(exx)
     return response

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -977,10 +977,10 @@ def hide_specific_error_message(request, response):
                                   user_object=request.User if hasattr(request, 'User') else None).any()
         if hide_message:
             content = response.json
-            detail = {
-                "message": _("Authentication failed."),
-                "threadid": content["detail"]["threadid"]
-            }
+            threadid = content.get("detail", {}).get("threadid")
+            detail = {"message": _("Authentication failed.")}
+            if threadid:
+                detail["threadid"] = threadid
             # Overwrite the whole detail object so that it always has the same content
             content["detail"] = detail
             response.set_data(json.dumps(content))

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -602,6 +602,8 @@ def _handle_fido2_auth(context: dict, credential_id: str):
             "serial": token.get_serial()
         })
         context["serial_list"].append(token.get_serial())
+    else:
+        context["details"]["message"] = gettext("Authentication failed.")
 
 
 def _handle_serial_auth(context: dict, serial: str):

--- a/privacyidea/lib/fido2/challenge.py
+++ b/privacyidea/lib/fido2/challenge.py
@@ -114,7 +114,7 @@ def verify_fido2_challenge(transaction_id: str, token: TokenClass, params: dict)
 
     # Get the user_verification requirement from the challenge data
     data = challenge.get_data()
-    if not "user_verification" in data:
+    if not isinstance(dict, data) or not "user_verification" in data:
         log.error(f"Invalid user_verification data in challenge with transaction_id {transaction_id}.")
         raise AuthError(f"Invalid user_verification data in challenge {transaction_id}.")
     user_verification = data["user_verification"]

--- a/privacyidea/lib/fido2/challenge.py
+++ b/privacyidea/lib/fido2/challenge.py
@@ -114,7 +114,7 @@ def verify_fido2_challenge(transaction_id: str, token: TokenClass, params: dict)
 
     # Get the user_verification requirement from the challenge data
     data = challenge.get_data()
-    if not isinstance(dict, data) or not "user_verification" in data:
+    if not isinstance(dict, data) or "user_verification" not in data:
         log.error(f"Invalid user_verification data in challenge with transaction_id {transaction_id}.")
         raise AuthError(f"Invalid user_verification data in challenge {transaction_id}.")
     user_verification = data["user_verification"]

--- a/privacyidea/lib/fido2/challenge.py
+++ b/privacyidea/lib/fido2/challenge.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from datetime import datetime, timezone
 from typing import Union
 from dataclasses import dataclass
@@ -27,14 +28,17 @@ def get_fido2_nonce() -> str:
 
 
 def create_fido2_challenge(rp_id: str, user_verification: str = "preferred", transaction_id: Union[str, None] = None,
-                           serial: Union[str, None] = None) -> dict:
+                           serial: Union[str, None] = None, nonce: Union[str, None] = None) -> dict:
     """
-    Returns a fido2 challenge. If a serial is provided, the challenge is bound to the token with the serial. By default,
-    the challenge is not bound to a token, which is the general use-case of FIDO2.
-    The challenge validity time is set to either WebauthnChallengeValidityTime, DefaultChallengeValidityTime or 120s
-    in that order of evaluation.
+    Returns a fido2 challenge. The challenge validity time is set to either WebauthnChallengeValidityTime,
+    DefaultChallengeValidityTime or 120s in that order of evaluation.
     The user_verification parameter can be one of "required", "preferred" or "discouraged". If the value is not one of
     these, "preferred" is used. user_verification is saved in the challenge data field.
+    If a serial is provided, the challenge is bound to the token with the serial.
+    This is the case when using the passkey_trigger_by_pin policy, where the passkey acts as a challenge-response token
+    that is triggered via the user and PIN. The challenge should then only be usable with the corresponding token.
+    By default, the challenge is not bound to a token, which is the general use-case of FIDO2, to allow usernameless
+    logins.
     The returned dict has the format:
         ::
 
@@ -46,7 +50,8 @@ def create_fido2_challenge(rp_id: str, user_verification: str = "preferred", tra
                 "userVerification": "preferred"
             }
     """
-    challenge = fido2.challenge.get_fido2_nonce()
+    if not nonce:
+        nonce = fido2.challenge.get_fido2_nonce()
     message = PasskeyTokenClass.get_default_challenge_text_auth()
     validity = int(get_from_config(FIDO2ConfigOptions.CHALLENGE_VALIDITY_TIME,
                                    get_from_config('DefaultChallengeValidityTime', 120)))
@@ -55,13 +60,15 @@ def create_fido2_challenge(rp_id: str, user_verification: str = "preferred", tra
         log.warning(f"Invalid user_verification value {user_verification}. Using 'preferred' instead.")
         user_verification = "preferred"
 
-    db_challenge = Challenge(serial or "", transaction_id=transaction_id, challenge=challenge,
-                             data=f"user_verification={user_verification}", validitytime=validity)
+    data = {"user_verification": user_verification}
+
+    db_challenge = Challenge(serial or "", transaction_id=transaction_id, challenge=nonce,
+                             data=json.dumps(data), validitytime=validity)
     db_challenge.save()
     transaction_id = db_challenge.transaction_id
     return {
         "transaction_id": transaction_id,
-        "challenge": challenge,
+        "challenge": nonce,
         "message": message,
         "rpId": rp_id,
         "user_verification": user_verification
@@ -106,12 +113,11 @@ def verify_fido2_challenge(transaction_id: str, token: TokenClass, params: dict)
         raise AuthError(f"The challenge {transaction_id} has timed out.")
 
     # Get the user_verification requirement from the challenge data
-    uv_string = challenge.get_data()
-    parts = uv_string.split("=")
-    if len(parts) != 2 or parts[0] != "user_verification":
+    data = challenge.get_data()
+    if not "user_verification" in data:
         log.error(f"Invalid user_verification data in challenge with transaction_id {transaction_id}.")
         raise AuthError(f"Invalid user_verification data in challenge {transaction_id}.")
-    user_verification = parts[1]
+    user_verification = data["user_verification"]
     if user_verification not in ["required", "preferred", "discouraged"]:
         log.error(
             f"Invalid user_verification value {user_verification} in challenge with transaction_id {transaction_id}."

--- a/privacyidea/lib/fido2/challenge.py
+++ b/privacyidea/lib/fido2/challenge.py
@@ -114,7 +114,7 @@ def verify_fido2_challenge(transaction_id: str, token: TokenClass, params: dict)
 
     # Get the user_verification requirement from the challenge data
     data = challenge.get_data()
-    if not isinstance(dict, data) or "user_verification" not in data:
+    if not isinstance(data, dict) or "user_verification" not in data:
         log.error(f"Invalid user_verification data in challenge with transaction_id {transaction_id}.")
         raise AuthError(f"Invalid user_verification data in challenge {transaction_id}.")
     user_verification = data["user_verification"]

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2435,7 +2435,8 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
                 challenge_info = challenge_info or {}
                 challenge_info["transaction_id"] = transaction_id
                 challenge_info["serial"] = token.token.serial
-                challenge_info["type"] = token.get_tokentype()
+                token_type = token.get_tokentype()
+                challenge_info["type"] = token_type
                 challenge_info["client_mode"] = token.client_mode
                 challenge_info["message"] = message
                 # If they exist, add next pin and next password change
@@ -2448,9 +2449,16 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
                 if next_passw:
                     challenge_info["next_password_change"] = next_passw
                     challenge_info["password_change"] = token.is_pin_change(password=True)
-                # FIXME: This is deprecated and should be remove one day
-                reply_dict.update(challenge_info)
+
+                # If a passkey challenge has been triggered, reuse the nonce for all other passkey challenges
+                # Normally, you would use allowCredentials, but we do one challenge per one token
+                if token_type == "passkey":
+                    passkey_nonce = challenge_info["challenge"]
+                    options["passkey_nonce"] = passkey_nonce
+
                 reply_dict["multi_challenge"].append(challenge_info)
+                reply_dict.update(challenge_info) # FIXME: This is deprecated and should be remove one day
+
     if message_list:
         unique_messages = set(message_list)
         reply_dict["message"] = ", ".join(unique_messages)

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2458,7 +2458,7 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
                     options["passkey_nonce"] = passkey_nonce
 
                 reply_dict["multi_challenge"].append(challenge_info)
-                reply_dict.update(challenge_info) # FIXME: This is deprecated and should be remove one day
+                reply_dict.update(challenge_info)  # FIXME: This is deprecated and should be removed one day
 
     if message_list:
         unique_messages = set(message_list)

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -2406,6 +2406,7 @@ def create_challenges_from_tokens(token_list, reply_dict, options=None):
     """
     options = options or {}
     options["push_triggered"] = False
+    options["passkey_nonce"] = None
     reply_dict["multi_challenge"] = []
     transaction_id = None
     message_list = []

--- a/privacyidea/lib/tokens/passkeytoken.py
+++ b/privacyidea/lib/tokens/passkeytoken.py
@@ -420,7 +420,9 @@ class PasskeyTokenClass(TokenClass):
         if options and PasskeyAction.EnableTriggerByPIN in options and options[PasskeyAction.EnableTriggerByPIN]:
             rp_id = get_required(options, FIDO2PolicyAction.RELYING_PARTY_ID)
             user_verification = get_optional(options, FIDO2PolicyAction.USER_VERIFICATION_REQUIREMENT, "preferred")
-            challenge = fido2.challenge.create_fido2_challenge(rp_id, user_verification=user_verification,
+            # check if options contains a nonce that was generated from a previous passkey challenge and reuse it
+            nonce = options.get("passkey_nonce", None)
+            challenge = fido2.challenge.create_fido2_challenge(rp_id, user_verification=user_verification, nonce=nonce,
                                                                transaction_id=transactionid, serial=self.token.serial)
             message = options.get("passkey_challenge_text", challenge["message"])
             transaction_id = challenge["transaction_id"]

--- a/privacyidea/lib/tokens/webauthntoken.py
+++ b/privacyidea/lib/tokens/webauthntoken.py
@@ -19,6 +19,7 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import binascii
+import json
 import logging
 
 from cryptography import x509
@@ -942,11 +943,12 @@ class WebAuthnTokenClass(TokenClass):
             response_detail['rollout_state'] = self.token.rollout_state
             # To aid with unit testing a fixed nonce may be passed in.
             nonce = self._get_nonce()
+            data = {"user_verification": user_verification}
             # Create the challenge in the database
             challenge = Challenge(serial=self.token.serial,
                                   transaction_id=get_optional(params, "transaction_id"),
                                   challenge=hexlify_and_unicode(nonce),
-                                  data=f"user_verification={user_verification}",
+                                  data=json.dumps(data),
                                   session=get_optional(params, "session"),
                                   validitytime=self._get_challenge_validity_time())
             challenge.save()
@@ -1097,12 +1099,12 @@ class WebAuthnTokenClass(TokenClass):
             nonce = binascii.unhexlify(challenge)
 
         user_verification = get_required(options, FIDO2PolicyAction.USER_VERIFICATION_REQUIREMENT)
-
+        data = {"user_verification": user_verification}
         # Create the challenge in the database
         db_challenge = Challenge(serial=self.token.serial,
                                  transaction_id=transactionid,
                                  challenge=challenge,
-                                 data=f"user_verification={user_verification}",
+                                 data=json.dumps(data),
                                  session=get_optional(options, "session"),
                                  validitytime=self._get_challenge_validity_time())
         db_challenge.save()

--- a/tests/test_api_passkey.py
+++ b/tests/test_api_passkey.py
@@ -66,7 +66,7 @@ class PasskeyAPITestBase(MyApiTestCase, PasskeyTestBase):
         set_policy(name, **kwargs)
         self.addCleanup(self.safe_delete_policy, name)
 
-    def _token_init_step_one(self):
+    def _token_init_step_one(self, exclude_credentials_size: int = 0):
         with patch('privacyidea.lib.fido2.challenge.get_fido2_nonce') as get_nonce:
             get_nonce.return_value = self.registration_challenge
 
@@ -89,9 +89,17 @@ class PasskeyAPITestBase(MyApiTestCase, PasskeyTestBase):
                 for param in passkey_registration["pubKeyCredParams"]:
                     self.assertIn(param["type"], ["public-key"])
                     self.assertIn(param["alg"], [-7, -37, -257])
-                # ExcludeCredentials should be empty because no other passkey token is registered for the user
-                self.assertEqual(0, len(passkey_registration["excludeCredentials"]),
-                                 "excludeCredentials should be empty")
+
+                # ExcludeCredentials should be either empty because no other passkey token is registered for the user
+                # or if there are multiple passkeys enrolled for the user for testing purposes, it should have the
+                # specified size
+                if exclude_credentials_size == 0:
+                    self.assertEqual(0, len(passkey_registration["excludeCredentials"]),
+                                     "excludeCredentials should be empty")
+                else:
+                    self.assertEqual(exclude_credentials_size, len(passkey_registration["excludeCredentials"]),
+                                     "excludeCredentials should have the specified size")
+
                 return res.json
 
     def _token_init_step_two(self, transaction_id, serial):
@@ -113,11 +121,11 @@ class PasskeyAPITestBase(MyApiTestCase, PasskeyTestBase):
             self.assertEqual(200, res.status_code)
             self._assert_result_value_true(res.json)
 
-    def _enroll_static_passkey(self) -> str:
+    def _enroll_static_passkey(self, exclude_credential_size: int = 0) -> str:
         """
         Returns the serial of the enrolled passkey token
         """
-        data = self._token_init_step_one()
+        data = self._token_init_step_one(exclude_credential_size)
         detail = data["detail"]
         serial = detail["serial"]
         transaction_id = detail["transaction_id"]
@@ -411,12 +419,17 @@ class PasskeyAPITest(PasskeyAPITestBase):
 
     def test_07_trigger_challenge(self):
         """
-        Just test if the challenge is returned by /validate/triggerchallenge. The response would be sent to
+        Test if the challenge is returned by /validate/triggerchallenge. The response would be sent to
         /validate/check and that is already tested. Requires the passkey_trigger_with_pin policy to be set.
+        This also makes sure that the nonce is the same for each challenge. Usually allowCredentials would be used as
+        specified by WebAuthn, but privacyidea has a one challenge per one token model.
         """
         self.set_policy_with_cleanup("passkey_trigger_with_pin", scope=SCOPE.AUTH,
                                      action=f"{PasskeyAction.EnableTriggerByPIN}=true")
-        serial = self._enroll_static_passkey()
+        serial1 = self._enroll_static_passkey()
+        # Enroll a second passkey, set the expected size of excludeCredentials to 1, because the user already has one
+        serial2 = self._enroll_static_passkey(1)
+
         with patch('privacyidea.lib.fido2.challenge.get_fido2_nonce') as get_nonce:
             get_nonce.return_value = self.authentication_challenge_no_uv
             with self.app.test_request_context('/validate/triggerchallenge', method='POST',
@@ -428,34 +441,42 @@ class PasskeyAPITest(PasskeyAPITestBase):
                 self.assertIn("multi_challenge", detail)
 
                 multi_challenge = detail["multi_challenge"]
-                self.assertEqual(len(multi_challenge), 1)
+                self.assertEqual(len(multi_challenge), 2)
 
-                challenge = multi_challenge[0]
-                self.assertIn("transaction_id", challenge)
-                transaction_id = challenge["transaction_id"]
+                challenge1 = multi_challenge[0]
+                challenge2 = multi_challenge[1]
+
+                self.assertIn("transaction_id", challenge1)
+                transaction_id = challenge1["transaction_id"]
                 self.assertTrue(transaction_id)
+                self.assertEqual(transaction_id, challenge2["transaction_id"])
 
-                self.assertIn("challenge", challenge)
-                self.assertEqual(self.authentication_challenge_no_uv, challenge["challenge"])
+                self.assertIn("challenge", challenge1)
+                self.assertEqual(self.authentication_challenge_no_uv, challenge1["challenge"])
+                self.assertEqual(challenge1["challenge"], challenge2["challenge"])
 
-                self.assertIn("serial", challenge)
-                self.assertEqual(serial, challenge["serial"])
+                self.assertIn("serial", challenge1)
+                self.assertIn("serial", challenge2)
+                serials = [challenge1["serial"], challenge2["serial"]]
+                self.assertIn(serial1, serials)
+                self.assertIn(serial2, serials)
 
-                self.assertIn("type", challenge)
-                self.assertEqual("passkey", challenge["type"])
+                self.assertIn("type", challenge1)
+                self.assertEqual("passkey", challenge1["type"])
 
-                self.assertIn("userVerification", challenge)
-                self.assertTrue(challenge["userVerification"])
+                self.assertIn("userVerification", challenge1)
+                self.assertTrue(challenge1["userVerification"])
 
-                self.assertIn("rpId", challenge)
-                self.assertEqual(self.rp_id, challenge["rpId"])
+                self.assertIn("rpId", challenge1)
+                self.assertEqual(self.rp_id, challenge1["rpId"])
 
-                self.assertIn("message", challenge)
-                self.assertTrue(challenge["message"])
+                self.assertIn("message", challenge1)
+                self.assertTrue(challenge1["message"])
 
-                self.assertIn("client_mode", challenge)
-                self.assertEqual("webauthn", challenge["client_mode"])
-        remove_token(serial)
+                self.assertIn("client_mode", challenge1)
+                self.assertEqual("webauthn", challenge1["client_mode"])
+        remove_token(serial1)
+        remove_token(serial2)
 
     def test_08_offline(self):
         serial = self._enroll_static_passkey()

--- a/tests/test_api_passkey.py
+++ b/tests/test_api_passkey.py
@@ -121,11 +121,11 @@ class PasskeyAPITestBase(MyApiTestCase, PasskeyTestBase):
             self.assertEqual(200, res.status_code)
             self._assert_result_value_true(res.json)
 
-    def _enroll_static_passkey(self, exclude_credential_size: int = 0) -> str:
+    def _enroll_static_passkey(self, exclude_credentials_size: int = 0) -> str:
         """
         Returns the serial of the enrolled passkey token
         """
-        data = self._token_init_step_one(exclude_credential_size)
+        data = self._token_init_step_one(exclude_credentials_size)
         detail = data["detail"]
         serial = detail["serial"]
         transaction_id = detail["transaction_id"]

--- a/tests/test_api_validate_webauthn.py
+++ b/tests/test_api_validate_webauthn.py
@@ -1,12 +1,10 @@
-from typing import Union
-
 from mock.mock import patch
 from webauthn.helpers import bytes_to_base64url
 
 from privacyidea.lib.fido2.util import hash_credential_id
 from privacyidea.lib.machine import attach_token, detach_token
-from privacyidea.lib.policy import SCOPE, set_policy, delete_policy, delete_policies
 from privacyidea.lib.policies.actions import PolicyAction
+from privacyidea.lib.policy import SCOPE, set_policy, delete_policy, delete_policies
 from privacyidea.lib.token import (get_tokens, init_token, remove_token,
                                    get_one_token)
 from privacyidea.lib.tokenclass import ROLLOUTSTATE


### PR DESCRIPTION
i did not add a fallback for the challenge data format of fido token (e.g. ```"userverification=preferred"```) as string because challenges and their data are volatile.