### PR TITLE
Run build also nightly

### DIFF
--- a/.github/workflows/webui-build.yml
+++ b/.github/workflows/webui-build.yml
@@ -9,6 +9,9 @@ on:
       - 'branch-*'
     paths:
       - 'privacyidea/static_new/**'
+  schedule:
+    # Nightly at 01:00 UTC
+    - cron: '0 1 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Run build also nightly to catch build errors that would not surface in PRs that are not up to date with master — for example, if master removes a function or changes an API that a pending PR still depends on, the breakage would only appear after merging. The nightly build detects such regressions proactively.   