### PR TITLE
Fix: undefined action values fall back to empty string

### DIFF
--- a/privacyidea/static_new/src/app/components/policies/policy-edit-page/policy-panels/edit-action-tab/action-selector/policy-action-item/policy-action-item-new.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/policies/policy-edit-page/policy-panels/edit-action-tab/action-selector/policy-action-item/policy-action-item-new.component.spec.ts
@@ -99,6 +99,12 @@ describe("PolicyActionItemComponent", () => {
     expect(component.isBooleanAction()).toBe(true);
   });
 
+  it("should default currentAction value to empty string for undefined actions", () => {
+    fixture.componentRef.setInput("actionValue", undefined);
+    fixture.detectChanges();
+    expect(component.currentAction().value).toBe("");
+  });
+
   it("should use the actionValue input as the default for non-bool actions", () => {
     fixture.componentRef.setInput("selectableAction", { ...defaultAction, detail: { type: "str", desc: "A string" } });
     fixture.componentRef.setInput("actionValue", "myDefault");

--- a/privacyidea/static_new/src/app/components/policies/policy-edit-page/policy-panels/edit-action-tab/action-selector/policy-action-item/policy-action-item-new.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/policies/policy-edit-page/policy-panels/edit-action-tab/action-selector/policy-action-item/policy-action-item-new.component.spec.ts
@@ -156,6 +156,13 @@ describe("PolicyActionItemComponent", () => {
   });
 
   describe("inputIsValid", () => {
+    it("should return false when actionValue is empty", () => {
+      fixture.componentRef.setInput("actionValue", "");
+      fixture.componentRef.setInput("selectableAction", { ...defaultAction, detail: { type: "str", desc: "desc" } });
+      fixture.detectChanges();
+      expect(component.inputIsValid()).toBe(false);
+    });
+
     it("should return false when actionValue is undefined", () => {
       fixture.componentRef.setInput("actionValue", undefined);
       fixture.componentRef.setInput("selectableAction", { ...defaultAction, detail: { type: "str", desc: "desc" } });

--- a/privacyidea/static_new/src/app/components/policies/policy-edit-page/policy-panels/edit-action-tab/action-selector/policy-action-item/policy-action-item-new.component.ts
+++ b/privacyidea/static_new/src/app/components/policies/policy-edit-page/policy-panels/edit-action-tab/action-selector/policy-action-item/policy-action-item-new.component.ts
@@ -59,7 +59,7 @@ export class PolicyActionItemComponent {
   readonly inputIsValid = computed<boolean>(() => {
     const detail = this.selectableAction().detail;
     const actionValue = this.currentAction()?.value;
-    if (!detail || actionValue === undefined) return false;
+    if (!detail || actionValue === undefined || actionValue === "") return false;
     return this.policyService.actionValueIsValid(detail, actionValue);
   });
   readonly selectActionByName = output<string>();

--- a/privacyidea/static_new/src/app/components/policies/policy-edit-page/policy-panels/edit-action-tab/action-selector/policy-action-item/policy-action-item-new.component.ts
+++ b/privacyidea/static_new/src/app/components/policies/policy-edit-page/policy-panels/edit-action-tab/action-selector/policy-action-item/policy-action-item-new.component.ts
@@ -27,7 +27,12 @@ import { SelectorButtonsComponent } from "@components/policies/policy-edit-page/
 import { MultiSelectOnlyComponent } from "@components/shared/multi-select-only/multi-select-only.component";
 import { PolicyActionDetail, PolicyService, PolicyServiceInterface } from "@services/policies/policies.service";
 
-export type SelectableAction = { label: string; actionName: string; scope: string; detail: PolicyActionDetail };
+export interface SelectableAction {
+  label: string;
+  actionName: string;
+  scope: string;
+  detail: PolicyActionDetail;
+}
 
 @Component({
   selector: "app-policy-action-item-new",
@@ -64,7 +69,7 @@ export class PolicyActionItemComponent {
     source: () => this.selectableAction(),
     computation: (selectableAction) => {
       const { actionName, detail } = selectableAction;
-      const defaultValue = detail?.type === "bool" ? "true" : this.actionValue();
+      const defaultValue = detail?.type === "bool" ? "true" : (this.actionValue() ?? "");
       return { name: actionName, value: defaultValue };
     }
   });


### PR DESCRIPTION
Policy actions were initialized with undefined values:
<img width="967" height="145" alt="image" src="https://github.com/user-attachments/assets/00450159-93de-4046-b541-a1cc7cbcfef0" />

Now undefined falls back to empty string