### PR TITLE
remove ng-csp

### DIFF
--- a/privacyidea/static/templates/header.html
+++ b/privacyidea/static/templates/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="privacyideaApp" ng-csp>
+<html ng-app="privacyideaApp">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
The ng-csp attribute is widely misunderstood — including in AngularJS docs. It's not a security mechanism. It's a hint to AngularJS about how to behave. The actual     
  security comes from the CSP header that Talisman sends; the browser enforces it regardless of what AngularJS does.                                                      
                                                                                                                                                                          
  How AngularJS handles CSP                                                                                                                                               
                                                                                                                                                                          
  AngularJS has two execution modes for evaluating template expressions like ng-click="...":                                                                              
                                                                                                                                                                          
  1. Optimized — uses new Function('return ...') to JIT-compile expressions. Fast. Requires unsafe-eval in CSP.                                                           
  2. Interpreter — parses and walks expressions at runtime. Slower. No eval needed.
                                                                                                                                                                          
  Why removing ng-csp doesn't defeat anything                                                                                                                             
                                                            
  With Talisman sending script-src 'self' (no unsafe-eval), the browser blocks Function() either way. So:                                                                 
   
  - With ng-csp: AngularJS skips the probe, goes straight to interpreter. End result: interpreter mode.                                                                   
  - Without ng-csp: AngularJS probes, the browser blocks the probe, AngularJS sees the throw and falls back to interpreter. End result: interpreter mode.
                                                                                                                                                                          
  Either way, you end up in interpreter mode. The CSP header is what enforces "no eval"; ng-csp just tells AngularJS to skip asking.                                      
                                                                                                                                                                          
  The only practical differences:                                                                                                                                         
                                                            
  1. Without ng-csp: you get one CSP violation at startup (the failed Function('return true') probe), which the browser logs as a console warning and may report to your  
  report-uri if configured. Cosmetic, one-time.
  2. The interpreter has a bug (or quirk) when forced explicitly via ng-csp that doesn't show up when reached via auto-fallback. That's apparently what's biting          
  search_on_enter and the datepicker — compound expressions like startOpened = openDate($event) don't fire in forced-CSP mode but work in auto-detected interpreter mode. 
  I can't fully explain why; this is "AngularJS-ism" empirics from the other branch's fix.
                                                                                                                                                                          
  What about no-inline-style?                                                                                                                                             
   
  The bare ng-csp also stops AngularJS from injecting an internal <style> block for .ng-hide, [ng-cloak], etc. Without ng-csp, AngularJS will try to inject that style    
  block — and style-src 'self' (no unsafe-inline) will block it. The injection fails silently, and your manually-defined rules in generic.css:83 cover it. So removing
  ng-csp doesn't break the visibility CSS — your manual rules already handle it.                                                                                          
                                                            
  TL;DR

  ng-csp doesn't enforce anything. The CSP header does. ng-csp just tells AngularJS "don't bother probing." Removing it lets AngularJS take a slightly different (and     
  apparently more correct) code path to the same interpreter mode, at the cost of one harmless startup probe failure. Security posture is identical.