### PR TITLE
Add push_challenge_text policy

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -705,6 +705,23 @@ this policy will not be in effect.
 
 .. versionadded:: 3.13
 
+.. _policy_push_challenge_text:
+
+push_challenge_text
+~~~~~~~~~~~~~~~~~~~
+
+.. index:: push token
+
+type: ``string``
+
+An alternative message to display in the application to tell the user, to confirm the authentication on his mobile
+device with the PUSH token.
+
+This can be used to display different messages, if the user e.g. has different token types, that triggered a challenge
+or in combination with :ref:`push_code_to_phone` to tell the user in more detail what to do.
+
+.. versionadded:: 3.13
+
 .. _policy_push_require_presence:
 
 push_require_presence

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -720,6 +720,9 @@ device with the PUSH token.
 This can be used to display different messages, if the user e.g. has different token types, that triggered a challenge
 or in combination with :ref:`push_code_to_phone` to tell the user in more detail what to do.
 
+If this policy is not set, the PUSH token falls back to the generic :ref:`policy_challenge_text` policy and finally
+to the built-in default text.
+
 .. versionadded:: 3.13
 
 .. _policy_push_require_presence:

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -714,10 +714,10 @@ push_challenge_text
 
 type: ``string``
 
-An alternative message to display in the application to tell the user, to confirm the authentication on his mobile
+An alternative message to display in the application to tell the user to confirm the authentication on his mobile
 device with the PUSH token.
 
-This can be used to display different messages, if the user e.g. has different token types, that triggered a challenge
+This can be used to display different messages, if the user e.g. has different token types that triggered a challenge
 or in combination with :ref:`push_code_to_phone` to tell the user in more detail what to do.
 
 If this policy is not set, the PUSH token falls back to the generic :ref:`policy_challenge_text` policy and finally

--- a/privacyidea/lib/tokens/push_types.py
+++ b/privacyidea/lib/tokens/push_types.py
@@ -37,6 +37,7 @@ class PushAction:
     PRESENCE_CUSTOM_OPTIONS = "push_presence_custom_options"
     PRESENCE_NUM_OPTIONS = "push_presence_num_options"
     USE_PIA_SCHEME = "push_use_pia_scheme"
+    CHALLENGE_TEXT = "push_challenge_text"
 
 
 class PushAllowPolling:

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -1126,12 +1126,8 @@ class PushTokenClass(TokenClass):
         additional challenge ``reply_dict``, which is displayed in the JSON challenges response.
         """
         options = options or {}
-        message = get_action_values_from_options(SCOPE.AUTH,
-                                                 "{0!s}_{1!s}".format(self.get_class_type(),
-                                                                      PolicyAction.CHALLENGETEXT),
-                                                 options) or str(DEFAULT_CHALLENGE_TEXT)
-
-        message = message.replace(r'\,', ',')
+        # Depending on the mode we have different default messages
+        default_message  = str(DEFAULT_CHALLENGE_TEXT)
 
         # Determine if require presence is enabled
         g = options.get("g")
@@ -1162,8 +1158,16 @@ class PushTokenClass(TokenClass):
                     "smartphone_confirmed": False,
                 }
 
-            message = _("Please enter the code displayed on your smartphone.")
+            # push_code_to_phone has a different default message
+            default_message = _("Please enter the code displayed on your smartphone.")
             client_mode = ClientMode.INTERACTIVE
+
+        # Now potentially get a different message from policies
+        message = get_action_values_from_options(SCOPE.AUTH,
+                                                 "{0!s}_{1!s}".format(self.get_class_type(),
+                                                                      PolicyAction.CHALLENGETEXT),
+                                                 options) or default_message
+        message = message.replace(r'\,', ',')
 
         # Initially we assume there is no error from Firebase
         res = True

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -467,7 +467,7 @@ class PushTokenClass(TokenClass):
                                'desc': _('The message that is shown above the code on the smartphone.'),
                                'group': 'PUSH'
                            },
-                           PolicyAction.CHALLENGETEXT: {
+                           PushAction.CHALLENGE_TEXT: {
                                'type': 'str',
                                'desc': _('Use an alternative challenge text for telling the '
                                          'user to confirm the authentication on his mobile device.')
@@ -1127,7 +1127,7 @@ class PushTokenClass(TokenClass):
         """
         options = options or {}
         # Depending on the mode we have different default messages
-        default_message  = str(DEFAULT_CHALLENGE_TEXT)
+        default_message = str(DEFAULT_CHALLENGE_TEXT)
 
         # Determine if require presence is enabled
         g = options.get("g")
@@ -1162,11 +1162,12 @@ class PushTokenClass(TokenClass):
             default_message = _("Please enter the code displayed on your smartphone.")
             client_mode = ClientMode.INTERACTIVE
 
-        # Now potentially get a different message from policies
-        message = get_action_values_from_options(SCOPE.AUTH,
-                                                 "{0!s}_{1!s}".format(self.get_class_type(),
-                                                                      PolicyAction.CHALLENGETEXT),
-                                                 options) or default_message
+        # Now potentially get a different message from policies. The push-specific policy
+        # takes precedence; fall back to the generic challenge_text policy for backwards
+        # compatibility, then to the mode-dependent default.
+        message = (get_action_values_from_options(SCOPE.AUTH, PushAction.CHALLENGE_TEXT, options)
+                   or get_action_values_from_options(SCOPE.AUTH, PolicyAction.CHALLENGETEXT, options)
+                   or default_message)
         message = message.replace(r'\,', ',')
 
         # Initially we assume there is no error from Firebase

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -60,7 +60,8 @@ from privacyidea.lib.error import (ResourceNotFoundError, ValidateError,
 from privacyidea.lib.log import log_with
 from privacyidea.lib.policies.actions import PolicyAction
 from privacyidea.lib.policy import (SCOPE, GROUP, Match,
-                                    get_action_values_from_options)
+                                    get_action_values_from_options,
+                                    comma_escape_text)
 from privacyidea.lib.smsprovider.SMSProvider import get_smsgateway, create_sms_instance
 from privacyidea.lib.token import get_one_token, init_token
 from privacyidea.lib.tokenclass import (TokenClass, AuthenticationMode, ClientMode,
@@ -464,6 +465,13 @@ class PushTokenClass(TokenClass):
                            PushAction.PUSH_CODE_TO_PHONE_MESSAGE: {
                                'type': 'str',
                                'desc': _('The message that is shown above the code on the smartphone.'),
+                               'group': 'PUSH'
+                           },
+                           PolicyAction.CHALLENGETEXT: {
+                               'type': 'str',
+                               'desc': _('Use an alternative challenge text for telling the '
+                                         'user to confirm the authentication on his mobile device.')
+                                       + " " + comma_escape_text,
                                'group': 'PUSH'
                            },
                            PushAction.PRESENCE_OPTIONS: {
@@ -1119,7 +1127,8 @@ class PushTokenClass(TokenClass):
         """
         options = options or {}
         message = get_action_values_from_options(SCOPE.AUTH,
-                                                 PolicyAction.CHALLENGETEXT,
+                                                 "{0!s}_{1!s}".format(self.get_class_type(),
+                                                                      PolicyAction.CHALLENGETEXT),
                                                  options) or str(DEFAULT_CHALLENGE_TEXT)
 
         message = message.replace(r'\,', ',')

--- a/tests/test_api_push_validate.py
+++ b/tests/test_api_push_validate.py
@@ -776,14 +776,14 @@ class PushAPITestCase(MyApiTestCase):
 
         self.setUp_user_realms()
         # Setup PUSH policies
-        individual_message = "Please confirm on your smartphone an enter the code here."
+        individual_message = "Please confirm on your smartphone and enter the code here."
         set_policy("push_config", scope=SCOPE.ENROLL,
                    action=f"{PushAction.FIREBASE_CONFIG}={POLL_ONLY},"
                           f"{PushAction.REGISTRATION_URL}={REGISTRATION_URL}")
         set_policy("push_mode_code_to_phone", scope=SCOPE.AUTH,
                    action=f"{PushAction.PUSH_CODE_TO_PHONE}=1")
         set_policy("push_challenge_text", scope=SCOPE.AUTH,
-                   action=f"push_{PolicyAction.CHALLENGETEXT}={individual_message}")
+                   action=f"{PushAction.CHALLENGE_TEXT}={individual_message}")
 
         expected_message = 'test message'
         set_policy("code_to_phone_message", scope=SCOPE.AUTH,
@@ -907,10 +907,37 @@ class PushAPITestCase(MyApiTestCase):
             self.assertEqual(AUTH_RESPONSE.ACCEPT,
                              res.json.get("result").get("authentication"), res.json)
 
+        # Verify backwards-compat fallback: with the push-specific policy removed,
+        # the generic challenge_text policy is honored on the next challenge.
+        delete_policy("push_challenge_text")
+        generic_message = "Generic challenge text fallback."
+        set_policy("generic_challenge_text", scope=SCOPE.AUTH,
+                   action=f"{PolicyAction.CHALLENGETEXT}={generic_message}")
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "selfservice",
+                                                 "pass": "push_pin"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertEqual(generic_message, res.json.get("detail").get("message"), res.json)
+
+        # Verify precedence: when both policies are set, push_challenge_text wins.
+        set_policy("push_challenge_text", scope=SCOPE.AUTH,
+                   action=f"{PushAction.CHALLENGE_TEXT}={individual_message}")
+        with self.app.test_request_context('/validate/check',
+                                           method='POST',
+                                           data={"user": "selfservice",
+                                                 "pass": "push_pin"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertEqual(individual_message, res.json.get("detail").get("message"), res.json)
+
         remove_token(self.serial_push)
         delete_policy("push_config")
         delete_policy("push_mode_code_to_phone")
         delete_policy("code_to_phone_message")
+        delete_policy("generic_challenge_text")
+        delete_policy("push_challenge_text")
 
     def test_18_push_code_to_phone_fail(self):
         """

--- a/tests/test_api_push_validate.py
+++ b/tests/test_api_push_validate.py
@@ -776,11 +776,14 @@ class PushAPITestCase(MyApiTestCase):
 
         self.setUp_user_realms()
         # Setup PUSH policies
+        individual_message = "Please confirm on your smartphone an enter the code here."
         set_policy("push_config", scope=SCOPE.ENROLL,
                    action=f"{PushAction.FIREBASE_CONFIG}={POLL_ONLY},"
                           f"{PushAction.REGISTRATION_URL}={REGISTRATION_URL}")
         set_policy("push_mode_code_to_phone", scope=SCOPE.AUTH,
                    action=f"{PushAction.PUSH_CODE_TO_PHONE}=1")
+        set_policy("push_challenge_text", scope=SCOPE.AUTH,
+                   action=f"push_{PolicyAction.CHALLENGETEXT}={individual_message}")
 
         expected_message = 'test message'
         set_policy("code_to_phone_message", scope=SCOPE.AUTH,
@@ -822,6 +825,8 @@ class PushAPITestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(200, res.status_code, res)
             detail = res.json.get("detail")
+            # Check the message
+            self.assertEqual(individual_message, detail.get("message"), res.json)
             # Get the challenge data
             transaction_id = detail.get("transaction_id")
             self.assertTrue(transaction_id)


### PR DESCRIPTION
That allows to have different text messages for e.g. TOTP token and PUSH token.

Closes #5300