### PR TITLE
Event table style

### DIFF
--- a/privacyidea/static_new/src/app/components/event/event.component.html
+++ b/privacyidea/static_new/src/app/components/event/event.component.html
@@ -91,12 +91,12 @@
           </th>
           <td
             *matCellDef="let element; let row"
-            [ngClass]="detailedView() ? 'detailed-cell' : 'compact-cell'"
+            class="column-max-width"
             mat-cell>
             @switch (column) {
               @case ("name") {
                 <div
-                  class="event-table-cell"
+                  [ngClass]="detailedView() ? 'break-words' : 'event-table-cell'"
                   [attr.title]="element.name">
                   @if (authService.actionAllowed("eventhandling_write")) {
                     <a

--- a/privacyidea/static_new/src/app/components/event/event.component.scss
+++ b/privacyidea/static_new/src/app/components/event/event.component.scss
@@ -10,8 +10,7 @@
   @include styles.table-container-styles;
   @include styles.base-table-structure(".event-handler-table", ".event-handler-table-filter", ".table-scroll-container");
   max-height: var(--max-height);
-  // navigation width is 295px and additionally keep margin around the component
-  max-width: calc(100vw - var(--double-global-padding) * 2 - 295px);
+  max-width: calc(100vw - var(--drawer-width) - 2 * var(--double-global-padding));
   overflow: auto;
   display: grid;
 }
@@ -64,8 +63,11 @@
   padding-left: 16px;
 }
 
+.column-max-width {
+  max-width: 280px;
+}
+
 .event-table-cell {
-  max-width: 250px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
* Limit the column width for events and conditions to avoid long content makes the table length huge
* Show event name in hint to make full name accessible if it is too long to display
* Limit complete width of the component to properly render the horizontal scroll