### PR TITLE
Refactor ca connector subclass registration

### DIFF
--- a/privacyidea/lib/caconnectors/baseca.py
+++ b/privacyidea/lib/caconnectors/baseca.py
@@ -25,7 +25,8 @@ This module is tested in tests/test_lib_caconnector.py
 """
 
 # This takes a set of all CA Connector modules.
-AvailableCAConnectors = []
+AvailableCAConnectors = ["privacyidea.lib.caconnectors.localca.LocalCAConnector",
+                         "privacyidea.lib.caconnectors.msca.MSCAConnector"]
 
 
 class BaseCAConnector:

--- a/privacyidea/lib/caconnectors/baseca.py
+++ b/privacyidea/lib/caconnectors/baseca.py
@@ -24,7 +24,7 @@ In this first implementation it is only a local certificate authority.
 This module is tested in tests/test_lib_caconnector.py
 """
 
-# This takes a set of all CA Connector modules.
+# This contains the fully qualified class paths of all available CA connectors.
 AvailableCAConnectors = ["privacyidea.lib.caconnectors.localca.LocalCAConnector",
                          "privacyidea.lib.caconnectors.msca.MSCAConnector"]
 

--- a/privacyidea/lib/caconnectors/localca.py
+++ b/privacyidea/lib/caconnectors/localca.py
@@ -27,7 +27,7 @@ This module is tested in tests/test_lib_caconnector.py
 """
 from privacyidea.lib.error import CAError
 from privacyidea.lib.utils import int_to_hex, to_unicode
-from privacyidea.lib.caconnectors.baseca import BaseCAConnector, AvailableCAConnectors
+from privacyidea.lib.caconnectors.baseca import BaseCAConnector
 from cryptography import x509
 from cryptography.hazmat.primitives.serialization import Encoding
 from subprocess import Popen, PIPE  # nosec B404
@@ -184,7 +184,7 @@ authorityKeyIdentifier=keyid:always,issuer:always
 [ crl_dp_policy ]
 """
 
-AvailableCAConnectors.append("privacyidea.lib.caconnectors.localca.LocalCAConnector")
+
 
 
 def _get_crl_next_update(filename: str) -> datetime.datetime:

--- a/privacyidea/lib/caconnectors/msca.py
+++ b/privacyidea/lib/caconnectors/msca.py
@@ -19,18 +19,22 @@ This implementation is for the Microsoft CA via our middleware.
 
 This module is tested in tests/test_lib_caconnector.py
 """
-from cryptography import x509
-from cryptography.hazmat.primitives import serialization
+
 import logging
 import traceback
 
-from privacyidea.lib.error import CAError
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+
+from privacyidea.lib import _
 from privacyidea.lib.caconnectors.baseca import BaseCAConnector
-from privacyidea.lib.utils import is_true, int_to_hex
+from privacyidea.lib.error import CAError
 from privacyidea.lib.error import CSRError, CSRPending
+from privacyidea.lib.utils import is_true, int_to_hex
 from privacyidea.lib.utils import to_bytes
 
 log = logging.getLogger(__name__)
+_grpc_available = False
 try:
     import grpc
     from privacyidea.lib.caconnectors.caservice_pb2_grpc import CAServiceStub
@@ -41,8 +45,7 @@ try:
                                                             GetCertificateRequest,
                                                             RevokeCertificateRequest,
                                                             RevokeCertificateReply)
-
-
+    _grpc_available = True
 except ImportError:  # pragma: no cover
     log.warning("Can not import grpc modules.")
 
@@ -147,6 +150,8 @@ class MSCAConnector(BaseCAConnector):
         """
         creates a connection to the middleware and returns it.
         """
+        if not _grpc_available:  # pragma: no cover
+            raise CAError(_("grpc module is not available. Cannot connect to MS CA worker."))
         if self.use_ssl:
             # Secure connection
             if not (self.ssl_ca_cert and self.ssl_client_cert and self.ssl_client_key):

--- a/privacyidea/lib/caconnectors/msca.py
+++ b/privacyidea/lib/caconnectors/msca.py
@@ -25,7 +25,7 @@ import logging
 import traceback
 
 from privacyidea.lib.error import CAError
-from privacyidea.lib.caconnectors.baseca import BaseCAConnector, AvailableCAConnectors
+from privacyidea.lib.caconnectors.baseca import BaseCAConnector
 from privacyidea.lib.utils import is_true, int_to_hex
 from privacyidea.lib.error import CSRError, CSRPending
 from privacyidea.lib.utils import to_bytes
@@ -42,7 +42,7 @@ try:
                                                             RevokeCertificateRequest,
                                                             RevokeCertificateReply)
 
-    AvailableCAConnectors.append("privacyidea.lib.caconnectors.msca.MSCAConnector")
+
 except ImportError:  # pragma: no cover
     log.warning("Can not import grpc modules.")
 

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -423,11 +423,8 @@ def get_caconnector_types():
     Returns a list of valid CA connector types
     :return:
     """
-    modules = get_caconnector_module_list()
-    types = []
-    for module in modules:
-        if inspect.isclass(module) and issubclass(module, BaseCAConnector) and module is not BaseCAConnector:
-            types.append(module.connector_type)
+    _, type_dict = get_caconnector_class_dict()
+    types = list(type_dict.values())
     return types
 
 

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -423,10 +423,12 @@ def get_caconnector_types():
     Returns a list of valid CA connector types
     :return:
     """
-    caconnector_types = []
-    for cacon in BaseCAConnector.__subclasses__():
-        caconnector_types.append(cacon.connector_type)
-    return caconnector_types
+    modules = get_caconnector_module_list()
+    types = []
+    for module in modules:
+        if inspect.isclass(module) and issubclass(module, BaseCAConnector) and module is not BaseCAConnector:
+            types.append(module.connector_type)
+    return types
 
 
 # @cache.cached(key_prefix="classes")

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -424,7 +424,7 @@ def get_caconnector_types():
     :return:
     """
     _, type_dict = get_caconnector_class_dict()
-    types = list(type_dict.values())
+    types = sorted(type_dict.values())
     return types
 
 

--- a/tests/test_lib_caconnector.py
+++ b/tests/test_lib_caconnector.py
@@ -21,9 +21,8 @@ from privacyidea.lib.caconnector import (get_caconnector_list,
                                          get_caconnector_type,
                                          get_caconnector_types,
                                          save_caconnector, delete_caconnector)
-from privacyidea.lib.caconnectors.baseca import AvailableCAConnectors
 from privacyidea.lib.caconnectors.localca import LocalCAConnector, ATTR
-from privacyidea.lib.caconnectors.msca import MSCAConnector, ATTR as MS_ATTR
+from privacyidea.lib.caconnectors.msca import MSCAConnector, ATTR as MS_ATTR, _grpc_available
 from privacyidea.lib.error import CAError, CSRError, CSRPending
 from privacyidea.lib.utils import int_to_hex
 from privacyidea.models import db, CAConnectorConfig
@@ -431,7 +430,7 @@ CONF_LAB = {MS_ATTR.HOSTNAME: "10.0.5.100",
             MS_ATTR.CA: "CA03.nilsca.com\\nilsca-CA03-CA"}
 
 
-@unittest.skipUnless("privacyidea.lib.caconnectors.msca.MSCAConnector" in AvailableCAConnectors,
+@unittest.skipUnless(_grpc_available,
                      "Can not test MSCA. grpc module seems not available.")
 class MSCATestCase(MyTestCase):
     """


### PR DESCRIPTION
- Moved `AvailableCAConnectors` from a dynamically populated list (via self-registration side effects) to a static list in `baseca.py`, explicitly declaring all available CA connectors in one place. This removes the need for the
  "unused" imports in `config.py` and makes adding new connectors straightforward.
- `get_caconnector_types()` was updated to use `get_caconnector_class_dict()` (consistent with how other types are resolved) instead of `__subclasses__()`, making it consistent with `get_caconnector_module_list()`.
-  Added a `_grpc_available` flag in `msca.py` that is set only when all grpc imports succeed. `_connect_to_worker()` now checks this flag and raises a clear `CAError` instead of a cryptic `NameError` if the grpc module is unavailable.

These changes now allow to always create / update CA connectors instead of raising an internal server error in case a module is not available. 