### PR TITLE
fix yubico token validation

### DIFF
--- a/privacyidea/lib/tokens/yubicotoken.py
+++ b/privacyidea/lib/tokens/yubicotoken.py
@@ -61,9 +61,9 @@ from privacyidea.lib.tokens.yubikeytoken import (yubico_check_api_signature,
 YUBICO_LEN_ID = 12
 YUBICO_LEN_OTP = 44
 YUBICO_URL = "https://api.yubico.com/wsapi/2.0/verify"
-# The Yubico API requires GET requests. See: https://developers.yubico.com/yubikey-val/Validation_Protocol_V2.0.html
-# Previously we used POST requests.
-# If you want to have the old behaviour, you can set this to True
+# The Yubico API requires GET requests. See:
+# https://developers.yubico.com/OTP/Specifications/OTP_validation_protocol.html
+# Previously we used POST requests. If you want to have the old behaviour, you can set this to True
 DO_YUBICO_POST = False
 DEFAULT_CLIENT_ID = 20771
 DEFAULT_API_KEY = "9iE9DRkPHQDJbAFFC31/dum5I54="
@@ -218,7 +218,7 @@ class YubicoTokenClass(TokenClass):
                             res = -2
                     else:
                         # possible results are listed here:
-                        # https://github.com/Yubico/yubikey-val/wiki/ValidationProtocolV20
+                        # https://developers.yubico.com/OTP/Specifications/OTP_validation_protocol.html
                         log.warning("failed with {0!r}".format(result))
 
             except Exception as ex:

--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -80,9 +80,15 @@ log = logging.getLogger(__name__)
 
 # Keys that are part of the Yubico Validation Protocol v2 and must be included
 # in the HMAC signature.  Everything else in request.all_data (e.g. 'ttype',
-# or any future privacyIDEA-internal key) is silently ignored.
-# https://developers.yubico.com/yubikey-val/Validation_Protocol_V2.0.html
-_YUBICO_PROTOCOL_KEYS = frozenset({"id", "nonce", "otp", "sl", "timeout", "timestamp"})
+# or any future privacyIDEA-internal key) is silently ignored.  This set is the
+# union of request fields (id, nonce, otp, sl, timeout, timestamp) and response
+# fields (otp, nonce, t, status, timestamp, sessioncounter, sessionuse, sl), so
+# the same helper can both sign outgoing requests and verify server responses.
+# https://developers.yubico.com/OTP/Specifications/OTP_validation_protocol.html
+_YUBICO_PROTOCOL_KEYS = frozenset({
+    "id", "nonce", "otp", "sl", "timeout", "timestamp",
+    "t", "status", "sessioncounter", "sessionuse",
+})
 
 
 def yubico_api_signature(data, api_key):
@@ -298,7 +304,8 @@ class YubikeyTokenClass(TokenClass):
         # occupies the last 2 bytes of the decrypted OTP value. Calculating the
         # CRC-16 checksum of the whole decrypted OTP should give a fixed
         # residual
-        # of 0xf0b8 (see Yubikey-Manual - Chapter 6: Implementation details).
+        # of 0xf0b8 (see Yubikey-Manual - Chapter 6: Implementation details,
+        # https://downloads.yubico.com/support/yubico_YubiKey-Technical-Manual-v3.3_2014.pdf).
         crc16 = checksum(msg_bin)
         log.debug("calculated checksum (61624): {0!r}".format(crc16))
         if crc16 != 0xf0b8:  # pragma: no cover
@@ -370,7 +377,7 @@ class YubikeyTokenClass(TokenClass):
 
         The endpoint /ttype/yubikey is used for the Yubico validate request
         according to
-        https://developers.yubico.com/yubikey-val/Validation_Protocol_V2.0.html
+        https://developers.yubico.com/OTP/Specifications/OTP_validation_protocol.html
 
         :param request: The Flask request
         :param g: The Flask global object g

--- a/privacyidea/static/components/config/controllers/configControllers.js
+++ b/privacyidea/static/components/config/controllers/configControllers.js
@@ -609,6 +609,8 @@ myApp.controller("tokenConfigController", ["$scope", "$location", "$rootScope",
                 $scope.form['radius.dictfile'] = "/etc/privacyidea/dictionary";
                 // SMS
                 $scope.form['sms.Provider'] = $scope.form['sms.Provider'] || $scope.defaultSMSProvider;
+                // Yubico
+                $scope.form['yubico.url'] = $scope.form['yubico.url'] || "https://api.yubico.com/wsapi/2.0/verify";
                 // Email
                 $scope.form['email.password.type'] = "password";
                 // We need to convert the values to bools - otherwise we have

--- a/privacyidea/static/components/config/views/config.token.yubico.html
+++ b/privacyidea/static/components/config/views/config.token.yubico.html
@@ -35,7 +35,6 @@
     <input type="url"
            required
            class="form-control"
-           placeholder="https://api.yubico.com/wsapi/2.0/verify"
            ng-model="form['yubico.url']" name="yubicoURL">
 </div>
 

--- a/tests/test_lib_tokens_yubico.py
+++ b/tests/test_lib_tokens_yubico.py
@@ -2,7 +2,9 @@
 This test file tests the lib.tokens.yubicotoken
 This depends on lib.tokenclass
 """
-from privacyidea.lib.token import init_token, get_tokens, import_tokens
+from unittest.mock import patch
+
+from privacyidea.lib.token import init_token, remove_token, get_tokens, import_tokens
 from .base import MyTestCase
 from privacyidea.lib.tokens.yubicotoken import (YubicoTokenClass, YUBICO_URL)
 from privacyidea.models import Token
@@ -11,7 +13,6 @@ from privacyidea.lib.config import set_privacyidea_config
 
 
 class YubicoTokenTestCase(MyTestCase):
-
     otppin = "topsecret"
     serial1 = "ser1"
     params1 = {"yubico.tokenid": "vvbgidlghkhgfbvetefnbrfibfctu"}
@@ -80,7 +81,6 @@ status=REPLAYED_OTP"""
         self.assertTrue(otpcount == -2, otpcount)
         set_privacyidea_config("yubico.do_post", False)
 
-
     @responses.activate
     def test_05_check_otp_fail(self):
         responses.add(responses.POST, YUBICO_URL,
@@ -92,6 +92,105 @@ status=REPLAYED_OTP"""
         otpcount = token.check_otp("vvbgidlghkhgndujklhhudbcuttkcklhvjktrjrt")
         # Status != "OK".
         self.assertTrue(otpcount == -1, otpcount)
+
+    # The two fixtures below are verbatim request/response pairs captured
+    # from https://api.yubico.com/wsapi/2.0/verify
+    # The ``h=`` values were computed by YubiCloud itself, so verifying them
+    # locally is a non-circular regression test for the HMAC whitelist in
+    # privacyidea.lib.tokens.yubikeytoken.
+    # NOTE: The API ID/key below were registered solely for these fixtures
+    # and are considered public. Do not use them for anything else.
+    YUBICLOUD_API_ID = "119564"
+    YUBICLOUD_API_KEY = "W4xuhNuYDdysTrZzceKXm4kw4dI="
+    YUBICLOUD_OTP = "vvccccccccvvjnkckcilhkfkvelejbnucncttbjnflte"
+    YUBICLOUD_TOKENID = "vvccccccccvv"
+
+    # status=OK capture (full field set incl. sl).
+    YUBICLOUD_OK_NONCE = "5859842555790891ee43f3bdb4e103fa4673186b"
+    YUBICLOUD_OK_BODY = (
+        "h=LwE1Ojk1kWNUN2YntJNKQuhWQJY=\r\n"
+        "t=2026-04-20T14:05:53Z0704\r\n"
+        "otp=vvccccccccvvjnkckcilhkfkvelejbnucncttbjnflte\r\n"
+        "nonce=5859842555790891ee43f3bdb4e103fa4673186b\r\n"
+        "sl=100\r\n"
+        "status=OK\r\n"
+    )
+
+    # status=REPLAYED_OTP capture (no sl field — exercises the case where a
+    # legitimate response omits optional fields).
+    YUBICLOUD_REPLAY_NONCE = "87e40880272bac0b94bb18f6342ce76d528ddc28"
+    YUBICLOUD_REPLAY_BODY = (
+        "h=S4Vp52zdQinaj2x3fvch7o61QIY=\r\n"
+        "t=2026-04-20T14:06:00Z0720\r\n"
+        "otp=vvccccccccvvjnkckcilhkfkvelejbnucncttbjnflte\r\n"
+        "nonce=87e40880272bac0b94bb18f6342ce76d528ddc28\r\n"
+        "status=REPLAYED_OTP\r\n"
+    )
+
+    def _enroll_yubicloud_token(self, serial):
+        db_token = Token(serial, tokentype="yubico")
+        db_token.save()
+        token = YubicoTokenClass(db_token)
+        # update() validates and truncates yubico.tokenid to 12 chars.
+        token.update({"yubico.tokenid": self.YUBICLOUD_TOKENID})
+        return token
+
+    @responses.activate
+    def test_05b_check_otp_yubicloud_real_ok(self):
+        """Verified against a real YubiCloud ``status=OK`` response."""
+        set_privacyidea_config("yubico.id", self.YUBICLOUD_API_ID)
+        set_privacyidea_config("yubico.secret", self.YUBICLOUD_API_KEY)
+        set_privacyidea_config("yubico.do_post", False)
+
+        responses.add(responses.GET, YUBICO_URL, body=self.YUBICLOUD_OK_BODY)
+        responses.add(responses.POST, YUBICO_URL, body=self.YUBICLOUD_OK_BODY)
+
+        token = self._enroll_yubicloud_token("UBCMREAL_OK")
+        try:
+            # Pin the nonce to the captured one so YubiCloud's real h= stays
+            # valid — our code never re-signs anything in this path.
+            with patch("privacyidea.lib.tokens.yubicotoken.geturandom",
+                       return_value=self.YUBICLOUD_OK_NONCE):
+                self.assertEqual(1, token.check_otp(self.YUBICLOUD_OTP))
+        finally:
+            remove_token("UBCMREAL_OK")
+            set_privacyidea_config("yubico.id", "")
+            set_privacyidea_config("yubico.secret", "")
+
+    @responses.activate
+    def test_05c_check_otp_yubicloud_real_replayed(self):
+        """Real YubiCloud ``status=REPLAYED_OTP`` — signature still must verify."""
+        set_privacyidea_config("yubico.id", self.YUBICLOUD_API_ID)
+        set_privacyidea_config("yubico.secret", self.YUBICLOUD_API_KEY)
+        set_privacyidea_config("yubico.do_post", False)
+
+        responses.add(responses.GET, YUBICO_URL,
+                      body=self.YUBICLOUD_REPLAY_BODY)
+        responses.add(responses.POST, YUBICO_URL,
+                      body=self.YUBICLOUD_REPLAY_BODY)
+
+        token = self._enroll_yubicloud_token("UBCMREAL_REPLAY")
+        try:
+            with (patch("privacyidea.lib.tokens.yubicotoken.geturandom",
+                        return_value=self.YUBICLOUD_REPLAY_NONCE),
+                  self.assertLogs("privacyidea.lib.tokens.yubicotoken",
+                                  level="WARNING") as lc):
+                # Non-OK status returns the default -1, but only after the
+                # signature check has passed; if the whitelist were wrong
+                # we'd see an ERROR-level "hash ... does not match" entry.
+                self.assertEqual(-1, token.check_otp(self.YUBICLOUD_OTP))
+            self.assertFalse(
+                any("does not match the data" in m for m in lc.output),
+                f"response signature verification failed: {lc.output}",
+            )
+            self.assertTrue(
+                any("REPLAYED_OTP" in m for m in lc.output),
+                f"expected REPLAYED_OTP warning, got: {lc.output}",
+            )
+        finally:
+            remove_token("UBCMREAL_REPLAY")
+            set_privacyidea_config("yubico.id", "")
+            set_privacyidea_config("yubico.secret", "")
 
     def test_06_check_otp_ID_too_short(self):
         db_token = Token.query.filter(Token.serial == self.serial1).first()

--- a/tests/test_lib_tokens_yubikey.py
+++ b/tests/test_lib_tokens_yubikey.py
@@ -286,13 +286,15 @@ class YubikeyTokenTestCase(MyTestCase):
                                 "serial": serial,
                                 "otpkey": key,
                                 "otplen": len(otp)})
-            self.assertEqual(expected_counter, token.check_otp(otp),
-                             f"vector {i} ({otp}) decoded to wrong counter")
-            # First check_otp auto-populates yubikey.tokenid from the
-            # decrypted private uid — verify it matches the spec.
-            self.assertEqual(uid, token.get_tokeninfo("yubikey.tokenid"),
-                             f"vector {i}: uid mismatch")
-            remove_token(serial)
+            try:
+                self.assertEqual(expected_counter, token.check_otp(otp),
+                                 f"vector {i} ({otp}) decoded to wrong counter")
+                # First check_otp auto-populates yubikey.tokenid from the
+                # decrypted private uid — verify it matches the spec.
+                self.assertEqual(uid, token.get_tokeninfo("yubikey.tokenid"),
+                                 f"vector {i}: uid mismatch")
+            finally:
+                remove_token(serial)
 
     def test_20_broken_otp_value(self):
         token = init_token({"type": "yubikey",

--- a/tests/test_lib_tokens_yubikey.py
+++ b/tests/test_lib_tokens_yubikey.py
@@ -253,6 +253,47 @@ class YubikeyTokenTestCase(MyTestCase):
         self.assertTrue("status=OK" in result, result)
         self.assertTrue("nonce={0!s}".format(nonce) in result, result)
 
+    def test_12_yubico_spec_otp_test_vectors(self):
+        """
+        Yubico OTP test vectors from
+        https://developers.yubico.com/OTP/Specifications/Test_vectors.html
+
+        Each vector pairs an AES key with an OTP whose decrypted payload has
+        a known private uid, usage counter, session counter and CRC. The
+        expected counter returned by check_otp is
+        (usage_counter << 8) | session_counter — the usage counter is stored
+        little-endian on the wire and reassembled big-endian by the decoder
+        (see yubikeytoken.py:330).
+        """
+        # (aes_key, expected_uid, expected_counter, otp)
+        vectors = [
+            ("000102030405060708090a0b0c0d0e0f", "010203040506", (0x0001 << 8) | 0x01,
+             "dvgtiblfkbgturecfllberrvkinnctnn"),
+            ("000102030405060708090a0b0c0d0e0f", "010203040506", (0x0001 << 8) | 0x02,
+             "rnibcnfhdninbrdebccrndfhjgnhftee"),
+            ("000102030405060708090a0b0c0d0e0f", "010203040506", (0x0fff << 8) | 0x01,
+             "iikkijbdknrrdhfdrjltvgrbkkjblcbh"),
+            ("88888888888888888888888888888888", "888888888888", (0x8888 << 8) | 0x88,
+             "dcihgvrhjeucvrinhdfddbjhfjftjdei"),
+            ("00000000000000000000000000000000", "000000000000", 0,
+             "kkkncjnvcnenkjvjgncjihljiibgbhbh"),
+            ("c4422890653076cde73d449b191b416a", "33c69e7f249e", (0x0001 << 8) | 0x00,
+             "iucvrkjiegbhidrcicvlgrcgkgurhjnj"),
+        ]
+        for i, (key, uid, expected_counter, otp) in enumerate(vectors):
+            serial = f"YKSPEC_{i}"
+            token = init_token({"type": "yubikey",
+                                "serial": serial,
+                                "otpkey": key,
+                                "otplen": len(otp)})
+            self.assertEqual(expected_counter, token.check_otp(otp),
+                             f"vector {i} ({otp}) decoded to wrong counter")
+            # First check_otp auto-populates yubikey.tokenid from the
+            # decrypted private uid — verify it matches the spec.
+            self.assertEqual(uid, token.get_tokeninfo("yubikey.tokenid"),
+                             f"vector {i}: uid mismatch")
+            remove_token(serial)
+
     def test_20_broken_otp_value(self):
         token = init_token({"type": "yubikey",
                             "otpkey": self.otpkey,

--- a/tests/test_lib_tokens_yubikey.py
+++ b/tests/test_lib_tokens_yubikey.py
@@ -262,8 +262,8 @@ class YubikeyTokenTestCase(MyTestCase):
         a known private uid, usage counter, session counter and CRC. The
         expected counter returned by check_otp is
         (usage_counter << 8) | session_counter — the usage counter is stored
-        little-endian on the wire and reassembled big-endian by the decoder
-        (see yubikeytoken.py:330).
+        little-endian on the wire and reassembled big-endian by
+        YubikeyTokenClass.check_otp when assembling the counter value.
         """
         # (aes_key, expected_uid, expected_counter, otp)
         vectors = [


### PR DESCRIPTION
- fixed parameters used for validation response
- added more tests from real captures and official vectors
- added the yubico api url as default value for the configuration so you dont have to type it