### PR TITLE
user settings part one

### DIFF
--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -424,3 +424,25 @@ You can do this using the following config values::
 
 In this example the file ``mystatic/templates/myindex.html`` would be loaded
 as the initial single page application.
+
+
+.. _user_settings:
+
+User Settings
+-------------
+
+The Web UI can store per-user settings (UI preferences) on the server via the
+``/user/settings`` endpoint. These settings are not interpreted by the backend;
+they are only stored and served back to the Web UI of the logged-in user.
+
+The set of accepted setting keys can be extended without a code change::
+
+    PI_USER_SETTINGS_ALLOWED_KEYS = ["my_custom_key", "another_key"]
+
+The value is a list of additional allowed keys (a comma-separated string is also
+accepted when set via an environment variable).
+
+.. note:: Key enforcement is not active yet. Currently any key is accepted (only
+   the document structure and a size limit are enforced) so the Web UI can evolve
+   its settings freely. ``PI_USER_SETTINGS_ALLOWED_KEYS`` will take effect once
+   key enforcement is enabled.

--- a/privacyidea/api/user.py
+++ b/privacyidea/api/user.py
@@ -180,7 +180,7 @@ def get_user_settings_api():
         :http:post:`/auth`.
     :status 200: the settings object in ``result.value``.
     """
-    subject = SettingsSubject.from_logged_in_user(g.logged_in_user)
+    subject = SettingsSubject.from_logged_in_user(g.logged_in_user, request.User)
     settings = get_user_settings(subject)
     g.audit_object.log({"success": True})
     return send_result(settings)
@@ -192,21 +192,23 @@ def set_user_settings_api():
     """
     Store WebUI settings for the logged-in principal.
 
-    The settings are validated against the server-side schema (unknown keys,
-    wrong types and oversized payloads are rejected). By default the given
-    keys are merged into the existing settings; pass ``replace=1`` to replace
-    the whole document. Always scoped to the caller's own JWT identity.
+    The settings must be a JSON object and stay within the server-side size
+    limit; key and value-type enforcement is not active yet, so any keys are
+    currently accepted (see ``PI_USER_SETTINGS_ALLOWED_KEYS``). By default the
+    given keys are merged into the existing settings; pass ``replace=1`` to
+    replace the whole document. Always scoped to the caller's own JWT identity.
 
     Requires authentication (any role).
 
     :jsonparam settings: a JSON object with the settings to store.
     :jsonparam replace: if true, replace the whole document instead of merging.
     :status 200: the stored settings object in ``result.value``.
-    :status 400: a setting is unknown, of the wrong type or too large.
+    :status 400: the settings are not a JSON object, not JSON-serializable, or
+        exceed the maximum size.
     """
     settings = get_required(request.all_data, "settings")
     replace = is_true(get_optional(request.all_data, "replace"))
-    subject = SettingsSubject.from_logged_in_user(g.logged_in_user)
+    subject = SettingsSubject.from_logged_in_user(g.logged_in_user, request.User)
     stored = set_user_settings(subject, settings, replace=replace)
     g.audit_object.log({"success": True})
     return send_result(stored)

--- a/privacyidea/api/user.py
+++ b/privacyidea/api/user.py
@@ -63,7 +63,8 @@ from privacyidea.lib.event import event
 from privacyidea.lib.policies.actions import PolicyAction
 from privacyidea.lib.policy import get_allowed_custom_attributes
 from privacyidea.lib.user import get_user_list, create_user, User, is_attribute_at_all, get_user_from_param
-from privacyidea.lib.usersetting import SettingsSubject, get_user_settings, set_user_settings
+from privacyidea.lib.usersetting import (SettingsSubject, delete_user_settings, get_user_settings,
+                                         set_user_settings)
 from privacyidea.lib.utils import is_true
 
 log = logging.getLogger(__name__)
@@ -171,8 +172,9 @@ def get_user_settings_api():
     Return the WebUI settings of the logged-in principal.
 
     The settings are always scoped to the caller's own JWT identity; there
-    is no way to read another principal's settings through this endpoint.
-    Declared defaults are merged in, so the response is always complete.
+    is no way to read another principal's settings through this endpoint. The
+    stored document is returned verbatim (an empty object if nothing has been
+    stored); the WebUI applies its own defaults for absent keys.
 
     Requires authentication (any role).
 
@@ -202,7 +204,8 @@ def set_user_settings_api():
 
     :jsonparam settings: a JSON object with the settings to store.
     :jsonparam replace: if true, replace the whole document instead of merging.
-    :status 200: the stored settings object in ``result.value``.
+    :status 200: the stored settings object in ``result.value`` -- the same
+        shape :http:get:`/user/settings` returns.
     :status 400: the settings are not a JSON object, not JSON-serializable, or
         exceed the maximum size.
     """
@@ -212,6 +215,28 @@ def set_user_settings_api():
     stored = set_user_settings(subject, settings, replace=replace)
     g.audit_object.log({"success": True})
     return send_result(stored)
+
+
+@user_blueprint.route('/settings', methods=['DELETE'])
+@user_blueprint.route('/settings/<key>', methods=['DELETE'])
+@event("user_settings_delete", request, g)
+def delete_user_settings_api(key=None):
+    """
+    Delete WebUI settings of the logged-in principal.
+
+    With a ``key`` path segment only that setting is removed (the WebUI then
+    falls back to its own default for it); without one the whole document is
+    cleared. Always scoped to the caller's own JWT identity.
+
+    Requires authentication (any role).
+
+    :param key: the single setting to delete; omit to clear all settings.
+    :status 200: the remaining settings object in ``result.value``.
+    """
+    subject = SettingsSubject.from_logged_in_user(g.logged_in_user, request.User)
+    remaining = delete_user_settings(subject, key=key)
+    g.audit_object.log({"success": True})
+    return send_result(remaining)
 
 
 @user_blueprint.route('/attribute', methods=['POST'])

--- a/privacyidea/api/user.py
+++ b/privacyidea/api/user.py
@@ -63,6 +63,7 @@ from privacyidea.lib.event import event
 from privacyidea.lib.policies.actions import PolicyAction
 from privacyidea.lib.policy import get_allowed_custom_attributes
 from privacyidea.lib.user import get_user_list, create_user, User, is_attribute_at_all, get_user_from_param
+from privacyidea.lib.usersetting import SettingsSubject, get_user_settings, set_user_settings
 from privacyidea.lib.utils import is_true
 
 log = logging.getLogger(__name__)
@@ -161,6 +162,54 @@ def get_users():
                         'info': f"realm: {realm!s}"})
 
     return send_result(users)
+
+
+@user_blueprint.route('/settings', methods=['GET'])
+@event("user_settings_get", request, g)
+def get_user_settings_api():
+    """
+    Return the WebUI settings of the logged-in principal.
+
+    The settings are always scoped to the caller's own JWT identity; there
+    is no way to read another principal's settings through this endpoint.
+    Declared defaults are merged in, so the response is always complete.
+
+    Requires authentication (any role).
+
+    :reqheader PI-Authorization: JWT auth token returned by
+        :http:post:`/auth`.
+    :status 200: the settings object in ``result.value``.
+    """
+    subject = SettingsSubject.from_logged_in_user(g.logged_in_user)
+    settings = get_user_settings(subject)
+    g.audit_object.log({"success": True})
+    return send_result(settings)
+
+
+@user_blueprint.route('/settings', methods=['POST'])
+@event("user_settings_set", request, g)
+def set_user_settings_api():
+    """
+    Store WebUI settings for the logged-in principal.
+
+    The settings are validated against the server-side schema (unknown keys,
+    wrong types and oversized payloads are rejected). By default the given
+    keys are merged into the existing settings; pass ``replace=1`` to replace
+    the whole document. Always scoped to the caller's own JWT identity.
+
+    Requires authentication (any role).
+
+    :jsonparam settings: a JSON object with the settings to store.
+    :jsonparam replace: if true, replace the whole document instead of merging.
+    :status 200: the stored settings object in ``result.value``.
+    :status 400: a setting is unknown, of the wrong type or too large.
+    """
+    settings = get_required(request.all_data, "settings")
+    replace = is_true(get_optional(request.all_data, "replace"))
+    subject = SettingsSubject.from_logged_in_user(g.logged_in_user)
+    stored = set_user_settings(subject, settings, replace=replace)
+    g.audit_object.log({"success": True})
+    return send_result(stored)
 
 
 @user_blueprint.route('/attribute', methods=['POST'])

--- a/privacyidea/cli/pitokenjanitor/main.py
+++ b/privacyidea/cli/pitokenjanitor/main.py
@@ -24,6 +24,7 @@ from privacyidea.cli.pitokenjanitor.utils.deprecated import deprecated
 from privacyidea.cli.pitokenjanitor.utils.findcontainer import findcontainer
 from privacyidea.cli.pitokenjanitor.utils.findinternalattributes import findinternalattributes
 from privacyidea.cli.pitokenjanitor.utils.findtokens import findtokens
+from privacyidea.cli.pitokenjanitor.utils.findusersettings import findusersettings
 from privacyidea.cli.pitokenjanitor.utils.importtokens import importtokens_cli
 from privacyidea.cli.pitokenjanitor.utils.updatetokens import updatetokens
 
@@ -61,6 +62,7 @@ cli.add_command(importtokens_cli)
 cli.add_command(updatetokens)
 cli.add_command(findcontainer)
 cli.add_command(findinternalattributes)
+cli.add_command(findusersettings)
 cli.add_command(deprecated)
 
 if __name__ == '__main__':

--- a/privacyidea/cli/pitokenjanitor/utils/findusersettings.py
+++ b/privacyidea/cli/pitokenjanitor/utils/findusersettings.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: (C) 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-FileCopyrightText: (C) 2026 Nils Behlen <nils.behlen@netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This code is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+Find and clean up orphaned rows in the ``usersetting`` table.
+
+A user removed from the user store, or a local admin deleted from the DB,
+leaves behind a ``usersetting`` row that the normal API can no longer reach.
+(Realm deletion is already handled by the realm foreign key.) This command
+surfaces those rows, and optionally deletes them.
+"""
+import click
+from flask.cli import AppGroup
+
+from privacyidea.lib.usersetting import (
+    delete_orphaned_user_settings,
+    find_orphaned_user_settings,
+)
+
+
+@click.group('user-settings', invoke_without_command=True, cls=AppGroup)
+@click.option('--orphaned-on-error', is_flag=True, default=False,
+              help="Treat a row as orphaned if the resolver raises while "
+                   "looking up the user (e.g. resolver unreachable).")
+@click.pass_context
+def findusersettings(ctx, orphaned_on_error):
+    """
+    Find orphaned rows in the user-settings table.
+
+    A row is orphaned when its principal no longer exists — a resolver user
+    deleted from the store, or a local admin removed from the database.
+    Without a subcommand the orphans are listed; pass ``delete`` to remove them.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj['orphans'] = find_orphaned_user_settings(orphaned_on_error=orphaned_on_error)
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(list_cmd)
+
+
+@findusersettings.command('list')
+@click.pass_context
+def list_cmd(ctx):
+    """List the orphaned user-settings rows."""
+    orphans = ctx.obj['orphans']
+    if not orphans:
+        click.echo("No orphaned user settings found.")
+        return
+    click.echo(f"Found {len(orphans)} orphaned row(s) in usersetting:")
+    for row in orphans:
+        if row.subject_type == "local_admin":
+            click.echo(f"  local_admin  username={row.username!r}")
+        else:
+            click.echo(f"  user  user_id={row.user_id!r}  resolver={row.resolver!r}  "
+                       f"realm_id={row.realm_id!r}")
+
+
+@findusersettings.command('delete')
+@click.option('--yes', is_flag=True, default=False,
+              help="Skip the interactive confirmation.")
+@click.pass_context
+def delete_cmd(ctx, yes):
+    """Delete every usersetting row that belongs to an orphaned principal."""
+    orphans = ctx.obj['orphans']
+    if not orphans:
+        click.echo("No orphaned user settings found.")
+        return
+    if not yes:
+        click.confirm(f"Delete user settings for {len(orphans)} orphaned principal(s)?",
+                      abort=True)
+    deleted = delete_orphaned_user_settings(orphans)
+    click.echo(f"Deleted {deleted} usersetting row(s).")

--- a/privacyidea/lib/usersetting.py
+++ b/privacyidea/lib/usersetting.py
@@ -34,10 +34,10 @@ import json
 import logging
 from dataclasses import dataclass
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 
-from privacyidea.lib.auth import ROLE
+from privacyidea.lib.auth import ROLE, db_admin_exists
 from privacyidea.lib.error import ParameterError, UserError
 from privacyidea.lib.framework import get_app_config_value
 from privacyidea.lib.user import User
@@ -219,7 +219,10 @@ def set_user_settings(subject: SettingsSubject, settings: dict, replace: bool = 
     if not subject.is_identified():
         raise UserError("Cannot store settings for an unidentified subject "
                         f"(subject_type={subject.subject_type!r}, username={subject.username!r}).")
-    row = db.session.scalars(_select_for_subject(subject)).first()
+    # Lock the row for the read-modify-write so two concurrent partial updates
+    # (e.g. two browser tabs) serialize instead of last-writer-wins clobbering
+    # each other's keys. No-op on SQLite; a real row lock on Postgres/MariaDB.
+    row = db.session.scalars(_select_for_subject(subject).with_for_update()).first()
     new_settings = _merge_settings(row.settings if row else None, settings, replace)
     # Re-validate the full document, not just the incoming delta, so the size
     # cap cannot be bypassed by accumulating keys across repeated partial writes.
@@ -243,7 +246,7 @@ def set_user_settings(subject: SettingsSubject, settings: dict, replace: bool = 
         # NULL realm_id makes the key non-unique, so that race can still leave a
         # duplicate row). Recover by re-reading and applying the update.
         db.session.rollback()
-        row = db.session.scalars(_select_for_subject(subject)).first()
+        row = db.session.scalars(_select_for_subject(subject).with_for_update()).first()
         if row is None:
             raise
         row.settings = _merge_settings(row.settings, settings, replace)
@@ -265,7 +268,8 @@ def delete_user_settings(subject: SettingsSubject, key: str | None = None) -> di
     # Same guard as reads: never match the shared row of unidentified principals.
     if not subject.is_identified():
         return {}
-    row = db.session.scalars(_select_for_subject(subject)).first()
+    # Lock the row so a key removal does not race with a concurrent write.
+    row = db.session.scalars(_select_for_subject(subject).with_for_update()).first()
     if row is None:
         return {}
     if key is None:
@@ -281,3 +285,67 @@ def delete_user_settings(subject: SettingsSubject, key: str | None = None) -> di
     row.settings = current
     row.save()
     return row.settings or {}
+
+
+def find_orphaned_user_settings(orphaned_on_error: bool = False) -> list[UserSetting]:
+    """
+    Return the ``usersetting`` rows whose principal no longer exists.
+
+    A row is orphaned when:
+
+    * (``user`` rows) its ``(user_id, resolver, realm_id)`` no longer resolves
+      to a user -- the resolver is gone, the uid no longer exists, or the row
+      has empty identifiers; or
+    * (``local_admin`` rows) its ``username`` is no longer in the ``admin``
+      table.
+
+    The realm FK removes rows when a *realm* is deleted, but a user removed
+    from the store (or an admin deleted from the DB) leaves a row that the
+    normal API can no longer reach. There is no periodic task for this -- like
+    ``internaluserattribute``, cleanup is a manual CLI command.
+
+    :param orphaned_on_error: if a resolver raises while looking up the user,
+        treat that row as orphaned (mirrors ``find_orphaned_internal_attributes``).
+    """
+    from privacyidea.lib.resolver import get_resolver_object
+
+    rows = db.session.scalars(select(UserSetting)).all()
+    orphans: list[UserSetting] = []
+    resolver_cache: dict = {}
+    for row in rows:
+        if row.subject_type == SUBJECT_LOCAL_ADMIN:
+            if not row.username or not db_admin_exists(row.username):
+                orphans.append(row)
+            continue
+        # SUBJECT_USER: reuse the internaluserattribute orphan logic.
+        if not row.user_id or not row.resolver:
+            orphans.append(row)
+            continue
+        if row.resolver not in resolver_cache:
+            resolver_cache[row.resolver] = get_resolver_object(row.resolver)
+        resolver = resolver_cache[row.resolver]
+        if resolver is None:
+            orphans.append(row)
+            continue
+        try:
+            login = resolver.getUsername(row.user_id)
+        except Exception:
+            if orphaned_on_error:
+                orphans.append(row)
+            continue
+        if not login:
+            orphans.append(row)
+    return orphans
+
+
+def delete_orphaned_user_settings(orphans: list[UserSetting]) -> int:
+    """
+    Delete the given orphaned ``usersetting`` rows (by id) and return the count.
+    Bypasses the normal API on purpose -- orphans cannot be addressed through it.
+    """
+    if not orphans:
+        return 0
+    ids = [row.id for row in orphans]
+    total = db.session.execute(delete(UserSetting).where(UserSetting.id.in_(ids))).rowcount
+    db.session.commit()
+    return total

--- a/privacyidea/lib/usersetting.py
+++ b/privacyidea/lib/usersetting.py
@@ -33,8 +33,9 @@ import logging
 from dataclasses import dataclass
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
-from privacyidea.lib.error import ParameterError
+from privacyidea.lib.error import ParameterError, UserError
 from privacyidea.lib.framework import get_app_config_value
 from privacyidea.lib.user import User
 from privacyidea.models import UserSetting, db
@@ -94,8 +95,23 @@ class SettingsSubject:
     resolver: str = ""
     realm_id: int | None = None
 
+    def is_identified(self) -> bool:
+        """
+        Whether the subject has a concrete identity to key a row on.
+
+        A local admin needs a username; a resolver user needs both a user_id
+        and a realm_id. An unresolved user has an empty user_id (and possibly a
+        NULL realm_id), and since SQL treats NULLs in the unique key as
+        distinct, keying a row on those empty values would make every
+        unresolved principal share one row (cross-user leak). Mirrors
+        ``User._require_resolved_for_write``.
+        """
+        if self.subject_type == SUBJECT_LOCAL_ADMIN:
+            return bool(self.username)
+        return bool(self.user_id) and bool(self.realm_id)
+
     @classmethod
-    def from_logged_in_user(cls, logged_in_user: dict) -> "SettingsSubject":
+    def from_logged_in_user(cls, logged_in_user: dict, resolved_user: "User | None" = None) -> "SettingsSubject":
         """
         Derive the settings subject from ``g.logged_in_user`` (carrying
         ``username``, ``realm`` and ``role`` from the JWT).
@@ -104,13 +120,23 @@ class SettingsSubject:
         principal with a realm (including realm-admins) is treated as a
         resolver user and keyed by its stable ``(user_id, resolver, realm_id)``
         identity.
+
+        ``resolved_user`` may be ``request.User`` to avoid a second resolver
+        lookup. It is only trusted for the ``user`` role: ``resolve_logged_in_user``
+        forces ``request.User`` to the JWT identity for users, whereas for an
+        admin it can reflect a ``user=`` request parameter, which must never
+        decide whose settings are read or written.
         """
         username = logged_in_user.get("username") or ""
         realm = logged_in_user.get("realm") or ""
         role = logged_in_user.get("role")
         if role == "admin" and not realm:
             return cls(subject_type=SUBJECT_LOCAL_ADMIN, username=username)
-        user = User(login=username, realm=realm)
+        if (role == "user" and resolved_user is not None and resolved_user.login == username
+                and (resolved_user.realm or "") == realm.lower() and resolved_user.uid):
+            user = resolved_user
+        else:
+            user = User(login=username, realm=realm)
         if not user.uid:
             log.warning(f"Could not resolve settings subject for user '{username}' in realm '{realm}'.")
         return cls(subject_type=SUBJECT_USER, username=username,
@@ -121,16 +147,23 @@ def validate_user_settings(settings: dict) -> None:
     """
     Validate a settings document before it is stored.
 
-    For now this only enforces structure: the document must be a JSON object
-    and stay within :data:`MAX_SETTINGS_BYTES`. Any key with any value is
-    accepted so the frontend can iterate on the setting set without a backend
-    change.
+    For now this only enforces structure: the document must be a JSON object,
+    be JSON-serializable, and stay within :data:`MAX_SETTINGS_BYTES`. Any key
+    with any value is accepted so the frontend can iterate on the setting set
+    without a backend change.
 
     Raises :class:`ParameterError` on the first problem found.
     """
     if not isinstance(settings, dict):
         raise ParameterError("The settings must be a JSON object.")
-    if len(json.dumps(settings).encode("utf-8")) > MAX_SETTINGS_BYTES:
+    try:
+        # ensure_ascii=False so the byte count matches what the JSON column
+        # actually stores; the default would inflate non-ASCII characters into
+        # \uXXXX escapes and reject valid documents below the real limit.
+        serialized = json.dumps(settings, ensure_ascii=False)
+    except (TypeError, ValueError) as error:
+        raise ParameterError(f"The settings must be JSON-serializable: {error}")
+    if len(serialized.encode("utf-8")) > MAX_SETTINGS_BYTES:
         raise ParameterError(f"The settings exceed the maximum size of {MAX_SETTINGS_BYTES} bytes.")
     # TODO: Enforce the set of allowed keys once the frontend has settled them.
     #  Reject any key not in get_allowed_keys() (SETTINGS_SCHEMA +
@@ -145,12 +178,24 @@ def _select_for_subject(subject: SettingsSubject):
                                          resolver=subject.resolver, realm_id=subject.realm_id)
 
 
+def _merge_settings(existing: dict | None, incoming: dict, replace: bool) -> dict:
+    """Compute the new settings document: ``incoming`` replaces or is merged onto ``existing``."""
+    if replace:
+        return incoming
+    return {**(existing or {}), **incoming}
+
+
 def get_user_settings(subject: SettingsSubject) -> dict:
     """
     Return the principal's settings, with every declared default filled in
     for keys the principal has not overridden.
     """
     defaults = {key: spec["default"] for key, spec in SETTINGS_SCHEMA.items()}
+    # An unidentified subject must not query with empty/NULL keys: it would
+    # match the shared row of every other unidentified principal. Reads are
+    # tolerated and just return the defaults.
+    if not subject.is_identified():
+        return defaults
     row = db.session.scalars(_select_for_subject(subject)).first()
     if row and row.settings:
         defaults.update(row.settings)
@@ -168,17 +213,32 @@ def set_user_settings(subject: SettingsSubject, settings: dict, replace: bool = 
     :return: the raw stored settings (without defaults merged in)
     """
     validate_user_settings(settings)
+    if not subject.is_identified():
+        raise UserError("Cannot store settings for an unidentified subject "
+                        f"(subject_type={subject.subject_type!r}, username={subject.username!r}).")
     row = db.session.scalars(_select_for_subject(subject)).first()
+    new_settings = _merge_settings(row.settings if row else None, settings, replace)
+    # Re-validate the full document, not just the incoming delta, so the size
+    # cap cannot be bypassed by accumulating keys across repeated partial writes.
+    validate_user_settings(new_settings)
     if row is None:
         row = UserSetting(subject_type=subject.subject_type, username=subject.username,
                           user_id=subject.user_id, resolver=subject.resolver,
-                          realm_id=subject.realm_id, settings=settings)
+                          realm_id=subject.realm_id, settings=new_settings)
     else:
-        if replace:
-            row.settings = settings
-        else:
-            merged = dict(row.settings or {})
-            merged.update(settings)
-            row.settings = merged
-    row.save()
+        row.settings = new_settings
+    try:
+        row.save()
+    except IntegrityError:
+        # A concurrent request created the row between our SELECT and INSERT
+        # (the unique constraint fires for resolver users; for local admins the
+        # NULL realm_id makes the key non-unique, so that race can still leave a
+        # duplicate row). Recover by re-reading and applying the update.
+        db.session.rollback()
+        row = db.session.scalars(_select_for_subject(subject)).first()
+        if row is None:
+            raise
+        row.settings = _merge_settings(row.settings, settings, replace)
+        validate_user_settings(row.settings)
+        row.save()
     return row.settings or {}

--- a/privacyidea/lib/usersetting.py
+++ b/privacyidea/lib/usersetting.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: (C) 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-FileCopyrightText: (C) 2026 Nils Behlen <nils.behlen@netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Per-principal frontend settings.
+
+This module stores and serves the WebUI settings of whoever is logged in
+(a local admin or a resolver user). The backend does not act on these
+settings; it only validates them on write and merges them over the
+declared defaults on read.
+
+The data lives in the ``usersetting`` table, one JSON document per
+principal. See :class:`privacyidea.models.usersetting.UserSetting` for the
+identity model (``local_admin`` keyed by username, ``user`` keyed by the
+resolver identity tuple).
+"""
+import json
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import select
+
+from privacyidea.lib.error import ParameterError
+from privacyidea.lib.framework import get_app_config_value
+from privacyidea.lib.user import User
+from privacyidea.models import UserSetting, db
+
+log = logging.getLogger(__name__)
+
+SUBJECT_LOCAL_ADMIN = "local_admin"
+SUBJECT_USER = "user"
+
+# Hard cap on the serialized settings document, so the column cannot be abused
+# as arbitrary per-principal storage. The settings are small UI preferences.
+MAX_SETTINGS_BYTES = 8192
+
+# pi.cfg / environment option letting admins extend the set of accepted setting
+# keys without a code change, e.g. PI_USER_SETTINGS_ALLOWED_KEYS = ["foo", "bar"].
+# Accepts a list (pi.cfg) or a comma-separated string (environment variable).
+# Placeholder for now: get_allowed_keys() is wired up but not yet enforced (see
+# the TODO in validate_user_settings).
+USER_SETTINGS_ALLOWED_KEYS_CONFIG = "PI_USER_SETTINGS_ALLOWED_KEYS"
+
+# Declarative registry of the settings the WebUI may store. The backend is the
+# source of truth for *which* settings exist; adding a new setting is a one-line
+# entry here. ``default`` is merged in on read; ``type`` will be checked on write
+# once key enforcement is turned on. Admins can add further accepted keys via
+# PI_USER_SETTINGS_ALLOWED_KEYS without touching this registry.
+#
+# NOTE: the keys below are PLACEHOLDERS to exercise the mechanism. The frontend
+# team defines the real set; do not treat these names as a committed API yet.
+SETTINGS_SCHEMA = {
+    "theme": {"type": str, "default": "light"},
+    "language": {"type": str, "default": "en"},
+    "tokens_per_page": {"type": int, "default": 25},
+    "advanced_mode": {"type": bool, "default": False},
+}
+
+
+def get_allowed_keys() -> set:
+    """
+    The set of accepted setting keys: the keys declared in
+    :data:`SETTINGS_SCHEMA` plus any added by the admin via the
+    ``PI_USER_SETTINGS_ALLOWED_KEYS`` config option.
+    """
+    allowed = set(SETTINGS_SCHEMA)
+    configured = get_app_config_value(USER_SETTINGS_ALLOWED_KEYS_CONFIG, [])
+    if isinstance(configured, str):
+        configured = [key.strip() for key in configured.split(",") if key.strip()]
+    allowed.update(configured or [])
+    return allowed
+
+
+@dataclass
+class SettingsSubject:
+    """The principal a settings document belongs to."""
+    subject_type: str
+    username: str = ""
+    user_id: str = ""
+    resolver: str = ""
+    realm_id: int | None = None
+
+    @classmethod
+    def from_logged_in_user(cls, logged_in_user: dict) -> "SettingsSubject":
+        """
+        Derive the settings subject from ``g.logged_in_user`` (carrying
+        ``username``, ``realm`` and ``role`` from the JWT).
+
+        A logged-in admin without a realm is an internal/local admin. Any
+        principal with a realm (including realm-admins) is treated as a
+        resolver user and keyed by its stable ``(user_id, resolver, realm_id)``
+        identity.
+        """
+        username = logged_in_user.get("username") or ""
+        realm = logged_in_user.get("realm") or ""
+        role = logged_in_user.get("role")
+        if role == "admin" and not realm:
+            return cls(subject_type=SUBJECT_LOCAL_ADMIN, username=username)
+        user = User(login=username, realm=realm)
+        if not user.uid:
+            log.warning(f"Could not resolve settings subject for user '{username}' in realm '{realm}'.")
+        return cls(subject_type=SUBJECT_USER, username=username,
+                   user_id=user.uid or "", resolver=user.resolver or "", realm_id=user.realm_id)
+
+
+def validate_user_settings(settings: dict) -> None:
+    """
+    Validate a settings document before it is stored.
+
+    For now this only enforces structure: the document must be a JSON object
+    and stay within :data:`MAX_SETTINGS_BYTES`. Any key with any value is
+    accepted so the frontend can iterate on the setting set without a backend
+    change.
+
+    Raises :class:`ParameterError` on the first problem found.
+    """
+    if not isinstance(settings, dict):
+        raise ParameterError("The settings must be a JSON object.")
+    if len(json.dumps(settings).encode("utf-8")) > MAX_SETTINGS_BYTES:
+        raise ParameterError(f"The settings exceed the maximum size of {MAX_SETTINGS_BYTES} bytes.")
+    # TODO: Enforce the set of allowed keys once the frontend has settled them.
+    #  Reject any key not in get_allowed_keys() (SETTINGS_SCHEMA +
+    #  PI_USER_SETTINGS_ALLOWED_KEYS) and type-check the SETTINGS_SCHEMA entries
+    #  against their declared "type" here (bool is a subclass of int, guard that).
+
+
+def _select_for_subject(subject: SettingsSubject):
+    if subject.subject_type == SUBJECT_LOCAL_ADMIN:
+        return select(UserSetting).filter_by(subject_type=SUBJECT_LOCAL_ADMIN, username=subject.username)
+    return select(UserSetting).filter_by(subject_type=SUBJECT_USER, user_id=subject.user_id,
+                                         resolver=subject.resolver, realm_id=subject.realm_id)
+
+
+def get_user_settings(subject: SettingsSubject) -> dict:
+    """
+    Return the principal's settings, with every declared default filled in
+    for keys the principal has not overridden.
+    """
+    defaults = {key: spec["default"] for key, spec in SETTINGS_SCHEMA.items()}
+    row = db.session.scalars(_select_for_subject(subject)).first()
+    if row and row.settings:
+        defaults.update(row.settings)
+    return defaults
+
+
+def set_user_settings(subject: SettingsSubject, settings: dict, replace: bool = False) -> dict:
+    """
+    Store settings for the principal and return the stored (raw) document.
+
+    ``settings`` is validated first. By default the given keys are merged into
+    the existing document (partial update); pass ``replace=True`` to overwrite
+    the whole document.
+
+    :return: the raw stored settings (without defaults merged in)
+    """
+    validate_user_settings(settings)
+    row = db.session.scalars(_select_for_subject(subject)).first()
+    if row is None:
+        row = UserSetting(subject_type=subject.subject_type, username=subject.username,
+                          user_id=subject.user_id, resolver=subject.resolver,
+                          realm_id=subject.realm_id, settings=settings)
+    else:
+        if replace:
+            row.settings = settings
+        else:
+            merged = dict(row.settings or {})
+            merged.update(settings)
+            row.settings = merged
+    row.save()
+    return row.settings or {}

--- a/privacyidea/lib/usersetting.py
+++ b/privacyidea/lib/usersetting.py
@@ -19,9 +19,11 @@
 Per-principal frontend settings.
 
 This module stores and serves the WebUI settings of whoever is logged in
-(a local admin or a resolver user). The backend does not act on these
-settings; it only validates them on write and merges them over the
-declared defaults on read.
+(a local admin or a resolver user). The backend is a pass-through store: it
+validates a document's shape and size on write and serves it back verbatim
+on read. It does not interpret the settings and does not supply default
+*values* -- the WebUI owns the defaults, so an absent key means "not
+customized, use the frontend default".
 
 The data lives in the ``usersetting`` table, one JSON document per
 principal. See :class:`privacyidea.models.usersetting.UserSetting` for the
@@ -35,6 +37,7 @@ from dataclasses import dataclass
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from privacyidea.lib.auth import ROLE
 from privacyidea.lib.error import ParameterError, UserError
 from privacyidea.lib.framework import get_app_config_value
 from privacyidea.lib.user import User
@@ -46,8 +49,9 @@ SUBJECT_LOCAL_ADMIN = "local_admin"
 SUBJECT_USER = "user"
 
 # Hard cap on the serialized settings document, so the column cannot be abused
-# as arbitrary per-principal storage. The settings are small UI preferences.
-MAX_SETTINGS_BYTES = 8192
+# as arbitrary per-principal storage. Generous enough for a dashboard layout
+# plus a pinned-item list, which are the largest expected settings.
+MAX_SETTINGS_BYTES = 16384
 
 # pi.cfg / environment option letting admins extend the set of accepted setting
 # keys without a code change, e.g. PI_USER_SETTINGS_ALLOWED_KEYS = ["foo", "bar"].
@@ -56,29 +60,29 @@ MAX_SETTINGS_BYTES = 8192
 # the TODO in validate_user_settings).
 USER_SETTINGS_ALLOWED_KEYS_CONFIG = "PI_USER_SETTINGS_ALLOWED_KEYS"
 
-# Declarative registry of the settings the WebUI may store. The backend is the
-# source of truth for *which* settings exist; adding a new setting is a one-line
-# entry here. ``default`` is merged in on read; ``type`` will be checked on write
-# once key enforcement is turned on. Admins can add further accepted keys via
+# Registry of the top-level setting keys the WebUI may store. Only used to seed
+# the (not-yet-enforced) allow-list; the backend stores the *values* verbatim
+# and never validates their structure. Admins can add further accepted keys via
 # PI_USER_SETTINGS_ALLOWED_KEYS without touching this registry.
 #
-# NOTE: the keys below are PLACEHOLDERS to exercise the mechanism. The frontend
-# team defines the real set; do not treat these names as a committed API yet.
-SETTINGS_SCHEMA = {
-    "theme": {"type": str, "default": "light"},
-    "language": {"type": str, "default": "en"},
-    "tokens_per_page": {"type": int, "default": 25},
-    "advanced_mode": {"type": bool, "default": False},
+# NOTE: these names are PLACEHOLDERS reflecting the intended settings. The
+# frontend team defines the real set; do not treat them as a committed API yet.
+KNOWN_SETTING_KEYS = {
+    "theme",
+    "starting_page",
+    "token_columns",
+    "dashboard",
+    "pinned_items",
 }
 
 
 def get_allowed_keys() -> set:
     """
-    The set of accepted setting keys: the keys declared in
-    :data:`SETTINGS_SCHEMA` plus any added by the admin via the
-    ``PI_USER_SETTINGS_ALLOWED_KEYS`` config option.
+    The set of accepted top-level setting keys: :data:`KNOWN_SETTING_KEYS` plus
+    any added by the admin via the ``PI_USER_SETTINGS_ALLOWED_KEYS`` config
+    option.
     """
-    allowed = set(SETTINGS_SCHEMA)
+    allowed = set(KNOWN_SETTING_KEYS)
     configured = get_app_config_value(USER_SETTINGS_ALLOWED_KEYS_CONFIG, [])
     if isinstance(configured, str):
         configured = [key.strip() for key in configured.split(",") if key.strip()]
@@ -130,9 +134,9 @@ class SettingsSubject:
         username = logged_in_user.get("username") or ""
         realm = logged_in_user.get("realm") or ""
         role = logged_in_user.get("role")
-        if role == "admin" and not realm:
+        if role == ROLE.ADMIN and not realm:
             return cls(subject_type=SUBJECT_LOCAL_ADMIN, username=username)
-        if (role == "user" and resolved_user is not None and resolved_user.login == username
+        if (role == ROLE.USER and resolved_user is not None and resolved_user.login == username
                 and (resolved_user.realm or "") == realm.lower() and resolved_user.uid):
             user = resolved_user
         else:
@@ -165,10 +169,10 @@ def validate_user_settings(settings: dict) -> None:
         raise ParameterError(f"The settings must be JSON-serializable: {error}")
     if len(serialized.encode("utf-8")) > MAX_SETTINGS_BYTES:
         raise ParameterError(f"The settings exceed the maximum size of {MAX_SETTINGS_BYTES} bytes.")
-    # TODO: Enforce the set of allowed keys once the frontend has settled them.
-    #  Reject any key not in get_allowed_keys() (SETTINGS_SCHEMA +
-    #  PI_USER_SETTINGS_ALLOWED_KEYS) and type-check the SETTINGS_SCHEMA entries
-    #  against their declared "type" here (bool is a subclass of int, guard that).
+    # TODO: Enforce the top-level key allow-list once the frontend has settled
+    #  the set of settings: reject any key not in get_allowed_keys()
+    #  (KNOWN_SETTING_KEYS + PI_USER_SETTINGS_ALLOWED_KEYS). Values stay
+    #  unvalidated -- the backend remains a pass-through store.
 
 
 def _select_for_subject(subject: SettingsSubject):
@@ -187,30 +191,29 @@ def _merge_settings(existing: dict | None, incoming: dict, replace: bool) -> dic
 
 def get_user_settings(subject: SettingsSubject) -> dict:
     """
-    Return the principal's settings, with every declared default filled in
-    for keys the principal has not overridden.
+    Return the principal's stored settings verbatim, or an empty dict if the
+    principal has not stored any. Defaults are not filled in -- the WebUI owns
+    those.
     """
-    defaults = {key: spec["default"] for key, spec in SETTINGS_SCHEMA.items()}
     # An unidentified subject must not query with empty/NULL keys: it would
     # match the shared row of every other unidentified principal. Reads are
-    # tolerated and just return the defaults.
+    # tolerated and just return an empty document.
     if not subject.is_identified():
-        return defaults
+        return {}
     row = db.session.scalars(_select_for_subject(subject)).first()
-    if row and row.settings:
-        defaults.update(row.settings)
-    return defaults
+    return (row.settings if row else None) or {}
 
 
 def set_user_settings(subject: SettingsSubject, settings: dict, replace: bool = False) -> dict:
     """
-    Store settings for the principal and return the stored (raw) document.
+    Store settings for the principal and return the stored document.
 
     ``settings`` is validated first. By default the given keys are merged into
     the existing document (partial update); pass ``replace=True`` to overwrite
-    the whole document.
+    the whole document. If the resulting document is empty the row is removed,
+    so an absent row and an empty document are the same state.
 
-    :return: the raw stored settings (without defaults merged in)
+    :return: the stored settings
     """
     validate_user_settings(settings)
     if not subject.is_identified():
@@ -221,6 +224,11 @@ def set_user_settings(subject: SettingsSubject, settings: dict, replace: bool = 
     # Re-validate the full document, not just the incoming delta, so the size
     # cap cannot be bypassed by accumulating keys across repeated partial writes.
     validate_user_settings(new_settings)
+    if not new_settings:
+        # Store absence rather than an empty document (absent == empty).
+        if row is not None:
+            row.delete()
+        return {}
     if row is None:
         row = UserSetting(subject_type=subject.subject_type, username=subject.username,
                           user_id=subject.user_id, resolver=subject.resolver,
@@ -241,4 +249,35 @@ def set_user_settings(subject: SettingsSubject, settings: dict, replace: bool = 
         row.settings = _merge_settings(row.settings, settings, replace)
         validate_user_settings(row.settings)
         row.save()
+    return row.settings or {}
+
+
+def delete_user_settings(subject: SettingsSubject, key: str | None = None) -> dict:
+    """
+    Delete one setting (``key``) or the whole document (``key=None``) and
+    return the remaining stored settings.
+
+    Deleting a key is the way to "reset to default": with the key gone the
+    WebUI falls back to its own default, which also tracks future default
+    changes (unlike pinning the current default value). When the last key is
+    removed the row is dropped, keeping absent == empty.
+    """
+    # Same guard as reads: never match the shared row of unidentified principals.
+    if not subject.is_identified():
+        return {}
+    row = db.session.scalars(_select_for_subject(subject)).first()
+    if row is None:
+        return {}
+    if key is None:
+        row.delete()
+        return {}
+    current = dict(row.settings or {})
+    if key not in current:
+        return current
+    del current[key]
+    if not current:
+        row.delete()
+        return {}
+    row.settings = current
+    row.save()
     return row.settings or {}

--- a/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
+++ b/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
@@ -1,7 +1,7 @@
 """v3.14: Add usersetting table for per-principal frontend settings
 
 Revision ID: d4f5a6b7c8e9
-Revises: 7d4e9b2c1a3f
+Revises: c2d3e4f5a6b7
 Create Date: 2026-06-18 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from privacyidea.models.db import (create_sequence_if_supported, restart_sequenc
 
 # revision identifiers, used by Alembic.
 revision = 'd4f5a6b7c8e9'
-down_revision = '7d4e9b2c1a3f'
+down_revision = 'c2d3e4f5a6b7'
 branch_labels = None
 depends_on = None
 

--- a/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
+++ b/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
@@ -7,11 +7,10 @@ Create Date: 2026-06-18 00:00:00.000000
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import text, Sequence
 from sqlalchemy.exc import OperationalError, ProgrammingError
-from sqlalchemy.schema import CreateSequence
 
-from privacyidea.models.db import build_restart_sequence_sql
+from privacyidea.models.db import (create_sequence_if_supported, restart_sequence_past_max,
+                                   sequence_id_column)
 
 # revision identifiers, used by Alembic.
 revision = 'd4f5a6b7c8e9'
@@ -19,32 +18,18 @@ down_revision = '7d4e9b2c1a3f'
 branch_labels = None
 depends_on = None
 
+SEQUENCE_NAME = "usersetting_seq"
+
 
 def upgrade():
-    bind = op.get_bind()
-    is_postgres = bind.dialect.name == 'postgresql'
-
     # The model declares Sequence('usersetting_seq'), so SQLAlchemy emits
-    # SELECT nextval(...) on every ORM insert. Create the sequence on any
-    # backend that supports CREATE SEQUENCE (Postgres + MariaDB 10.3+) via
-    # SQLAlchemy's CreateSequence construct, which the increment_by_zero
-    # @compiles hook rewrites to append INCREMENT BY 0 on MariaDB so a Galera
-    # cluster accepts the cached sequence. A raw "CREATE SEQUENCE" string would
-    # bypass that hook.
-    if bind.dialect.supports_sequences:
-        op.execute(CreateSequence(Sequence("usersetting_seq"), if_not_exists=True))
+    # SELECT nextval(...) on every ORM insert; create it where supported.
+    create_sequence_if_supported(op, SEQUENCE_NAME)
 
     try:
-        if is_postgres:
-            id_column = sa.Column(
-                'id', sa.Integer(), nullable=False,
-                server_default=sa.text("nextval('usersetting_seq')"),
-            )
-        else:
-            id_column = sa.Column('id', sa.Integer(), nullable=False, autoincrement=True)
         op.create_table(
             'usersetting',
-            id_column,
+            sequence_id_column(op, SEQUENCE_NAME),
             sa.Column('subject_type', sa.Unicode(length=20), nullable=False),
             sa.Column('username', sa.Unicode(length=320), nullable=True),
             sa.Column('user_id', sa.Unicode(length=320), nullable=True),
@@ -57,6 +42,9 @@ def upgrade():
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('subject_type', 'username', 'user_id', 'resolver', 'realm_id',
                                 name='uq_usersetting_subject'),
+            # Serves the resolver-user lookup, which keys on
+            # (user_id, resolver, realm_id) and is not a prefix of the unique key.
+            sa.Index('ix_usersetting_user', 'user_id', 'resolver', 'realm_id'),
         )
     except (OperationalError, ProgrammingError) as ex:
         if "already exists" in str(ex.orig).lower():
@@ -66,14 +54,9 @@ def upgrade():
             raise
 
     # Advance the sequence past any existing rows (covers the
-    # table-already-exists branch where the sequence would otherwise hand out a
-    # value <= MAX(id)). build_restart_sequence_sql emits each dialect's syntax
-    # and appends INCREMENT BY 0 on MariaDB for Galera.
-    if bind.dialect.supports_sequences:
-        max_id = bind.execute(
-            text("SELECT COALESCE(MAX(id), 0) FROM usersetting")
-        ).scalar() or 0
-        op.execute(build_restart_sequence_sql("usersetting_seq", max_id + 1, bind.dialect.name))
+    # table-already-exists branch where it would otherwise hand out a value
+    # <= MAX(id)).
+    restart_sequence_past_max(op, 'usersetting', SEQUENCE_NAME)
 
 
 def downgrade():

--- a/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
+++ b/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
@@ -1,0 +1,90 @@
+"""v3.14: Add usersetting table for per-principal frontend settings
+
+Revision ID: d4f5a6b7c8e9
+Revises: 7d4e9b2c1a3f
+Create Date: 2026-06-18 00:00:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text, Sequence
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.schema import CreateSequence
+
+from privacyidea.models.db import build_restart_sequence_sql
+
+# revision identifiers, used by Alembic.
+revision = 'd4f5a6b7c8e9'
+down_revision = '7d4e9b2c1a3f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == 'postgresql'
+
+    # The model declares Sequence('usersetting_seq'), so SQLAlchemy emits
+    # SELECT nextval(...) on every ORM insert. Create the sequence on any
+    # backend that supports CREATE SEQUENCE (Postgres + MariaDB 10.3+) via
+    # SQLAlchemy's CreateSequence construct, which the increment_by_zero
+    # @compiles hook rewrites to append INCREMENT BY 0 on MariaDB so a Galera
+    # cluster accepts the cached sequence. A raw "CREATE SEQUENCE" string would
+    # bypass that hook.
+    if bind.dialect.supports_sequences:
+        op.execute(CreateSequence(Sequence("usersetting_seq"), if_not_exists=True))
+
+    try:
+        if is_postgres:
+            id_column = sa.Column(
+                'id', sa.Integer(), nullable=False,
+                server_default=sa.text("nextval('usersetting_seq')"),
+            )
+        else:
+            id_column = sa.Column('id', sa.Integer(), nullable=False, autoincrement=True)
+        op.create_table(
+            'usersetting',
+            id_column,
+            sa.Column('subject_type', sa.Unicode(length=20), nullable=False),
+            sa.Column('username', sa.Unicode(length=320), nullable=True),
+            sa.Column('user_id', sa.Unicode(length=320), nullable=True),
+            sa.Column('resolver', sa.Unicode(length=120), nullable=True),
+            sa.Column('realm_id', sa.Integer(), nullable=True),
+            sa.Column('settings', sa.JSON(), nullable=True),
+            sa.Column('last_modified', sa.DateTime(), nullable=True),
+            sa.Column('node', sa.Unicode(length=120), nullable=True),
+            sa.ForeignKeyConstraint(['realm_id'], ['realm.id'], ondelete='CASCADE'),
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('subject_type', 'username', 'user_id', 'resolver', 'realm_id',
+                                name='uq_usersetting_subject'),
+        )
+    except (OperationalError, ProgrammingError) as ex:
+        if "already exists" in str(ex.orig).lower():
+            print("Table 'usersetting' already exists.")
+        else:
+            print("Could not add table 'usersetting' to database.")
+            raise
+
+    # Advance the sequence past any existing rows (covers the
+    # table-already-exists branch where the sequence would otherwise hand out a
+    # value <= MAX(id)). build_restart_sequence_sql emits each dialect's syntax
+    # and appends INCREMENT BY 0 on MariaDB for Galera.
+    if bind.dialect.supports_sequences:
+        max_id = bind.execute(
+            text("SELECT COALESCE(MAX(id), 0) FROM usersetting")
+        ).scalar() or 0
+        op.execute(build_restart_sequence_sql("usersetting_seq", max_id + 1, bind.dialect.name))
+
+
+def downgrade():
+    try:
+        op.drop_table('usersetting')
+        if op.get_bind().dialect.supports_sequences:
+            op.execute("DROP SEQUENCE IF EXISTS usersetting_seq")
+    except (OperationalError, ProgrammingError) as ex:
+        msg = str(ex.orig).lower()
+        if "no such table" in msg or "unknown table" in msg or "does not exist" in msg:
+            print("Table 'usersetting' already removed.")
+        else:
+            print("Could not remove table 'usersetting'.")
+            raise

--- a/privacyidea/models/__init__.py
+++ b/privacyidea/models/__init__.py
@@ -64,6 +64,7 @@ from .tokencontainer import (TokenContainer, TokenContainerInfo,
                              TokenContainerStates, TokenContainerTemplate,
                              TokenContainerToken)
 from .tokengroup import Tokengroup, TokenTokengroup
+from .usersetting import UserSetting
 
 # We don't use "import *" but to avoid the unused import warning we define this
 __all__ = ["db", "Audit", "audit_column_length", "AuthCache", "UserCache",
@@ -86,4 +87,4 @@ __all__ = ["db", "Audit", "audit_column_length", "AuthCache", "UserCache",
            "TokenContainerRealm", "TokenContainerOwner",
            "TokenContainerStates", "TokenContainerTemplate",
            "TokenContainerToken",
-           "Tokengroup", "TokenTokengroup"]
+           "Tokengroup", "TokenTokengroup", "UserSetting"]

--- a/privacyidea/models/db.py
+++ b/privacyidea/models/db.py
@@ -17,6 +17,7 @@
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Column, Integer, Sequence, text
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import CreateSequence
 
@@ -63,6 +64,55 @@ def build_restart_sequence_sql(name, restart_with, dialect_name):
     if dialect_name in ("mysql", "mariadb"):
         sql += " INCREMENT BY 0"
     return sql
+
+def create_sequence_if_supported(op, sequence_name):  # pragma: no cover
+    """Emit ``CREATE SEQUENCE <sequence_name> IF NOT EXISTS`` on backends that
+    support sequences (PostgreSQL, MariaDB 10.3+); a no-op elsewhere.
+
+    Built through SQLAlchemy's :class:`CreateSequence` construct so the
+    :func:`increment_by_zero` hook can append ``INCREMENT BY 0`` on MariaDB (a
+    raw ``CREATE SEQUENCE`` string would bypass it and fail in a Galera cluster).
+
+    Pairs with :func:`sequence_id_column` and :func:`restart_sequence_past_max`
+    so migrations adding a sequence-backed table do not each re-implement the
+    cross-dialect dance.
+    """
+    bind = op.get_bind()
+    if bind.dialect.supports_sequences:
+        op.execute(CreateSequence(Sequence(sequence_name), if_not_exists=True))
+
+
+def sequence_id_column(op, sequence_name):  # pragma: no cover
+    """Return the primary-key ``id`` :class:`~sqlalchemy.Column` for a table
+    backed by ``sequence_name``.
+
+    On PostgreSQL the column default is wired to ``nextval(...)`` so raw INSERTs
+    (e.g. a data migration) still get an id; other backends use plain
+    ``autoincrement``. Pass the result into :func:`alembic.op.create_table`.
+    """
+    if op.get_bind().dialect.name == "postgresql":
+        return Column('id', Integer(), nullable=False,
+                      server_default=text(f"nextval('{sequence_name}')"))
+    return Column('id', Integer(), nullable=False, autoincrement=True)
+
+
+def restart_sequence_past_max(op, table_name, sequence_name):  # pragma: no cover
+    """Advance ``sequence_name`` past ``MAX(id)`` in ``table_name`` on backends
+    that support sequences; a no-op elsewhere.
+
+    Covers the table-already-exists case where the sequence (newly created or
+    pre-existing) would otherwise hand out a value ``<= MAX(id)`` and cause a
+    duplicate-PK error on the next insert. Uses :func:`build_restart_sequence_sql`
+    so MariaDB gets the Galera-required ``INCREMENT BY 0``.
+
+    ``table_name`` and ``sequence_name`` must be trusted, code-defined
+    identifiers — they are interpolated verbatim.
+    """
+    bind = op.get_bind()
+    if bind.dialect.supports_sequences:
+        max_id = bind.execute(text(f"SELECT COALESCE(MAX(id), 0) FROM {table_name}")).scalar() or 0
+        op.execute(build_restart_sequence_sql(sequence_name, max_id + 1, bind.dialect.name))
+
 
 # Compile JSON type to CLOB for Oracle
 @compiles(db.JSON, 'oracle')

--- a/privacyidea/models/usersetting.py
+++ b/privacyidea/models/usersetting.py
@@ -55,6 +55,11 @@ class UserSetting(MethodsMixin, db.Model):
 
     Only principals that deviate from the defaults get a row, so the
     table stays small even with a large user base.
+
+    The ``realm_id`` foreign key is ``ON DELETE CASCADE``: deleting a realm
+    removes its users' settings, since those users are gone with it. Rows
+    orphaned by *user* or *resolver* removal (which the FK does not cover) are
+    pruned by the ``pi-tokenjanitor user-settings`` CLI command.
     """
     __tablename__ = 'usersetting'
     __table_args__ = (

--- a/privacyidea/models/usersetting.py
+++ b/privacyidea/models/usersetting.py
@@ -65,6 +65,11 @@ class UserSetting(MethodsMixin, db.Model):
         # treats NULLs in a unique key as distinct.
         UniqueConstraint('subject_type', 'username', 'user_id', 'resolver', 'realm_id',
                          name='uq_usersetting_subject'),
+        # The local-admin lookup (subject_type, username) uses the unique key's
+        # leading prefix, but the resolver-user lookup keys on
+        # (user_id, resolver, realm_id) -- which is not a prefix of the unique
+        # key -- so it gets its own index to stay seekable as the table grows.
+        db.Index('ix_usersetting_user', 'user_id', 'resolver', 'realm_id'),
     )
 
     id: Mapped[int] = mapped_column(Integer, Sequence("usersetting_seq"), primary_key=True)

--- a/privacyidea/models/usersetting.py
+++ b/privacyidea/models/usersetting.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (C) 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-FileCopyrightText: (C) 2026 Nils Behlen <nils.behlen@netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This code is free software; you can redistribute it and/or
+# modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+# as published by the Free Software Foundation; either
+# version 3 of the License, or any later version.
+#
+# This code is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import logging
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    Sequence,
+    Unicode,
+    Integer,
+    DateTime,
+    ForeignKey,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from privacyidea.models import db
+from privacyidea.models.utils import MethodsMixin, utc_now
+
+log = logging.getLogger(__name__)
+
+
+class UserSetting(MethodsMixin, db.Model):
+    """
+    Per-principal frontend settings (one row per principal, the whole
+    settings document stored as a single JSON value).
+
+    The backend does not interpret these settings; it stores and serves
+    them for the WebUI. A "principal" is whoever logged in, which is not
+    always a resolver user:
+
+    * ``subject_type='local_admin'`` — an internal admin from the
+      ``admin`` table. Identified by ``username`` alone; ``user_id``,
+      ``resolver`` and ``realm_id`` are empty/NULL.
+    * ``subject_type='user'`` — a resolver user (this also covers
+      realm-admins). Identified by the ``(user_id, resolver, realm_id)``
+      tuple, the same stable identity used by ``tokenowner``;
+      ``username`` is kept only as a convenience for logging/lookups.
+
+    Only principals that deviate from the defaults get a row, so the
+    table stays small even with a large user base.
+    """
+    __tablename__ = 'usersetting'
+    __table_args__ = (
+        # One settings document per principal. For local admins only username is
+        # set; for users the (user_id, resolver, realm_id) tuple identifies the
+        # row. Uniqueness for local admins (realm_id NULL) is additionally
+        # guaranteed by the get-or-create logic in lib.usersetting, since SQL
+        # treats NULLs in a unique key as distinct.
+        UniqueConstraint('subject_type', 'username', 'user_id', 'resolver', 'realm_id',
+                         name='uq_usersetting_subject'),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, Sequence("usersetting_seq"), primary_key=True)
+    subject_type: Mapped[str] = mapped_column(Unicode(20), nullable=False)
+    username: Mapped[str | None] = mapped_column(Unicode(320), default='')
+    user_id: Mapped[str | None] = mapped_column(Unicode(320), default='')
+    resolver: Mapped[str | None] = mapped_column(Unicode(120), default='')
+    realm_id: Mapped[int | None] = mapped_column(Integer, ForeignKey('realm.id', ondelete='CASCADE'))
+    settings: Mapped[Any | None] = mapped_column(JSON, nullable=True)
+    last_modified: Mapped[datetime | None] = mapped_column(
+        DateTime,
+        default=utc_now,
+        onupdate=utc_now,
+    )
+    # Reserved for future HA use: NULL means the value is global (valid on any node).
+    node: Mapped[str | None] = mapped_column(Unicode(120), nullable=True, default=None)
+
+    def __init__(self, subject_type, username='', user_id='', resolver='', realm_id=None, settings=None, node=None):
+        self.subject_type = subject_type
+        self.username = username
+        self.user_id = user_id
+        self.resolver = resolver
+        self.realm_id = realm_id
+        self.settings = settings
+        self.node = node

--- a/tests/cli/test_cli_pitokenjanitor_usersettings.py
+++ b/tests/cli/test_cli_pitokenjanitor_usersettings.py
@@ -103,6 +103,13 @@ class TestUserSettingsJanitor:
         assert result.exit_code == 0, result.output
         assert "No orphaned user settings" in result.output
 
+    def test_delete_when_no_orphans(self, app, realm):
+        # With nothing to clean up, delete reports it and exits 0 (no prompt).
+        runner = app.test_cli_runner()
+        result = runner.invoke(cli, ["user-settings", "delete", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "No orphaned user settings" in result.output
+
     def test_orphan_when_resolver_was_deleted(self, app, realm):
         with app.app_context():
             db.session.add(UserSetting(subject_type=SUBJECT_USER, user_id="some-uid",

--- a/tests/cli/test_cli_pitokenjanitor_usersettings.py
+++ b/tests/cli/test_cli_pitokenjanitor_usersettings.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: (C) 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-FileCopyrightText: (C) 2026 Nils Behlen <nils.behlen@netknights.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+import pytest
+from sqlalchemy.orm.session import close_all_sessions
+
+from privacyidea.app import create_app
+from privacyidea.cli.pitokenjanitor.main import cli
+from privacyidea.lib.auth import create_db_admin
+from privacyidea.lib.lifecycle import call_finalizers
+from privacyidea.lib.realm import set_realm
+from privacyidea.lib.resolver import save_resolver
+from privacyidea.lib.user import User
+from privacyidea.lib.usersetting import SUBJECT_LOCAL_ADMIN, SUBJECT_USER
+from privacyidea.models import UserSetting, db
+
+
+@pytest.fixture(scope="function")
+def app():
+    app = create_app(config_name="testing", config_file="", silent=True)
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        call_finalizers()
+        close_all_sessions()
+        db.drop_all()
+        db.engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def realm(app):
+    with app.app_context():
+        save_resolver({"resolver": "testresolver",
+                       "type": "passwdresolver",
+                       "fileName": "tests/testdata/passwords"})
+        set_realm(realm="realm1", resolvers=[{"name": "testresolver"}])
+        db.session.commit()
+        yield
+
+
+@pytest.fixture(scope="function")
+def settings(app, realm):
+    """Live principals (a resolvable user + a present local admin) plus two
+    orphan rows: a user uid the resolver never saw and a deleted local admin."""
+    live_user = User(login="cornelius", realm="realm1")
+    create_db_admin("admin1", "admin1@localhost", "pw")
+    db.session.add_all([
+        UserSetting(subject_type=SUBJECT_USER, username="cornelius", user_id=live_user.uid,
+                    resolver="testresolver", realm_id=live_user.realm_id, settings={"theme": "dark"}),
+        UserSetting(subject_type=SUBJECT_LOCAL_ADMIN, username="admin1", settings={"theme": "dark"}),
+        UserSetting(subject_type=SUBJECT_USER, user_id="ghost-9999", resolver="testresolver",
+                    realm_id=live_user.realm_id, settings={"a": 1}),
+        UserSetting(subject_type=SUBJECT_LOCAL_ADMIN, username="ghost-admin", settings={"a": 1}),
+    ])
+    db.session.commit()
+    yield
+
+
+class TestUserSettingsJanitor:
+    def test_list_reports_orphans(self, app, settings):
+        runner = app.test_cli_runner()
+        result = runner.invoke(cli, ["user-settings", "list"])
+        assert result.exit_code == 0, result.output
+        assert "ghost-9999" in result.output
+        assert "ghost-admin" in result.output
+        # Live principals must not appear as orphans.
+        assert "cornelius" not in result.output
+        assert "admin1" not in result.output
+
+    def test_default_subcommand_is_list(self, app, settings):
+        runner = app.test_cli_runner()
+        result = runner.invoke(cli, ["user-settings"])
+        assert result.exit_code == 0, result.output
+        assert "ghost-9999" in result.output
+
+    def test_delete_with_yes_removes_orphans(self, app, settings):
+        runner = app.test_cli_runner()
+        result = runner.invoke(cli, ["user-settings", "delete", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "Deleted 2" in result.output
+
+        # Live principals' rows survive.
+        with app.app_context():
+            assert db.session.query(UserSetting).filter_by(username="cornelius").count() == 1
+            assert db.session.query(UserSetting).filter_by(username="admin1").count() == 1
+
+        result = runner.invoke(cli, ["user-settings", "list"])
+        assert result.exit_code == 0, result.output
+        assert "No orphaned user settings" in result.output
+
+    def test_delete_aborts_without_yes(self, app, settings):
+        runner = app.test_cli_runner()
+        result = runner.invoke(cli, ["user-settings", "delete"], input="n\n")
+        assert result.exit_code != 0  # click.confirm(abort=True) raises Abort
+        with app.app_context():
+            assert db.session.query(UserSetting).filter_by(username="ghost-admin").count() == 1
+
+    def test_list_when_no_orphans(self, app, realm):
+        runner = app.test_cli_runner()
+        result = runner.invoke(cli, ["user-settings", "list"])
+        assert result.exit_code == 0, result.output
+        assert "No orphaned user settings" in result.output
+
+    def test_orphan_when_resolver_was_deleted(self, app, realm):
+        with app.app_context():
+            db.session.add(UserSetting(subject_type=SUBJECT_USER, user_id="some-uid",
+                                       resolver="ghost-resolver", realm_id=None, settings={"a": 1}))
+            db.session.commit()
+        runner = app.test_cli_runner()
+        result = runner.invoke(cli, ["user-settings", "list"])
+        assert result.exit_code == 0, result.output
+        assert "some-uid" in result.output
+        assert "ghost-resolver" in result.output

--- a/tests/test_api_user_settings.py
+++ b/tests/test_api_user_settings.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (C) 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Tests for the /user/settings API endpoints.
+"""
+import json
+
+from privacyidea.lib.usersetting import SETTINGS_SCHEMA
+from .base import MyApiTestCase
+
+
+class UserSettingsAPITestCase(MyApiTestCase):
+
+    def test_01_get_returns_defaults_for_admin(self):
+        with self.app.test_request_context('/user/settings', method='GET',
+                                            headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            value = res.json["result"]["value"]
+            self.assertEqual(SETTINGS_SCHEMA["theme"]["default"], value["theme"])
+
+    def test_02_post_merges_and_get_reflects_it(self):
+        with self.app.test_request_context('/user/settings', method='POST',
+                                            headers={'Authorization': self.at},
+                                            content_type='application/json',
+                                            data=json.dumps({"settings": {"theme": "dark"}})):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json["result"]["status"])
+            self.assertEqual("dark", res.json["result"]["value"]["theme"])
+
+        with self.app.test_request_context('/user/settings', method='GET',
+                                            headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual("dark", res.json["result"]["value"]["theme"])
+            # default still present for unset key
+            self.assertEqual(SETTINGS_SCHEMA["language"]["default"],
+                             res.json["result"]["value"]["language"])
+
+    def test_03_open_mode_accepts_unknown_key(self):
+        # While ENFORCE_KNOWN_KEYS is off, the frontend may store any key
+        with self.app.test_request_context('/user/settings', method='POST',
+                                            headers={'Authorization': self.at},
+                                            content_type='application/json',
+                                            data=json.dumps({"settings": {"frontend_key": "v"}})):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertEqual("v", res.json["result"]["value"]["frontend_key"])
+
+    def test_04_post_rejects_oversized_payload(self):
+        with self.app.test_request_context('/user/settings', method='POST',
+                                            headers={'Authorization': self.at},
+                                            content_type='application/json',
+                                            data=json.dumps({"settings": {"big": "x" * 9000}})):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(400, res.status_code, res)
+
+    def test_05_post_requires_settings_param(self):
+        with self.app.test_request_context('/user/settings', method='POST',
+                                            headers={'Authorization': self.at},
+                                            content_type='application/json',
+                                            data=json.dumps({})):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(400, res.status_code, res)
+
+    def test_06_requires_authentication(self):
+        with self.app.test_request_context('/user/settings', method='GET'):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(401, res.status_code, res)

--- a/tests/test_api_user_settings.py
+++ b/tests/test_api_user_settings.py
@@ -5,7 +5,7 @@ Tests for the /user/settings API endpoints.
 """
 import json
 
-from privacyidea.lib.usersetting import SETTINGS_SCHEMA
+from privacyidea.lib.usersetting import SETTINGS_SCHEMA, SettingsSubject, get_user_settings
 from .base import MyApiTestCase
 
 
@@ -38,7 +38,8 @@ class UserSettingsAPITestCase(MyApiTestCase):
                              res.json["result"]["value"]["language"])
 
     def test_03_open_mode_accepts_unknown_key(self):
-        # While ENFORCE_KNOWN_KEYS is off, the frontend may store any key
+        # Key enforcement is not active yet (see the TODO in validate_user_settings),
+        # so the frontend may store any key.
         with self.app.test_request_context('/user/settings', method='POST',
                                             headers={'Authorization': self.at},
                                             content_type='application/json',
@@ -67,3 +68,19 @@ class UserSettingsAPITestCase(MyApiTestCase):
         with self.app.test_request_context('/user/settings', method='GET'):
             res = self.app.full_dispatch_request()
             self.assertEqual(401, res.status_code, res)
+
+    def test_07_admin_user_param_cannot_redirect_write(self):
+        # An admin passing a stray 'user=' parameter must still write to its own
+        # (local_admin) settings, never to that resolver user's row.
+        self.setUp_user_realms()
+        with self.app.test_request_context('/user/settings', method='POST',
+                                            headers={'Authorization': self.at},
+                                            content_type='application/json',
+                                            data=json.dumps({"settings": {"theme": "admin-only"},
+                                                             "user": "cornelius", "realm": "realm1"})):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+        # The resolver user 'cornelius' got nothing written; still pure defaults.
+        victim = SettingsSubject.from_logged_in_user(
+            {"username": "cornelius", "realm": "realm1", "role": "user"})
+        self.assertEqual(SETTINGS_SCHEMA["theme"]["default"], get_user_settings(victim)["theme"])

--- a/tests/test_api_user_settings.py
+++ b/tests/test_api_user_settings.py
@@ -5,64 +5,54 @@ Tests for the /user/settings API endpoints.
 """
 import json
 
-from privacyidea.lib.usersetting import SETTINGS_SCHEMA, SettingsSubject, get_user_settings
+from privacyidea.lib.usersetting import MAX_SETTINGS_BYTES, SettingsSubject, get_user_settings
 from .base import MyApiTestCase
 
 
 class UserSettingsAPITestCase(MyApiTestCase):
 
-    def test_01_get_returns_defaults_for_admin(self):
-        with self.app.test_request_context('/user/settings', method='GET',
-                                            headers={'Authorization': self.at}):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(200, res.status_code, res)
-            value = res.json["result"]["value"]
-            self.assertEqual(SETTINGS_SCHEMA["theme"]["default"], value["theme"])
-
-    def test_02_post_merges_and_get_reflects_it(self):
+    def _post(self, body):
         with self.app.test_request_context('/user/settings', method='POST',
                                             headers={'Authorization': self.at},
                                             content_type='application/json',
-                                            data=json.dumps({"settings": {"theme": "dark"}})):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(200, res.status_code, res)
-            self.assertTrue(res.json["result"]["status"])
-            self.assertEqual("dark", res.json["result"]["value"]["theme"])
+                                            data=json.dumps(body)):
+            return self.app.full_dispatch_request()
 
+    def _get(self):
         with self.app.test_request_context('/user/settings', method='GET',
                                             headers={'Authorization': self.at}):
-            res = self.app.full_dispatch_request()
-            self.assertEqual("dark", res.json["result"]["value"]["theme"])
-            # default still present for unset key
-            self.assertEqual(SETTINGS_SCHEMA["language"]["default"],
-                             res.json["result"]["value"]["language"])
+            return self.app.full_dispatch_request()
+
+    def test_01_get_empty_for_fresh_admin(self):
+        res = self._get()
+        self.assertEqual(200, res.status_code, res)
+        # Pass-through store: nothing stored -> empty document, no defaults
+        self.assertEqual({}, res.json["result"]["value"])
+
+    def test_02_post_roundtrip_and_get_match(self):
+        res = self._post({"settings": {"theme": "dark"}})
+        self.assertEqual(200, res.status_code, res)
+        self.assertTrue(res.json["result"]["status"])
+        post_value = res.json["result"]["value"]
+        # Returned verbatim, no phantom default keys
+        self.assertEqual({"theme": "dark"}, post_value)
+        # GET returns exactly the same shape
+        self.assertEqual(post_value, self._get().json["result"]["value"])
 
     def test_03_open_mode_accepts_unknown_key(self):
         # Key enforcement is not active yet (see the TODO in validate_user_settings),
         # so the frontend may store any key.
-        with self.app.test_request_context('/user/settings', method='POST',
-                                            headers={'Authorization': self.at},
-                                            content_type='application/json',
-                                            data=json.dumps({"settings": {"frontend_key": "v"}})):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(200, res.status_code, res)
-            self.assertEqual("v", res.json["result"]["value"]["frontend_key"])
+        res = self._post({"settings": {"frontend_key": "v"}})
+        self.assertEqual(200, res.status_code, res)
+        self.assertEqual("v", res.json["result"]["value"]["frontend_key"])
 
     def test_04_post_rejects_oversized_payload(self):
-        with self.app.test_request_context('/user/settings', method='POST',
-                                            headers={'Authorization': self.at},
-                                            content_type='application/json',
-                                            data=json.dumps({"settings": {"big": "x" * 9000}})):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(400, res.status_code, res)
+        res = self._post({"settings": {"big": "x" * (MAX_SETTINGS_BYTES + 1000)}})
+        self.assertEqual(400, res.status_code, res)
 
     def test_05_post_requires_settings_param(self):
-        with self.app.test_request_context('/user/settings', method='POST',
-                                            headers={'Authorization': self.at},
-                                            content_type='application/json',
-                                            data=json.dumps({})):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(400, res.status_code, res)
+        res = self._post({})
+        self.assertEqual(400, res.status_code, res)
 
     def test_06_requires_authentication(self):
         with self.app.test_request_context('/user/settings', method='GET'):
@@ -73,14 +63,29 @@ class UserSettingsAPITestCase(MyApiTestCase):
         # An admin passing a stray 'user=' parameter must still write to its own
         # (local_admin) settings, never to that resolver user's row.
         self.setUp_user_realms()
-        with self.app.test_request_context('/user/settings', method='POST',
-                                            headers={'Authorization': self.at},
-                                            content_type='application/json',
-                                            data=json.dumps({"settings": {"theme": "admin-only"},
-                                                             "user": "cornelius", "realm": "realm1"})):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(200, res.status_code, res)
-        # The resolver user 'cornelius' got nothing written; still pure defaults.
+        res = self._post({"settings": {"theme": "admin-only"}, "user": "cornelius", "realm": "realm1"})
+        self.assertEqual(200, res.status_code, res)
+        # The resolver user 'cornelius' got nothing written -> still empty.
         victim = SettingsSubject.from_logged_in_user(
             {"username": "cornelius", "realm": "realm1", "role": "user"})
-        self.assertEqual(SETTINGS_SCHEMA["theme"]["default"], get_user_settings(victim)["theme"])
+        self.assertEqual({}, get_user_settings(victim))
+
+    def test_08_delete_single_key(self):
+        self._post({"settings": {"theme": "dark", "token_columns": ["serial"]}, "replace": 1})
+        with self.app.test_request_context('/user/settings/theme', method='DELETE',
+                                            headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            # Routed to the settings endpoint (not the user-delete route) and the
+            # one key is gone.
+            self.assertEqual({"token_columns": ["serial"]}, res.json["result"]["value"])
+        self.assertEqual({"token_columns": ["serial"]}, self._get().json["result"]["value"])
+
+    def test_09_delete_all_clears_document(self):
+        self._post({"settings": {"theme": "dark"}, "replace": 1})
+        with self.app.test_request_context('/user/settings', method='DELETE',
+                                            headers={'Authorization': self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertEqual({}, res.json["result"]["value"])
+        self.assertEqual({}, self._get().json["result"]["value"])

--- a/tests/test_api_user_settings.py
+++ b/tests/test_api_user_settings.py
@@ -89,3 +89,49 @@ class UserSettingsAPITestCase(MyApiTestCase):
             self.assertEqual(200, res.status_code, res)
             self.assertEqual({}, res.json["result"]["value"])
         self.assertEqual({}, self._get().json["result"]["value"])
+
+    def _user_request(self, method, path, body=None):
+        kwargs = {"method": method, "headers": {"Authorization": self.at_user}}
+        if body is not None:
+            kwargs["content_type"] = "application/json"
+            kwargs["data"] = json.dumps(body)
+        with self.app.test_request_context(path, **kwargs):
+            return self.app.full_dispatch_request()
+
+    def test_10_user_role_crud_and_isolation(self):
+        # Exercise the SUBJECT_USER endpoint path with a real user-role JWT.
+        self.setUp_user_realms()
+        self.authenticate_selfservice_user()
+
+        # Nothing stored yet
+        self.assertEqual({}, self._user_request("GET", "/user/settings").json["result"]["value"])
+
+        res = self._user_request("POST", "/user/settings", {"settings": {"theme": "user-dark"}})
+        self.assertEqual(200, res.status_code, res)
+        self.assertEqual({"theme": "user-dark"}, res.json["result"]["value"])
+        self.assertEqual({"theme": "user-dark"},
+                         self._user_request("GET", "/user/settings").json["result"]["value"])
+
+        # Isolation: the admin (local_admin row) does not see the user's value
+        self.assertNotEqual("user-dark", self._get().json["result"]["value"].get("theme"))
+
+        # Delete the user's key
+        res = self._user_request("DELETE", "/user/settings/theme")
+        self.assertEqual(200, res.status_code, res)
+        self.assertEqual({}, res.json["result"]["value"])
+        self.assertEqual({}, self._user_request("GET", "/user/settings").json["result"]["value"])
+
+    def test_11_user_param_cannot_redirect_user_write(self):
+        # A user passing a stray 'user=' is forced back to their own identity by
+        # resolve_logged_in_user, so the write lands on the caller, not the target.
+        self.setUp_user_realms()
+        self.authenticate_selfservice_user()
+        res = self._user_request("POST", "/user/settings",
+                                 {"settings": {"theme": "mine"}, "user": "cornelius", "realm": "realm1"})
+        self.assertEqual(200, res.status_code, res)
+        # 'cornelius' was not targeted -> still empty
+        victim = SettingsSubject.from_logged_in_user(
+            {"username": "cornelius", "realm": "realm1", "role": "user"})
+        self.assertEqual({}, get_user_settings(victim))
+        # The caller (selfservice) got it
+        self.assertEqual("mine", self._user_request("GET", "/user/settings").json["result"]["value"]["theme"])

--- a/tests/test_api_user_settings.py
+++ b/tests/test_api_user_settings.py
@@ -50,6 +50,12 @@ class UserSettingsAPITestCase(MyApiTestCase):
         res = self._post({"settings": {"big": "x" * (MAX_SETTINGS_BYTES + 1000)}})
         self.assertEqual(400, res.status_code, res)
 
+    def test_04b_post_rejects_non_object_settings(self):
+        # The settings document must be a JSON object; a list (or any non-object)
+        # is rejected with 400 rather than stored.
+        res = self._post({"settings": ["not", "an", "object"]})
+        self.assertEqual(400, res.status_code, res)
+
     def test_05_post_requires_settings_param(self):
         res = self._post({})
         self.assertEqual(400, res.status_code, res)

--- a/tests/test_lib_usersetting.py
+++ b/tests/test_lib_usersetting.py
@@ -6,13 +6,18 @@ Tests for privacyidea.lib.usersetting (per-principal frontend settings).
 The backend is a pass-through store: it returns stored documents verbatim and
 does not supply default values (the WebUI owns those).
 """
+from unittest.mock import patch
+
+from sqlalchemy import select
+
 from privacyidea.lib.error import ParameterError, UserError
 from privacyidea.lib.user import User
 from privacyidea.lib.usersetting import (SettingsSubject, SUBJECT_LOCAL_ADMIN, SUBJECT_USER,
                                          KNOWN_SETTING_KEYS, MAX_SETTINGS_BYTES,
                                          get_allowed_keys, get_user_settings, set_user_settings,
                                          delete_user_settings, validate_user_settings,
-                                         find_orphaned_user_settings, delete_orphaned_user_settings)
+                                         find_orphaned_user_settings, delete_orphaned_user_settings,
+                                         _select_for_subject)
 from privacyidea.models import UserSetting
 from .base import MyTestCase
 
@@ -216,3 +221,92 @@ class UserSettingTestCase(MyTestCase):
         self.assertEqual([], find_orphaned_user_settings())
         self.assertEqual("dark", get_user_settings(self._admin_subject())["theme"])
         self.assertEqual("dark", get_user_settings(self._user_subject())["theme"])
+
+    def test_21_allowed_keys_accepts_comma_separated_string(self):
+        # Set via an environment variable, PI_USER_SETTINGS_ALLOWED_KEYS arrives
+        # as a comma-separated string instead of a list; it must be split (and
+        # blank entries from stray commas/whitespace dropped).
+        self.app.config["PI_USER_SETTINGS_ALLOWED_KEYS"] = "alpha, beta ,, gamma "
+        try:
+            allowed = get_allowed_keys()
+        finally:
+            del self.app.config["PI_USER_SETTINGS_ALLOWED_KEYS"]
+        self.assertTrue({"alpha", "beta", "gamma"}.issubset(allowed))
+        self.assertNotIn("", allowed)
+        # The built-in known keys are still present alongside the configured ones.
+        self.assertTrue(KNOWN_SETTING_KEYS.issubset(allowed))
+
+    def test_22_delete_on_absent_identified_row_is_noop(self):
+        # An identified principal that has never stored anything: delete must
+        # short-circuit on the missing row rather than error (distinct from the
+        # unidentified-subject guard exercised in test_09). A fresh username
+        # keeps this independent of rows other tests leave behind.
+        subject = SettingsSubject.from_logged_in_user(
+            {"username": "never-stored-admin", "realm": "", "role": "admin"})
+        self.assertTrue(subject.is_identified())
+        self.assertEqual({}, delete_user_settings(subject, "theme"))
+        self.assertEqual({}, delete_user_settings(subject))
+
+    def test_23_orphan_user_with_empty_identifiers(self):
+        # A SUBJECT_USER row with an empty user_id (or resolver) can never resolve
+        # to a user, so it is always an orphan -- caught before any resolver call.
+        UserSetting(subject_type=SUBJECT_USER, user_id="", resolver="",
+                    realm_id=None, settings={"a": 1}).save()
+        flagged = find_orphaned_user_settings()
+        self.assertTrue(any(o.subject_type == SUBJECT_USER and not o.user_id for o in flagged))
+
+    def test_24_orphaned_on_error_controls_unreadable_resolver(self):
+        # When the resolver raises while looking up the uid, the row counts as
+        # orphaned only with orphaned_on_error=True; otherwise it is skipped so a
+        # transiently unreachable resolver does not get a live user pruned.
+        realm_id = self._user_subject().realm_id
+        UserSetting(subject_type=SUBJECT_USER, user_id="boom-uid",
+                    resolver=self.resolvername1, realm_id=realm_id, settings={"a": 1}).save()
+
+        class _BoomResolver:
+            def getUsername(self, uid):
+                raise Exception("resolver unreachable")
+
+        # get_resolver_object is imported lazily inside find_orphaned_user_settings,
+        # so patch it at its source module.
+        with patch("privacyidea.lib.resolver.get_resolver_object", return_value=_BoomResolver()):
+            on_error = {o.user_id for o in find_orphaned_user_settings(orphaned_on_error=True)}
+            self.assertIn("boom-uid", on_error)
+            skipped = {o.user_id for o in find_orphaned_user_settings(orphaned_on_error=False)}
+            self.assertNotIn("boom-uid", skipped)
+
+    def test_25_delete_orphans_handles_empty_list(self):
+        # Nothing to delete -> returns 0 without touching the database.
+        self.assertEqual(0, delete_orphaned_user_settings([]))
+
+    def test_26_integrity_error_recovery_merges_into_existing(self):
+        # Simulate the concurrent-insert race: the first lookup misses (forcing
+        # the INSERT branch), the INSERT then trips the unique constraint because
+        # a row already exists, and the recovery path re-reads and merges the
+        # incoming keys onto the winning document instead of failing.
+        subject = self._user_subject()
+        # Clean slate for this principal, then plant the row a concurrent request
+        # "already committed".
+        delete_user_settings(subject)
+        UserSetting(subject_type=SUBJECT_USER, username="cornelius", user_id=subject.user_id,
+                    resolver=subject.resolver, realm_id=subject.realm_id,
+                    settings={"theme": "winner"}).save()
+
+        real_select = _select_for_subject
+        calls = {"n": 0}
+
+        def fake_select(subj):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # First lookup must miss the existing row to take the INSERT path.
+                return select(UserSetting).filter_by(
+                    subject_type=SUBJECT_USER, user_id="__never__",
+                    resolver="__never__", realm_id=-1)
+            return real_select(subj)
+
+        with patch("privacyidea.lib.usersetting._select_for_subject", side_effect=fake_select):
+            stored = set_user_settings(subject, {"token_columns": ["serial"]})
+
+        self.assertEqual({"theme": "winner", "token_columns": ["serial"]}, stored)
+        self.assertEqual({"theme": "winner", "token_columns": ["serial"]},
+                         get_user_settings(subject))

--- a/tests/test_lib_usersetting.py
+++ b/tests/test_lib_usersetting.py
@@ -11,7 +11,9 @@ from privacyidea.lib.user import User
 from privacyidea.lib.usersetting import (SettingsSubject, SUBJECT_LOCAL_ADMIN, SUBJECT_USER,
                                          KNOWN_SETTING_KEYS, MAX_SETTINGS_BYTES,
                                          get_allowed_keys, get_user_settings, set_user_settings,
-                                         delete_user_settings, validate_user_settings)
+                                         delete_user_settings, validate_user_settings,
+                                         find_orphaned_user_settings, delete_orphaned_user_settings)
+from privacyidea.models import UserSetting
 from .base import MyTestCase
 
 
@@ -178,3 +180,39 @@ class UserSettingTestCase(MyTestCase):
         set_user_settings(subject, {"theme": "dark"})
         self.assertEqual({}, set_user_settings(subject, {}, replace=True))
         self.assertEqual({}, get_user_settings(subject))
+
+    def test_19_realm_fk_is_on_delete_cascade(self):
+        # Deleting a realm must cascade-delete its users' settings. SQLite does
+        # not enforce FKs in the unit-test engine, so assert the declaration
+        # (the behaviour is exercised by the migration tests on Postgres/MariaDB).
+        realm_fk = next(fk for fk in UserSetting.__table__.foreign_keys
+                        if fk.column.table.name == "realm")
+        self.assertEqual("CASCADE", realm_fk.ondelete)
+
+    def test_20_find_and_delete_orphans(self):
+        # Valid principals: a present local admin and a resolvable user.
+        set_user_settings(self._admin_subject(), {"theme": "dark"})
+        set_user_settings(self._user_subject(), {"theme": "dark"})
+        cornelius_uid = self._user_subject().user_id
+        realm_id = self._user_subject().realm_id
+        # Orphans created directly, bypassing the identity guard: an admin that
+        # no longer exists and a user uid the resolver cannot resolve.
+        UserSetting(subject_type=SUBJECT_LOCAL_ADMIN, username="ghost-admin",
+                    settings={"a": 1}).save()
+        UserSetting(subject_type=SUBJECT_USER, user_id="999999",
+                    resolver=self.resolvername1, realm_id=realm_id, settings={"a": 1}).save()
+
+        described = {(o.subject_type, o.username or "", o.user_id or "")
+                     for o in find_orphaned_user_settings()}
+        self.assertIn((SUBJECT_LOCAL_ADMIN, "ghost-admin", ""), described)
+        self.assertIn((SUBJECT_USER, "", "999999"), described)
+        # The valid principals are not flagged
+        self.assertNotIn((SUBJECT_LOCAL_ADMIN, "testadmin", ""), described)
+        self.assertNotIn((SUBJECT_USER, "cornelius", cornelius_uid), described)
+
+        deleted = delete_orphaned_user_settings(find_orphaned_user_settings())
+        self.assertGreaterEqual(deleted, 2)
+        # Orphans are gone; the valid principals' settings survive.
+        self.assertEqual([], find_orphaned_user_settings())
+        self.assertEqual("dark", get_user_settings(self._admin_subject())["theme"])
+        self.assertEqual("dark", get_user_settings(self._user_subject())["theme"])

--- a/tests/test_lib_usersetting.py
+++ b/tests/test_lib_usersetting.py
@@ -3,7 +3,8 @@
 """
 Tests for privacyidea.lib.usersetting (per-principal frontend settings).
 """
-from privacyidea.lib.error import ParameterError
+from privacyidea.lib.error import ParameterError, UserError
+from privacyidea.lib.user import User
 from privacyidea.lib.usersetting import (SettingsSubject, SUBJECT_LOCAL_ADMIN, SUBJECT_USER,
                                          SETTINGS_SCHEMA, MAX_SETTINGS_BYTES,
                                          get_allowed_keys, get_user_settings, set_user_settings,
@@ -93,3 +94,59 @@ class UserSettingTestCase(MyTestCase):
             self.assertIn("custom_admin_key", get_allowed_keys())
         finally:
             del self.app.config["PI_USER_SETTINGS_ALLOWED_KEYS"]
+
+    def test_09_unidentified_user_is_not_shared(self):
+        # An unresolvable user (no uid/realm_id) must not read or write a row:
+        # otherwise every unresolved principal would share one row.
+        ghost = SettingsSubject.from_logged_in_user(
+            {"username": "does-not-exist", "realm": self.realm1, "role": "user"})
+        self.assertFalse(ghost.is_identified())
+        # Read is tolerated and returns only defaults
+        self.assertEqual(SETTINGS_SCHEMA["theme"]["default"], get_user_settings(ghost)["theme"])
+        # Write is refused
+        self.assertRaises(UserError, set_user_settings, ghost, {"theme": "dark"})
+
+    def test_10_size_cap_not_bypassable_by_merge(self):
+        # Each partial write is small, but the merged document must still be
+        # bounded by MAX_SETTINGS_BYTES.
+        subject = self._admin_subject()
+        chunk = "x" * (MAX_SETTINGS_BYTES // 2)
+        set_user_settings(subject, {"a": chunk})
+        # Merging a second half-cap chunk would push the stored doc over the cap
+        self.assertRaises(ParameterError, set_user_settings, subject, {"b": chunk})
+
+    def test_11_validation_rejects_non_serializable(self):
+        # A non-JSON-serializable value yields a controlled ParameterError,
+        # not an unhandled TypeError.
+        self.assertRaises(ParameterError, validate_user_settings, {"x": {1, 2, 3}})
+
+    def test_13_reuses_resolved_user_for_user_role(self):
+        # When request.User is the JWT user, it is reused (no re-resolution)
+        # and produces the same identity as resolving from scratch.
+        resolved = User(login="cornelius", realm=self.realm1)
+        reused = SettingsSubject.from_logged_in_user(
+            {"username": "cornelius", "realm": self.realm1, "role": "user"}, resolved)
+        fresh = self._user_subject()
+        self.assertEqual(SUBJECT_USER, reused.subject_type)
+        self.assertEqual(fresh.user_id, reused.user_id)
+        self.assertEqual(fresh.resolver, reused.resolver)
+        self.assertEqual(fresh.realm_id, reused.realm_id)
+
+    def test_14_admin_ignores_resolved_user(self):
+        # For an admin, request.User may reflect a 'user=' request parameter and
+        # must NOT decide whose settings are touched. A local admin stays keyed
+        # by its own username regardless of the passed-in user.
+        attacker_param_user = User(login="cornelius", realm=self.realm1)
+        subject = SettingsSubject.from_logged_in_user(
+            {"username": "testadmin", "realm": "", "role": "admin"}, attacker_param_user)
+        self.assertEqual(SUBJECT_LOCAL_ADMIN, subject.subject_type)
+        self.assertEqual("testadmin", subject.username)
+        self.assertEqual("", subject.user_id)
+
+    def test_12_non_ascii_counted_by_real_byte_size(self):
+        # ensure_ascii=False: a non-ASCII string near the cap is measured by its
+        # real UTF-8 size, not the inflated \\uXXXX-escaped size.
+        # "ä" is 2 UTF-8 bytes; MAX_SETTINGS_BYTES//2 of them ~= the cap in real
+        # bytes but would be ~3x over if counted as escapes.
+        value = "ä" * (MAX_SETTINGS_BYTES // 2 - 20)
+        validate_user_settings({"k": value})  # does not raise

--- a/tests/test_lib_usersetting.py
+++ b/tests/test_lib_usersetting.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
 Tests for privacyidea.lib.usersetting (per-principal frontend settings).
+
+The backend is a pass-through store: it returns stored documents verbatim and
+does not supply default values (the WebUI owns those).
 """
 from privacyidea.lib.error import ParameterError, UserError
 from privacyidea.lib.user import User
 from privacyidea.lib.usersetting import (SettingsSubject, SUBJECT_LOCAL_ADMIN, SUBJECT_USER,
-                                         SETTINGS_SCHEMA, MAX_SETTINGS_BYTES,
+                                         KNOWN_SETTING_KEYS, MAX_SETTINGS_BYTES,
                                          get_allowed_keys, get_user_settings, set_user_settings,
-                                         validate_user_settings)
+                                         delete_user_settings, validate_user_settings)
 from .base import MyTestCase
 
 
@@ -38,34 +41,28 @@ class UserSettingTestCase(MyTestCase):
         self.assertTrue(user.user_id)
         self.assertIsNotNone(user.realm_id)
 
-    def test_02_get_returns_defaults(self):
-        settings = get_user_settings(self._admin_subject())
-        # No row stored yet -> every declared default is present
-        for key, spec in SETTINGS_SCHEMA.items():
-            self.assertEqual(spec["default"], settings[key])
+    def test_02_get_empty_returns_empty_dict(self):
+        # No row stored yet -> empty document, no backend-supplied defaults
+        self.assertEqual({}, get_user_settings(self._admin_subject()))
 
-    def test_03_set_merges_and_persists(self):
+    def test_03_set_and_get_roundtrip_verbatim(self):
         subject = self._admin_subject()
         set_user_settings(subject, {"theme": "dark"})
-        settings = get_user_settings(subject)
-        self.assertEqual("dark", settings["theme"])
-        # Untouched key keeps its default
-        self.assertEqual(SETTINGS_SCHEMA["language"]["default"], settings["language"])
+        # Returned verbatim, no extra default keys injected
+        self.assertEqual({"theme": "dark"}, get_user_settings(subject))
 
-        # A second partial write merges, it does not clobber the first
-        set_user_settings(subject, {"language": "de"})
-        settings = get_user_settings(subject)
-        self.assertEqual("dark", settings["theme"])
-        self.assertEqual("de", settings["language"])
+        # A second partial write merges at the top level, not clobbering the first
+        set_user_settings(subject, {"token_columns": ["serial", "type"]})
+        self.assertEqual({"theme": "dark", "token_columns": ["serial", "type"]},
+                         get_user_settings(subject))
 
     def test_04_replace_overwrites_document(self):
         subject = self._admin_subject()
-        set_user_settings(subject, {"theme": "dark", "language": "de"})
+        set_user_settings(subject, {"theme": "dark", "starting_page": "tokens"})
         stored = set_user_settings(subject, {"theme": "light"}, replace=True)
         self.assertEqual({"theme": "light"}, stored)
-        settings = get_user_settings(subject)
-        # 'language' fell back to its default after the replace
-        self.assertEqual(SETTINGS_SCHEMA["language"]["default"], settings["language"])
+        # The dropped key is simply gone (the WebUI falls back to its default)
+        self.assertEqual({"theme": "light"}, get_user_settings(subject))
 
     def test_05_admin_and_user_settings_are_isolated(self):
         set_user_settings(self._admin_subject(), {"theme": "dark"})
@@ -81,14 +78,14 @@ class UserSettingTestCase(MyTestCase):
 
     def test_07_open_mode_accepts_unknown_keys_and_types(self):
         # Keys are not enforced yet: unknown keys and arbitrary value types pass
-        validate_user_settings({"unknown_key": 1, "tokens_per_page": "many"})
+        validate_user_settings({"unknown_key": 1, "whatever": "many"})
         stored = set_user_settings(self._admin_subject(), {"frontend_only_key": {"nested": True}})
         self.assertEqual({"nested": True}, stored["frontend_only_key"])
 
     def test_08_allowed_keys_placeholder_includes_config(self):
         # get_allowed_keys() is wired up (for the later enforcement step) and
-        # already merges the admin-configured keys with the schema keys.
-        self.assertTrue(set(SETTINGS_SCHEMA).issubset(get_allowed_keys()))
+        # already merges the admin-configured keys with the known keys.
+        self.assertTrue(KNOWN_SETTING_KEYS.issubset(get_allowed_keys()))
         self.app.config["PI_USER_SETTINGS_ALLOWED_KEYS"] = ["custom_admin_key"]
         try:
             self.assertIn("custom_admin_key", get_allowed_keys())
@@ -101,10 +98,12 @@ class UserSettingTestCase(MyTestCase):
         ghost = SettingsSubject.from_logged_in_user(
             {"username": "does-not-exist", "realm": self.realm1, "role": "user"})
         self.assertFalse(ghost.is_identified())
-        # Read is tolerated and returns only defaults
-        self.assertEqual(SETTINGS_SCHEMA["theme"]["default"], get_user_settings(ghost)["theme"])
+        # Read is tolerated and returns an empty document
+        self.assertEqual({}, get_user_settings(ghost))
         # Write is refused
         self.assertRaises(UserError, set_user_settings, ghost, {"theme": "dark"})
+        # Delete is a no-op (never matches the shared row)
+        self.assertEqual({}, delete_user_settings(ghost, "theme"))
 
     def test_10_size_cap_not_bypassable_by_merge(self):
         # Each partial write is small, but the merged document must still be
@@ -119,6 +118,14 @@ class UserSettingTestCase(MyTestCase):
         # A non-JSON-serializable value yields a controlled ParameterError,
         # not an unhandled TypeError.
         self.assertRaises(ParameterError, validate_user_settings, {"x": {1, 2, 3}})
+
+    def test_12_non_ascii_counted_by_real_byte_size(self):
+        # ensure_ascii=False: a non-ASCII string near the cap is measured by its
+        # real UTF-8 size, not the inflated \\uXXXX-escaped size.
+        # "ä" is 2 UTF-8 bytes; MAX_SETTINGS_BYTES//2 of them ~= the cap in real
+        # bytes but would be ~3x over if counted as escapes.
+        value = "ä" * (MAX_SETTINGS_BYTES // 2 - 20)
+        validate_user_settings({"k": value})  # does not raise
 
     def test_13_reuses_resolved_user_for_user_role(self):
         # When request.User is the JWT user, it is reused (no re-resolution)
@@ -143,10 +150,31 @@ class UserSettingTestCase(MyTestCase):
         self.assertEqual("testadmin", subject.username)
         self.assertEqual("", subject.user_id)
 
-    def test_12_non_ascii_counted_by_real_byte_size(self):
-        # ensure_ascii=False: a non-ASCII string near the cap is measured by its
-        # real UTF-8 size, not the inflated \\uXXXX-escaped size.
-        # "ä" is 2 UTF-8 bytes; MAX_SETTINGS_BYTES//2 of them ~= the cap in real
-        # bytes but would be ~3x over if counted as escapes.
-        value = "ä" * (MAX_SETTINGS_BYTES // 2 - 20)
-        validate_user_settings({"k": value})  # does not raise
+    def test_15_delete_key_resets_to_default(self):
+        subject = self._admin_subject()
+        # replace=True for a clean baseline independent of other tests' writes
+        set_user_settings(subject, {"theme": "dark", "starting_page": "tokens"}, replace=True)
+        remaining = delete_user_settings(subject, "theme")
+        self.assertEqual({"starting_page": "tokens"}, remaining)
+        self.assertEqual({"starting_page": "tokens"}, get_user_settings(subject))
+        # Deleting an absent key is a no-op
+        self.assertEqual({"starting_page": "tokens"}, delete_user_settings(subject, "theme"))
+
+    def test_16_delete_last_key_removes_row(self):
+        subject = self._admin_subject()
+        set_user_settings(subject, {"theme": "dark"}, replace=True)
+        self.assertEqual({}, delete_user_settings(subject, "theme"))
+        # Row is gone -> indistinguishable from never-set
+        self.assertEqual({}, get_user_settings(subject))
+
+    def test_17_delete_all_clears_document(self):
+        subject = self._admin_subject()
+        set_user_settings(subject, {"theme": "dark", "starting_page": "tokens"})
+        self.assertEqual({}, delete_user_settings(subject))
+        self.assertEqual({}, get_user_settings(subject))
+
+    def test_18_replace_with_empty_prunes_row(self):
+        subject = self._admin_subject()
+        set_user_settings(subject, {"theme": "dark"})
+        self.assertEqual({}, set_user_settings(subject, {}, replace=True))
+        self.assertEqual({}, get_user_settings(subject))

--- a/tests/test_lib_usersetting.py
+++ b/tests/test_lib_usersetting.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: (C) 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Tests for privacyidea.lib.usersetting (per-principal frontend settings).
+"""
+from privacyidea.lib.error import ParameterError
+from privacyidea.lib.usersetting import (SettingsSubject, SUBJECT_LOCAL_ADMIN, SUBJECT_USER,
+                                         SETTINGS_SCHEMA, MAX_SETTINGS_BYTES,
+                                         get_allowed_keys, get_user_settings, set_user_settings,
+                                         validate_user_settings)
+from .base import MyTestCase
+
+
+class UserSettingTestCase(MyTestCase):
+
+    def setUp(self):
+        self.setUp_user_realms()
+
+    def _user_subject(self):
+        return SettingsSubject.from_logged_in_user(
+            {"username": "cornelius", "realm": self.realm1, "role": "user"})
+
+    def _admin_subject(self):
+        return SettingsSubject.from_logged_in_user(
+            {"username": "testadmin", "realm": "", "role": "admin"})
+
+    def test_01_subject_resolution(self):
+        admin = self._admin_subject()
+        self.assertEqual(SUBJECT_LOCAL_ADMIN, admin.subject_type)
+        self.assertEqual("testadmin", admin.username)
+        self.assertEqual("", admin.user_id)
+        self.assertIsNone(admin.realm_id)
+
+        user = self._user_subject()
+        self.assertEqual(SUBJECT_USER, user.subject_type)
+        self.assertEqual(self.resolvername1, user.resolver)
+        self.assertTrue(user.user_id)
+        self.assertIsNotNone(user.realm_id)
+
+    def test_02_get_returns_defaults(self):
+        settings = get_user_settings(self._admin_subject())
+        # No row stored yet -> every declared default is present
+        for key, spec in SETTINGS_SCHEMA.items():
+            self.assertEqual(spec["default"], settings[key])
+
+    def test_03_set_merges_and_persists(self):
+        subject = self._admin_subject()
+        set_user_settings(subject, {"theme": "dark"})
+        settings = get_user_settings(subject)
+        self.assertEqual("dark", settings["theme"])
+        # Untouched key keeps its default
+        self.assertEqual(SETTINGS_SCHEMA["language"]["default"], settings["language"])
+
+        # A second partial write merges, it does not clobber the first
+        set_user_settings(subject, {"language": "de"})
+        settings = get_user_settings(subject)
+        self.assertEqual("dark", settings["theme"])
+        self.assertEqual("de", settings["language"])
+
+    def test_04_replace_overwrites_document(self):
+        subject = self._admin_subject()
+        set_user_settings(subject, {"theme": "dark", "language": "de"})
+        stored = set_user_settings(subject, {"theme": "light"}, replace=True)
+        self.assertEqual({"theme": "light"}, stored)
+        settings = get_user_settings(subject)
+        # 'language' fell back to its default after the replace
+        self.assertEqual(SETTINGS_SCHEMA["language"]["default"], settings["language"])
+
+    def test_05_admin_and_user_settings_are_isolated(self):
+        set_user_settings(self._admin_subject(), {"theme": "dark"})
+        set_user_settings(self._user_subject(), {"theme": "light"})
+        self.assertEqual("dark", get_user_settings(self._admin_subject())["theme"])
+        self.assertEqual("light", get_user_settings(self._user_subject())["theme"])
+
+    def test_06_open_mode_always_enforces_structure(self):
+        # Structural checks hold regardless of key enforcement
+        self.assertRaises(ParameterError, validate_user_settings, ["not", "a", "dict"])
+        self.assertRaises(ParameterError, validate_user_settings,
+                          {"theme": "x" * (MAX_SETTINGS_BYTES + 1)})
+
+    def test_07_open_mode_accepts_unknown_keys_and_types(self):
+        # Keys are not enforced yet: unknown keys and arbitrary value types pass
+        validate_user_settings({"unknown_key": 1, "tokens_per_page": "many"})
+        stored = set_user_settings(self._admin_subject(), {"frontend_only_key": {"nested": True}})
+        self.assertEqual({"nested": True}, stored["frontend_only_key"])
+
+    def test_08_allowed_keys_placeholder_includes_config(self):
+        # get_allowed_keys() is wired up (for the later enforcement step) and
+        # already merges the admin-configured keys with the schema keys.
+        self.assertTrue(set(SETTINGS_SCHEMA).issubset(get_allowed_keys()))
+        self.app.config["PI_USER_SETTINGS_ALLOWED_KEYS"] = ["custom_admin_key"]
+        try:
+            self.assertIn("custom_admin_key", get_allowed_keys())
+        finally:
+            del self.app.config["PI_USER_SETTINGS_ALLOWED_KEYS"]


### PR DESCRIPTION
closes #4220 
Does not contain validation, as this is the first step. Validation is a follow up in #5478 after we implemented stuff in the frontend and know what the keys actually are.

Settings are stored as JSON, so its one row per user.
Local admins can also have settings, the user type (local/from resolver) is differentiated by subject_type