### PR TITLE
get userlist only once

### DIFF
--- a/privacyidea/static/components/user/controllers/userControllers.js
+++ b/privacyidea/static/components/user/controllers/userControllers.js
@@ -403,7 +403,7 @@ angular.module("privacyideaApp")
             // Change the pagination
             $scope.pageChanged = function () {
                 //debug: console.log('Page changed to: ' + $scope.params.page);
-                $scope._getUsers();
+                $scope._applyPageSlice();
             };
             $scope.$on("piReload", function () {
                 $scope._getUsers(false);
@@ -455,15 +455,20 @@ angular.module("privacyideaApp")
                     UserFactory.getUsers(params,
                         function (data) {
                             //debug: console.log("success");
-                            const userList = data.result.value;
-                            // The userList is the complete list of the users.
-                            $scope.userCount = userList.length;
-                            const start = ($scope.params.page - 1) * $scope.usersPerPage;
-                            const stop = start + $scope.usersPerPage;
-                            $scope.userlist = userList.slice(start, stop);
+                            // The backend returns the complete list of users; pagination is done client-side.
+                            $scope._allUsers = data.result.value;
+                            $scope.userCount = $scope._allUsers.length;
+                            $scope._applyPageSlice();
                             //debug: console.log($scope.userlist);
                         });
                 }
+            };
+
+            $scope._applyPageSlice = function () {
+                const all = $scope._allUsers || [];
+                const start = ($scope.params.page - 1) * $scope.usersPerPage;
+                const stop = start + $scope.usersPerPage;
+                $scope.userlist = all.slice(start, stop);
             };
 
             $scope.getRealms = function () {


### PR DESCRIPTION
* previously, the webui made a new request to get ALL users, each time you change the page in the list, eventhough you get the full list on the first request already
* now that first result is reused and just sliced into pages