### PR TITLE
Increase log level in case of errors

### DIFF
--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -143,7 +143,7 @@ class SharedConfigClass(object):
                             try:
                                 value = json.loads(rconf.Value)
                             except json.JSONDecodeError as error:
-                                log.debug(
+                                log.warning(
                                     f"Could not load {rconf.Key} ({rconf.Value}) from resolver config as JSON: {error}")
                                 value = rconf.Value
                         elif rconf.Type == "dict_with_password":
@@ -155,7 +155,7 @@ class SharedConfigClass(object):
                                         value[key] = decryptPassword(val)
                                         resolverdef["censor_keys"].append(f"{rconf.Key}.{key}")
                             except json.JSONDecodeError as error:
-                                log.debug(
+                                log.warning(
                                     f"Could not load {rconf.Key} ({rconf.Value}) from resolver config as JSON: {error}")
                                 value = rconf.Value
                         else:


### PR DESCRIPTION
When we are catching exceptions we log warnings or errors. In some cases in addition we add a traceback in debug level. However, from a project and support perspective it is mandatory to see, if something does not behave as expected.
When config values, that are supposed to be dicts can not be converted so such, this is at least a warning. It is probably an error.

So we need this in 3.13.1.