### PR TITLE
verify enrollment improvements in UI and backend

### DIFF
--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -769,9 +769,6 @@ def verify_enrollment(request=None, action=None):
 
     # Lookup the token
     token_list = get_tokens(serial=serial)
-    if len(token_list) != 1:
-        return
-
     token = token_list[0]
     # Early exit: token not in verify_pending state
     if token.rollout_state != RolloutState.VERIFY_PENDING:

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -780,7 +780,6 @@ def verify_enrollment(request=None, action=None):
     # Check if verify parameter is present
     verify = getParam(request.all_data, "verify", optional)
     if not verify:
-        from privacyidea.lib.error import ParameterError
         raise ParameterError("Token is in verify_pending state but 'verify' parameter is missing.")
 
     # Verify the token enrollment
@@ -793,7 +792,6 @@ def verify_enrollment(request=None, action=None):
         token.token.rollout_state = RolloutState.ENROLLED
         token.token.save()  # todo evaluate
     else:
-        from privacyidea.lib.error import ParameterError
         raise ParameterError("Verification of the new token failed.")
 
 

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -769,6 +769,13 @@ def verify_enrollment(request=None, action=None):
 
     # Lookup the token
     token_list = get_tokens(serial=serial)
+    if len(token_list) != 1:
+        log.debug(
+            "Found {0!s} tokens with serial {1!s}. Expected 1. Enrollment can not be verified."
+            .format(len(token_list), serial)
+        )
+        return
+
     token = token_list[0]
     # Early exit: token not in verify_pending state
     if token.rollout_state != RolloutState.VERIFY_PENDING:

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -763,24 +763,38 @@ def verify_enrollment(request=None, action=None):
     :return:
     """
     serial = getParam(request.all_data, "serial", optional)
+    # Early exit: no serial provided
+    if not serial:
+        return
+
+    # Lookup the token
+    token_list = get_tokens(serial=serial)
+    if len(token_list) != 1:
+        return
+
+    token = token_list[0]
+    # Early exit: token not in verify_pending state
+    if token.rollout_state != RolloutState.VERIFY_PENDING:
+        return
+
+    # Check if verify parameter is present
     verify = getParam(request.all_data, "verify", optional)
-    if verify and serial:
-        # Only now, we check if we need to verify
-        tokenobj_list = get_tokens(serial=serial)
-        if len(tokenobj_list) == 1:
-            tokenobj = tokenobj_list[0]
-            if tokenobj.rollout_state == RolloutState.VERIFY_PENDING:
-                log.debug("Verifying the token enrollment for token {0!s}.".format(serial))
-                r = tokenobj.verify_enrollment(verify)
-                log.info("Result of enrollment verification for token {0!s}: {1!s}".format(serial, r))
-                if r:
-                    # TODO: we need to add the tokentype here or the second init_token() call fails
-                    request.all_data.update(type=tokenobj.get_tokentype())
-                    tokenobj.token.rollout_state = RolloutState.ENROLLED
-                    tokenobj.token.save() # todo evaluate
-                else:
-                    from privacyidea.lib.error import ParameterError
-                    raise ParameterError("Verification of the new token failed.")
+    if not verify:
+        from privacyidea.lib.error import ParameterError
+        raise ParameterError("Token is in verify_pending state but 'verify' parameter is missing.")
+
+    # Verify the token enrollment
+    log.debug("Verifying the token enrollment for token {0!s}.".format(serial))
+    r = token.verify_enrollment(verify)
+    log.info("Result of enrollment verification for token {0!s}: {1!s}".format(serial, r))
+    if r:
+        # TODO: we need to add the tokentype here or the second init_token() call fails
+        request.all_data.update(type=token.get_tokentype())
+        token.token.rollout_state = RolloutState.ENROLLED
+        token.token.save()  # todo evaluate
+    else:
+        from privacyidea.lib.error import ParameterError
+        raise ParameterError("Verification of the new token failed.")
 
 
 def check_max_token_user(request=None, action=None, token_type=None):

--- a/privacyidea/static/components/directives/controllers/directives.js
+++ b/privacyidea/static/components/directives/controllers/directives.js
@@ -1005,10 +1005,11 @@ myApp.directive("verifyEnrolledToken", ["instanceUrl", "versioningSuffixProvider
             },
             templateUrl: instanceUrl + "/static/components/directives/views/directive.verifyEnrolledToken.html" + versioningSuffixProvider.$get(),
             link: function (scope, element, attr) {
+                scope.verifyData = {response: ""};
                 scope.sendVerifyResponse = function () {
                     const params = {
                         "serial": scope.enrolledToken.serial,
-                        "verify": scope.verifyResponse,
+                        "verify": scope.verifyData.response,
                         "type": scope.tokenType
                     };
                     if (scope.enrolledToken.init_params) {
@@ -1024,7 +1025,7 @@ myApp.directive("verifyEnrolledToken", ["instanceUrl", "versioningSuffixProvider
                             inform.add(gettextCatalog.getString("Token successfully verified"),
                                 {type: "success", ttl: 10000});
                         }
-                        scope.verifyResponse = "";
+                        scope.verifyData.response = "";
                         scope.callback(data);
                     });
                 };

--- a/privacyidea/static/components/directives/views/directive.verifyEnrolledToken.html
+++ b/privacyidea/static/components/directives/views/directive.verifyEnrolledToken.html
@@ -16,6 +16,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <!-- Verify Token enrollment -->
 <form ng-submit="sendVerifyResponse()" ng-if="enrolledToken.rollout_state === 'verify'">
+    <p class="help-block" translate>
+        The token was enrolled, but it still needs to be verified. Please enter the verification value.
+    </p>
     <div class="form-group">
         <label for="verifyResponse">{{ enrolledToken.verify.message }}</label>
         <input type="text" ng-model="verifyData.response"

--- a/privacyidea/static/components/directives/views/directive.verifyEnrolledToken.html
+++ b/privacyidea/static/components/directives/views/directive.verifyEnrolledToken.html
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <!-- Verify Token enrollment -->
-<form ng-submit="sendVerifyResponse()">
+<form ng-submit="sendVerifyResponse()" ng-if="enrolledToken.rollout_state === 'verify'">
     <div class="form-group">
         <label for="verifyResponse">{{ enrolledToken.verify.message }}</label>
         <input type="text" ng-model="verifyResponse"

--- a/privacyidea/static/components/directives/views/directive.verifyEnrolledToken.html
+++ b/privacyidea/static/components/directives/views/directive.verifyEnrolledToken.html
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <form ng-submit="sendVerifyResponse()" ng-if="enrolledToken.rollout_state === 'verify'">
     <div class="form-group">
         <label for="verifyResponse">{{ enrolledToken.verify.message }}</label>
-        <input type="text" ng-model="verifyResponse"
+        <input type="text" ng-model="verifyData.response"
                id="verifyResponse"
                autofocus
                required
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     </div>
     <div class="text-center">
         <button type="submit"
-                ng-disabled="!verifyResponse || verifyResponse.length === 0"
+                ng-disabled="!verifyData.response || verifyData.response.length === 0"
                 class="btn btn-primary" translate>Verify Token
         </button>
     </div>

--- a/privacyidea/static/components/directives/views/directive.verifyEnrolledToken.html
+++ b/privacyidea/static/components/directives/views/directive.verifyEnrolledToken.html
@@ -15,19 +15,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <!-- Verify Token enrollment -->
-<div ng-show="enrolledToken.rollout_state === 'verify'">
-    <p translate>The token was enrolled, but you still need to verify it before you can use it!</p>
+<form ng-submit="sendVerifyResponse()">
     <div class="form-group">
         <label for="verifyResponse">{{ enrolledToken.verify.message }}</label>
         <input type="text" ng-model="verifyResponse"
                id="verifyResponse"
                autofocus
+               required
                class="form-control"
                name="verifyResponse">
     </div>
     <div class="text-center">
-        <button type="button" ng-click="sendVerifyResponse()"
+        <button type="submit"
+                ng-disabled="!verifyResponse || verifyResponse.length === 0"
                 class="btn btn-primary" translate>Verify Token
         </button>
     </div>
-</div>
+</form>

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -6233,13 +6233,17 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         self.assertIsNone(result)
 
     def test_20b_verify_enrollment_token_not_found(self):
-        """Test verify_enrollment prepolicy with non-existent serial - should return early"""
+        """Test verify_enrollment prepolicy with non-existent serial - should return early
+
+        This tests the early exit when len(token_list) != 1 (specifically when len == 0).
+        The case where len > 1 cannot occur because serial is a unique database constraint.
+        """
         builder = EnvironBuilder(method='POST', data={}, headers={})
         env = builder.get_environ()
         req = Request(env)
         req.all_data = {"serial": "NONEXISTENT", "verify": "123456"}
 
-        # Should return None without error (early exit - token not found)
+        # Should return None without error (early exit - token not found, len(token_list) == 0)
         result = verify_enrollment(req, None)
         self.assertIsNone(result)
 
@@ -6325,6 +6329,42 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # Token should still be in enrolled state (unchanged)
         tok = get_tokens(serial=serial)[0]
         self.assertEqual(tok.token.rollout_state, RolloutState.ENROLLED)
+        remove_token(serial)
+
+    def test_20f_verify_enrollment_success(self):
+        """Test verify_enrollment prepolicy happy path - successful verification"""
+        from privacyidea.lib.tokenclass import RolloutState
+
+        otpkey_hex = ("5287c8247735148e48cc66412e8510de0414eb996da86edf18d944dd9844d13f9b804fce48a4c6d3f43f27788f70122b"
+                      "457dffc12563e8d319c23c8b6fac5395")
+        first_otp = "148752"
+
+        serial = "HOTP_VERIFY_SUCCESS"
+        tok = init_token({"serial": serial,
+                          "type": "hotp",
+                          "otpkey": otpkey_hex})
+        # Set token to VERIFY_PENDING state
+        tok.token.rollout_state = RolloutState.VERIFY_PENDING
+        tok.save()
+
+        builder = EnvironBuilder(method='POST', data={}, headers={})
+        env = builder.get_environ()
+        req = Request(env)
+        req.all_data = {"serial": serial, "verify": first_otp, "type": "hotp"}
+
+        # Should succeed without raising an error
+        result = verify_enrollment(req, None)
+        self.assertIsNone(result)  # prepolicy returns None on success
+
+        # Token should now be in ENROLLED state
+        tok = get_tokens(serial=serial)[0]
+        self.assertEqual(tok.token.rollout_state, RolloutState.ENROLLED)
+
+        # Verify that the OTP counter was incremented (token consumed the OTP)
+        # The same OTP should not work again
+        r = tok.check_otp(first_otp)
+        self.assertEqual(r, -1)  # -1 means OTP already used
+
         remove_token(serial)
 
     def test_21_preferred_client_mode_for_user_allowed(self):

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -6314,8 +6314,9 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         tok = init_token({"serial": serial,
                           "type": "hotp",
                           "otpkey": "31323334353637383940"})
-        # Token is in ENROLLED state (default), not VERIFY_PENDING
-        self.assertEqual(tok.token.rollout_state, RolloutState.ENROLLED)
+        # Token that are enrolled directly without verify or 2step have the empty enrollment state
+        # TODO should be unified
+        self.assertEqual(tok.token.rollout_state, "")
 
         builder = EnvironBuilder(method='POST', data={}, headers={})
         env = builder.get_environ()
@@ -6326,9 +6327,9 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         result = verify_enrollment(req, None)
         self.assertIsNone(result)
 
-        # Token should still be in enrolled state (unchanged)
+        # Token should still be empty (unchanged)
         tok = get_tokens(serial=serial)[0]
-        self.assertEqual(tok.token.rollout_state, RolloutState.ENROLLED)
+        self.assertEqual(tok.token.rollout_state, "")
         remove_token(serial)
 
     def test_20f_verify_enrollment_success(self):

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -6221,7 +6221,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         self.assertEqual(tok.token.rollout_state, RolloutState.VERIFY_PENDING)
         delete_policy("verify_toks")
 
-    def test_20a_verify_enrollment_prepolicy_no_serial(self):
+    def test_20a_verify_enrollment_no_serial(self):
         """Test verify_enrollment prepolicy with no serial - should return early"""
         builder = EnvironBuilder(method='POST', data={}, headers={})
         env = builder.get_environ()
@@ -6232,7 +6232,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         result = verify_enrollment(req, None)
         self.assertIsNone(result)
 
-    def test_20b_verify_enrollment_prepolicy_token_not_found(self):
+    def test_20b_verify_enrollment_token_not_found(self):
         """Test verify_enrollment prepolicy with non-existent serial - should return early"""
         builder = EnvironBuilder(method='POST', data={}, headers={})
         env = builder.get_environ()
@@ -6243,8 +6243,8 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         result = verify_enrollment(req, None)
         self.assertIsNone(result)
 
-    def test_20c_verify_enrollment_prepolicy_missing_verify_param(self):
-        """Test verify_enrollment prepolicy with token in verify_pending but no verify param - should raise error"""
+    def test_20c_verify_enrollment_missing_verify_param(self):
+        """Test verify_enrollment prepolicy with token in verify_pending but no verify param - should raise an error"""
         from privacyidea.lib.tokenclass import RolloutState
         from privacyidea.lib.error import ParameterError
 
@@ -6273,7 +6273,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         self.assertEqual(tok.token.rollout_state, RolloutState.VERIFY_PENDING)
         remove_token(serial)
 
-    def test_20d_verify_enrollment_prepolicy_wrong_verify_value(self):
+    def test_20d_verify_enrollment_wrong_verify_value(self):
         """Test verify_enrollment prepolicy with wrong verify value - should raise error"""
         from privacyidea.lib.tokenclass import RolloutState
         from privacyidea.lib.error import ParameterError
@@ -6300,6 +6300,31 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # Token should still be in verify_pending state
         tok = get_tokens(serial=serial)[0]
         self.assertEqual(tok.token.rollout_state, RolloutState.VERIFY_PENDING)
+        remove_token(serial)
+
+    def test_20e_verify_enrollment_not_in_verify_pending_state(self):
+        """Test verify_enrollment prepolicy with token not in verify_pending state - should exit early"""
+        from privacyidea.lib.tokenclass import RolloutState
+
+        serial = "HOTP_NOT_VERIFY_PENDING"
+        tok = init_token({"serial": serial,
+                          "type": "hotp",
+                          "otpkey": "31323334353637383940"})
+        # Token is in ENROLLED state (default), not VERIFY_PENDING
+        self.assertEqual(tok.token.rollout_state, RolloutState.ENROLLED)
+
+        builder = EnvironBuilder(method='POST', data={}, headers={})
+        env = builder.get_environ()
+        req = Request(env)
+        req.all_data = {"serial": serial, "verify": "123456"}
+
+        # Should return None without error (early exit - not in verify_pending state)
+        result = verify_enrollment(req, None)
+        self.assertIsNone(result)
+
+        # Token should still be in enrolled state (unchanged)
+        tok = get_tokens(serial=serial)[0]
+        self.assertEqual(tok.token.rollout_state, RolloutState.ENROLLED)
         remove_token(serial)
 
     def test_21_preferred_client_mode_for_user_allowed(self):

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -56,7 +56,7 @@ from privacyidea.api.lib.prepolicy import (check_token_upload,
                                            check_token_action, check_user_params,
                                            check_client_container_action, container_registration_config,
                                            smartphone_config, check_client_container_disabled_action, rss_age,
-                                           hide_container_info, force_server_generate_key)
+                                           hide_container_info, force_server_generate_key, verify_enrollment)
 from privacyidea.lib.auth import ROLE
 from privacyidea.lib.config import set_privacyidea_config, SYSCONF
 from privacyidea.lib.container import (init_container, find_container_by_serial, create_container_template,
@@ -6220,6 +6220,87 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
         # Also check the token object.
         self.assertEqual(tok.token.rollout_state, RolloutState.VERIFY_PENDING)
         delete_policy("verify_toks")
+
+    def test_20a_verify_enrollment_prepolicy_no_serial(self):
+        """Test verify_enrollment prepolicy with no serial - should return early"""
+        builder = EnvironBuilder(method='POST', data={}, headers={})
+        env = builder.get_environ()
+        req = Request(env)
+        req.all_data = {"verify": "123456"}  # verify present but no serial
+
+        # Should return None without error (early exit)
+        result = verify_enrollment(req, None)
+        self.assertIsNone(result)
+
+    def test_20b_verify_enrollment_prepolicy_token_not_found(self):
+        """Test verify_enrollment prepolicy with non-existent serial - should return early"""
+        builder = EnvironBuilder(method='POST', data={}, headers={})
+        env = builder.get_environ()
+        req = Request(env)
+        req.all_data = {"serial": "NONEXISTENT", "verify": "123456"}
+
+        # Should return None without error (early exit - token not found)
+        result = verify_enrollment(req, None)
+        self.assertIsNone(result)
+
+    def test_20c_verify_enrollment_prepolicy_missing_verify_param(self):
+        """Test verify_enrollment prepolicy with token in verify_pending but no verify param - should raise error"""
+        from privacyidea.lib.tokenclass import RolloutState
+        from privacyidea.lib.error import ParameterError
+
+        serial = "HOTP_VERIFY_PENDING"
+        tok = init_token({"serial": serial,
+                          "type": "hotp",
+                          "otpkey": "31323334353637383940"})
+        # Set token to VERIFY_PENDING state
+        tok.token.rollout_state = RolloutState.VERIFY_PENDING
+        tok.save()
+
+        builder = EnvironBuilder(method='POST', data={}, headers={})
+        env = builder.get_environ()
+        req = Request(env)
+        req.all_data = {"serial": serial}  # No verify parameter
+
+        # Should raise ParameterError
+        with self.assertRaises(ParameterError) as cm:
+            verify_enrollment(req, None)
+
+        self.assertIn("verify_pending", str(cm.exception))
+        self.assertIn("verify", str(cm.exception).lower())
+
+        # Token should still be in verify_pending state
+        tok = get_tokens(serial=serial)[0]
+        self.assertEqual(tok.token.rollout_state, RolloutState.VERIFY_PENDING)
+        remove_token(serial)
+
+    def test_20d_verify_enrollment_prepolicy_wrong_verify_value(self):
+        """Test verify_enrollment prepolicy with wrong verify value - should raise error"""
+        from privacyidea.lib.tokenclass import RolloutState
+        from privacyidea.lib.error import ParameterError
+
+        serial = "HOTP_VERIFY_WRONG"
+        tok = init_token({"serial": serial,
+                          "type": "hotp",
+                          "otpkey": "31323334353637383940"})
+        # Set token to VERIFY_PENDING state
+        tok.token.rollout_state = RolloutState.VERIFY_PENDING
+        tok.save()
+
+        builder = EnvironBuilder(method='POST', data={}, headers={})
+        env = builder.get_environ()
+        req = Request(env)
+        req.all_data = {"serial": serial, "verify": "wrong_value"}
+
+        # Should raise ParameterError for wrong verification
+        with self.assertRaises(ParameterError) as cm:
+            verify_enrollment(req, None)
+
+        self.assertIn("Verification of the new token failed", str(cm.exception))
+
+        # Token should still be in verify_pending state
+        tok = get_tokens(serial=serial)[0]
+        self.assertEqual(tok.token.rollout_state, RolloutState.VERIFY_PENDING)
+        remove_token(serial)
 
     def test_21_preferred_client_mode_for_user_allowed(self):
         """


### PR DESCRIPTION
Add verify_enrollment prepolicy tests and improve token verification handling

- Added unit tests for `verify_enrollment` prepolicy, covering edge cases like missing serial, missing or incorrect verification values, and non-existent tokens.
- Refactored `verify_enrollment` to include clearer logic, early exits, and improved error handling.
- Fixed validation form in the directive to ensure user input is required and properly handled.