### PR TITLE
MariaDB Galera migration-test CI job; make v3.9 seed sequences Galera-safe

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -148,10 +148,14 @@ jobs:
         run: |
           for i in $(seq 1 30); do
             if docker exec galera healthcheck.sh --connect --innodb_initialized; then
-              docker exec -e MYSQL_PWD=root galera \
-                mariadb -uroot -N -e "SHOW STATUS LIKE 'wsrep_cluster_size'; SHOW STATUS LIKE 'wsrep_ready'"
-              echo "Galera node is ready."
-              exit 0
+              ready=$(docker exec -e MYSQL_PWD=root galera \
+                mariadb -uroot -N -B -e "SHOW STATUS LIKE 'wsrep_ready'" | awk '{print $2}')
+              if [ "$ready" = "ON" ]; then
+                docker exec -e MYSQL_PWD=root galera \
+                  mariadb -uroot -N -e "SHOW STATUS LIKE 'wsrep_cluster_size'; SHOW STATUS LIKE 'wsrep_ready'"
+                echo "Galera node is ready."
+                exit 0
+              fi
             fi
             echo "Waiting for Galera... ($i)"
             sleep 5

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -109,3 +109,74 @@ jobs:
           PYTHONWARNINGS: "once::DeprecationWarning"
         run: |
           python -b -m pytest -v --tb=short -m migration tests/test_migrations.py tests/test_migration_*.py
+
+  # MariaDB Galera needs server flags (wsrep provider + --wsrep-new-cluster) that
+  # a `services:` container can't pass, so the node is started with `docker run`.
+  # A single bootstrapped node is enough to exercise the Galera-only DDL rules
+  # (e.g. sequences require INCREMENT BY 0; CACHE without it is rejected).
+  galera-migration-tests:
+    name: Migration tests (MariaDB Galera / Python 3.13)
+    permissions:
+      checks: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Start single-node MariaDB Galera cluster
+        run: |
+          docker run -d --name galera \
+            -e MARIADB_ROOT_PASSWORD=root \
+            -e MARIADB_DATABASE=privacyidea_migration_test \
+            -e MARIADB_USER=privacyidea \
+            -e MARIADB_PASSWORD=privacyidea \
+            -p 3306:3306 \
+            mariadb:11 \
+            --wsrep-on=ON \
+            --wsrep-provider=/usr/lib/galera/libgalera_smm.so \
+            --wsrep-cluster-address=gcomm:// \
+            --wsrep-cluster-name=ci-galera \
+            --wsrep-node-address=127.0.0.1 \
+            --binlog-format=ROW \
+            --default-storage-engine=InnoDB \
+            --innodb-autoinc-lock-mode=2 \
+            --wsrep-new-cluster
+
+      - name: Wait for Galera to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if docker exec galera healthcheck.sh --connect --innodb_initialized; then
+              docker exec -e MYSQL_PWD=root galera \
+                mariadb -uroot -N -e "SHOW STATUS LIKE 'wsrep_cluster_size'; SHOW STATUS LIKE 'wsrep_ready'"
+              echo "Galera node is ready."
+              exit 0
+            fi
+            echo "Waiting for Galera... ($i)"
+            sleep 5
+          done
+          echo "::error::Galera node did not become ready in time"
+          docker logs galera
+          exit 1
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            tests/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          pip install -r tests/requirements.txt
+          pip install PyMySQL
+
+      - name: Run migration tests
+        env:
+          TEST_DATABASE_URL: "mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3306/privacyidea_migration_test"
+          PYTHONWARNINGS: "once::DeprecationWarning"
+        run: |
+          python -b -m pytest -v --tb=short -m migration tests/test_migrations.py tests/test_migration_*.py

--- a/tests/testdata/migrations/seed_v3.9_5cb310101a1f_mariadb.sql
+++ b/tests/testdata/migrations/seed_v3.9_5cb310101a1f_mariadb.sql
@@ -1264,45 +1264,52 @@ INSERT INTO `pidea_audit` (`date`, `action`, `success`, `serial`, `token_type`, 
 -- SEQUENCEs in directly to match the on-disk state of an upgraded install.
 -- START WITH values match MAX(id)+1 of the seeded data so the next nextval
 -- returns a free PK.
+--
+-- INCREMENT BY 0 is required for the seed to load on a MariaDB Galera cluster:
+-- Galera rejects a cached sequence (the default) unless INCREMENT BY 0 is set,
+-- failing with "CACHE without INCREMENT BY 0 in Galera cluster" (ERROR 1235).
+-- On a standalone server INCREMENT BY 0 behaves like the default increment of
+-- 1, so the same seed loads identically on both — see the Galera CI job in
+-- .github/workflows/migration-tests.yml.
 -- ---------------------------------------------------------------------------
-CREATE SEQUENCE `audit_seq` START WITH 3;
-CREATE SEQUENCE `authcache_seq` START WITH 1;
-CREATE SEQUENCE `caconfig_seq` START WITH 1;
-CREATE SEQUENCE `caconnector_seq` START WITH 1;
-CREATE SEQUENCE `challenge_seq` START WITH 1;
-CREATE SEQUENCE `clientapp_seq` START WITH 3;
-CREATE SEQUENCE `customuserattribute_seq` START WITH 2;
-CREATE SEQUENCE `eventcounter_seq` START WITH 3;
-CREATE SEQUENCE `eventhandler_seq` START WITH 2;
-CREATE SEQUENCE `eventhandlercond_seq` START WITH 2;
-CREATE SEQUENCE `eventhandleropt_seq` START WITH 3;
-CREATE SEQUENCE `machineresolver_seq` START WITH 1;
-CREATE SEQUENCE `machineresolverconf_seq` START WITH 1;
-CREATE SEQUENCE `machinetoken_seq` START WITH 1;
-CREATE SEQUENCE `machtokenopt_seq` START WITH 1;
-CREATE SEQUENCE `monitoringstats_seq` START WITH 3;
-CREATE SEQUENCE `periodictask_seq` START WITH 2;
-CREATE SEQUENCE `periodictasklastrun_seq` START WITH 2;
-CREATE SEQUENCE `periodictaskopt_seq` START WITH 2;
-CREATE SEQUENCE `policy_seq` START WITH 5;
-CREATE SEQUENCE `policycondition_seq` START WITH 2;
-CREATE SEQUENCE `privacyideaserver_seq` START WITH 1;
-CREATE SEQUENCE `pwreset_seq` START WITH 1;
-CREATE SEQUENCE `radiusserver_seq` START WITH 1;
-CREATE SEQUENCE `realm_seq` START WITH 3;
-CREATE SEQUENCE `resolver_seq` START WITH 2;
-CREATE SEQUENCE `resolverconf_seq` START WITH 2;
-CREATE SEQUENCE `resolverrealm_seq` START WITH 3;
-CREATE SEQUENCE `serviceid_seq` START WITH 2;
-CREATE SEQUENCE `smsgateway_seq` START WITH 2;
-CREATE SEQUENCE `smsgwoption_seq` START WITH 3;
-CREATE SEQUENCE `smtpserver_seq` START WITH 2;
-CREATE SEQUENCE `subscription_seq` START WITH 1;
-CREATE SEQUENCE `token_seq` START WITH 4;
-CREATE SEQUENCE `tokeninfo_seq` START WITH 5;
-CREATE SEQUENCE `tokenowner_seq` START WITH 3;
-CREATE SEQUENCE `tokenrealm_seq` START WITH 4;
-CREATE SEQUENCE `usercache_seq` START WITH 1;
+CREATE SEQUENCE `audit_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `authcache_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `caconfig_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `caconnector_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `challenge_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `clientapp_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `customuserattribute_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `eventcounter_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `eventhandler_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `eventhandlercond_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `eventhandleropt_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `machineresolver_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `machineresolverconf_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `machinetoken_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `machtokenopt_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `monitoringstats_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `periodictask_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `periodictasklastrun_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `periodictaskopt_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `policy_seq` START WITH 5 INCREMENT BY 0;
+CREATE SEQUENCE `policycondition_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `privacyideaserver_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `pwreset_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `radiusserver_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `realm_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `resolver_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `resolverconf_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `resolverrealm_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `serviceid_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `smsgateway_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `smsgwoption_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `smtpserver_seq` START WITH 2 INCREMENT BY 0;
+CREATE SEQUENCE `subscription_seq` START WITH 1 INCREMENT BY 0;
+CREATE SEQUENCE `token_seq` START WITH 4 INCREMENT BY 0;
+CREATE SEQUENCE `tokeninfo_seq` START WITH 5 INCREMENT BY 0;
+CREATE SEQUENCE `tokenowner_seq` START WITH 3 INCREMENT BY 0;
+CREATE SEQUENCE `tokenrealm_seq` START WITH 4 INCREMENT BY 0;
+CREATE SEQUENCE `usercache_seq` START WITH 1 INCREMENT BY 0;
 
 -- ---------------------------------------------------------------------------
 -- alembic_version — stamp the DB at START_REVISION


### PR DESCRIPTION
Adds a galera-migration-tests job to the migration-tests workflow. Galera needs wsrep server flags and --wsrep-new-cluster, which a services: container block can't pass, so the node is started with docker run and a readiness wait. A single bootstrapped node is enough to exercise the Galera-only DDL rules.

Appends INCREMENT BY 0 to every CREATE SEQUENCE in the MariaDB v3.9 seed: Galera rejects a cached sequence without it (ERROR 1235, "CACHE without INCREMENT BY 0 in Galera cluster"). On a standalone server INCREMENT BY 0 behaves like the default increment of 1, so the same seed loads identically on both. Verified: 12 migration tests pass on both a Galera node and a standalone mariadb:11.