### PR TITLE
docker-compose-dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,35 @@
+services:
+  mariadb-test:
+    # DB URI: mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3306/privacyidea_test
+    image: mariadb:11
+    container_name: pi-mariadb-test
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: privacyidea_test
+      MARIADB_USER: privacyidea
+      MARIADB_PASSWORD: privacyidea
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  postgres-test:
+    # DB URI: postgresql+psycopg2://privacyidea:privacyidea@127.0.0.1:5432/privacyidea_test
+    image: postgres:17
+    container_name: privacyidea-postgres
+    environment:
+      POSTGRES_DB: privacyidea_test
+      POSTGRES_USER: privacyidea
+      POSTGRES_PASSWORD: privacyidea
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U privacyidea -d privacyidea_test"]
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
Can be used for services to use while developing. e.g. in pycharm you can configure each service as a run action and have that action run before running tests or the server.