### PR TITLE
fix sequence identity mismatch for tokencredentialidhash table

### DIFF
--- a/privacyidea/migrations/script.py.mako
+++ b/privacyidea/migrations/script.py.mako
@@ -15,6 +15,13 @@ down_revision = ${repr(down_revision)}
 branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
 
+# NOTE: If this migration changes data (UPDATE/INSERT/DELETE on existing rows,
+# backfilling new columns, rewriting values, etc.) — not just schema — you are
+# expected to add a dedicated test under tests/test_migration_<revision>.py
+# using MigrationTestBase. Schema-only migrations are covered by the generic
+# tests in tests/test_migrations.py and do not need their own test file.
+# Delete this note once you have addressed it.
+
 
 def upgrade():
     ${upgrades if upgrades else "pass"}

--- a/privacyidea/migrations/versions/903a6ed6f6c4_.py
+++ b/privacyidea/migrations/versions/903a6ed6f6c4_.py
@@ -17,7 +17,8 @@ down_revision = 'c128c01a5520'
 def upgrade():
     try:
         op.create_table('tokencredentialidhash',
-                        sa.Column('id', sa.Integer(), sa.Identity(), primary_key=True),
+                        sa.Column('id', sa.Integer(), sa.Sequence('tokencredentialidhash_seq'),
+                                  primary_key=True),
                         sa.Column('credential_id_hash', sa.String(length=256), nullable=False),
                         sa.Column('token_id', sa.Integer(), nullable=False),
                         sa.ForeignKeyConstraint(['token_id'], ['token.id'], ),

--- a/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
+++ b/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
@@ -51,3 +51,4 @@ def downgrade():
         op.execute("DROP SEQUENCE IF EXISTS tokencredentialidhash_seq")
     except (OperationalError, ProgrammingError) as ex:
         print(f"Could not drop sequence 'tokencredentialidhash_seq': {ex}")
+        raise

--- a/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
+++ b/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
@@ -1,11 +1,11 @@
 """Create missing tokencredentialidhash_seq on existing installs
 
-Migration 903a6ed6f6c4 created the table with sa.Identity() instead of
-sa.Sequence(), so the sequence declared by the model was never created.
-SQLAlchemy 2.0's MariaDB dialect honors Sequence() and emits
-SELECT nextval(tokencredentialidhash_seq) on insert, which fails with
-"Unknown SEQUENCE" on already-upgraded installs. Create it here if missing
-and advance it past any existing ids.
+The TokenCredentialIdHash model declares Sequence('tokencredentialidhash_seq')
+on its id column, so SQLAlchemy 2.0's MariaDB/Postgres dialect emits
+SELECT nextval(tokencredentialidhash_seq) on every insert. Some installs
+ended up with the table but without the sequence, causing every insert to
+fail with "Unknown SEQUENCE". Create it here if missing and advance it past
+any existing ids so the next insert gets a free PK.
 
 Revision ID: b1a2c3d4e5f6
 Revises: 06b105a4f941
@@ -18,23 +18,26 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 
 revision = 'b1a2c3d4e5f6'
 down_revision = '06b105a4f941'
+branch_labels = None
+depends_on = None
 
 
 def upgrade():
     bind = op.get_bind()
-    dialect = bind.dialect.name
-    if dialect not in ('mysql', 'mariadb', 'postgresql'):
+    if not bind.dialect.supports_sequences:
+        # MySQL itself has no CREATE SEQUENCE; only MariaDB 10.3+ and Postgres do.
         return
     try:
         max_id = bind.execute(
             text("SELECT COALESCE(MAX(id), 0) FROM tokencredentialidhash")
         ).scalar() or 0
         start = max_id + 1
-        if dialect == 'postgresql':
-            op.execute(f"CREATE SEQUENCE IF NOT EXISTS tokencredentialidhash_seq START WITH {start}")
-            op.execute(f"SELECT setval('tokencredentialidhash_seq', {start}, false)")
-        else:
-            op.execute(f"CREATE SEQUENCE IF NOT EXISTS tokencredentialidhash_seq START WITH {start}")
+        # CREATE-IF-NOT-EXISTS handles the missing-sequence case; the explicit
+        # RESTART afterwards covers installs where a sequence already exists
+        # but is behind MAX(id), which would otherwise still produce duplicate
+        # PK errors on the next insert.
+        op.execute(f"CREATE SEQUENCE IF NOT EXISTS tokencredentialidhash_seq START WITH {start}")
+        op.execute(f"ALTER SEQUENCE tokencredentialidhash_seq RESTART WITH {start}")
     except (OperationalError, ProgrammingError) as ex:
         print(f"Could not create sequence 'tokencredentialidhash_seq': {ex}")
         raise
@@ -42,8 +45,7 @@ def upgrade():
 
 def downgrade():
     bind = op.get_bind()
-    dialect = bind.dialect.name
-    if dialect not in ('mysql', 'mariadb', 'postgresql'):
+    if not bind.dialect.supports_sequences:
         return
     try:
         op.execute("DROP SEQUENCE IF EXISTS tokencredentialidhash_seq")

--- a/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
+++ b/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
@@ -1,0 +1,51 @@
+"""Create missing tokencredentialidhash_seq on existing installs
+
+Migration 903a6ed6f6c4 created the table with sa.Identity() instead of
+sa.Sequence(), so the sequence declared by the model was never created.
+SQLAlchemy 2.0's MariaDB dialect honors Sequence() and emits
+SELECT nextval(tokencredentialidhash_seq) on insert, which fails with
+"Unknown SEQUENCE" on already-upgraded installs. Create it here if missing
+and advance it past any existing ids.
+
+Revision ID: b1a2c3d4e5f6
+Revises: 06b105a4f941
+Create Date: 2026-04-22 14:30:00.000000
+
+"""
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+revision = 'b1a2c3d4e5f6'
+down_revision = '06b105a4f941'
+
+
+def upgrade():
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect not in ('mysql', 'mariadb', 'postgresql'):
+        return
+    try:
+        max_id = bind.execute(
+            text("SELECT COALESCE(MAX(id), 0) FROM tokencredentialidhash")
+        ).scalar() or 0
+        start = max_id + 1
+        if dialect == 'postgresql':
+            op.execute(f"CREATE SEQUENCE IF NOT EXISTS tokencredentialidhash_seq START WITH {start}")
+            op.execute(f"SELECT setval('tokencredentialidhash_seq', {start}, false)")
+        else:
+            op.execute(f"CREATE SEQUENCE IF NOT EXISTS tokencredentialidhash_seq START WITH {start}")
+    except (OperationalError, ProgrammingError) as ex:
+        print(f"Could not create sequence 'tokencredentialidhash_seq': {ex}")
+        raise
+
+
+def downgrade():
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect not in ('mysql', 'mariadb', 'postgresql'):
+        return
+    try:
+        op.execute("DROP SEQUENCE IF EXISTS tokencredentialidhash_seq")
+    except (OperationalError, ProgrammingError) as ex:
+        print(f"Could not drop sequence 'tokencredentialidhash_seq': {ex}")

--- a/tests/migration_test_utils.py
+++ b/tests/migration_test_utils.py
@@ -57,15 +57,42 @@ def drop_all_tables(engine) -> None:
             conn.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
             for table in sa_inspect(engine).get_table_names():
                 conn.execute(text(f"DROP TABLE IF EXISTS `{table}`"))
+            # Drop sequences too — the v3.9 seed creates them and they
+            # would otherwise survive between tests and collide on reload.
+            sequences = conn.execute(text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = DATABASE() AND table_type = 'SEQUENCE'"
+            )).fetchall()
+            for (seq,) in sequences:
+                conn.execute(text(f"DROP SEQUENCE IF EXISTS `{seq}`"))
             conn.execute(text("SET FOREIGN_KEY_CHECKS = 1"))
         conn.commit()
 
 
+def read_seed_statements(seed_revision: str = START_REVISION, db_url: str = DB_URL) -> list[str]:
+    """
+    Read the dialect-specific seed SQL file and split it into individual
+    statements (split on semicolons), discarding empty / comment-only chunks.
+    """
+    path = get_seed_path(seed_revision, db_url)
+    sql = path.read_text(encoding="utf-8")
+    statements = []
+    for chunk in sql.split(";"):
+        stripped = chunk.strip()
+        if not stripped:
+            continue
+        non_comment_lines = [
+            line for line in stripped.splitlines()
+            if line.strip() and not line.strip().startswith("--")
+        ]
+        if non_comment_lines:
+            statements.append(stripped)
+    return statements
+
+
 def load_seed(seed_revision: str = START_REVISION, db_url: str = DB_URL) -> None:
     """Load the dialect-specific seed SQL for *seed_revision* into the database."""
-    path = get_seed_path(seed_revision, db_url)
-    raw = path.read_text(encoding="utf-8")
-    statements = [s.strip() for s in raw.split(";") if s.strip()]
+    statements = read_seed_statements(seed_revision, db_url)
     engine = create_engine(db_url)
     try:
         with engine.connect() as conn:
@@ -134,9 +161,7 @@ class MigrationTestBase:
         After this call the database is in the state immediately before the
         migration under test.  The caller is responsible for disposing *engine*.
         """
-        path = get_seed_path()
-        raw = path.read_text(encoding="utf-8")
-        statements = [s.strip() for s in raw.split(";") if s.strip()]
+        statements = read_seed_statements()
         with engine.connect() as conn:
             for stmt in statements:
                 conn.execute(text(stmt))

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,7 +1,47 @@
 """
-Note: Data transformation tests for specific migrations do not belong in this
-file.  See ``tests/README.md`` for the full guide on when a per-migration test
-is required and how to write one.
+Generic, migration-agnostic checks for the Alembic migration chain.
+
+The goal of this file is to catch structural and behavioural regressions in
+the migration history *as a whole*, without knowing what any individual
+migration does. Concretely, it verifies that:
+
+  - The chain is well-formed: a single head, every down_revision points at a
+    real revision, every revision has a non-empty message.
+  - Upgrading from a pinned baseline (START_REVISION, currently v3.9) to head
+    produces every table the SQLAlchemy models declare, and the alembic
+    version stamp matches the script head.
+  - The resulting schema matches the models — columns, types, indexes,
+    constraints — using Alembic autogenerate, modulo a small set of
+    documented dialect false positives.
+  - Every Sequence() declared on a model exists in the live database after
+    upgrade. Alembic autogenerate does not compare sequences, so this is
+    checked separately.
+  - Every migration in the window has a working downgrade(), and every
+    upgrade → downgrade → upgrade round-trip produces the same per-table
+    columns/indexes/foreign-keys/unique-constraints both times. This catches
+    downgrades that forget to drop something (or upgrades that don't fully
+    restore after one).
+  - A default INSERT succeeds against every model-declared table after
+    upgrade-to-head, exercising the auto-PK path. This catches sequence/
+    identity misconfigurations and missing NOT NULL defaults that schema-
+    only checks cannot see.
+  - Downgrading to the baseline does not destroy data in tables that survive
+    the downgrade.
+
+Tests are run against the dialect provided in TEST_DATABASE_URL — the
+project supports MariaDB and PostgreSQL — and use a pre-written seed file
+per dialect (tests/testdata/migrations/) as a complete, on-disk snapshot of
+the database state at START_REVISION. No runtime fixups; the seed is
+authoritative.
+
+Migrations older than START_REVISION are intentionally not covered: the pin
+exists because nothing in the supported window upgrades from older state,
+and exercising those migrations would only burn CI on code paths that no
+real install hits anymore. Bump the pin when keeping it gets in the way.
+
+Data-transformation tests for specific migrations do NOT belong here. They
+live in tests/test_migration_<revision>.py and use MigrationTestBase. See
+tests/README.md for the full guide.
 """
 
 import os
@@ -152,6 +192,15 @@ def _drop_all_tables(engine) -> None:
             conn.execute(text("SET FOREIGN_KEY_CHECKS = 0;"))
             for table in sa_inspect(engine).get_table_names():
                 conn.execute(text(f"DROP TABLE IF EXISTS `{table}`;"))
+            # Drop sequences too — MariaDB exposes them via information_schema
+            # with table_type='SEQUENCE'. The seed CREATE SEQUENCEs would
+            # otherwise collide between tests.
+            sequences = conn.execute(text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = DATABASE() AND table_type = 'SEQUENCE'"
+            )).fetchall()
+            for (seq,) in sequences:
+                conn.execute(text(f"DROP SEQUENCE IF EXISTS `{seq}`;"))
             conn.execute(text("SET FOREIGN_KEY_CHECKS = 1;"))
         conn.commit()
 
@@ -183,15 +232,9 @@ def _load_seed_db(db_url: str = DB_URL) -> None:
     Load the dialect-specific v3.9 seed SQL file into the database.
 
     Seed files are pre-written for each supported dialect (mariadb, postgresql)
-    so no on-the-fly SQL transformation is needed.
-
-    The seed marks revision 5cb310101a1f as already applied, but its body —
-    which walks model metadata and CREATEs a Sequence for every table with an
-    `id` column whose default is a Sequence — is therefore skipped by
-    flask_upgrade(). Real installs *did* run that body, so we replay its
-    effect here to put the test DB in the same starting state. Without this,
-    tests can't tell the difference between sequences created by the seed
-    revision and sequences a later migration forgot to create.
+    and are complete snapshots of the state at START_REVISION — including any
+    sequences the v3.9 migration body would have created. No runtime fixup
+    needed.
     """
     statements = _read_seed_statements(db_url)
     engine = create_engine(db_url)
@@ -200,35 +243,8 @@ def _load_seed_db(db_url: str = DB_URL) -> None:
             for stmt in statements:
                 conn.execute(text(stmt))
             conn.commit()
-        _replay_seed_revision_sequences(engine)
     finally:
         engine.dispose()
-
-
-def _replay_seed_revision_sequences(engine) -> None:
-    """Mirror the upgrade() body of revision 5cb310101a1f against `engine`."""
-    from sqlalchemy import Sequence
-    from sqlalchemy.schema import CreateSequence
-    from privacyidea.models import db
-
-    if not engine.dialect.supports_sequences:
-        return
-
-    inspector = sa_inspect(engine)
-    existing_tables = set(inspector.get_table_names())
-    with engine.connect() as conn:
-        for tbl in db.metadata.sorted_tables:
-            if tbl.name not in existing_tables or "id" not in tbl.c:
-                continue
-            seq = tbl.c["id"].default
-            if not isinstance(seq, Sequence):
-                continue
-            current_id = conn.execute(
-                text(f"SELECT COALESCE(MAX(id), 0) FROM {tbl.name}")
-            ).scalar() or 0
-            conn.execute(CreateSequence(Sequence(seq.name, start=current_id + 1),
-                                        if_not_exists=True))
-        conn.commit()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -161,6 +161,14 @@ def _load_seed_db(db_url: str = DB_URL) -> None:
 
     Seed files are pre-written for each supported dialect (mariadb, postgresql)
     so no on-the-fly SQL transformation is needed.
+
+    The seed marks revision 5cb310101a1f as already applied, but its body —
+    which walks model metadata and CREATEs a Sequence for every table with an
+    `id` column whose default is a Sequence — is therefore skipped by
+    flask_upgrade(). Real installs *did* run that body, so we replay its
+    effect here to put the test DB in the same starting state. Without this,
+    tests can't tell the difference between sequences created by the seed
+    revision and sequences a later migration forgot to create.
     """
     statements = _read_seed_statements(db_url)
     engine = create_engine(db_url)
@@ -169,8 +177,35 @@ def _load_seed_db(db_url: str = DB_URL) -> None:
             for stmt in statements:
                 conn.execute(text(stmt))
             conn.commit()
+        _replay_seed_revision_sequences(engine)
     finally:
         engine.dispose()
+
+
+def _replay_seed_revision_sequences(engine) -> None:
+    """Mirror the upgrade() body of revision 5cb310101a1f against `engine`."""
+    from sqlalchemy import Sequence
+    from sqlalchemy.schema import CreateSequence
+    from privacyidea.models import db
+
+    if not engine.dialect.supports_sequences:
+        return
+
+    inspector = sa_inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    with engine.connect() as conn:
+        for tbl in db.metadata.sorted_tables:
+            if tbl.name not in existing_tables or "id" not in tbl.c:
+                continue
+            seq = tbl.c["id"].default
+            if not isinstance(seq, Sequence):
+                continue
+            current_id = conn.execute(
+                text(f"SELECT COALESCE(MAX(id), 0) FROM {tbl.name}")
+            ).scalar() or 0
+            conn.execute(CreateSequence(Sequence(seq.name, start=current_id + 1),
+                                        if_not_exists=True))
+        conn.commit()
 
 
 @pytest.fixture(autouse=True)
@@ -457,6 +492,76 @@ def test_schema_matches_models_after_upgrade_to_head(flask_app):
         + "\n".join(str(d) for d in filtered_diffs)
         + "\n\nThis means either a migration is missing or incomplete. "
         f"Run `flask db migrate` to generate the missing migration."
+    )
+
+
+def _get_declared_sequence_names() -> set[str]:
+    """
+    Collect every Sequence(...) name declared on any mapped_column across the
+    models. Alembic's autogenerate does not compare sequences, so we have to
+    check these ourselves — otherwise a migration that creates a table with
+    sa.Identity() while the model declares Sequence() ships silently and
+    blows up on the first insert on MariaDB 10.3+ / SQLAlchemy 2.x (which
+    honors Sequence() on MySQL/MariaDB and emits SELECT nextval(...)).
+    """
+    from sqlalchemy import Sequence
+    from privacyidea.models import db
+
+    names: set[str] = set()
+    for table in db.metadata.tables.values():
+        for col in table.columns:
+            default = col.default
+            if isinstance(default, Sequence):
+                names.add(default.name)
+    return names
+
+
+def _get_existing_sequence_names(engine) -> set[str]:
+    """Return the set of sequence names present in the live database."""
+    with engine.connect() as conn:
+        if _is_postgres(str(engine.url)):
+            rows = conn.execute(
+                text("SELECT sequencename FROM pg_sequences WHERE schemaname = 'public'")
+            ).fetchall()
+        else:
+            rows = conn.execute(text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = DATABASE() AND table_type = 'SEQUENCE'"
+            )).fetchall()
+    return {r[0] for r in rows}
+
+
+def test_all_declared_sequences_exist_after_upgrade_to_head(flask_app):
+    """
+    Every Sequence(...) declared on a model must exist in the database after
+    upgrading to head. Alembic's autogenerate does not compare sequences, so
+    this check is not covered by test_schema_matches_models_after_upgrade_to_head.
+
+    Regression guard for the tokencredentialidhash_seq incident: migration
+    903a6ed6f6c4 created the table with sa.Identity() instead of sa.Sequence(),
+    so the sequence was never created. Inserts then failed on MariaDB 10.3+
+    with "Unknown SEQUENCE" because SQLAlchemy 2.x emits SELECT nextval(...)
+    whenever a column has a Sequence() default.
+    """
+    from flask_migrate import upgrade as flask_upgrade
+
+    _load_seed_db()
+    flask_upgrade()
+
+    engine = create_engine(DB_URL)
+    try:
+        actual = _get_existing_sequence_names(engine)
+    finally:
+        engine.dispose()
+
+    expected = _get_declared_sequence_names()
+    missing = expected - actual
+    assert not missing, (
+        f"The following sequences are declared on the models but do not exist "
+        f"in the database after upgrade to head: {sorted(missing)}.\n"
+        f"This means a migration creates the table without issuing CREATE SEQUENCE "
+        f"(e.g. via sa.Identity() instead of sa.Sequence()). Inserts will fail "
+        f"on MariaDB 10.3+ with 'Unknown SEQUENCE'."
     )
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -49,11 +49,19 @@ import pathlib
 import time
 
 import pytest
-from alembic.config import Config as AlembicConfig
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, text, inspect as sa_inspect
 from sqlalchemy.exc import OperationalError
+
+from tests.migration_test_utils import (
+    DB_URL,
+    START_REVISION,
+    drop_all_tables,
+    get_alembic_cfg,
+    is_postgres,
+    load_seed,
+)
 
 # Skip these tests if no database URL is provided
 pytestmark = [
@@ -63,36 +71,6 @@ pytestmark = [
         reason="TEST_DATABASE_URL environment variable is not set"
     ),
 ]
-
-DB_URL = os.environ.get("TEST_DATABASE_URL", "")
-
-# The revision from which we test migrations forward to head.
-# Pinned at v3.9 (2022) — every migration added after this point is covered.
-# Update this pin when it becomes too old or causes issues.
-START_REVISION = "5cb310101a1f"  # v3.9: Create sequences needed for SQLAlchemy 1.4
-
-# Directory that holds dialect-specific seed SQL files.
-# Naming convention: seed_v<version>_<revision>_<dialect>.sql
-#   dialect = "mariadb" or "postgresql"
-SEED_SQL_DIR = pathlib.Path(__file__).parent / "testdata" / "migrations"
-
-
-def _get_seed_sql_path(db_url: str = DB_URL) -> pathlib.Path:
-    """Return the seed file path for the active dialect."""
-    dialect = "postgresql" if _is_postgres(db_url) else "mariadb"
-    return SEED_SQL_DIR / f"seed_v3.9_{START_REVISION}_{dialect}.sql"
-
-
-def _get_script_dir() -> str:
-    return str(pathlib.Path(__file__).parent.parent / "privacyidea" / "migrations")
-
-
-def _get_alembic_cfg() -> AlembicConfig:
-    ini_path = str(pathlib.Path(_get_script_dir()) / "alembic.ini")
-    cfg = AlembicConfig(ini_path)
-    cfg.set_main_option("script_location", _get_script_dir())
-    cfg.set_main_option("sqlalchemy.url", DB_URL)
-    return cfg
 
 
 def _get_expected_tables() -> set[str]:
@@ -150,10 +128,6 @@ def _get_current_revision(engine) -> str | None:
         return MigrationContext.configure(conn).get_current_revision()
 
 
-def _is_postgres(db_url: str = DB_URL) -> bool:
-    return db_url.startswith("postgresql")
-
-
 def _wait_for_db(engine, timeout: int = 30, interval: float = 1.0) -> None:
     """
     Block until the database accepts connections or *timeout* seconds elapse.
@@ -174,90 +148,17 @@ def _wait_for_db(engine, timeout: int = 30, interval: float = 1.0) -> None:
     ) from last_exc
 
 
-def _drop_all_tables(engine) -> None:
-    """Drop every table (and for Postgres, every sequence) in the database, dialect-safe."""
-    with engine.connect() as conn:
-        if _is_postgres(str(engine.url)):
-            # Postgres: drop each table with CASCADE to handle FK dependencies.
-            for table in sa_inspect(engine).get_table_names():
-                conn.execute(text(f'DROP TABLE IF EXISTS "{table}" CASCADE;'))
-            # Also drop all sequences so the seed file can re-create them cleanly.
-            sequences = conn.execute(
-                text("SELECT sequencename FROM pg_sequences WHERE schemaname = 'public';")
-            ).fetchall()
-            for (seq,) in sequences:
-                conn.execute(text(f'DROP SEQUENCE IF EXISTS "{seq}" CASCADE;'))
-        else:
-            # MariaDB/MySQL: disable FK checks, use backtick quoting.
-            conn.execute(text("SET FOREIGN_KEY_CHECKS = 0;"))
-            for table in sa_inspect(engine).get_table_names():
-                conn.execute(text(f"DROP TABLE IF EXISTS `{table}`;"))
-            # Drop sequences too — MariaDB exposes them via information_schema
-            # with table_type='SEQUENCE'. The seed CREATE SEQUENCEs would
-            # otherwise collide between tests.
-            sequences = conn.execute(text(
-                "SELECT table_name FROM information_schema.tables "
-                "WHERE table_schema = DATABASE() AND table_type = 'SEQUENCE'"
-            )).fetchall()
-            for (seq,) in sequences:
-                conn.execute(text(f"DROP SEQUENCE IF EXISTS `{seq}`;"))
-            conn.execute(text("SET FOREIGN_KEY_CHECKS = 1;"))
-        conn.commit()
-
-
-def _read_seed_statements(db_url: str = DB_URL) -> list[str]:
-    """
-    Read the dialect-specific seed SQL file and split it into individual
-    statements (split on semicolons), discarding empty / comment-only chunks.
-    """
-    seed_path = _get_seed_sql_path(db_url)
-    sql = seed_path.read_text(encoding="utf-8")
-    statements = []
-    for chunk in sql.split(";"):
-        stripped = chunk.strip()
-        if not stripped:
-            continue
-        # Discard chunks that consist entirely of comment lines
-        non_comment_lines = [
-            line for line in stripped.splitlines()
-            if line.strip() and not line.strip().startswith("--")
-        ]
-        if non_comment_lines:
-            statements.append(stripped)
-    return statements
-
-
-def _load_seed_db(db_url: str = DB_URL) -> None:
-    """
-    Load the dialect-specific v3.9 seed SQL file into the database.
-
-    Seed files are pre-written for each supported dialect (mariadb, postgresql)
-    and are complete snapshots of the state at START_REVISION — including any
-    sequences the v3.9 migration body would have created. No runtime fixup
-    needed.
-    """
-    statements = _read_seed_statements(db_url)
-    engine = create_engine(db_url)
-    try:
-        with engine.connect() as conn:
-            for stmt in statements:
-                conn.execute(text(stmt))
-            conn.commit()
-    finally:
-        engine.dispose()
-
-
 @pytest.fixture(autouse=True)
 def clean_database():
     """Wipe the database before and after every test."""
     engine = create_engine(DB_URL)
     _wait_for_db(engine)
-    _drop_all_tables(engine)
+    drop_all_tables(engine)
     engine.dispose()
     yield
     engine = create_engine(DB_URL)
     _wait_for_db(engine)
-    _drop_all_tables(engine)
+    drop_all_tables(engine)
     engine.dispose()
 
 
@@ -265,7 +166,7 @@ def clean_database():
 def flask_app():
     """
     Provide a Flask app context pointing at the test database.
-    Schema setup is done by _load_seed_db(), not db.create_all().
+    Schema setup is done by load_seed(), not db.create_all().
     """
     from privacyidea.app import create_app
 
@@ -285,7 +186,7 @@ def test_migration_history_has_single_head():
     down_revision parents) — these are intentional and valid. What matters
     is that all branches are eventually merged into a single head.
     """
-    heads = ScriptDirectory.from_config(_get_alembic_cfg()).get_heads()
+    heads = ScriptDirectory.from_config(get_alembic_cfg()).get_heads()
     assert len(heads) == 1, (
         f"Migration history has multiple heads: {heads}. "
         f"Either add a merge migration or fix the branching revision."
@@ -298,7 +199,7 @@ def test_migrations_since_start_revision_have_non_empty_messages():
     An empty message makes the migration history unreadable and the upgrade log
     unhelpful (e.g. 'Applying abc -> def (head), empty message...').
     """
-    script = ScriptDirectory.from_config(_get_alembic_cfg())
+    script = ScriptDirectory.from_config(get_alembic_cfg())
     revisions_in_window = list(script.iterate_revisions("head", START_REVISION))
 
     empty = [
@@ -320,7 +221,7 @@ def test_upgrade_to_head_creates_all_model_tables(flask_app):
     """
     from flask_migrate import upgrade as flask_upgrade
 
-    _load_seed_db()
+    load_seed()
     flask_upgrade()
 
     engine = create_engine(DB_URL)
@@ -339,10 +240,10 @@ def test_current_revision_matches_head_after_upgrade(flask_app):
     """After upgrading to head, the alembic_version in the DB must equal the head revision."""
     from flask_migrate import upgrade as flask_upgrade
 
-    _load_seed_db()
+    load_seed()
     flask_upgrade()
 
-    head_rev = ScriptDirectory.from_config(_get_alembic_cfg()).get_current_head()
+    head_rev = ScriptDirectory.from_config(get_alembic_cfg()).get_current_head()
     engine = create_engine(DB_URL)
     current_rev = _get_current_revision(engine)
     engine.dispose()
@@ -359,10 +260,10 @@ def test_migrations_since_start_revision_are_reversible(flask_app):
     """
     from alembic import command
 
-    _load_seed_db()
-    command.upgrade(_get_alembic_cfg(), "head")
+    load_seed()
+    command.upgrade(get_alembic_cfg(), "head")
 
-    script = ScriptDirectory.from_config(_get_alembic_cfg())
+    script = ScriptDirectory.from_config(get_alembic_cfg())
     # Walk from head down to (but not including) START_REVISION
     revisions_in_window = list(script.iterate_revisions("head", START_REVISION))
 
@@ -378,7 +279,7 @@ def test_migrations_since_start_revision_are_reversible(flask_app):
         else:
             target = rev.down_revision
         try:
-            command.downgrade(_get_alembic_cfg(), target)
+            command.downgrade(get_alembic_cfg(), target)
         except Exception as e:
             pytest.fail(
                 f"downgrade() of revision {rev.revision!r} "
@@ -394,14 +295,14 @@ def test_upgrade_then_downgrade_then_upgrade_is_idempotent(flask_app):
     from alembic import command
     from flask_migrate import upgrade as flask_upgrade
 
-    _load_seed_db()
+    load_seed()
     flask_upgrade()
 
     engine = create_engine(DB_URL)
     tables_first = _get_tables(engine)
     engine.dispose()
 
-    command.downgrade(_get_alembic_cfg(), START_REVISION)
+    command.downgrade(get_alembic_cfg(), START_REVISION)
     flask_upgrade()
 
     engine = create_engine(DB_URL)
@@ -435,7 +336,7 @@ def test_schema_matches_models_after_upgrade_to_head(flask_app):
     from flask_migrate import upgrade as flask_upgrade
     from privacyidea.models import db
 
-    _load_seed_db()
+    load_seed()
     flask_upgrade()
 
     engine = create_engine(DB_URL)
@@ -462,7 +363,7 @@ def test_schema_matches_models_after_upgrade_to_head(flask_app):
     #
     # Postgres:
     # - 'modify_nullable': similar mismatch for Boolean columns.
-    if _is_postgres():
+    if is_postgres():
         # PostgreSQL false positives:
         # - 'add_index'/'remove_index': Alembic detects named non-unique indexes
         #   declared in models (ix_*) that migrations don't explicitly create,
@@ -558,7 +459,7 @@ def _get_declared_sequence_names() -> set[str]:
 def _get_existing_sequence_names(engine) -> set[str]:
     """Return the set of sequence names present in the live database."""
     with engine.connect() as conn:
-        if _is_postgres(str(engine.url)):
+        if is_postgres(str(engine.url)):
             rows = conn.execute(
                 text("SELECT sequencename FROM pg_sequences WHERE schemaname = 'public'")
             ).fetchall()
@@ -584,7 +485,7 @@ def test_all_declared_sequences_exist_after_upgrade_to_head(flask_app):
     """
     from flask_migrate import upgrade as flask_upgrade
 
-    _load_seed_db()
+    load_seed()
     flask_upgrade()
 
     engine = create_engine(DB_URL)
@@ -677,11 +578,11 @@ def test_default_insert_succeeds_for_every_model_table(flask_app):
     from sqlalchemy import Sequence
     from privacyidea.models import db
 
-    _load_seed_db()
+    load_seed()
     flask_upgrade()
 
     engine = create_engine(DB_URL)
-    is_pg = _is_postgres()
+    is_pg = is_postgres()
     failures: list[tuple[str, str]] = []
 
     try:
@@ -757,7 +658,7 @@ def test_all_down_revisions_point_to_existing_revisions():
     Note: merge revisions have a tuple of down_revisions (multiple parents),
     which is valid Alembic syntax — all parents are checked individually.
     """
-    script = ScriptDirectory.from_config(_get_alembic_cfg())
+    script = ScriptDirectory.from_config(get_alembic_cfg())
     all_revisions = {rev.revision for rev in script.walk_revisions()}
 
     def _iter_down_revisions(rev):
@@ -805,12 +706,12 @@ def test_each_migration_survives_round_trip(flask_app):
     """
     from alembic import command
 
-    script = ScriptDirectory.from_config(_get_alembic_cfg())
+    script = ScriptDirectory.from_config(get_alembic_cfg())
     # Chronological order: oldest (just after START_REVISION) first.
     revisions_in_window = list(reversed(list(script.iterate_revisions("head", START_REVISION))))
 
     # Set up the DB once — all iterations share this starting point.
-    _load_seed_db()
+    load_seed()
 
     for rev in revisions_in_window:
         # Merge revisions have a tuple of parents — use the first one.
@@ -823,7 +724,7 @@ def test_each_migration_survives_round_trip(flask_app):
 
         # 1. Upgrade to the revision under test.
         try:
-            command.upgrade(_get_alembic_cfg(), rev.revision)
+            command.upgrade(get_alembic_cfg(), rev.revision)
         except Exception as e:
             pytest.fail(
                 f"First upgrade() to revision {rev.revision!r} ('{rev.doc}') failed: {e}"
@@ -835,7 +736,7 @@ def test_each_migration_survives_round_trip(flask_app):
 
         # 2. Downgrade one step back.
         try:
-            command.downgrade(_get_alembic_cfg(), parent_revision)
+            command.downgrade(get_alembic_cfg(), parent_revision)
         except Exception as e:
             pytest.fail(
                 f"downgrade() of revision {rev.revision!r} ('{rev.doc}') "
@@ -844,7 +745,7 @@ def test_each_migration_survives_round_trip(flask_app):
 
         # 3. Upgrade to the revision again.
         try:
-            command.upgrade(_get_alembic_cfg(), rev.revision)
+            command.upgrade(get_alembic_cfg(), rev.revision)
         except Exception as e:
             pytest.fail(
                 f"Second upgrade() to revision {rev.revision!r} ('{rev.doc}') "
@@ -908,12 +809,12 @@ def test_downgrade_does_not_destroy_data_in_surviving_tables(flask_app):
     from alembic import command
     from flask_migrate import upgrade as flask_upgrade
 
-    _load_seed_db()
+    load_seed()
     flask_upgrade()
 
     # The seed already has realm rows (id=1 'defrealm', id=2 'testrealm').
     # Downgrade all the way back to START_REVISION and verify they survived.
-    command.downgrade(_get_alembic_cfg(), START_REVISION)
+    command.downgrade(get_alembic_cfg(), START_REVISION)
 
     engine = create_engine(DB_URL)
     with engine.connect() as conn:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -560,11 +560,11 @@ def test_all_declared_sequences_exist_after_upgrade_to_head(flask_app):
     upgrading to head. Alembic's autogenerate does not compare sequences, so
     this check is not covered by test_schema_matches_models_after_upgrade_to_head.
 
-    Regression guard for the tokencredentialidhash_seq incident: migration
-    903a6ed6f6c4 created the table with sa.Identity() instead of sa.Sequence(),
-    so the sequence was never created. Inserts then failed on MariaDB 10.3+
-    with "Unknown SEQUENCE" because SQLAlchemy 2.x emits SELECT nextval(...)
-    whenever a column has a Sequence() default.
+    On MariaDB 10.3+ / SQLAlchemy 2.x, a column with a Sequence() default
+    causes SQLAlchemy to emit SELECT nextval(<seq>) on insert. If the
+    corresponding CREATE SEQUENCE was never issued by a migration (e.g. the
+    table was created with sa.Identity() while the model declares Sequence()),
+    every insert fails at runtime with "Unknown SEQUENCE".
     """
     from flask_migrate import upgrade as flask_upgrade
 
@@ -585,6 +585,141 @@ def test_all_declared_sequences_exist_after_upgrade_to_head(flask_app):
         f"This means a migration creates the table without issuing CREATE SEQUENCE "
         f"(e.g. via sa.Identity() instead of sa.Sequence()). Inserts will fail "
         f"on MariaDB 10.3+ with 'Unknown SEQUENCE'."
+    )
+
+
+def _generic_dummy_value(col):
+    """
+    Return a value appropriate for *col*'s SQL type, used by the insert smoke
+    test to populate NOT NULL columns without per-table fixtures. Returns None
+    only for column types we don't know how to fill — caller must skip those.
+    """
+    import datetime as dt
+    from sqlalchemy import (
+        BigInteger, Boolean, Date, DateTime, Float, Integer, Interval,
+        JSON, LargeBinary, Numeric, SmallInteger, String, Text, Time,
+        Unicode, UnicodeText,
+    )
+
+    t = col.type
+    if isinstance(t, (String, Unicode, UnicodeText, Text)):
+        length = getattr(t, "length", None) or 8
+        return "x" * min(length, 8)
+    if isinstance(t, Boolean):
+        return False
+    if isinstance(t, (Integer, BigInteger, SmallInteger)):
+        return 1
+    if isinstance(t, DateTime):
+        return dt.datetime(2000, 1, 1)
+    if isinstance(t, Date):
+        return dt.date(2000, 1, 1)
+    if isinstance(t, Time):
+        return dt.time(0, 0)
+    if isinstance(t, Interval):
+        return dt.timedelta(0)
+    if isinstance(t, (Float, Numeric)):
+        return 0
+    if isinstance(t, LargeBinary):
+        return b"x"
+    if isinstance(t, JSON):
+        return {}
+    return None
+
+
+def test_default_insert_succeeds_for_every_model_table(flask_app):
+    """
+    For every table the SQLAlchemy models declare, build a minimal INSERT and
+    execute it against the live (upgraded-to-head) DB. Catches failures that
+    schema checks cannot — e.g. a Sequence default declared on the model but
+    no CREATE SEQUENCE issued by any migration, an Identity column SQLAlchemy
+    can't drive on this dialect, or a NOT NULL column whose default isn't
+    actually applied.
+
+    Strategy:
+      - PKs whose default is a Sequence or that are autoincrement are omitted
+        so SQLAlchemy fires its auto-PK path — this is the exact path that
+        breaks when the migration created the table without the matching
+        CREATE SEQUENCE / AUTO_INCREMENT machinery the model expects.
+      - NOT NULL columns without any default get a type-appropriate dummy.
+      - Nullable columns and columns with Python/server defaults are omitted.
+      - FK checks are disabled for the duration so we don't have to insert in
+        dependency order; this test is about INSERT mechanics, not referential
+        integrity.
+      - All inserts run inside a single transaction that is rolled back at
+        the end, so no rows leak into the test DB.
+    """
+    from flask_migrate import upgrade as flask_upgrade
+    from sqlalchemy import Sequence
+    from privacyidea.models import db
+
+    _load_seed_db()
+    flask_upgrade()
+
+    engine = create_engine(DB_URL)
+    is_pg = _is_postgres()
+    failures: list[tuple[str, str]] = []
+
+    try:
+        with engine.connect() as conn:
+            outer = conn.begin()
+            try:
+                if is_pg:
+                    conn.execute(text("SET session_replication_role = 'replica'"))
+                else:
+                    conn.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
+
+                for table in db.metadata.sorted_tables:
+                    values = {}
+                    skip_reason = None
+                    for col in table.columns:
+                        # A PK column is auto-generated only if it has an
+                        # explicit Sequence/Identity, OR it's the sole integer
+                        # PK with autoincrement not explicitly disabled.
+                        # Composite PKs and string PKs do not auto-generate
+                        # — every member must be filled by the caller.
+                        from sqlalchemy import BigInteger, Integer, SmallInteger
+                        is_sole_int_pk = (
+                            col.primary_key
+                            and len(table.primary_key.columns) == 1
+                            and isinstance(col.type, (Integer, BigInteger, SmallInteger))
+                            and col.autoincrement is not False
+                        )
+                        is_auto_pk = isinstance(col.default, Sequence) or is_sole_int_pk
+                        if is_auto_pk:
+                            continue
+                        if col.default is not None or col.server_default is not None:
+                            continue
+                        if col.nullable:
+                            continue
+                        val = _generic_dummy_value(col)
+                        if val is None:
+                            skip_reason = f"no dummy generator for column {col.name!r} of type {col.type!r}"
+                            break
+                        values[col.name] = val
+
+                    if skip_reason is not None:
+                        failures.append((table.name, f"SKIPPED: {skip_reason}"))
+                        continue
+
+                    sp = conn.begin_nested()
+                    try:
+                        conn.execute(table.insert().values(**values))
+                        sp.rollback()
+                    except Exception as e:
+                        sp.rollback()
+                        first_line = str(e).splitlines()[0] if str(e) else type(e).__name__
+                        failures.append((table.name, first_line))
+            finally:
+                outer.rollback()
+    finally:
+        engine.dispose()
+
+    assert not failures, (
+        "INSERT failed for the following model tables after upgrade-to-head. "
+        "This usually means a migration created the table without the auto-PK "
+        "machinery the model expects (e.g. sa.Identity() instead of sa.Sequence(), "
+        "or a NOT NULL column added without a default):\n"
+        + "\n".join(f"  {tbl}: {msg}" for tbl, msg in failures)
     )
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -573,6 +573,15 @@ def test_all_declared_sequences_exist_after_upgrade_to_head(flask_app):
 
     engine = create_engine(DB_URL)
     try:
+        # supports_sequences is a class attribute on the base MySQL dialect
+        # (False) and is upgraded to True only after connection-time server
+        # detection identifies a MariaDB server. Connect first, then check.
+        with engine.connect() as conn:
+            if not conn.dialect.supports_sequences:
+                pytest.skip(
+                    f"Dialect {conn.dialect.name!r} does not support sequences; "
+                    "the model declares Sequence() but the dialect ignores it."
+                )
         actual = _get_existing_sequence_names(engine)
     finally:
         engine.dispose()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -68,18 +68,41 @@ def _get_tables(engine) -> set[str]:
     return set(sa_inspect(engine).get_table_names())
 
 
-def _get_schema_snapshot(engine) -> dict[str, set[str]]:
+def _get_schema_snapshot(engine) -> dict[str, dict]:
     """
-    Return a mapping of {table_name: {col_name, ...}} for every table in the DB.
-    This gives a richer comparison than just table names — it catches leftover
-    columns that a downgrade() forgot to drop, or columns that an upgrade() forgot
-    to add.
+    Return a per-table snapshot of columns, indexes, foreign keys, and unique
+    constraints. Used by the round-trip test to detect downgrades that forget
+    to drop something the upgrade added (or upgrades that don't fully restore
+    after a downgrade).
+
+    The snapshot is compared against itself across an upgrade→downgrade→upgrade
+    cycle on the same engine, so dialect-specific artefacts (e.g. MariaDB
+    auto-creating indexes for FK columns) appear in both snapshots and cancel.
     """
     inspector = sa_inspect(engine)
-    return {
-        table: {col["name"] for col in inspector.get_columns(table)}
-        for table in inspector.get_table_names()
-    }
+    snapshot: dict[str, dict] = {}
+    for table in inspector.get_table_names():
+        snapshot[table] = {
+            "columns": frozenset(col["name"] for col in inspector.get_columns(table)),
+            "indexes": frozenset(
+                (idx.get("name"), tuple(idx["column_names"]), bool(idx.get("unique", False)))
+                for idx in inspector.get_indexes(table)
+            ),
+            "foreign_keys": frozenset(
+                (
+                    fk.get("name"),
+                    tuple(fk["constrained_columns"]),
+                    fk["referred_table"],
+                    tuple(fk["referred_columns"]),
+                )
+                for fk in inspector.get_foreign_keys(table)
+            ),
+            "unique_constraints": frozenset(
+                (uc.get("name"), tuple(uc["column_names"]))
+                for uc in inspector.get_unique_constraints(table)
+            ),
+        }
+    return snapshot
 
 
 def _get_current_revision(engine) -> str | None:
@@ -684,18 +707,26 @@ def test_each_migration_survives_round_trip(flask_app):
             f"  Only after second upgrade: {tables_second - tables_first}"
         )
 
-        # Compare columns per table
+        # Compare columns, indexes, FKs and unique constraints per table.
+        # If any aspect differs, the offending downgrade() likely forgot to
+        # drop something the upgrade() added (or vice versa).
+        ASPECT_HINTS = {
+            "columns": "downgrade() likely forgot to drop a column, or upgrade() forgot to add one",
+            "indexes": "downgrade() likely forgot to drop an index, or upgrade() forgot to recreate one",
+            "foreign_keys": "downgrade() likely forgot to drop a foreign key, or upgrade() forgot to recreate one",
+            "unique_constraints": "downgrade() likely forgot to drop a unique constraint, or upgrade() forgot to recreate one",
+        }
         for table in tables_first:
-            cols_first = schema_after_first_upgrade[table]
-            cols_second = schema_after_second_upgrade.get(table, set())
-            assert cols_first == cols_second, (
-                f"Migration {rev.revision!r} ('{rev.doc}'): column set for table "
-                f"'{table}' differs between first and second upgrade after round-trip.\n"
-                f"  Only after first upgrade:  {cols_first - cols_second}\n"
-                f"  Only after second upgrade: {cols_second - cols_first}\n"
-                f"  This likely means downgrade() forgot to drop a column, or "
-                f"upgrade() forgot to add one."
-            )
+            for aspect, hint in ASPECT_HINTS.items():
+                first = schema_after_first_upgrade[table][aspect]
+                second = schema_after_second_upgrade[table][aspect]
+                assert first == second, (
+                    f"Migration {rev.revision!r} ('{rev.doc}'): {aspect} for table "
+                    f"'{table}' differ between first and second upgrade after round-trip.\n"
+                    f"  Only after first upgrade:  {sorted(first - second)}\n"
+                    f"  Only after second upgrade: {sorted(second - first)}\n"
+                    f"  {hint}."
+                )
 
         assert current_rev == rev.revision, (
             f"After round-trip for {rev.revision!r}, current revision is "

--- a/tests/testdata/migrations/seed_v3.9_5cb310101a1f_mariadb.sql
+++ b/tests/testdata/migrations/seed_v3.9_5cb310101a1f_mariadb.sql
@@ -1255,6 +1255,56 @@ INSERT INTO `pidea_audit` (`date`, `action`, `success`, `serial`, `token_type`, 
     ('2023-06-01 10:01:00', 'validate/check', 0, 'TOTP0001', 'totp', 'alice', 'defrealm', '', '10.0.0.1', 'INFO', 'default', '12346');
 
 -- ---------------------------------------------------------------------------
+-- Sequences (MariaDB 10.3+)
+--
+-- v3.9 migration 5cb310101a1f walks model metadata and creates one sequence
+-- per integer-PK table whose model column declares Sequence(). Real installs
+-- ran that body, but the seed is stamped at exactly that revision so its
+-- body is skipped on upgrade. We therefore bake the resulting CREATE
+-- SEQUENCEs in directly to match the on-disk state of an upgraded install.
+-- START WITH values match MAX(id)+1 of the seeded data so the next nextval
+-- returns a free PK.
+-- ---------------------------------------------------------------------------
+CREATE SEQUENCE `audit_seq` START WITH 3;
+CREATE SEQUENCE `authcache_seq` START WITH 1;
+CREATE SEQUENCE `caconfig_seq` START WITH 1;
+CREATE SEQUENCE `caconnector_seq` START WITH 1;
+CREATE SEQUENCE `challenge_seq` START WITH 1;
+CREATE SEQUENCE `clientapp_seq` START WITH 3;
+CREATE SEQUENCE `customuserattribute_seq` START WITH 2;
+CREATE SEQUENCE `eventcounter_seq` START WITH 3;
+CREATE SEQUENCE `eventhandler_seq` START WITH 2;
+CREATE SEQUENCE `eventhandlercond_seq` START WITH 2;
+CREATE SEQUENCE `eventhandleropt_seq` START WITH 3;
+CREATE SEQUENCE `machineresolver_seq` START WITH 1;
+CREATE SEQUENCE `machineresolverconf_seq` START WITH 1;
+CREATE SEQUENCE `machinetoken_seq` START WITH 1;
+CREATE SEQUENCE `machtokenopt_seq` START WITH 1;
+CREATE SEQUENCE `monitoringstats_seq` START WITH 3;
+CREATE SEQUENCE `periodictask_seq` START WITH 2;
+CREATE SEQUENCE `periodictasklastrun_seq` START WITH 2;
+CREATE SEQUENCE `periodictaskopt_seq` START WITH 2;
+CREATE SEQUENCE `policy_seq` START WITH 5;
+CREATE SEQUENCE `policycondition_seq` START WITH 2;
+CREATE SEQUENCE `privacyideaserver_seq` START WITH 1;
+CREATE SEQUENCE `pwreset_seq` START WITH 1;
+CREATE SEQUENCE `radiusserver_seq` START WITH 1;
+CREATE SEQUENCE `realm_seq` START WITH 3;
+CREATE SEQUENCE `resolver_seq` START WITH 2;
+CREATE SEQUENCE `resolverconf_seq` START WITH 2;
+CREATE SEQUENCE `resolverrealm_seq` START WITH 3;
+CREATE SEQUENCE `serviceid_seq` START WITH 2;
+CREATE SEQUENCE `smsgateway_seq` START WITH 2;
+CREATE SEQUENCE `smsgwoption_seq` START WITH 3;
+CREATE SEQUENCE `smtpserver_seq` START WITH 2;
+CREATE SEQUENCE `subscription_seq` START WITH 1;
+CREATE SEQUENCE `token_seq` START WITH 4;
+CREATE SEQUENCE `tokeninfo_seq` START WITH 5;
+CREATE SEQUENCE `tokenowner_seq` START WITH 3;
+CREATE SEQUENCE `tokenrealm_seq` START WITH 4;
+CREATE SEQUENCE `usercache_seq` START WITH 1;
+
+-- ---------------------------------------------------------------------------
 -- alembic_version — stamp the DB at START_REVISION
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS `alembic_version` (


### PR DESCRIPTION
### Bug fix                                                                                                                               
  - migrations/versions/903a6ed6f6c4_.py: changed the tokencredentialidhash.id column from sa.Identity() to sa.Sequence('tokencredentialidhash_seq'). This is what fresh  
  installs need so that op.create_table actually issues CREATE SEQUENCE on MariaDB/Postgres.                                                                              
  - migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py (new): repair migration for installs that already ran the broken Identity version. Creates the sequence
  if missing and ALTER SEQUENCE … RESTART WITH MAX(id)+1 so the next insert gets a free PK. Gated on bind.dialect.supports_sequences (skips real MySQL, runs on MariaDB   
  and Postgres).                                                                                                                                                          
  
###   New regression tests in tests/test_migrations.py                                                                                                                        
  - test_all_declared_sequences_exist_after_upgrade_to_head: every Sequence() declared on a model must exist in the DB after upgrade-to-head. Alembic autogenerate doesn't
   compare sequences, so this gap was previously uncovered. Skips on dialects without sequence support.                                                                   
  - test_default_insert_succeeds_for_every_model_table: builds a minimal INSERT for every model table after upgrade-to-head, with type-aware dummy values for NOT NULL
  columns and auto-PK columns omitted so the auto-generation path actually fires. Catches sequence/identity misconfigurations and missing NOT NULL defaults that          
  schema-only checks can't see. FK checks disabled, all inserts rolled back.                                                                                              
                                                                            
###   Hardening of existing tests                                                                                                                                             
  - _get_schema_snapshot now captures indexes, foreign keys, and unique constraints per table (was columns-only). test_each_migration_survives_round_trip compares all    
  four aspects — catches downgrades that forget to drop a constraint/index the upgrade added.                                                                             
                                                                                                                                                                          
###   Seed-file cleanup                                                                                                                                                       
  - Baked the v3.9 CREATE SEQUENCE statements directly into tests/testdata/migrations/seed_v3.9_5cb310101a1f_mariadb.sql (the Postgres seed already had them). The seed is
   now a complete on-disk snapshot of an upgraded v3.9 install.                                                                                                           
  - Removed the _replay_seed_revision_sequences runtime helper. It was masking a real class of bug: a migration that adds Sequence() to an existing v3.9 table's model but
   forgets the matching CREATE SEQUENCE would have passed CI silently.                                                                                                    
  - Extended _drop_all_tables to also drop sequences on MariaDB (Postgres branch already did) so the new seed CREATE SEQUENCEs don't collide between tests.               
  
###   Documentation                                                                                                                                                           
  - Added a top-of-file docstring to tests/test_migrations.py summarizing what the suite is trying to achieve and pointing contributors at
  tests/test_migration_<revision>.py + MigrationTestBase for per-migration data tests.                                                                                    
  - Added a note to privacyidea/migrations/script.py.mako reminding contributors to add a dedicated test file when their migration changes data (not just schema).
