### PR TITLE
Add "resolver" to requested attributes

### DIFF
--- a/privacyidea/static/components/user/controllers/userControllers.js
+++ b/privacyidea/static/components/user/controllers/userControllers.js
@@ -1,4 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: 2015 NetKnights GmbH <https://netknights.it>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
  * http://www.privacyidea.org
  * (c) cornelius kölbel, cornelius@privacyidea.org
  *
@@ -447,7 +450,7 @@ angular.module("privacyideaApp")
                     if ($scope.params.emailFilter) {
                         params.email = "*" + $scope.params.emailFilter + "*";
                     }
-                    params.attributes = "username,givenname,surname,email,phone,mobile,description,userid,editable";
+                    params.attributes = "username,givenname,surname,email,phone,mobile,description,userid,editable,resolver";
                     UserFactory.getUsers(params,
                         function (data) {
                             //debug: console.log("success");


### PR DESCRIPTION
Add the "resolver" to the attributes requested when searching for the user. The resolver is passed as a state parameter to the userDetailsController and is required when deleting (and probably also editing) a user.