### PR TITLE
add lightweight before request for healthz

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -121,6 +121,22 @@ def before_user_request():
     before_request()
 
 
+@healthz_blueprint.before_request
+def before_healthz_request():
+    """
+    Lightweight request setup for the anonymous /healthz probes.
+
+    The healthz endpoints are polled frequently by orchestrators and must stay
+    cheap, so unlike :func:`before_request` this does not build an audit object
+    or resolve a user. It only populates the minimal request context that policy
+    matching relies on (the policy object and the client IP), so endpoints like
+    /healthz/resolversz can evaluate policies without raising AttributeError.
+    """
+    g.policy_object = PolicyClass()
+    g.client_ip = get_client_ip(request, get_from_config(SYSCONF.OVERRIDECLIENT))
+    g.policies = {}
+
+
 def before_create_user_request():
     """
     This function is executed before the create user endpoint.

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -121,22 +121,6 @@ def before_user_request():
     before_request()
 
 
-@healthz_blueprint.before_request
-def before_healthz_request():
-    """
-    Lightweight request setup for the anonymous /healthz probes.
-
-    The healthz endpoints are polled frequently by orchestrators and must stay
-    cheap, so unlike :func:`before_request` this does not build an audit object
-    or resolve a user. It only populates the minimal request context that policy
-    matching relies on (the policy object and the client IP), so endpoints like
-    /healthz/resolversz can evaluate policies without raising AttributeError.
-    """
-    g.policy_object = PolicyClass()
-    g.client_ip = get_client_ip(request, get_from_config(SYSCONF.OVERRIDECLIENT))
-    g.policies = {}
-
-
 def before_create_user_request():
     """
     This function is executed before the create user endpoint.

--- a/privacyidea/api/healthcheck.py
+++ b/privacyidea/api/healthcheck.py
@@ -35,15 +35,17 @@ authenticated administrator. Because the ``/healthz`` endpoints expose
 information about this server without authentication, they should be reachable
 only from a trusted network and not exposed to untrusted clients.
 """
-from flask import Blueprint, current_app, g
+from flask import Blueprint, current_app, g, request
 
 from privacyidea.api.auth import check_auth_token
 from privacyidea.api.lib.utils import send_result
 from privacyidea.lib.auth import ROLE
+from privacyidea.lib.config import get_from_config, SYSCONF, ensure_no_config_object
 from privacyidea.lib.crypto import get_hsm
 from privacyidea.lib.error import AuthError, Error
-from privacyidea.lib.policy import Match, SCOPE, PolicyAction
+from privacyidea.lib.policy import Match, PolicyClass, SCOPE, PolicyAction
 from privacyidea.lib.resolver import get_resolver_list, get_resolver_class
+from privacyidea.lib.utils import get_client_ip
 import logging
 import time
 
@@ -324,8 +326,19 @@ def resolversz():
     # So names are always admin-only (the secure default, no policy needed); the
     # policy only re-adds the 401 for a present-but-unusable token, while a
     # header-less probe stays anonymous (status only) either way.
+    #
+    # The /healthz probes have no before_request hook, so build the minimal
+    # context the policy match needs here — and only here. The other probes
+    # (livez/readyz/startupz) deliberately stay independent of the DB/config
+    # subsystem so they keep answering even while the database is unavailable.
+    ensure_no_config_object()
+    g.policy_object = PolicyClass()
+    g.client_ip = get_client_ip(request, get_from_config(SYSCONF.OVERRIDECLIENT))
+    # write_to_audit_log=False: this lightweight context has no audit object, and
+    # we do not want frequent probes writing to the audit log anyway.
     require_auth = Match.action_only(g, scope=SCOPE.AUTHZ,
-                                     action=PolicyAction.REQUIRE_AUTH_FOR_RESOLVER_DETAILS).any()
+                                     action=PolicyAction.REQUIRE_AUTH_FOR_RESOLVER_DETAILS).any(
+        write_to_audit_log=False)
     authenticated = False
     try:
         check_auth_token(required_role=[ROLE.ADMIN])

--- a/privacyidea/api/healthcheck.py
+++ b/privacyidea/api/healthcheck.py
@@ -331,14 +331,22 @@ def resolversz():
     # context the policy match needs here — and only here. The other probes
     # (livez/readyz/startupz) deliberately stay independent of the DB/config
     # subsystem so they keep answering even while the database is unavailable.
-    ensure_no_config_object()
-    g.policy_object = PolicyClass()
-    g.client_ip = get_client_ip(request, get_from_config(SYSCONF.OVERRIDECLIENT))
-    # write_to_audit_log=False: this lightweight context has no audit object, and
-    # we do not want frequent probes writing to the audit log anyway.
-    require_auth = Match.action_only(g, scope=SCOPE.AUTHZ,
-                                     action=PolicyAction.REQUIRE_AUTH_FOR_RESOLVER_DETAILS).any(
-        write_to_audit_log=False)
+    # Building this context reads the config/policies from the DB, so guard it the
+    # same way as the resolver probe below: on a DB/config failure answer with the
+    # 503 status response rather than letting an unhandled exception become a 500.
+    try:
+        ensure_no_config_object()
+        g.policy_object = PolicyClass()
+        g.client_ip = get_client_ip(request, get_from_config(SYSCONF.OVERRIDECLIENT))
+        # write_to_audit_log=False: this lightweight context has no audit object,
+        # and we do not want frequent probes writing to the audit log anyway.
+        require_auth = Match.action_only(g, scope=SCOPE.AUTHZ,
+                                         action=PolicyAction.REQUIRE_AUTH_FOR_RESOLVER_DETAILS).any(
+            write_to_audit_log=False)
+    except Exception as e:
+        log.debug(f"Exception building policy context in /resolversz endpoint: {e}")
+        return send_result({"status": "error"}), 503
+
     authenticated = False
     try:
         check_auth_token(required_role=[ROLE.ADMIN])

--- a/tests/test_api_healthcheck.py
+++ b/tests/test_api_healthcheck.py
@@ -187,21 +187,36 @@ class APIHealthcheckTestCase(MyApiTestCase):
                 check_resolvers(401, auth_token="")  # present but invalid token -> rejected
 
     def test_resolversz_without_before_request_context(self):
-        # The endpoint evaluates the require_auth_for_resolver_details policy, which
-        # needs g.client_ip and g.policy_object. A fresh request reaches the endpoint
-        # with these unset (the test base pre-seeds them on a shared app context, so
-        # we remove them here to mirror a real request); the blueprint's before_request
-        # hook must populate them so the probe still answers 200.
+        # /healthz has no before_request hook, so resolversz must build the policy
+        # context (g.policy_object, g.client_ip) it needs to evaluate the
+        # require_auth_for_resolver_details policy by itself. The test base keeps a
+        # shared app context across requests, so leftovers from earlier requests
+        # (e.g. /auth) pre-seed g.audit_object and friends and would mask missing
+        # setup. We therefore clear every request-scoped field a prior request might
+        # have left behind to mirror a truly fresh request, and restore them in a
+        # finally so the deletions do not leak into later tests sharing the context.
         from flask import g
+        cleared_attrs = ("client_ip", "policy_object", "policies", "audit_object",
+                         "request_headers", "request_data", "user_agent", "logged_in_user")
         with setup_policy("auth_for_resolvers", scope=SCOPE.AUTHZ,
                           action=f"{PolicyAction.REQUIRE_AUTH_FOR_RESOLVER_DETAILS}=true"):
             with self.app.test_request_context('/healthz/resolversz', method='GET'):
-                for attr in ("client_ip", "policy_object", "policies"):
+                saved = {attr: getattr(g, attr) for attr in cleared_attrs if hasattr(g, attr)}
+                for attr in cleared_attrs:
                     if hasattr(g, attr):
                         delattr(g, attr)
-                res = self.app.full_dispatch_request()
+                try:
+                    res = self.app.full_dispatch_request()
+                finally:
+                    for attr, value in saved.items():
+                        setattr(g, attr, value)
                 self.assertEqual(res.status_code, 200, res.data)
-                self.assertIn("status", res.json["result"]["value"])
+                value = res.json["result"]["value"]
+                self.assertIn("status", value)
+                # Anonymous probe (no Authorization header) with the policy on must
+                # not disclose per-resolver names.
+                self.assertNotIn("ldapresolver", value)
+                self.assertNotIn("sqlresolver", value)
 
     def test_resolversz_rejects_crafted_jwt_alg(self):
         # A token whose header alg is a trusted-JWT algorithm (e.g. RS256) but matches no

--- a/tests/test_api_healthcheck.py
+++ b/tests/test_api_healthcheck.py
@@ -218,6 +218,18 @@ class APIHealthcheckTestCase(MyApiTestCase):
                 self.assertNotIn("ldapresolver", value)
                 self.assertNotIn("sqlresolver", value)
 
+    def test_resolversz_returns_503_when_config_unavailable(self):
+        # Building the policy context reads config/policies from the DB. If that
+        # fails (e.g. DB outage), resolversz must degrade to its documented 503
+        # status response, not raise an unhandled exception that becomes a 500.
+        from unittest.mock import patch
+        with patch("privacyidea.api.healthcheck.get_from_config",
+                   side_effect=Exception("DB down")):
+            with self.app.test_request_context('/healthz/resolversz', method='GET'):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(503, res.status_code, res.data)
+                self.assertEqual("error", res.json["result"]["value"]["status"])
+
     def test_resolversz_rejects_crafted_jwt_alg(self):
         # A token whose header alg is a trusted-JWT algorithm (e.g. RS256) but matches no
         # PI_TRUSTED_JWT entry decodes against HS256 and would raise jwt.InvalidAlgorithmError.

--- a/tests/test_api_healthcheck.py
+++ b/tests/test_api_healthcheck.py
@@ -186,6 +186,23 @@ class APIHealthcheckTestCase(MyApiTestCase):
                 check_resolvers(200, "OK", ldap_expected_status="OK", sql_expected_status="OK", auth_token=self.at)
                 check_resolvers(401, auth_token="")  # present but invalid token -> rejected
 
+    def test_resolversz_without_before_request_context(self):
+        # The endpoint evaluates the require_auth_for_resolver_details policy, which
+        # needs g.client_ip and g.policy_object. A fresh request reaches the endpoint
+        # with these unset (the test base pre-seeds them on a shared app context, so
+        # we remove them here to mirror a real request); the blueprint's before_request
+        # hook must populate them so the probe still answers 200.
+        from flask import g
+        with setup_policy("auth_for_resolvers", scope=SCOPE.AUTHZ,
+                          action=f"{PolicyAction.REQUIRE_AUTH_FOR_RESOLVER_DETAILS}=true"):
+            with self.app.test_request_context('/healthz/resolversz', method='GET'):
+                for attr in ("client_ip", "policy_object", "policies"):
+                    if hasattr(g, attr):
+                        delattr(g, attr)
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 200, res.data)
+                self.assertIn("status", res.json["result"]["value"])
+
     def test_resolversz_rejects_crafted_jwt_alg(self):
         # A token whose header alg is a trusted-JWT algorithm (e.g. RS256) but matches no
         # PI_TRUSTED_JWT entry decodes against HS256 and would raise jwt.InvalidAlgorithmError.


### PR DESCRIPTION
API function were missing the client_ip because they did not have a before_request that populated the ip, but its required for policy matching.
Tests did not catch it because the current test structure pre-seeded it with None, from a test running before.