### PR TITLE
add action to catch python req drift, update structure

### DIFF
--- a/.github/python-versions.env
+++ b/.github/python-versions.env
@@ -11,8 +11,12 @@ MIN=3.10
 # Newest supported Python version (upper bound of test matrices).
 MAX=3.14
 
-# Version used for release builds and the migration test workflow.
-CURRENT=3.13
+# Python version used to build the sdist/wheel for releases.
+RELEASE=3.13
+
+# Python version used by the migration test workflow.
+# Kept separate from RELEASE so that bumping one does not silently move the other.
+MIGRATION=3.13
 
 # All supported Python versions (used by the nightly full matrix).
 # Space-separated; a setup step converts this to a JSON array.

--- a/.github/python-versions.env
+++ b/.github/python-versions.env
@@ -1,0 +1,19 @@
+# Single source of truth for Python versions used by GitHub Actions workflows.
+# Keep in sync with the "Programming Language :: Python :: 3.x" classifiers and
+# `requires-python` in pyproject.toml.
+#
+# Loaded by workflows via a shell step that re-exports the values into
+# $GITHUB_OUTPUT (see .github/workflows/*.yml).
+
+# Oldest supported Python version (lower bound of test matrices, pip-compile).
+MIN=3.10
+
+# Newest supported Python version (upper bound of test matrices).
+MAX=3.14
+
+# Version used for release builds and the migration test workflow.
+CURRENT=3.13
+
+# All supported Python versions (used by the nightly full matrix).
+# Space-separated; a setup step converts this to a JSON array.
+ALL="3.10 3.11 3.12 3.13 3.14"

--- a/.github/workflows/gitlab-trigger-branch-tag.yml
+++ b/.github/workflows/gitlab-trigger-branch-tag.yml
@@ -1,4 +1,4 @@
-name: GitLab (branch tag)
+name: GitLab Tag on Branch
 
 on:
   push:

--- a/.github/workflows/gitlab-trigger-master.yml
+++ b/.github/workflows/gitlab-trigger-master.yml
@@ -1,4 +1,4 @@
-name: GitLab
+name: GitLab Push to Master Branch
 
 on:
   push:

--- a/.github/workflows/gitlab-trigger-on-tag.yml
+++ b/.github/workflows/gitlab-trigger-on-tag.yml
@@ -1,4 +1,4 @@
-name: GitLab
+name: GitLab Tag Master Branch
 
 on:
   push:
@@ -20,6 +20,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Fetch branch-* heads
+        # actions/checkout only fetches the triggering tag ref; the
+        # `branch-*` remote-tracking refs need to be fetched explicitly
+        # before `git branch -r --contains` can see them.
+        run: git fetch --no-tags origin '+refs/heads/branch-*:refs/remotes/origin/branch-*'
 
       - name: Skip if tag is on a branch-* branch
         id: check

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -34,8 +34,23 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
+  versions:
+    name: Load Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      current: ${{ steps.load.outputs.current }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - id: load
+        run: |
+          set -a; source .github/python-versions.env; set +a
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+
   migration-tests:
-    name: Migration tests (${{ matrix.db.label }} / Python 3.13)
+    needs: versions
+    name: Migration tests (${{ matrix.db.label }} / Python ${{ needs.versions.outputs.current }})
     permissions:
       checks: write
     runs-on: ubuntu-latest
@@ -89,10 +104,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ needs.versions.outputs.current }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13'
+          python-version: ${{ needs.versions.outputs.current }}
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -24,6 +24,7 @@ on:
       - 'pyproject.toml'
       - 'requirements.txt'
       - '.github/workflows/migration-tests.yml'
+      - '.github/python-versions.env'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -35,23 +35,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
-  versions:
-    name: Load Python versions
-    runs-on: ubuntu-latest
-    outputs:
-      current: ${{ steps.load.outputs.current }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - id: load
-        run: |
-          set -a; source .github/python-versions.env; set +a
-          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-
   migration-tests:
-    needs: versions
-    name: Migration tests (${{ matrix.db.label }} / Python ${{ needs.versions.outputs.current }})
+    name: Migration tests (${{ matrix.db.label }})
     permissions:
       checks: write
     runs-on: ubuntu-latest
@@ -105,10 +90,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python ${{ needs.versions.outputs.current }}
+      - name: Load Python versions
+        id: pyversions
+        run: |
+          set -a; source .github/python-versions.env; set +a
+          echo "migration=$MIGRATION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python ${{ steps.pyversions.outputs.migration }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ needs.versions.outputs.current }}
+          python-version: ${{ steps.pyversions.outputs.migration }}
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt

--- a/.github/workflows/python-dist.yml
+++ b/.github/workflows/python-dist.yml
@@ -57,7 +57,7 @@ jobs:
       id: pyversions
       run: |
         set -a; source .github/python-versions.env; set +a
-        echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+        echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
     # Get the new WebUI from the build artifacts
     - name: Get new WebUI build artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -67,10 +67,10 @@ jobs:
     - name: List downloaded artifact
       run: ls -R ./privacyidea/static_new/dist
     - run: mkdir -p dist
-    - name: Set up Python ${{ steps.pyversions.outputs.current }}
+    - name: Set up Python ${{ steps.pyversions.outputs.release }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: ${{ steps.pyversions.outputs.current }}
+        python-version: ${{ steps.pyversions.outputs.release }}
     - name: Install build environment
       run: >-
         python -m pip install build --user

--- a/.github/workflows/python-dist.yml
+++ b/.github/workflows/python-dist.yml
@@ -53,6 +53,11 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+    - name: Load Python versions
+      id: pyversions
+      run: |
+        set -a; source .github/python-versions.env; set +a
+        echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
     # Get the new WebUI from the build artifacts
     - name: Get new WebUI build artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -62,10 +67,10 @@ jobs:
     - name: List downloaded artifact
       run: ls -R ./privacyidea/static_new/dist
     - run: mkdir -p dist
-    - name: Set up Python 3.13
+    - name: Set up Python ${{ steps.pyversions.outputs.current }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: "3.13"
+        python-version: ${{ steps.pyversions.outputs.current }}
     - name: Install build environment
       run: >-
         python -m pip install build --user

--- a/.github/workflows/python-requirements-sync.yml
+++ b/.github/workflows/python-requirements-sync.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: CC0-1.0
+#
+name: Python requirements sync
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'branch-*'
+    paths:
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - 'tests/requirements.txt'
+      - 'doc/requirements.txt'
+
+permissions:
+  contents: read
+
+jobs:
+  check-requirements-sync:
+    name: pip-compile drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Load Python versions
+        id: pyversions
+        run: |
+          set -a; source .github/python-versions.env; set +a
+          echo "min=$MIN" >> "$GITHUB_OUTPUT"
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ steps.pyversions.outputs.min }}
+      - name: Install pip-tools
+        run: pip install pip-tools
+      - name: Recompile runtime requirements
+        run: pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt pyproject.toml
+      - name: Recompile test requirements
+        run: pip-compile --allow-unsafe --extra=test --generate-hashes --output-file=tests/requirements.txt pyproject.toml
+      - name: Recompile doc requirements
+        run: pip-compile --allow-unsafe --extra=doc --generate-hashes --output-file=doc/requirements.txt pyproject.toml
+      - name: Fail on drift
+        run: |
+          if ! git diff --exit-code requirements.txt tests/requirements.txt doc/requirements.txt; then
+            echo "::error::pyproject.toml and the pinned requirements files are out of sync."
+            echo "Run pip-compile locally (see each file's header) and commit the result."
+            exit 1
+          fi

--- a/.github/workflows/python-requirements-sync.yml
+++ b/.github/workflows/python-requirements-sync.yml
@@ -13,6 +13,7 @@ on:
       - 'tests/requirements.txt'
       - 'doc/requirements.txt'
       - '.github/python-versions.env'
+      - '.github/workflows/python-requirements-sync.yml'
 
 permissions:
   contents: read
@@ -35,7 +36,10 @@ jobs:
         with:
           python-version: ${{ steps.pyversions.outputs.min }}
       - name: Install pip-tools
-        run: pip install pip-tools
+        # Pinned so the drift check always uses the same pip-compile version.
+        # pip-compile output can change between pip-tools releases, which would
+        # otherwise produce spurious diffs unrelated to the PR.
+        run: pip install pip-tools==7.4.1
       - name: Recompile runtime requirements
         run: pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt pyproject.toml
       - name: Recompile test requirements

--- a/.github/workflows/python-requirements-sync.yml
+++ b/.github/workflows/python-requirements-sync.yml
@@ -48,8 +48,13 @@ jobs:
       - name: Recompile doc requirements
         run: pip-compile --allow-unsafe --extra=doc --generate-hashes --output-file=doc/requirements.txt pyproject.toml
       - name: Fail on drift
+        # -I ignores hunks whose changed lines all match the pattern. The
+        # pip-compile invocation header records default-valued CLI flags
+        # (--cert=None etc.) which differ between local and CI without
+        # reflecting any real dependency change.
         run: |
-          if ! git diff --exit-code requirements.txt tests/requirements.txt doc/requirements.txt; then
+          if ! git diff --exit-code -I '^#    pip-compile' \
+                requirements.txt tests/requirements.txt doc/requirements.txt; then
             echo "::error::pyproject.toml and the pinned requirements files are out of sync."
             echo "Run pip-compile locally (see each file's header) and commit the result."
             exit 1

--- a/.github/workflows/python-requirements-sync.yml
+++ b/.github/workflows/python-requirements-sync.yml
@@ -36,10 +36,11 @@ jobs:
         with:
           python-version: ${{ steps.pyversions.outputs.min }}
       - name: Install pip-tools
-        # Pinned so the drift check always uses the same pip-compile version.
-        # pip-compile output can change between pip-tools releases, which would
-        # otherwise produce spurious diffs unrelated to the PR.
-        run: pip install pip-tools==7.4.1
+        # Pin both pip and pip-tools so the drift check is reproducible.
+        # pip-compile output can change between pip-tools releases (spurious
+        # diffs), and pip-tools 7.4.1 is incompatible with pip>=25 (which
+        # dropped PackageFinder.allow_all_prereleases).
+        run: pip install "pip==24.3.1" "pip-tools==7.4.1"
       - name: Recompile runtime requirements
         run: pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt pyproject.toml
       - name: Recompile test requirements

--- a/.github/workflows/python-requirements-sync.yml
+++ b/.github/workflows/python-requirements-sync.yml
@@ -12,6 +12,7 @@ on:
       - 'requirements.txt'
       - 'tests/requirements.txt'
       - 'doc/requirements.txt'
+      - '.github/python-versions.env'
 
 permissions:
   contents: read

--- a/.github/workflows/python-versions-validate.yml
+++ b/.github/workflows/python-versions-validate.yml
@@ -55,16 +55,23 @@ jobs:
               fail=1
             fi
           done
-          # ALL must be a space-separated list of "3.X" tokens
-          for v in $ALL; do
-            if ! [[ "$v" =~ ^3\.[0-9]+$ ]]; then
-              echo "::error file=.github/python-versions.env::ALL contains invalid token: $v"
-              fail=1
-            fi
-          done
+          # Validate ALL using the same splitting the consumer workflows use:
+          # `jq -Rc 'split(" ")'` does NOT collapse repeated/leading/trailing
+          # spaces, so a value like "3.10  3.14" would yield an empty matrix
+          # entry. Reject anything that doesn't match a strict single-space
+          # separated list of "3.X" tokens.
+          tokens=$(printf '%s' "$ALL" | jq -Rc 'split(" ")')
+          if printf '%s' "$tokens" | jq -e 'any(.[]; . == "")' >/dev/null; then
+            echo "::error file=.github/python-versions.env::ALL contains empty token (check for repeated/leading/trailing spaces)"
+            fail=1
+          fi
+          if ! printf '%s' "$tokens" | jq -e 'all(.[]; test("^3\\.[0-9]+$"))' >/dev/null; then
+            echo "::error file=.github/python-versions.env::ALL contains a token that does not match 3.X"
+            fail=1
+          fi
           # ALL must contain MIN and MAX
           for required in "$MIN" "$MAX"; do
-            if ! printf '%s\n' $ALL | grep -qx "$required"; then
+            if ! printf '%s' "$tokens" | jq -e --arg v "$required" 'any(.[]; . == $v)' >/dev/null; then
               echo "::error file=.github/python-versions.env::ALL does not contain $required"
               fail=1
             fi

--- a/.github/workflows/python-versions-validate.yml
+++ b/.github/workflows/python-versions-validate.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: CC0-1.0
+#
+# Sanity-checks .github/python-versions.env so a typo (e.g. unquoted spaces,
+# missing key) is caught at PR time rather than at consumer-workflow runtime.
+
+name: Validate python-versions.env
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'branch-*'
+    paths:
+      - '.github/python-versions.env'
+      - '.github/workflows/python-versions-validate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate env file
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Source and check required keys
+        run: |
+          set -a
+          source .github/python-versions.env
+          set +a
+          missing=0
+          for key in MIN MAX RELEASE MIGRATION ALL; do
+            if [ -z "${!key}" ]; then
+              echo "::error file=.github/python-versions.env::$key is unset or empty"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || exit 1
+
+      - name: Check value formats
+        run: |
+          set -a
+          source .github/python-versions.env
+          set +a
+          fail=0
+          # MIN/MAX/RELEASE/MIGRATION must look like "3.X"
+          for key in MIN MAX RELEASE MIGRATION; do
+            value=${!key}
+            if ! [[ "$value" =~ ^3\.[0-9]+$ ]]; then
+              echo "::error file=.github/python-versions.env::$key=$value does not match 3.X"
+              fail=1
+            fi
+          done
+          # ALL must be a space-separated list of "3.X" tokens
+          for v in $ALL; do
+            if ! [[ "$v" =~ ^3\.[0-9]+$ ]]; then
+              echo "::error file=.github/python-versions.env::ALL contains invalid token: $v"
+              fail=1
+            fi
+          done
+          # ALL must contain MIN and MAX
+          for required in "$MIN" "$MAX"; do
+            if ! printf '%s\n' $ALL | grep -qx "$required"; then
+              echo "::error file=.github/python-versions.env::ALL does not contain $required"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1

--- a/.github/workflows/unit-tests-mariadb.yml
+++ b/.github/workflows/unit-tests-mariadb.yml
@@ -32,7 +32,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  versions:
+    name: Load Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      min: ${{ steps.load.outputs.min }}
+      matrix: ${{ steps.load.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - id: load
+        # On push/PR only test min and max; nightly runs all versions.
+        env:
+          IS_SCHEDULE: ${{ github.event_name == 'schedule' }}
+        run: |
+          set -a; source .github/python-versions.env; set +a
+          echo "min=$MIN" >> "$GITHUB_OUTPUT"
+          if [ "$IS_SCHEDULE" = "true" ]; then
+            echo -n "matrix=" >> "$GITHUB_OUTPUT"
+            printf '%s\n' "$ALL" | jq -Rc 'split(" ")' >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[\"$MIN\",\"$MAX\"]" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: versions
     name: 'Python ${{ matrix.python-version }}'
     permissions:
       checks: write # allow the python tests to mark an action run as failed
@@ -41,13 +66,7 @@ jobs:
       # Do not cancel running matrix tests when one test fails
       fail-fast: false
       matrix:
-        # On push/PR only test min and max; nightly runs all versions.
-        python-version: >-
-          ${{
-            (github.event_name == 'schedule')
-            && fromJSON('["3.10","3.11","3.12","3.13","3.14"]')
-            || fromJSON('["3.10","3.14"]')
-          }}
+        python-version: ${{ fromJSON(needs.versions.outputs.matrix) }}
 
     services:
       mariadb:
@@ -102,20 +121,21 @@ jobs:
         TEST_DATABASE_URL: "mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3306/privacyidea_test"
         PYTHONWARNINGS: "once::DeprecationWarning"
         PYTHON_VERSION: ${{ matrix.python-version }}
+        MIN_PYTHON_VERSION: ${{ needs.versions.outputs.min }}
       run: |
         pip freeze
         # Collect coverage only on the lowest Python version to avoid redundant
         # reports and reduce overhead on all other matrix jobs.
         # --dist=loadfile keeps all tests in one file on one worker, preserving
         # the intra-file ordering the unittest-style suite currently relies on.
-        if [ "$PYTHON_VERSION" = "3.10" ]; then
+        if [ "$PYTHON_VERSION" = "$MIN_PYTHON_VERSION" ]; then
           python -b -m pytest -v -n auto --dist=loadfile --cov=privacyidea --cov-report=xml -m "not migration" tests/
         else
           python -b -m pytest -v -n auto --dist=loadfile -m "not migration" tests/
         fi
 
     - name: Codecov upload
-      if: ${{ steps.pytest_run.outcome == 'success' && matrix.python-version == '3.10' }}
+      if: ${{ steps.pytest_run.outcome == 'success' && matrix.python-version == needs.versions.outputs.min }}
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
         files: ./coverage.xml

--- a/.github/workflows/unit-tests-mariadb.yml
+++ b/.github/workflows/unit-tests-mariadb.yml
@@ -19,6 +19,7 @@ on:
       - 'requirements.txt'
       - 'tools/**'
       - '.github/workflows/unit-tests-mariadb.yml'
+      - '.github/python-versions.env'
   schedule:
     # Nightly at 02:00 UTC — runs all Python versions as a dependency health check
     - cron: '0 2 * * *'

--- a/.github/workflows/unit-tests-postgres.yml
+++ b/.github/workflows/unit-tests-postgres.yml
@@ -16,6 +16,7 @@ on:
       - 'requirements.txt'
       - 'tools/**'
       - '.github/workflows/unit-tests-postgres.yml'
+      - '.github/python-versions.env'
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests-postgres.yml
+++ b/.github/workflows/unit-tests-postgres.yml
@@ -26,7 +26,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  versions:
+    name: Load Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.load.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - id: load
+        # Run on oldest and latest supported versions only — enough to catch
+        # PostgreSQL dialect issues without duplicating the full MariaDB matrix.
+        run: |
+          set -a; source .github/python-versions.env; set +a
+          echo "matrix=[\"$MIN\",\"$MAX\"]" >> "$GITHUB_OUTPUT"
+
   test:
+    needs: versions
     name: 'Python ${{ matrix.python-version }}'
     permissions:
       checks: write
@@ -34,9 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run on oldest and latest supported versions only — enough to catch
-        # PostgreSQL dialect issues without duplicating the full MariaDB matrix.
-        python-version: ['3.10', '3.14']
+        python-version: ${{ fromJSON(needs.versions.outputs.matrix) }}
 
     services:
       postgres:


### PR DESCRIPTION
- put python version in env file for single source of truth
- add an action that catches drift between the pinned deps and pyproject toml