### PR TITLE
old webui js fixes

### DIFF
--- a/privacyidea/static/components/config/views/config.policies.list.html
+++ b/privacyidea/static/components/config/views/config.policies.list.html
@@ -10,15 +10,15 @@
             </th>
             <th class="pifilter">
                 <button class="btn btn-default unsorted" pi-sort-by="name" translate>Policy Name</button>
-                <pi-filter ng-model="filter.name" ng-change="$apply()"></pi-filter>
+                <pi-filter ng-model="filter.name"></pi-filter>
             </th>
             <th class="pifilter">
                 <button class="btn btn-default unsorted" pi-sort-by="scope" translate>Scope</button>
-                <pi-filter ng-model="filter.scope" ng-change="$apply()"></pi-filter>
+                <pi-filter ng-model="filter.scope"></pi-filter>
             </th>
              <th class="pifilter">
                 <button class="btn btn-default unsorted" pi-sort-by="action" translate>Action</button>
-                <pi-filter ng-model="filter.action_desc" ng-change="$apply()"></pi-filter>
+                <pi-filter ng-model="filter.action_desc"></pi-filter>
             </th>
             <th translate>Realm</th>
             <th translate>User</th>

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -80,6 +80,10 @@ myApp.directive("piFilter", ["instanceUrl", "versioningSuffixProvider", function
                     scope.onSubmit();
                 }
             };
+            scope.toggleFilter = function () {
+                scope.filterVisible = !scope.filterVisible;
+                scope.focusInput = true;
+            };
             ctrl.$viewChangeListeners.push(function () {
                 if (scope.ngChange) {
                     scope.ngChange();

--- a/privacyidea/static/components/directives/views/directive.filter.table.html
+++ b/privacyidea/static/components/directives/views/directive.filter.table.html
@@ -1,9 +1,9 @@
 <span class="glyphicon glyphicon-filter"
-      ng-click="filterVisible=!filterVisible; focusInput=true"
+      ng-click="toggleFilter()"
       ng-class="{filtered:filterValue}"
       role="button"
       tabindex="0"
-      ng-keydown="($event.keyCode === 13 || $event.keyCode === 32) && (filterVisible=!filterVisible; focusInput=true)"
+      ng-keydown="($event.keyCode === 13 || $event.keyCode === 32) && toggleFilter()"
       aria-label="{{ 'Toggle filter' | translate }}"
       title="{{ 'Toggle filter' | translate }}"
       aria-hidden="false"></span>


### PR DESCRIPTION
Add toggleFilter function to improve filter visibility handling and remove unnecessary ng-change attributes.
first is a syntax error that requires making it a function. second was causing cascading error in the browser console.