### PR TITLE
Move missing gssapi package warning

### DIFF
--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -433,15 +433,15 @@ class IdResolver(UserIdResolver):
             # if the utf-8 decoding fails, we try the UUID conversion
             if uidtype.lower() == "objectguid":
                 # Active Directory uses little endian byte order
-                log.debug(f"Found a byte-array as uid ({binascii.hexlify(uid)}), trying to convert it to a UUID "
-                          f"assuming little endian byte order. ({e})")
+                log.debug(f"Found a byte-array as uid ({binascii.hexlify(uid).decode()}), "
+                          f"trying to convert it to a UUID assuming little endian byte order. ({e})")
                 log.debug(traceback.format_exc())
                 uid = str(uuid.UUID(bytes_le=uid))
             else:
                 # ldap3 defines a standard formatter using big endian byte order for GUID (eDirectory), entryUUID
                 # (openLDAP), and UUID. Hence, we assume it as the default byte order here.
-                log.debug(f"Found a byte-array as uid ({binascii.hexlify(uid)}), trying to convert it to a UUID "
-                          f"assuming big endian byte order. ({e})")
+                log.debug(f"Found a byte-array as uid ({binascii.hexlify(uid).decode()}), "
+                          f"trying to convert it to a UUID assuming big endian byte order. ({e})")
                 log.debug(traceback.format_exc())
                 uid = str(uuid.UUID(bytes=uid))
 
@@ -1230,8 +1230,8 @@ class IdResolver(UserIdResolver):
             success = True
 
         except Exception as e:
-            message = f"{e!r}"
-            log.warning(f"LDAP Resolver Test failed for resolver {resolvername!r}: {message}")
+            message = f"{e}"
+            log.warning(f"LDAP Resolver Test failed for resolver {resolvername!r}: {e!r}")
             log.debug("{0!s}".format(traceback.format_exc()))
 
         return success, message

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -1,4 +1,7 @@
 /**
+ * SPDX-FileCopyrightText:  NetKnights GmbH <https://netknights.it>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
  * http://www.privacyidea.org
  * (c) cornelius kölbel, cornelius@privacyidea.org
  *
@@ -1107,6 +1110,11 @@ myApp.controller("LdapResolverController", ["$scope", "ConfigFactory", "$state",
                 $scope.params.group_search_filter = "";
                 $scope.params.group_attribute_mapping_key = "";
             }
+            // Remove username and password from params in case of anonymous bind
+            if ($scope.params.AUTHTYPE === "Anonymous") {
+                $scope.params.BINDDN = "";
+                $scope.params.BINDPW = "";
+            }
             ConfigFactory.setResolver($scope.resolvername, $scope.params, function (data) {
                 $scope.set_result = data.result.value;
                 $scope.getResolvers();
@@ -1123,6 +1131,11 @@ myApp.controller("LdapResolverController", ["$scope", "ConfigFactory", "$state",
                 params["group_name_attribute"] = "";
                 params["group_search_filter"] = "";
                 params["group_attribute_mapping_key"] = "";
+            }
+            // Remove username and password from params in case of anonymous bind
+            if ($scope.params.AUTHTYPE === "Anonymous") {
+                params["BINDDN"] = "";
+                params["BINDPW"] = "";
             }
             ConfigFactory.testResolver(params, function (data) {
                 if (data.result.value === true) {

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -1115,13 +1115,14 @@ myApp.controller("LdapResolverController", ["$scope", "ConfigFactory", "$state",
         };
 
         $scope.testResolver = function (size_limit) {
-            var params = $.extend({}, $scope.params);
+            let params = $.extend({}, $scope.params);
             params["SIZELIMIT"] = size_limit;
             params["resolver"] = $scope.resolvername;
-            if (params['AUTHTYPE'] === $scope.authtypes['Anonymous']) {
-                params['AUTHTYPE'] = $scope.authtypes['Simple'];
-                params['BINDPW'] = '';
-                params['BINDDN'] = '';
+            if (!$scope.params.recursive_group_search) {
+                params["group_base_dn"] = "";
+                params["group_name_attribute"] = "";
+                params["group_search_filter"] = "";
+                params["group_attribute_mapping_key"] = "";
             }
             ConfigFactory.testResolver(params, function (data) {
                 if (data.result.value === true) {

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2015 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 This test file tests the lib.resolver and all
 the resolvers under it:
@@ -1173,7 +1176,7 @@ class LDAPResolverTestCase(MyTestCase):
                                 })
 
         self.assertFalse(res[0], res)
-        self.assertTrue("Authtype unknown not supported" in res[1], res)
+        self.assertEqual("ERR907: Unsupported authentication type: unknown", res[1], res)
 
     def test_06_split_uri(self):
         uri = "ldap://server"


### PR DESCRIPTION
The warning was logged on every initialization of the app. This included recurring scripts.
The warning is now issued when the password of a user is checked. But this is probably never reached because we also need gssapi to search for the user. The ldap3 packages throws a corresponding error in this case.

- Add cache for recursive user group searches
- Add the missing "group_base_dn" string to the class descriptor
- Remove recursive groups search parameters from testconnection call
- Remove change of AUTHTYPE parameter in testconnection call when "Anonymous" was selected.
- Also fixed some spelling and formatting.