### PR TITLE
Make tokencredentialidhash_seq migration portable across Galera and O…

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,3 +33,23 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  oracle-test:
+    # DB URI: oracle+oracledb://privacyidea:privacyidea@127.0.0.1:1521/?service_name=XEPDB1
+    # gvenzl/oracle-xe is a no-login Oracle XE image on Docker Hub. XE 21c (< 23c)
+    # rejects "CREATE/DROP SEQUENCE IF EXISTS" and accepts "RESTART START WITH",
+    # so it matches the documented Oracle 19c+ baseline for migration testing.
+    image: gvenzl/oracle-xe:21-slim
+    container_name: pi-oracle-test
+    environment:
+      ORACLE_PASSWORD: root
+      APP_USER: privacyidea
+      APP_USER_PASSWORD: privacyidea
+    ports:
+      - "1521:1521"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh"]
+      start_period: 30s
+      interval: 10s
+      timeout: 10s
+      retries: 30

--- a/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
+++ b/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
@@ -1,7 +1,7 @@
 """Create missing tokencredentialidhash_seq on existing installs
 
 The TokenCredentialIdHash model declares Sequence('tokencredentialidhash_seq')
-on its id column, so SQLAlchemy 2.0's MariaDB/Postgres dialect emits
+on its id column, so SQLAlchemy 2.0's MariaDB/Postgres/Oracle dialect emits
 SELECT nextval(tokencredentialidhash_seq) on every insert. Some installs
 ended up with the table but without the sequence, causing every insert to
 fail with "Unknown SEQUENCE". Create it here if missing and advance it past
@@ -13,41 +13,64 @@ Create Date: 2026-04-22 14:30:00.000000
 
 """
 from alembic import op
-from sqlalchemy import text, Sequence
+from sqlalchemy import text, inspect, Sequence
 from sqlalchemy.exc import OperationalError, ProgrammingError
-from sqlalchemy.schema import CreateSequence
+from sqlalchemy.schema import CreateSequence, DropSequence
+from privacyidea.models.db import build_restart_sequence_sql
 
 revision = 'b1a2c3d4e5f6'
 down_revision = '06b105a4f941'
 branch_labels = None
 depends_on = None
 
+SEQ_NAME = "tokencredentialidhash_seq"
+
+
+def _sequence_exists(bind) -> bool:
+    """Return True if SEQ_NAME already exists. Reflected names are upper-cased on
+    Oracle, so compare case-insensitively."""
+    existing = {name.lower() for name in inspect(bind).get_sequence_names()}
+    return SEQ_NAME.lower() in existing
+
 
 def upgrade():
     bind = op.get_bind()
     if not bind.dialect.supports_sequences:
-        # MySQL itself has no CREATE SEQUENCE; only MariaDB 10.3+ and Postgres do.
+        # MySQL itself has no CREATE SEQUENCE; only MariaDB 10.3+, Postgres and
+        # Oracle do.
         return
     try:
         max_id = bind.execute(
             text("SELECT COALESCE(MAX(id), 0) FROM tokencredentialidhash")
         ).scalar() or 0
         start = max_id + 1
-        # Build the sequence through SQLAlchemy's CreateSequence construct rather
-        # than a raw "CREATE SEQUENCE" string. CreateSequence is rewritten by the
-        # increment_by_zero @compiles hook in privacyidea.models.db, which appends
-        # INCREMENT BY 0 on MariaDB. A Galera cluster only accepts a cached
-        # sequence when it is defined that way (so each node gets a distinct
-        # offset); a plain string would bypass the hook and fail with "CACHE
-        # without INCREMENT BY 0 in Galera cluster". if_not_exists handles the
-        # already-present case; the explicit RESTART afterwards covers installs
-        # where the sequence exists but lags MAX(id), which would otherwise still
-        # produce duplicate-PK errors on the next insert.
-        seq = Sequence("tokencredentialidhash_seq", start=start)
-        op.execute(CreateSequence(seq, if_not_exists=True))
-        op.execute(f"ALTER SEQUENCE tokencredentialidhash_seq RESTART WITH {start}")
+        # Oracle (19c+) supports neither "CREATE SEQUENCE IF NOT EXISTS" nor
+        # "ALTER SEQUENCE ... RESTART WITH" (both are 23c-only / wrong syntax), so
+        # reflect first and branch: create only when absent, otherwise advance it
+        # with build_restart_sequence_sql, which emits Oracle's RESTART START WITH.
+        if bind.dialect.name == "oracle":
+            if not _sequence_exists(bind):
+                op.execute(CreateSequence(Sequence(SEQ_NAME, start=start)))
+            else:
+                op.execute(build_restart_sequence_sql(SEQ_NAME, start, "oracle"))
+            return
+        # MariaDB/Postgres: build the sequence through SQLAlchemy's CreateSequence
+        # construct rather than a raw "CREATE SEQUENCE" string. CreateSequence is
+        # rewritten by the increment_by_zero @compiles hook in privacyidea.models.db,
+        # which appends INCREMENT BY 0 on MariaDB. A Galera cluster only accepts a
+        # cached sequence when it is defined that way (so each node gets a distinct
+        # offset); a plain string would bypass the hook and fail with "CACHE without
+        # INCREMENT BY 0 in Galera cluster". if_not_exists handles the already-present
+        # case; the explicit RESTART afterwards covers installs where the sequence
+        # exists but lags MAX(id), which would otherwise still produce duplicate-PK
+        # errors on the next insert.
+        op.execute(CreateSequence(Sequence(SEQ_NAME, start=start), if_not_exists=True))
+        # The RESTART needs the same INCREMENT BY 0 treatment as the CREATE above
+        # for Galera; there is no SQLAlchemy DDL construct for ALTER SEQUENCE that
+        # the hook could rewrite, so build_restart_sequence_sql appends it on MariaDB.
+        op.execute(build_restart_sequence_sql(SEQ_NAME, start, bind.dialect.name))
     except (OperationalError, ProgrammingError) as ex:
-        print(f"Could not create sequence 'tokencredentialidhash_seq': {ex}")
+        print(f"Could not create sequence '{SEQ_NAME}': {ex}")
         raise
 
 
@@ -56,7 +79,13 @@ def downgrade():
     if not bind.dialect.supports_sequences:
         return
     try:
-        op.execute("DROP SEQUENCE IF EXISTS tokencredentialidhash_seq")
+        # Oracle (19c+) has no "DROP SEQUENCE IF EXISTS", so reflect and drop only
+        # if present. MariaDB/Postgres accept the IF EXISTS guard directly.
+        if bind.dialect.name == "oracle":
+            if _sequence_exists(bind):
+                op.execute(DropSequence(Sequence(SEQ_NAME)))
+        else:
+            op.execute(f"DROP SEQUENCE IF EXISTS {SEQ_NAME}")
     except (OperationalError, ProgrammingError) as ex:
-        print(f"Could not drop sequence 'tokencredentialidhash_seq': {ex}")
+        print(f"Could not drop sequence '{SEQ_NAME}': {ex}")
         raise

--- a/privacyidea/models/db.py
+++ b/privacyidea/models/db.py
@@ -36,6 +36,34 @@ def increment_by_zero(element, compiler, **kw):  # pragma: no cover
     text = text + " INCREMENT BY 0"
     return text
 
+
+def build_restart_sequence_sql(name, restart_with, dialect_name):
+    """Build an ``ALTER SEQUENCE`` statement that restarts ``name`` at
+    ``restart_with``, using each dialect's accepted syntax.
+
+    SQLAlchemy has no DDL construct for ``ALTER SEQUENCE ... RESTART``, so
+    migrations build the statement through this helper instead of a raw string
+    that would only be correct on one backend:
+
+    * **MariaDB/MySQL** use ``RESTART WITH n`` and additionally require
+      ``INCREMENT BY 0`` — a Galera cluster otherwise rejects ``RESTART`` on a
+      cached sequence with "CACHE without INCREMENT BY 0 in Galera cluster", the
+      same constraint the :func:`increment_by_zero` hook handles for
+      ``CREATE SEQUENCE``. (MySQL has no sequences and never reaches this path.)
+    * **Oracle** (19c+) uses ``RESTART START WITH n``; ``RESTART WITH n`` is a
+      syntax error there, and ``INCREMENT BY 0`` is invalid.
+    * **PostgreSQL** uses plain ``RESTART WITH n``.
+
+    ``name`` must be a trusted, code-defined sequence identifier — it is
+    interpolated verbatim.
+    """
+    if dialect_name == "oracle":
+        return f"ALTER SEQUENCE {name} RESTART START WITH {restart_with}"
+    sql = f"ALTER SEQUENCE {name} RESTART WITH {restart_with}"
+    if dialect_name in ("mysql", "mariadb"):
+        sql += " INCREMENT BY 0"
+    return sql
+
 # Compile JSON type to CLOB for Oracle
 @compiles(db.JSON, 'oracle')
 def compile_json_oracle(type_, compiler, **kw):  # pragma: no cover

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -796,31 +796,22 @@ def test_each_migration_survives_round_trip(flask_app):
         # Leave the DB at rev.revision — the next iteration will upgrade from here.
 
 
-def test_migrations_do_not_emit_raw_create_sequence_sql():
+def _iter_op_execute_sql_literals():
     """
-    Migrations must create sequences via SQLAlchemy's CreateSequence construct,
-    never a raw "CREATE SEQUENCE ..." SQL string.
+    Yield ``(location, sql_upper)`` for every literal SQL string passed to an
+    ``op.execute(...)`` call across all migration version files. ``location`` is
+    ``"<filename>:<lineno>"`` and ``sql_upper`` is the upper-cased literal.
 
-    CreateSequence is rewritten by the increment_by_zero @compiles hook in
-    privacyidea.models.db, which appends INCREMENT BY 0 on MariaDB. A Galera
-    cluster only accepts a cached sequence defined that way; a raw string
-    bypasses the hook and fails with "CACHE without INCREMENT BY 0 in Galera
-    cluster". We cannot reproduce that rejection in CI — it needs a live wsrep
-    provider, and standalone MariaDB accepts the cached sequence — so this
-    static check is the guard against the gap.
-
-    Only CREATE is restricted: ALTER SEQUENCE / DROP SEQUENCE carry no such
-    Galera constraint and may stay as raw strings.
-
-    The check only inspects strings passed to op.execute(...) — docstrings,
-    comments and print() messages that merely mention "create sequence" are
-    ignored. Both plain strings and f-strings are covered (an f-string's
-    literal segments are ast.Constant nodes).
+    Only the static literal content is inspected — docstrings, comments and
+    print() messages are ignored, as are dynamically built statements passed via
+    a variable or a helper call (those resolve to an empty literal). Both plain
+    strings and f-strings are covered (an f-string's literal segments are
+    ast.Constant nodes), and ``text("...")`` / ``sa.text("...")`` wrappers are
+    unwrapped.
     """
     import ast
 
     def _literal_sql(node) -> str:
-        """Concatenate the literal string content of a string, f-string, or text('...') argument."""
         if isinstance(node, ast.Constant) and isinstance(node.value, str):
             return node.value
         if isinstance(node, ast.JoinedStr):
@@ -828,7 +819,6 @@ def test_migrations_do_not_emit_raw_create_sequence_sql():
                 part.value for part in node.values
                 if isinstance(part, ast.Constant) and isinstance(part.value, str)
             )
-        # Unwrap text("...") / sa.text("...") wrappers.
         if isinstance(node, ast.Call) and node.args:
             func = node.func
             name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
@@ -846,20 +836,67 @@ def test_migrations_do_not_emit_raw_create_sequence_sql():
         )
 
     versions_dir = pathlib.Path(__file__).parent.parent / "privacyidea" / "migrations" / "versions"
-    offenders: list[str] = []
     for path in sorted(versions_dir.glob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
             if _is_op_execute(node) and node.args:
-                if "CREATE SEQUENCE" in _literal_sql(node.args[0]).upper():
-                    offenders.append(f"{path.name}:{node.lineno}")
+                sql = _literal_sql(node.args[0])
+                if sql:
+                    yield f"{path.name}:{node.lineno}", sql.upper()
 
+
+def test_migrations_do_not_emit_raw_create_sequence_sql():
+    """
+    Migrations must create sequences via SQLAlchemy's CreateSequence construct,
+    never a raw "CREATE SEQUENCE ..." SQL string.
+
+    CreateSequence is rewritten by the increment_by_zero @compiles hook in
+    privacyidea.models.db, which appends INCREMENT BY 0 on MariaDB. A Galera
+    cluster only accepts a cached sequence defined that way; a raw string
+    bypasses the hook and fails with "CACHE without INCREMENT BY 0 in Galera
+    cluster". We cannot reproduce that rejection in CI — it needs a live wsrep
+    provider, and standalone MariaDB accepts the cached sequence — so this
+    static check is the guard against the gap.
+
+    ALTER SEQUENCE ... RESTART hits the same constraint and is guarded by
+    test_migrations_do_not_emit_raw_alter_sequence_sql. DROP SEQUENCE carries no
+    Galera constraint and may stay a raw string.
+    """
+    offenders = [loc for loc, sql in _iter_op_execute_sql_literals() if "CREATE SEQUENCE" in sql]
     assert not offenders, (
         "The following migrations build a sequence from a raw 'CREATE SEQUENCE' "
         "string instead of SQLAlchemy's CreateSequence construct:\n"
         + "\n".join(f"  {o}" for o in offenders)
         + "\n\nUse op.execute(CreateSequence(Sequence(name, start=...), if_not_exists=...)) "
         "so the increment_by_zero hook can make it Galera-safe."
+    )
+
+
+def test_migrations_do_not_emit_raw_alter_sequence_sql():
+    """
+    Migrations must not RESTART a sequence with a raw "ALTER SEQUENCE ..." SQL
+    string. On a Galera cluster, ALTER SEQUENCE ... RESTART on a cached sequence
+    fails with the same "CACHE without INCREMENT BY 0 in Galera cluster" error as
+    CREATE SEQUENCE does. SQLAlchemy has no DDL construct for ALTER SEQUENCE that
+    the increment_by_zero hook could rewrite, and INCREMENT BY 0 is valid only on
+    MariaDB (Postgres rejects a zero increment), so the statement cannot be a
+    single dialect-agnostic literal. As with CREATE, the rejection needs a live
+    wsrep provider we don't have in CI, so this static check is the guard.
+
+    On Oracle the same statement needs different syntax again (RESTART START
+    WITH n; RESTART WITH n is a syntax error), so a raw string can be correct on
+    at most one backend.
+
+    Use privacyidea.models.db.build_restart_sequence_sql(name, n, dialect_name),
+    whose per-dialect output is verified by test_build_restart_sequence_sql_per_dialect.
+    """
+    offenders = [loc for loc, sql in _iter_op_execute_sql_literals() if "ALTER SEQUENCE" in sql]
+    assert not offenders, (
+        "The following migrations RESTART a sequence from a raw 'ALTER SEQUENCE' "
+        "string, which is not portable across backends:\n"
+        + "\n".join(f"  {o}" for o in offenders)
+        + "\n\nUse op.execute(build_restart_sequence_sql(name, restart_with, bind.dialect.name)) "
+        "(privacyidea.models.db) for the correct per-dialect syntax."
     )
 
 
@@ -887,6 +924,41 @@ def test_create_sequence_is_galera_safe_on_mariadb():
     assert "INCREMENT BY 0" not in postgres_sql, (
         f"CREATE SEQUENCE on PostgreSQL must NOT include INCREMENT BY 0 (zero increment is invalid), "
         f"got: {postgres_sql!r}"
+    )
+
+
+def test_build_restart_sequence_sql_per_dialect():
+    """
+    build_restart_sequence_sql (privacyidea.models.db) must emit the correct
+    ALTER SEQUENCE ... RESTART syntax for each backend. This is the ALTER
+    counterpart of test_create_sequence_is_galera_safe_on_mariadb and guards the
+    helper every sequence-restarting migration relies on:
+
+    * MariaDB/MySQL: RESTART WITH n + INCREMENT BY 0 (Galera rejects a cached
+      sequence's RESTART without it).
+    * PostgreSQL: plain RESTART WITH n (a zero increment is invalid).
+    * Oracle: RESTART START WITH n (RESTART WITH n is a syntax error, and
+      INCREMENT BY 0 is invalid).
+    """
+    from privacyidea.models.db import build_restart_sequence_sql
+
+    for dialect_name in ("mariadb", "mysql"):
+        sql = build_restart_sequence_sql("dummy_seq", 5, dialect_name).upper()
+        assert "RESTART WITH 5" in sql and "INCREMENT BY 0" in sql, (
+            f"ALTER SEQUENCE RESTART on {dialect_name} must be 'RESTART WITH n INCREMENT BY 0' "
+            f"to work on Galera, got: {sql!r}"
+        )
+
+    postgres_sql = build_restart_sequence_sql("dummy_seq", 5, "postgresql").upper()
+    assert "RESTART WITH 5" in postgres_sql and "INCREMENT BY 0" not in postgres_sql, (
+        f"ALTER SEQUENCE RESTART on PostgreSQL must be 'RESTART WITH n' without INCREMENT BY 0 "
+        f"(zero increment is invalid), got: {postgres_sql!r}"
+    )
+
+    oracle_sql = build_restart_sequence_sql("dummy_seq", 5, "oracle").upper()
+    assert "RESTART START WITH 5" in oracle_sql and "INCREMENT BY 0" not in oracle_sql, (
+        f"ALTER SEQUENCE RESTART on Oracle must be 'RESTART START WITH n' "
+        f"('RESTART WITH n' is a syntax error there), got: {oracle_sql!r}"
     )
 
 


### PR DESCRIPTION
…racle

The migration emitted "ALTER SEQUENCE ... RESTART WITH n" as a raw string, which a Galera cluster rejects ("CACHE without INCREMENT BY 0 in Galera cluster") and Oracle rejects as invalid syntax. CREATE/DROP SEQUENCE IF [NOT] EXISTS also fail on Oracle below 23c.

- Add build_restart_sequence_sql() emitting per-dialect RESTART syntax (MariaDB: RESTART WITH n INCREMENT BY 0; Postgres: RESTART WITH n; Oracle: RESTART START WITH n).
- Rework the migration to reflect existing sequences on Oracle and use plain CreateSequence/DropSequence constructs instead of IF [NOT] EXISTS clauses.
- Add static guards against raw ALTER SEQUENCE strings and a per-dialect unit test for the helper.
- Add an oracle-test service to docker-compose.dev.yml for local DB testing.