### PR TITLE
docs: expand FIDO2 / passkey / WebAuthn documentation

### DIFF
--- a/doc/configuration/tokenconfig/webauthn.rst
+++ b/doc/configuration/tokenconfig/webauthn.rst
@@ -20,6 +20,24 @@ trusted (it will still be checked for validity). Therefore it is mandatory to
 set this, if :ref:`policy_webauthn_enroll_authenticator_attestation_level` is
 set to “trusted” through policy for any user.
 
+What this verifies (and what it does not):
+
+* Certificates must be **PEM-encoded** files. Files that cannot be parsed as
+  X.509 certificates are logged and silently skipped, so a directory with a
+  mix of valid and invalid files will still work but trust will be reduced
+  accordingly.
+* Only the **leaf attestation certificate** is matched against the configured
+  roots; **full certificate chain traversal is not performed**. If your
+  authenticators ship intermediate certificates, ensure that the certificate
+  that directly signs the attestation statement is itself present in this
+  directory (not just the ultimate root).
+* There is **no FIDO Metadata Service (MDS) integration** and no AAGUID-based
+  trust evaluation. AAGUID allow-listing is a separate mechanism configured
+  via :ref:`policy_webauthn_enroll_authenticator_selection_list`.
+* This setting is only consulted by the :ref:`webauthn` token type. The
+  :ref:`passkey` token type does not perform attestation trust validation;
+  any attestation certificate it receives is archived for reference only.
+
 WebAuthn Required Policies
 ..........................
 
@@ -51,3 +69,21 @@ party for the entire company) or the name of the department or other
 organizational unit the relying party represents.
 
 See also: :ref:`policy_webauthn_enroll_relying_party_name`.
+
+Challenge Validity Time
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The validity time of a FIDO2 challenge — for both WebAuthn and passkey
+enrollment and authentication — is governed by the system-wide
+:ref:`challenge_validity_time` setting. To override this just for FIDO2
+challenges, for example to give users more time to interact with their
+authenticator without lengthening the validity time of every other challenge
+type, set the config key ``WebauthnChallengeValidityTime`` (in seconds). The
+lookup order is ``WebauthnChallengeValidityTime`` →
+``DefaultChallengeValidityTime`` → ``120`` seconds.
+
+If you raise :ref:`policy_webauthn_enroll_timeout` or
+:ref:`policy_webauthn_authn_timeout` beyond the challenge validity time, the
+client-side wait is meaningless: the server will already have discarded the
+challenge by the time the response arrives. Keep the challenge validity time
+at or above the largest WebAuthn/passkey client timeout in use.

--- a/doc/configuration/tokenconfig/webauthn.rst
+++ b/doc/configuration/tokenconfig/webauthn.rst
@@ -23,7 +23,7 @@ set to “trusted” through policy for any user.
 What this verifies (and what it does not):
 
 * Certificates must be **PEM-encoded** files. Files that cannot be parsed as
-  X.509 certificates are logged and silently skipped, so a directory with a
+  X.509 certificates are logged and skipped, so a directory with a
   mix of valid and invalid files will still work but trust will be reduced
   accordingly.
 * Only the **leaf attestation certificate** is matched against the configured

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -1015,6 +1015,14 @@ supported by the token.
 .. note:: If you configure this, you will likely also want to configure
     :ref:`policy_webauthn_enroll_user_verification_requirement`.
 
+.. note:: When this is not set to ``required`` and a user has multiple
+    discoverable credentials for the same relying party on a single
+    authenticator (typical for external FIDO2 security keys), the browser's
+    account picker may show generic placeholder labels instead of the user
+    names. The authenticator only releases the credentials'
+    ``user.name`` / ``user.displayName`` fields after user verification.
+    See :ref:`passkey` for more detail.
+
 
 question_number
 ~~~~~~~~~~~~~~~
@@ -1056,6 +1064,8 @@ used a TOTP token to authenticate, an input field to enter the OTP value is disp
 This policy takes precedence over the `preferred_client_mode` policy.
 
 .. versionadded:: 3.12
+
+.. _policy_passkey_trigger_by_pin:
 
 passkey_trigger_by_pin
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -750,8 +750,13 @@ component may follow it and is ignored, but the value must contain exactly two
 rejected. Several examples::
 
     webauthn_req=subject/.*Yubico.*/
-    webauthn_req=issuer/.*FIDO2 CA.*/
+    webauthn_req='issuer/.*FIDO2 CA.*/'
     webauthn_req=serial/^4711$/
+
+If the value contains whitespace (as in the second example above), the whole
+action value must be wrapped in single quotes. Otherwise it is split on
+whitespace into separate values, each of which is then parsed individually and
+fails.
 
 During registration of the WebAuthn authenticator the information is fetched
 from the attestation certificate. The token can only be enrolled if the

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -743,11 +743,12 @@ The action value is parsed as a slash-delimited expression with three parts:
 ``<field>/<regex>/<trailing>``. The leading ``<field>`` selects which field
 of the attestation certificate is checked and must be one of ``subject``,
 ``issuer`` or ``serial``. ``<regex>`` is a Python regular expression that is
-applied via ``re.search`` against that field and therefore may not itself
-contain a ``/``. The trailing ``/`` is required as a terminator. A third path
-component may follow it and is ignored, but the value must contain exactly two
-``/`` separators in total: any additional ``/`` causes the action to be
-rejected. Several examples::
+applied via ``re.search`` against that field. Because ``/`` is the delimiter
+of this expression, the regex itself may not contain a ``/``. A second ``/``
+is required to terminate the regex part; the ``<trailing>`` text after it is
+optional and ignored. The value must contain exactly two ``/`` separators in
+total: any additional ``/`` causes the action to be rejected. Several
+examples::
 
     webauthn_req=subject/.*Yubico.*/
     webauthn_req='issuer/.*FIDO2 CA.*/'

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -558,14 +558,14 @@ webauthn_authenticator_attachment
 type: ``string``
 
 This action configures whether to limit roll out of WebAuthn tokens to either
-only platform authenticators, or only platform authenticators. Cross-platform
-authenticators are authenticators, that are intended to be plugged into
-different devices, whereas platform authenticators are those, that are built
-directly into one particular device and can not (easily) be removed and plugged
-into a different device.
+only platform authenticators, or only cross-platform authenticators.
+Cross-platform authenticators are authenticators, that are intended to be
+plugged into different devices, whereas platform authenticators are those,
+that are built directly into one particular device and can not (easily) be
+removed and plugged into a different device.
 
-The default is to allow both `platform` and `cross-platform` attachment for
-authenticators.
+The default is to allow both ``platform`` and ``cross-platform`` attachment
+for authenticators.
 
 .. _policy_webauthn_enroll_authenticator_selection_list:
 
@@ -714,12 +714,20 @@ passkey_attestation_conveyance_preference
 
 type: string
 
-This action configures the attestation conveyance preference for the passkey enrollment. Possible values are:
-"none", "indirect" and "direct" and "enterprise". The default is "none". If attestation is requested and the
-authenticator return a statement, the certificate will be saved in the token info. Currently, there is no further
-validation.
+This action configures the attestation conveyance preference for the passkey enrollment. Possible values are
+``none``, ``indirect``, ``direct`` and ``enterprise``. The default is ``none``.
+
+If attestation is requested and the authenticator returns a statement, the leaf certificate from the attestation
+statement is saved in the token info as ``attestation_certificate``, and the token description is set to the
+certificate's Common Name if no description has been set yet. Currently, there is no further validation of the
+attestation data.
+
+Requesting attestation also reveals the AAGUID of the authenticator (which is zeroed out when attestation is
+``none``) and typically causes the browser to show an additional consent dialog to the user during registration.
+For these reasons, ``none`` is the recommended setting for passkeys; see :ref:`passkey` for details.
+
 This policy is separate from :ref:`policy_webauthn_enroll_authenticator_attestation_form` and
-:ref:`policy_webauthn_enroll_authenticator_attestation_level` which are not used for passkey enrollment.
+:ref:`policy_webauthn_enroll_authenticator_attestation_level`, which are not used for passkey enrollment.
 
 .. _policy_webauthn_enroll_req:
 
@@ -731,14 +739,22 @@ type: ``string``
 This action allows filtering of WebAuthn tokens by the fields of the
 attestation certificate.
 
-The action can be specified like this::
+The action value is parsed as a slash-delimited expression with three parts:
+``<field>/<regex>/<trailing>``. The leading ``<field>`` selects which field
+of the attestation certificate is checked and must be one of ``subject``,
+``issuer`` or ``serial``. ``<regex>`` is a Python regular expression that is
+applied via ``re.search`` against that field. The trailing ``/`` is required
+as a terminator; anything after it is ignored. Several examples::
 
     webauthn_req=subject/.*Yubico.*/
+    webauthn_req=issuer/.*FIDO2 CA.*/
+    webauthn_req=serial/^4711$/
 
-The keyword can be "subject", "issuer" or "serial". Followed by a
-regular expression. During registration of the WebAuthn authenticator the
-information is fetched from the attestation certificate. Only if the attribute
-in the attestation certificate matches accordingly the token can be enrolled.
+During registration of the WebAuthn authenticator the information is fetched
+from the attestation certificate. The token can only be enrolled if the
+selected field matches the regular expression. If the attestation statement
+contains no certificate (for example because attestation form is ``none``),
+filtering fails and enrollment is denied.
 
 .. note:: If you configure this, you will likely also want to configure
     :ref:`policy_webauthn_authz_req`.

--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -743,8 +743,11 @@ The action value is parsed as a slash-delimited expression with three parts:
 ``<field>/<regex>/<trailing>``. The leading ``<field>`` selects which field
 of the attestation certificate is checked and must be one of ``subject``,
 ``issuer`` or ``serial``. ``<regex>`` is a Python regular expression that is
-applied via ``re.search`` against that field. The trailing ``/`` is required
-as a terminator; anything after it is ignored. Several examples::
+applied via ``re.search`` against that field and therefore may not itself
+contain a ``/``. The trailing ``/`` is required as a terminator. A third path
+component may follow it and is ignored, but the value must contain exactly two
+``/`` separators in total: any additional ``/`` causes the action to be
+rejected. Several examples::
 
     webauthn_req=subject/.*Yubico.*/
     webauthn_req=issuer/.*FIDO2 CA.*/

--- a/doc/tokens/tokentypes/passkey.rst
+++ b/doc/tokens/tokentypes/passkey.rst
@@ -31,8 +31,45 @@ always required for enrollment. Therefore, :ref:`policy_webauthn_enroll_user_ver
 affect passkey enrollment. The same policy :ref:`policy_webauthn_authn_user_verification_requirement` is available in
 the scope authentication and that policy does affect passkey authentication.
 
+.. note:: If user verification is **not** required on authentication and a user has multiple discoverable credentials
+    for the same relying party on one authenticator (typically an external FIDO2 security key with several passkeys
+    enrolled to the same site), the browser's account picker may display generic placeholder labels for the
+    credentials (for example "Passkey 1", "Passkey 2" or "Unknown") instead of the actual user names. This is a
+    CTAP2 behavior: the authenticator only releases the ``user.name`` and ``user.displayName`` fields of a
+    discoverable credential after user verification has been performed. Without UV, the browser has only the opaque
+    ``user.id`` handle to work with and falls back to a non-identifying label. The exact string shown depends on the
+    browser and operating system. Platform authenticators (Touch ID, Windows Hello, Face ID, synced platform
+    passkeys) intrinsically perform user verification on every assertion and are not affected. Set
+    :ref:`policy_webauthn_authn_user_verification_requirement` to ``required`` if you want the names to appear in
+    the picker for external security keys as well.
+
 On the token detail page, the passkey can be tested and, if successful, will show the username that is returned by
 privacyIDEA to use for login.
+
+Attestation
+~~~~~~~~~~~
+
+Attestation during passkey registration is controlled by its own policy,
+:ref:`policy_passkey_attestation_conveyance_preference`. The WebAuthn attestation policies
+:ref:`policy_webauthn_enroll_authenticator_attestation_form` and
+:ref:`policy_webauthn_enroll_authenticator_attestation_level` do **not** apply to passkey enrollment.
+
+The default and recommended value is ``none``. Passkeys are intended as a user-friendly, privacy-preserving
+credential, and requesting attestation works against both goals:
+
+* With ``none``, the authenticator data returned to privacyIDEA contains a zeroed AAGUID and no attestation
+  statement, so the specific make and model of the authenticator is not disclosed.
+* With ``indirect``, ``direct`` or ``enterprise``, the authenticator returns its real AAGUID and an attestation
+  statement. If the statement contains an x5c certificate chain, the leaf certificate (which typically identifies
+  the make and model of the authenticator) is stored in the token info as ``attestation_certificate``. If the
+  token has no description yet, its description is set to the certificate's Common Name.
+* Requesting attestation also causes additional friction during enrollment: most browsers will show an extra
+  consent dialog informing the user that information identifying their authenticator will be sent to the site,
+  which can be confusing for end users and is not aligned with how passkeys are typically presented.
+
+privacyIDEA currently only archives the attestation certificate; there is no trust-chain validation, AAGUID
+allow-listing or filtering of passkey tokens based on attestation data. If attestation-based filtering or trust
+validation is required, use the :ref:`webauthn_otp_token` instead.
 
 Avoiding double registration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -47,5 +84,15 @@ Tokens that have been **revoked** are excluded from this list, so the same authe
 the user after revocation. Tokens that are merely **disabled** are still included, since disabling is reversible
 and the underlying credential is still bound to the user. Tokens whose enrollment never finished
 (rollout state ``clientwait``) are also excluded.
+
+Relationship to the WebAuthn token
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Platform credentials (Touch ID, Windows Hello, synced platform passkeys) that
+were enrolled as WebAuthn tokens before the passkey token type existed are
+still usable through the usernameless passkey flow. See
+:ref:`webauthn_passkey_interop` for the encoding background and the
+recommendation to prefer the passkey token when both a passkey and a WebAuthn
+token are triggered for the same user in one transaction.
 
 A non-exhaustive list of devices that are known to work can be found here :ref:`fido_device_matrix`.

--- a/doc/tokens/tokentypes/webauthn.rst
+++ b/doc/tokens/tokentypes/webauthn.rst
@@ -63,8 +63,9 @@ certificate's issuer, subject and serial in token info
 (``attestation_issuer``, ``attestation_subject``, ``attestation_serial``),
 along with the AAGUID. The attestation signature is verified, but a
 self-signed or unknown-signer attestation is accepted. If the token has no
-description yet, the description is set to the leaf certificate's Common
-Name (otherwise it falls back to ``Generic WebAuthn Token``).
+description yet, its description is set to the leaf certificate's Common Name
+if the certificate has one; otherwise it falls back to ``Generic WebAuthn
+Token``. A description already set on the token is left unchanged.
 
 Setting the level to ``trusted`` requires configuring a directory of trusted
 attestation roots; see :ref:`webauthn_otp_token`. Enrollment is then rejected

--- a/doc/tokens/tokentypes/webauthn.rst
+++ b/doc/tokens/tokentypes/webauthn.rst
@@ -5,6 +5,16 @@ WebAuthn
 
 .. index:: WebAuth, FIDO2
 
+.. note:: For new deployments the :ref:`passkey` token type is recommended over
+    WebAuthn. The passkey token is a re-implementation on top of a maintained
+    FIDO2 library and was created specifically to address shortcomings of the
+    older WebAuthn implementation. The WebAuthn token type is kept primarily
+    for existing deployments and for the few cases where attestation-based
+    filtering (:ref:`policy_webauthn_enroll_req`,
+    :ref:`policy_webauthn_enroll_authenticator_selection_list`,
+    :ref:`policy_webauthn_enroll_authenticator_attestation_level` = ``trusted``)
+    is required, which the passkey token does not provide.
+
 Starting with version 3.4 privacyIDEA supports WebAuthn tokens. The
 administrator or the user himself can register a WebAuthn device and use this
 WebAuthn token to login to the privacyIDEA WebUI or to authenticate against
@@ -16,9 +26,13 @@ present, which typically happens by tapping a button on the token. The user may
 also be required by policy to provide some form of verification, which might be
 biometric or knowledge-based, depending on the token.
 
-When enrolling, the authenticator is not requested to create a resident key, in contrast to the passkey token: :ref:`passkey`.
-However, the authenticator can still decide to create a resident key. If that is the case, the WebAuthn token can be used
-like a passkey token for usernameless logins with privacyIDEA.
+When enrolling, the authenticator is not requested to create a resident key, in contrast to the :ref:`passkey` token,
+which always requires one. The WebAuthn token does not pass a ``resident_key`` option to the authenticator, so the
+authenticator falls back to its own default behavior. Some authenticators (notably platform authenticators such as
+Touch ID, Windows Hello and synced platform passkeys) will still create a discoverable credential anyway. If that is
+the case, the WebAuthn token can be used like a passkey token for usernameless logins; see
+:ref:`webauthn_passkey_interop` below. There is no policy that lets you force or forbid resident-key creation on the
+WebAuthn token — use the :ref:`passkey` token type if you need a guaranteed discoverable credential.
 
 .. note:: This is a normal token object which can also be reassigned to
     another user.
@@ -31,3 +45,99 @@ For configuring privacyIDEA for the use of WebAuthn tokens, please see
 
 For further details and information how to add this to your application, see
 the code documentation at :ref:`code_webauthn_token`.
+
+Attestation
+~~~~~~~~~~~
+
+Attestation during WebAuthn enrollment is controlled by two policies:
+
+* :ref:`policy_webauthn_enroll_authenticator_attestation_form` — what the
+  client is asked to convey. ``none``, ``indirect``, ``direct`` (the default).
+* :ref:`policy_webauthn_enroll_authenticator_attestation_level` — how
+  strictly privacyIDEA evaluates whatever it receives. ``none``, ``untrusted``
+  (the default), or ``trusted``.
+
+With the default ``direct`` + ``untrusted`` combination, the authenticator
+returns a full attestation statement and privacyIDEA records the leaf
+certificate's issuer, subject and serial in token info
+(``attestation_issuer``, ``attestation_subject``, ``attestation_serial``),
+along with the AAGUID. The attestation signature is verified, but a
+self-signed or unknown-signer attestation is accepted. If the token has no
+description yet, the description is set to the leaf certificate's Common
+Name (otherwise it falls back to ``Generic WebAuthn Token``).
+
+Setting the level to ``trusted`` requires configuring a directory of trusted
+attestation roots; see :ref:`webauthn_otp_token`. Enrollment is then rejected
+unless the attestation statement's leaf certificate is signed directly by one
+of the configured roots. **Full certificate chain traversal is not
+performed**, and there is no FIDO Metadata Service (MDS) integration — trust
+decisions are based purely on the configured leaf-signing roots. For AAGUID
+allow-listing, use :ref:`policy_webauthn_enroll_authenticator_selection_list`
+separately.
+
+In contrast to the :ref:`passkey` token, the WebAuthn token type is the right
+choice when attestation data must drive enrollment decisions: the
+:ref:`policy_webauthn_enroll_req` policy filters acceptable authenticators
+based on the attestation certificate's subject, issuer or serial fields, and
+:ref:`policy_webauthn_enroll_authenticator_selection_list` restricts
+enrollment to a list of known AAGUIDs. The corresponding ``..._authz_...``
+policies enforce the same conditions at authentication time. None of these
+filters are available for passkey tokens.
+
+.. note:: Requesting attestation (``direct`` or ``indirect``) typically
+    causes the browser to display an additional consent dialog to the user
+    during enrollment, informing them that information identifying their
+    authenticator will be sent to the server. With ``none``, the AAGUID is
+    zeroed and no attestation statement is conveyed, which is more
+    privacy-preserving but disables all attestation-based filtering.
+
+.. _webauthn_passkey_interop:
+
+Using existing WebAuthn tokens as passkeys
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Older versions of privacyIDEA expected the WebAuthn challenge in the
+``clientDataJSON`` returned by the authenticator to be hex-encoded. This
+deviates from the WebAuthn specification, which mandates base64url. Challenges
+generated by :http:post:`/validate/initialize` — the endpoint used for the
+usernameless passkey flow — are base64url-encoded as the spec requires.
+
+A common real-world situation is that a platform passkey (for example a Touch
+ID credential on macOS, or a synced platform credential on Windows or Android)
+was enrolled into privacyIDEA as a WebAuthn token before the passkey token type
+existed. Such a credential *is* a discoverable passkey at the authenticator
+level, so the browser will offer it during a usernameless challenge. To keep
+those credentials usable in the passkey flow, the WebAuthn token's
+authentication verifier accepts both the legacy hex encoding and the
+spec-compliant base64url encoding of the challenge in ``clientDataJSON``.
+
+This dual-encoding tolerance applies only to authentication:
+
+* When the credential is used through the **usernameless passkey path**
+  (challenge from :http:post:`/validate/initialize`), the response will be
+  base64url-encoded and the WebAuthn verifier accepts it.
+* When the credential is used through the **classical, bound challenge-response
+  path** (a challenge created by a /validate/check or
+  /validate/triggerchallenge against a specific token/user, including the
+  passkey-as-WebAuthn case enabled by
+  :ref:`policy_passkey_trigger_by_pin`), the legacy hex encoding is used. If a
+  user has both a WebAuthn token and a passkey token triggered in the same
+  transaction, clients should prefer the passkey token to avoid encoding
+  ambiguity.
+
+Newly enrolled passkey tokens use base64url-encoded challenges throughout. The
+hex/base64url tolerance in the WebAuthn token verifier is a backwards
+compatibility layer; correcting the encoding everywhere would require a
+coordinated upgrade of the privacyIDEA server and *every* client application
+in use at a given site, since clients currently carry matching encode/decode
+logic for both shapes. For this reason the legacy encoding is preserved on the
+WebAuthn token and is not planned to change. New deployments should use the
+:ref:`passkey` token type, which uses base64url end-to-end.
+
+.. note:: An "open" challenge issued by :http:post:`/validate/initialize` is
+    not bound to a specific user or token at creation time; it is resolved to
+    a token only when the authenticator response comes back and the credential
+    id can be matched against an enrolled token. Classical challenges, by
+    contrast, are bound to a token and user from the moment they are created
+    (the user proves possession of the token via its PIN to trigger the
+    challenge).


### PR DESCRIPTION
Document behaviors that are user-visible but were previously implicit or absent from the docs:

- Passkey: attestation conveyance defaults to none and why (AAGUID zeroing, browser consent dialog friction, no trust validation); CN side-effect on the token description; CTAP2 picker behavior when user verification is not required.
- WebAuthn: recommend the passkey token for new deployments; clarify that no policy forces/forbids resident-key creation; new Attestation section covering direct+untrusted defaults, leaf-only trusted matching, and the lack of FIDO MDS integration; document the hex vs base64url challenge encoding tolerance kept for legacy platform passkeys enrolled before the passkey token type existed.
- Trust Anchor Directory config: PEM-only, invalid files silently skipped, leaf-only matching, no MDS, scoped to the WebAuthn token.
- Policies: sharpen webauthn_req grammar; fix the webauthn_authenticator_attachment platform/cross-platform typo; cross-reference the AUTH-scope UV policy to the passkey CTAP2 note; add anchor for passkey_trigger_by_pin.
- Config: document WebauthnChallengeValidityTime and its fallback chain.