### PR TITLE
fix(user-controllers): show error toast when setPassword returns false (#5181)

### DIFF
--- a/privacyidea/static/components/user/controllers/userControllers.js
+++ b/privacyidea/static/components/user/controllers/userControllers.js
@@ -92,10 +92,20 @@ angular.module("privacyideaApp")
                         username: $scope.User.username,
                         password: $scope.User.password
                     }, function (data) {
-                        inform.add(gettextCatalog.getString("Password set successfully."),
-                            {type: "info"});
-                        $scope.User.password = "";
-                        $scope.password2 = "";
+                        // The backend returns the standard PI envelope: success
+                        // is `data.result.value === true`. The previous handler
+                        // unconditionally announced success, so an LDAP/policy
+                        // failure surfaced as a misleading "Password set
+                        // successfully" toast (#5181).
+                        if (data.result && data.result.value) {
+                            inform.add(gettextCatalog.getString("Password set successfully."),
+                                {type: "info"});
+                            $scope.User.password = "";
+                            $scope.password2 = "";
+                        } else {
+                            inform.add(gettextCatalog.getString("Failed to set Password"),
+                                {type: "danger"});
+                        }
                     });
             };
 


### PR DESCRIPTION
Fixes #5181. `setPassword` in `privacyidea/static/components/user/controllers/userControllers.js` unconditionally announced "Password set successfully" inside the success callback, so an LDAP/bind-permission failure or password-policy violation surfaced as a misleading green toast even though the backend correctly returned `data.result.value === false` and an error in the audit log.

The reporter pointed at the same pattern already used elsewhere in the file (line 88-100 link in the issue):

```js
if (data.result.value) { ... } else {
  inform.add(gettextCatalog.getString("Failed to set Password"), {type: "danger"});
}
```

This PR applies that pattern to `setPassword`, gating the "Password set successfully" toast and the password-field reset on `data.result.value` and falling through to a danger toast otherwise.

## Test plan

- [x] `node -c` syntax check on the modified file
- [x] No backend change — server already returns the right `result.value` per the issue; only the frontend was misreporting