### PR TITLE
Webui language switcher

### DIFF
--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -354,9 +354,9 @@ def create_app(config_name="development",
         if (request.method == "GET"
                 and not request.path.startswith("/static/")
                 and request.accept_mimetypes.best_match(["text/html", "application/json"]) == "text/html"):
-            from privacyidea.webui.login import _serve_locale
+            from privacyidea.webui.login import _serve_locale, get_preferred_language
             locale_prefix_match = re.match(rf'^/({locale_pattern})(/|$)', request.path)
-            locale = locale_prefix_match.group(1) if locale_prefix_match else "en"
+            locale = locale_prefix_match.group(1) if locale_prefix_match else (get_preferred_language() or "en")
             new_ui = _serve_locale(locale) or _serve_locale("en")
             if new_ui:
                 return new_ui

--- a/privacyidea/static_new/src/app/app.component.spec.ts
+++ b/privacyidea/static_new/src/app/app.component.spec.ts
@@ -64,7 +64,7 @@ describe("AppComponent", () => {
     expect(fixture.componentInstance.title).toBe("privacyidea-webui");
   });
 
-  it("shows snackbar when user already authenticated", () => {
+  it("does not warn when the user is already authenticated (e.g. session restored after reload)", () => {
     const auth = TestBed.inject(AuthService) as unknown as MockAuthService;
     const note = TestBed.inject(NotificationService) as unknown as MockNotificationService;
 
@@ -72,7 +72,7 @@ describe("AppComponent", () => {
 
     TestBed.createComponent(AppComponent).detectChanges();
 
-    expect(note.warning).toHaveBeenCalledWith("User is already logged in.");
+    expect(note.warning).not.toHaveBeenCalled();
   });
 
   it("resets & restarts timer on user interaction", () => {
@@ -104,11 +104,20 @@ describe("AppComponent", () => {
       await Promise.resolve();
     });
 
-    it("navigates to /login", async () => {
+    it("navigates to /login when unauthenticated", async () => {
+      auth.isAuthenticated.set(false);
       await router.navigate(["/login"]);
       jest.runOnlyPendingTimers();
       await Promise.resolve();
       expect(location.path()).toBe("/login");
+    });
+
+    it("redirects an authenticated user away from /login to the landing page", async () => {
+      auth.isAuthenticated.set(true);
+      await router.navigate(["/login"]);
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
+      expect(location.path()).toBe("/tokens");
     });
 
     it("navigates to /token", async () => {
@@ -118,7 +127,8 @@ describe("AppComponent", () => {
       expect(location.path()).toBe("/tokens");
     });
 
-    it("redirects unknown routes to /login", async () => {
+    it("redirects unknown routes to /login when unauthenticated", async () => {
+      auth.isAuthenticated.set(false);
       await router.navigate(["/does-not-exist"]);
       jest.runOnlyPendingTimers();
       await Promise.resolve();

--- a/privacyidea/static_new/src/app/app.component.spec.ts
+++ b/privacyidea/static_new/src/app/app.component.spec.ts
@@ -43,8 +43,8 @@ describe("AppComponent", () => {
         provideRouter(routes),
         { provide: AuthService, useClass: MockAuthService },
         {
-          provode: AuthGuard,
-          useValue: { canActivate: () => true, canMatch: () => true }
+          provide: AuthGuard,
+          useValue: { canActivate: () => true, canActivateChild: () => true, canMatch: () => true }
         },
         { provide: NotificationService, useClass: MockNotificationService },
         { provide: SessionTimerService, useClass: MockSessionTimerService }
@@ -85,6 +85,26 @@ describe("AppComponent", () => {
 
     expect(timer.resetTimer).toHaveBeenCalled();
     expect(timer.startTimer).toHaveBeenCalled();
+  });
+
+  it("arms the session timer at bootstrap when a session was restored (already authenticated)", () => {
+    const auth = TestBed.inject(AuthService) as unknown as MockAuthService;
+    const timer = TestBed.inject(SessionTimerService) as unknown as MockSessionTimerService;
+
+    auth.isAuthenticated.set(true);
+    TestBed.createComponent(AppComponent);
+
+    expect(timer.initialTimerStart).toHaveBeenCalled();
+  });
+
+  it("does not arm the session timer at bootstrap when unauthenticated", () => {
+    const auth = TestBed.inject(AuthService) as unknown as MockAuthService;
+    const timer = TestBed.inject(SessionTimerService) as unknown as MockSessionTimerService;
+
+    auth.isAuthenticated.set(false);
+    TestBed.createComponent(AppComponent);
+
+    expect(timer.initialTimerStart).not.toHaveBeenCalled();
   });
 
   describe("Routing", () => {

--- a/privacyidea/static_new/src/app/app.component.ts
+++ b/privacyidea/static_new/src/app/app.component.ts
@@ -113,6 +113,11 @@ export class AppComponent {
   lastSessionReset = 0;
 
   constructor() {
+    // A session restored on bootstrap (e.g. after a language-switch reload) must arm the
+    // session timer here, because initialTimerStart() otherwise only runs on interactive login.
+    if (this.authService.isAuthenticated()) {
+      this.sessionTimerService.initialTimerStart();
+    }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _welcomeInit = inject(WelcomeDialogService);
     /** Uncomment to enable subscription expiry dialog

--- a/privacyidea/static_new/src/app/app.component.ts
+++ b/privacyidea/static_new/src/app/app.component.ts
@@ -20,7 +20,6 @@ import { Component, HostListener, inject } from "@angular/core";
 import { RouterOutlet } from "@angular/router";
 import { WelcomeDialogService } from "@services/welcome/welcome-dialog.service";
 import { AuthService, AuthServiceInterface } from "./services/auth/auth.service";
-import { NotificationService, NotificationServiceInterface } from "./services/notification/notification.service";
 import { SessionTimerService, SessionTimerServiceInterface } from "./services/session-timer/session-timer.service";
 
 export interface PiResponse<Value, Detail = unknown> {
@@ -108,17 +107,12 @@ export function challengesTriggered<Value, Detail = unknown>(response: PiRespons
 })
 export class AppComponent {
   private readonly authService: AuthServiceInterface = inject(AuthService);
-  private readonly notificationService: NotificationServiceInterface = inject(NotificationService);
   private readonly sessionTimerService: SessionTimerServiceInterface = inject(SessionTimerService);
 
   title = "privacyidea-webui";
   lastSessionReset = 0;
 
   constructor() {
-    if (this.authService.isAuthenticated()) {
-      console.warn("User is already logged in.");
-      this.notificationService.warning("User is already logged in.");
-    }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _welcomeInit = inject(WelcomeDialogService);
     /** Uncomment to enable subscription expiry dialog

--- a/privacyidea/static_new/src/app/app.config.ts
+++ b/privacyidea/static_new/src/app/app.config.ts
@@ -27,6 +27,7 @@ import {
 } from "@angular/core";
 import { MatPaginatorIntl } from "@angular/material/paginator";
 import { provideRouter } from "@angular/router";
+import { localeBaseHref } from "@core/locale";
 import { routes } from "./app.routes";
 import { createPaginatorIntl } from "./paginator-intl";
 import { loadingInterceptor } from "./interceptor/loading/loading.interceptor";
@@ -36,10 +37,7 @@ import { ConfigService } from "./services/config/config.service";
 import { ThemeService } from "./services/theme/theme.service";
 
 export function baseHrefFactory(): string {
-  const locale = inject(LOCALE_ID);
-  return locale === "en" || locale.toLowerCase().startsWith("en-")
-    ? "/app/v2/"
-    : `/app/v2/${locale}/`;
+  return localeBaseHref(inject(LOCALE_ID));
 }
 
 export const appConfig: ApplicationConfig = {

--- a/privacyidea/static_new/src/app/app.routes.ts
+++ b/privacyidea/static_new/src/app/app.routes.ts
@@ -20,7 +20,7 @@ import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 import { LayoutComponent } from "./components/layout/layout.component";
 import { LoginComponent } from "./components/login/login.component";
-import { adminMatch, AuthGuard, selfServiceMatch } from "./guards/auth.guard";
+import { adminMatch, AuthGuard, loginGuard, selfServiceMatch } from "./guards/auth.guard";
 import { ApplicationService } from "@services/application/application.service";
 import { AuditService } from "@services/audit/audit.service";
 import { CaConnectorService } from "@services/ca-connector/ca-connector.service";
@@ -54,7 +54,7 @@ import { UiPolicyService } from "@services/ui-policy/ui-policy.service";
 import { UserService } from "@services/user/user.service";
 
 export const routes: Routes = [
-  { path: "login", component: LoginComponent },
+  { path: "login", component: LoginComponent, canActivate: [loginGuard] },
   { path: "", redirectTo: "login", pathMatch: "full" },
   {
     path: "",

--- a/privacyidea/static_new/src/app/components/container/container-create/container-create.self-service.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-create.self-service.component.ts
@@ -54,12 +54,12 @@ export class ContainerCreateSelfServiceComponent extends ContainerCreateComponen
   protected override authService: AuthServiceInterface = inject(AuthService);
 
   override selectedUserRealm = linkedSignal(() => {
-    const realm = this.authService.authData()?.realm ?? "";
+    const realm = this.authService.realm();
     assert(realm != "", "User must have a realm to create a container in self-service");
     return realm;
   });
   override selectedUser = computed(() => {
-    const userName = this.authService.authData()?.username ?? "";
+    const userName = this.authService.username();
     assert(userName != "", "User must be authenticated to create a container in self-service");
     return userName;
   });

--- a/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.component.html
+++ b/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.component.html
@@ -32,6 +32,7 @@
       <i class="node-text"> {{ localNode() }} </i>
     }
   </div>
+  <app-language-switcher></app-language-switcher>
   <app-theme-switcher></app-theme-switcher>
   <button
     (click)="refreshPage()"

--- a/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.component.ts
+++ b/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.component.ts
@@ -24,6 +24,7 @@ import { MatIcon } from "@angular/material/icon";
 import { MatTooltip } from "@angular/material/tooltip";
 import { Router } from "@angular/router";
 import { ROUTE_PATHS } from "@app/route_paths";
+import { LanguageSwitcherComponent } from "@components/shared/language-switcher/language-switcher.component";
 import { SaveAndExitDialogComponent } from "@components/shared/dialog/save-and-exit-dialog/save-and-exit-dialog.component";
 import { ThemeSwitcherComponent } from "@components/shared/theme-switcher/theme-switcher.component";
 import { AuditService, AuditServiceInterface } from "@services/audit/audit.service";
@@ -73,7 +74,7 @@ import { from } from "rxjs";
 
 @Component({
   selector: "app-user-utils-panel",
-  imports: [MatIcon, MatIconButton, MatTooltip, ThemeSwitcherComponent, NgClass, DatePipe],
+  imports: [MatIcon, MatIconButton, MatTooltip, LanguageSwitcherComponent, ThemeSwitcherComponent, NgClass, DatePipe],
   templateUrl: "./user-utils-panel.component.html",
   styleUrl: "./user-utils-panel.component.scss"
 })

--- a/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.self-service.component.html
+++ b/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.self-service.component.html
@@ -19,6 +19,7 @@
 
 <div class="utils-group-self-service utils">
   @if (!wizard()) {
+    <app-language-switcher></app-language-switcher>
     <app-theme-switcher></app-theme-switcher>
     <button
       (click)="refreshPage()"

--- a/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.self-service.component.ts
+++ b/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.self-service.component.ts
@@ -23,11 +23,12 @@ import { MatIconButton } from "@angular/material/button";
 import { MatIcon } from "@angular/material/icon";
 import { MatTooltip } from "@angular/material/tooltip";
 import { UserUtilsPanelComponent } from "@components/layout/user-utils-panel/user-utils-panel.component";
+import { LanguageSwitcherComponent } from "@components/shared/language-switcher/language-switcher.component";
 import { ThemeSwitcherComponent } from "@components/shared/theme-switcher/theme-switcher.component";
 
 @Component({
   selector: "app-user-utils-panel-self-service",
-  imports: [MatIcon, MatIconButton, MatTooltip, ThemeSwitcherComponent, NgClass, DatePipe],
+  imports: [MatIcon, MatIconButton, MatTooltip, LanguageSwitcherComponent, ThemeSwitcherComponent, NgClass, DatePipe],
   templateUrl: "./user-utils-panel.self-service.component.html",
   styleUrl: "./user-utils-panel.component.scss"
 })

--- a/privacyidea/static_new/src/app/components/login/login.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/login/login.component.spec.ts
@@ -116,6 +116,7 @@ describe("LoginComponent", () => {
     it("should redirect to token wizard", () => {
       authService.authData.set({
         ...authService.authData()!,
+        role: "user",
         token_wizard: true
       });
       component.onSubmit();
@@ -126,6 +127,7 @@ describe("LoginComponent", () => {
     it("should redirect to token wizard first if token and container wizard are enabled", () => {
       authService.authData.set({
         ...authService.authData()!,
+        role: "user",
         token_wizard: true,
         container_wizard: { enabled: true, type: "smartphone", registration: false, template: null }
       });
@@ -137,6 +139,7 @@ describe("LoginComponent", () => {
     it("should redirect to container wizard if only container wizard is enabled", () => {
       authService.authData.set({
         ...authService.authData()!,
+        role: "user",
         token_wizard: false,
         container_wizard: { enabled: true, type: "smartphone", registration: false, template: null }
       });
@@ -470,14 +473,10 @@ describe("LoginComponent", () => {
   });
 
   describe("logout", () => {
-    it("should remove token, logout, and navigate to login", async () => {
+    it("delegates to authService.logout() (which clears storage and navigates)", () => {
       const authServiceSpy = jest.spyOn(authService, "logout");
       component.logout();
-      fixture.whenStable().then(() => {
-        expect(localService.removeData).toHaveBeenCalledWith("bearer_token");
-        expect(authServiceSpy).toHaveBeenCalled();
-        expect(router.navigate).toHaveBeenCalledWith(["login"]);
-      });
+      expect(authServiceSpy).toHaveBeenCalled();
     });
   });
 

--- a/privacyidea/static_new/src/app/components/login/login.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/login/login.component.spec.ts
@@ -382,7 +382,6 @@ describe("LoginComponent", () => {
       component.passkeyLogin();
 
       expect(validateService.authenticatePasskey).toHaveBeenCalled();
-      expect(localService.saveData).toHaveBeenCalledWith("bearer_token", "passkey-token");
       expect(router.navigateByUrl).toHaveBeenCalledWith("/tokens");
     });
 
@@ -468,7 +467,6 @@ describe("LoginComponent", () => {
         password: "",
         transaction_id: "tx-push-success"
       });
-      expect(localService.saveData).toHaveBeenCalledWith("bearer_token", "push-token");
     });
   });
 

--- a/privacyidea/static_new/src/app/components/login/login.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/login/login.component.spec.ts
@@ -92,7 +92,7 @@ describe("LoginComponent", () => {
   });
 
   describe("when already logged in", () => {
-    it("should warn and open a snack bar on initialization", () => {
+    it("does not warn (loginGuard redirects authenticated users away from the login route)", () => {
       authService.isAuthenticated.set(true);
       const warn = jest.spyOn(console, "warn").mockImplementation();
 
@@ -100,8 +100,8 @@ describe("LoginComponent", () => {
       const loggedInFixture = TestBed.createComponent(LoginComponent);
       loggedInFixture.detectChanges();
 
-      expect(notificationService.warning).toHaveBeenCalledWith("User is already logged in.");
-      expect(warn).toHaveBeenCalledWith("User is already logged in.");
+      expect(notificationService.warning).not.toHaveBeenCalledWith("User is already logged in.");
+      expect(warn).not.toHaveBeenCalledWith("User is already logged in.");
 
       warn.mockRestore();
     });

--- a/privacyidea/static_new/src/app/components/login/login.component.ts
+++ b/privacyidea/static_new/src/app/components/login/login.component.ts
@@ -43,7 +43,6 @@ import { ClearButtonComponent } from "@components/shared/clear-button/clear-butt
 import { environment } from "@env/environment";
 import { AuthResponse, AuthService, AuthServiceInterface, PasswordLoginParams } from "@services/auth/auth.service";
 import { ConfigService } from "@services/config/config.service";
-import { LocalService, LocalServiceInterface } from "@services/local/local.service";
 import { NotificationService, NotificationServiceInterface } from "@services/notification/notification.service";
 import { SessionTimerService, SessionTimerServiceInterface } from "@services/session-timer/session-timer.service";
 import { ValidateService, ValidateServiceInterface, WebAuthnSignRequest } from "@services/validate/validate.service";
@@ -77,7 +76,6 @@ const NO_REALM_SENTINEL = "-";
 export class LoginComponent implements OnDestroy, AfterViewInit {
   private readonly authService: AuthServiceInterface = inject(AuthService);
   private readonly router = inject(Router);
-  private readonly localService: LocalServiceInterface = inject(LocalService);
   private readonly notificationService: NotificationServiceInterface = inject(NotificationService);
   private readonly sessionTimerService: SessionTimerServiceInterface = inject(SessionTimerService);
   private readonly validateService: ValidateServiceInterface = inject(ValidateService);
@@ -304,8 +302,8 @@ export class LoginComponent implements OnDestroy, AfterViewInit {
 
   private evaluateResponse(response: AuthResponse, context: "password" | "passkey" | "webauthn"): void {
     if (isAuthenticationSuccessful(response)) {
-      // Successful auth -> log in
-      this.localService.saveData("bearer_token", response.result.value.token);
+      // Successful auth -> log in. AuthService.authenticate() (which every login path goes
+      // through) has already persisted the token and auth data, so nothing to store here.
       this.showOtpField.set(false);
       this.sessionTimerService.initialTimerStart();
       this.router.navigateByUrl(resolveLandingPath(this.authService)).then();

--- a/privacyidea/static_new/src/app/components/login/login.component.ts
+++ b/privacyidea/static_new/src/app/components/login/login.component.ts
@@ -38,7 +38,7 @@ import { MatFormField, MatInput, MatLabel, MatSuffix } from "@angular/material/i
 import { MatOption, MatSelect } from "@angular/material/select";
 import { Router } from "@angular/router";
 import { challengesTriggered, isAuthenticationSuccessful } from "@app/app.component";
-import { ROUTE_PATHS } from "@app/route_paths";
+import { resolveLandingPath } from "@app/guards/auth.guard";
 import { ClearButtonComponent } from "@components/shared/clear-button/clear-button.component";
 import { environment } from "@env/environment";
 import { AuthResponse, AuthService, AuthServiceInterface, PasswordLoginParams } from "@services/auth/auth.service";
@@ -156,10 +156,9 @@ export class LoginComponent implements OnDestroy, AfterViewInit {
   node = computed(() => this.configService.config()?.show_node);
 
   constructor() {
-    if (this.authService.isAuthenticated()) {
-      console.warn("User is already logged in.");
-      this.notificationService.warning($localize`User is already logged in.`);
-    } else {
+    // Authenticated users are redirected away from the login route by loginGuard, so the
+    // form only needs setup for the unauthenticated case.
+    if (!this.authService.isAuthenticated()) {
       this.showOtpField.set(false);
     }
 
@@ -315,17 +314,7 @@ export class LoginComponent implements OnDestroy, AfterViewInit {
       this.localService.saveData("bearer_token", response.result.value.token);
       this.showOtpField.set(false);
       this.sessionTimerService.initialTimerStart();
-      if (this.authService.tokenWizard()) {
-        this.router.navigateByUrl(ROUTE_PATHS.TOKENS_WIZARD).then();
-      } else if (this.authService.containerWizard().enabled) {
-        this.router.navigateByUrl(ROUTE_PATHS.CONTAINERS_WIZARD).then();
-      } else if (this.authService.role() === "user" || this.authService.anyTokenActionAllowed()) {
-        this.router.navigateByUrl(ROUTE_PATHS.TOKENS).then();
-      } else if (this.authService.anyContainerActionAllowed()) {
-        this.router.navigateByUrl(ROUTE_PATHS.CONTAINERS).then();
-      } else {
-        this.router.navigateByUrl(ROUTE_PATHS.TOKENS).then();
-      }
+      this.router.navigateByUrl(resolveLandingPath(this.authService)).then();
     } else if (challengesTriggered(response)) {
       // Setup depending on what kind of challenges were triggered
       if (response.detail.multi_challenge?.length) {

--- a/privacyidea/static_new/src/app/components/login/login.component.ts
+++ b/privacyidea/static_new/src/app/components/login/login.component.ts
@@ -227,7 +227,6 @@ export class LoginComponent implements OnDestroy, AfterViewInit {
   }
 
   logout(): void {
-    // AuthService.logout() already clears stored session keys and navigates to /login.
     this.authService.logout();
   }
 
@@ -302,8 +301,7 @@ export class LoginComponent implements OnDestroy, AfterViewInit {
 
   private evaluateResponse(response: AuthResponse, context: "password" | "passkey" | "webauthn"): void {
     if (isAuthenticationSuccessful(response)) {
-      // Successful auth -> log in. AuthService.authenticate() (which every login path goes
-      // through) has already persisted the token and auth data, so nothing to store here.
+      // Successful auth -> log in
       this.showOtpField.set(false);
       this.sessionTimerService.initialTimerStart();
       this.router.navigateByUrl(resolveLandingPath(this.authService)).then();

--- a/privacyidea/static_new/src/app/components/login/login.component.ts
+++ b/privacyidea/static_new/src/app/components/login/login.component.ts
@@ -156,12 +156,7 @@ export class LoginComponent implements OnDestroy, AfterViewInit {
   node = computed(() => this.configService.config()?.show_node);
 
   constructor() {
-    // Authenticated users are redirected away from the login route by loginGuard, so the
-    // form only needs setup for the unauthenticated case.
-    if (!this.authService.isAuthenticated()) {
-      this.showOtpField.set(false);
-    }
-
+    // Authenticated users are redirected away from the login route by loginGuard.
     effect(() => {
       if (this.showOtpField()) {
         // Use a timeout to ensure the element is rendered before trying to focus it.
@@ -234,9 +229,8 @@ export class LoginComponent implements OnDestroy, AfterViewInit {
   }
 
   logout(): void {
+    // AuthService.logout() already clears stored session keys and navigates to /login.
     this.authService.logout();
-    this.localService.removeData("bearer_token");
-    this.router.navigate(["login"]);
   }
 
   resetLogin(): void {

--- a/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.html
+++ b/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.html
@@ -1,0 +1,41 @@
+<!--
+ (c) NetKnights GmbH 2026,  https://netknights.it
+
+ This code is free software; you can redistribute it and/or
+ modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ as published by the Free Software Foundation; either
+ version 3 of the License, or any later version.
+
+ This code is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+
+ You should have received a copy of the GNU Affero General Public
+ License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<button
+  [matMenuTriggerFor]="languageMenu"
+  aria-label="Change language"
+  i18n-aria-label
+  i18n-matTooltip
+  mat-icon-button
+  matTooltip="Change language">
+  <mat-icon>language</mat-icon>
+</button>
+<mat-menu #languageMenu="matMenu">
+  @for (locale of locales; track locale.code) {
+    <button
+      (click)="switchTo(locale.code)"
+      [disabled]="locale.code === currentLocale"
+      mat-menu-item>
+      <span>{{ locale.label }}</span>
+      @if (locale.code === currentLocale) {
+        <mat-icon>check</mat-icon>
+      }
+    </button>
+  }
+</mat-menu>

--- a/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { LOCALE_ID } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { LanguageSwitcherComponent, LOCALE_COOKIE_NAME } from "./language-switcher.component";
+
+describe("LanguageSwitcherComponent", () => {
+  let navigateSpy: jest.SpyInstance;
+
+  interface TestableSwitcher {
+    currentLocale: string;
+    switchTo: (code: string) => void;
+    navigate: (url: string) => void;
+  }
+
+  const create = (locale: string): TestableSwitcher => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [LanguageSwitcherComponent],
+      providers: [{ provide: LOCALE_ID, useValue: locale }]
+    });
+    const fixture: ComponentFixture<LanguageSwitcherComponent> = TestBed.createComponent(LanguageSwitcherComponent);
+    fixture.detectChanges();
+    // Members are protected (template-only); access them through the instance for testing.
+    const component = fixture.componentInstance as unknown as TestableSwitcher;
+    navigateSpy = jest.spyOn(component, "navigate").mockImplementation(() => {});
+    return component;
+  };
+
+  beforeEach(() => {
+    // Clear the locale cookie between tests.
+    document.cookie = `${LOCALE_COOKIE_NAME}=; path=/; max-age=0`;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates", () => {
+    expect(create("en")).toBeTruthy();
+  });
+
+  it("reports the compiled locale as current", () => {
+    expect(create("de").currentLocale).toBe("de");
+    expect(create("zh-Hant").currentLocale).toBe("zh-Hant");
+  });
+
+  it("normalizes English region variants to 'en'", () => {
+    expect(create("en-US").currentLocale).toBe("en");
+    expect(create("en").currentLocale).toBe("en");
+  });
+
+  it("switching to another locale sets the cookie and navigates to that bundle", () => {
+    create("en").switchTo("de");
+    expect(document.cookie).toContain(`${LOCALE_COOKIE_NAME}=de`);
+    expect(navigateSpy).toHaveBeenCalledWith("/app/v2/de/");
+  });
+
+  it("switching to English navigates to the subpath-less base", () => {
+    create("de").switchTo("en");
+    expect(document.cookie).toContain(`${LOCALE_COOKIE_NAME}=en`);
+    expect(navigateSpy).toHaveBeenCalledWith("/app/v2/");
+  });
+
+  it("selecting the current locale is a no-op", () => {
+    create("de").switchTo("de");
+    expect(navigateSpy).not.toHaveBeenCalled();
+    expect(document.cookie).not.toContain(`${LOCALE_COOKIE_NAME}=de`);
+  });
+});

--- a/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.spec.ts
@@ -96,4 +96,11 @@ describe("LanguageSwitcherComponent", () => {
     create("en").switchTo("de");
     expect(navigateSpy).toHaveBeenCalledWith("/app/v2/de/tokens");
   });
+
+  it("does not double the locale prefix when a foreign locale segment is in the URL", () => {
+    // e.g. the English bundle served in place at a non-English URL after a missing-bundle fallback.
+    window.history.replaceState({}, "", "/app/v2/zh-Hant/tokens");
+    create("en").switchTo("de");
+    expect(navigateSpy).toHaveBeenCalledWith("/app/v2/de/tokens");
+  });
 });

--- a/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.spec.ts
@@ -44,8 +44,9 @@ describe("LanguageSwitcherComponent", () => {
   };
 
   beforeEach(() => {
-    // Clear the locale cookie between tests.
+    // Clear the locale cookie and reset the URL to a known root between tests.
     document.cookie = `${LOCALE_COOKIE_NAME}=; path=/; max-age=0`;
+    window.history.replaceState({}, "", "/");
   });
 
   afterEach(() => {
@@ -82,5 +83,17 @@ describe("LanguageSwitcherComponent", () => {
     create("de").switchTo("de");
     expect(navigateSpy).not.toHaveBeenCalled();
     expect(document.cookie).not.toContain(`${LOCALE_COOKIE_NAME}=de`);
+  });
+
+  it("preserves the current in-app route and query string when switching", () => {
+    window.history.replaceState({}, "", "/app/v2/de/tokens/details/OATH0001?foo=bar");
+    create("de").switchTo("fr");
+    expect(navigateSpy).toHaveBeenCalledWith("/app/v2/fr/tokens/details/OATH0001?foo=bar");
+  });
+
+  it("maps the route correctly when leaving English (no locale subpath)", () => {
+    window.history.replaceState({}, "", "/app/v2/tokens");
+    create("en").switchTo("de");
+    expect(navigateSpy).toHaveBeenCalledWith("/app/v2/de/tokens");
   });
 });

--- a/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.ts
@@ -76,7 +76,14 @@ export class LanguageSwitcherComponent {
     // language preference and reconcile the cookie from it on login.
     // Each locale is a separately compiled bundle at its own base href, so applying a
     // language is always a full-page navigation to that bundle (English has no subpath).
-    this.navigate(code === "en" ? "/app/v2/" : `/app/v2/${code}/`);
+    // Preserve the current in-app route (plus query/hash) so the user stays on the same
+    // page instead of bouncing through the root -> login redirect after the reload. The
+    // base path for a locale mirrors baseHrefFactory: English has no locale subpath.
+    const baseFor = (locale: string) => (locale === "en" ? "/app/v2/" : `/app/v2/${locale}/`);
+    const currentBase = baseFor(this.currentLocale);
+    const path = window.location.pathname;
+    const subPath = path.startsWith(currentBase) ? path.slice(currentBase.length) : "";
+    this.navigate(baseFor(code) + subPath + window.location.search + window.location.hash);
   }
 
   protected navigate(url: string): void {

--- a/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.ts
@@ -1,0 +1,85 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { Component, inject, LOCALE_ID } from "@angular/core";
+import { MatButtonModule } from "@angular/material/button";
+import { MatIconModule } from "@angular/material/icon";
+import { MatMenuModule } from "@angular/material/menu";
+import { MatTooltipModule } from "@angular/material/tooltip";
+
+interface UiLocale {
+  /** Canonical locale code; matches the built bundle folder and the /app/v2/<code>/ path. */
+  code: string;
+  /** Endonym (the language's own name); intentionally not translated. */
+  label: string;
+}
+
+/** Name of the cookie that records the explicit language choice. Read by the backend
+ *  before the Accept-Language header when resolving which locale bundle to serve. */
+export const LOCALE_COOKIE_NAME = "pi_ui_locale";
+
+/** Available UI languages. Order and codes mirror the backend DEFAULT_LANGUAGE_LIST. */
+const UI_LOCALES: UiLocale[] = [
+  { code: "en", label: "English" },
+  { code: "de", label: "Deutsch" },
+  { code: "nl", label: "Nederlands" },
+  { code: "zh-Hant", label: "繁體中文" },
+  { code: "fr", label: "Français" },
+  { code: "es", label: "Español" },
+  { code: "tr", label: "Türkçe" },
+  { code: "cs", label: "Čeština" },
+  { code: "it", label: "Italiano" },
+  { code: "ta", label: "தமிழ்" },
+  { code: "pt", label: "Português" },
+  { code: "ru", label: "Русский" },
+  { code: "uk", label: "Українська" }
+];
+
+@Component({
+  selector: "app-language-switcher",
+  standalone: true,
+  imports: [MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule],
+  templateUrl: "./language-switcher.component.html"
+})
+export class LanguageSwitcherComponent {
+  private readonly localeId = inject(LOCALE_ID);
+  protected readonly locales = UI_LOCALES;
+  protected readonly currentLocale = this.normalize(this.localeId);
+
+  private normalize(code: string): string {
+    return code === "en" || code.toLowerCase().startsWith("en-") ? "en" : code;
+  }
+
+  protected switchTo(code: string): void {
+    if (code === this.currentLocale) {
+      return;
+    }
+    // Persist the explicit choice for a year. The backend reads this before the
+    // Accept-Language header, so the preference survives reloads and deep links.
+    document.cookie = `${LOCALE_COOKIE_NAME}=${code}; path=/; max-age=31536000; SameSite=Lax`;
+    // later: when authenticated, also persist this to /user/settings as the user's
+    // language preference and reconcile the cookie from it on login.
+    // Each locale is a separately compiled bundle at its own base href, so applying a
+    // language is always a full-page navigation to that bundle (English has no subpath).
+    this.navigate(code === "en" ? "/app/v2/" : `/app/v2/${code}/`);
+  }
+
+  protected navigate(url: string): void {
+    window.location.assign(url);
+  }
+}

--- a/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/language-switcher/language-switcher.component.ts
@@ -21,6 +21,7 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatIconModule } from "@angular/material/icon";
 import { MatMenuModule } from "@angular/material/menu";
 import { MatTooltipModule } from "@angular/material/tooltip";
+import { APP_PREFIX, localeBaseHref } from "@core/locale";
 
 interface UiLocale {
   /** Canonical locale code; matches the built bundle folder and the /app/v2/<code>/ path. */
@@ -50,6 +51,9 @@ const UI_LOCALES: UiLocale[] = [
   { code: "uk", label: "Українська" }
 ];
 
+/** Locale codes that may appear as the first path segment of an /app/v2/ URL. */
+const LOCALE_CODES = new Set(UI_LOCALES.map((locale) => locale.code));
+
 @Component({
   selector: "app-language-switcher",
   standalone: true,
@@ -74,16 +78,21 @@ export class LanguageSwitcherComponent {
     document.cookie = `${LOCALE_COOKIE_NAME}=${code}; path=/; max-age=31536000; SameSite=Lax`;
     // later: when authenticated, also persist this to /user/settings as the user's
     // language preference and reconcile the cookie from it on login.
-    // Each locale is a separately compiled bundle at its own base href, so applying a
-    // language is always a full-page navigation to that bundle (English has no subpath).
-    // Preserve the current in-app route (plus query/hash) so the user stays on the same
-    // page instead of bouncing through the root -> login redirect after the reload. The
-    // base path for a locale mirrors baseHrefFactory: English has no locale subpath.
-    const baseFor = (locale: string) => (locale === "en" ? "/app/v2/" : `/app/v2/${locale}/`);
-    const currentBase = baseFor(this.currentLocale);
+    // Each locale is a separately compiled bundle, so applying a language is a full-page
+    // navigation. Preserve the current in-app route (plus query/hash) so the user stays on
+    // the same page instead of bouncing through the root -> login redirect after the reload.
+    this.navigate(localeBaseHref(code) + this.currentSubPath() + window.location.search + window.location.hash);
+  }
+
+  /** The in-app route after the /app/v2/ prefix and any leading locale segment. */
+  private currentSubPath(): string {
     const path = window.location.pathname;
-    const subPath = path.startsWith(currentBase) ? path.slice(currentBase.length) : "";
-    this.navigate(baseFor(code) + subPath + window.location.search + window.location.hash);
+    if (!path.startsWith(APP_PREFIX)) {
+      return "";
+    }
+    const rest = path.slice(APP_PREFIX.length);
+    const firstSegment = rest.split("/", 1)[0];
+    return LOCALE_CODES.has(firstSegment) ? rest.slice(firstSegment.length + 1) : rest;
   }
 
   protected navigate(url: string): void {

--- a/privacyidea/static_new/src/app/core/constants.ts
+++ b/privacyidea/static_new/src/app/core/constants.ts
@@ -18,3 +18,4 @@
  **/
 export const APP_THEME_STORAGE_KEY = "appTheme";
 export const BEARER_TOKEN_STORAGE_KEY = "bearer_token";
+export const AUTH_DATA_STORAGE_KEY = "auth_data";

--- a/privacyidea/static_new/src/app/core/locale.ts
+++ b/privacyidea/static_new/src/app/core/locale.ts
@@ -1,0 +1,29 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+
+/** Mount point of the new WebUI; locale bundles live at APP_PREFIX or APP_PREFIX + "<locale>/". */
+export const APP_PREFIX = "/app/v2/";
+
+/**
+ * Base href for a compiled locale bundle. The source locale (English) is served at the app
+ * root without a locale subpath; every other locale lives under /app/v2/<locale>/.
+ */
+export function localeBaseHref(locale: string): string {
+  return locale === "en" || locale.toLowerCase().startsWith("en-") ? APP_PREFIX : `${APP_PREFIX}${locale}/`;
+}

--- a/privacyidea/static_new/src/app/guards/auth.guard.spec.ts
+++ b/privacyidea/static_new/src/app/guards/auth.guard.spec.ts
@@ -19,11 +19,21 @@
 import { provideHttpClient } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
-import { CanMatchFn, Route, Router, UrlSegment } from "@angular/router";
-import { AuthService } from "@services/auth/auth.service";
+import {
+  ActivatedRouteSnapshot,
+  CanMatchFn,
+  provideRouter,
+  Route,
+  Router,
+  RouterStateSnapshot,
+  UrlSegment,
+  UrlTree
+} from "@angular/router";
+import { ROUTE_PATHS } from "@app/route_paths";
+import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { NotificationService } from "@services/notification/notification.service";
 import { MockAuthService, MockLocalService, MockNotificationService, MockRouter } from "@testing/mock-services";
-import { adminMatch, AuthGuard, selfServiceMatch } from "./auth.guard";
+import { adminMatch, AuthGuard, loginGuard, resolveLandingPath, selfServiceMatch } from "./auth.guard";
 
 const flushPromises = () => new Promise((r) => setTimeout(r, 0));
 
@@ -154,5 +164,64 @@ describe("AuthGuard class", () => {
     await flushPromises();
 
     expect(notificationService.warning).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveLandingPath", () => {
+  let authMock: MockAuthService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [{ provide: AuthService, useClass: MockAuthService }]
+    });
+    authMock = TestBed.inject(AuthService) as unknown as MockAuthService;
+  });
+
+  const landingPath = () => resolveLandingPath(authMock as unknown as AuthServiceInterface);
+
+  it("prioritizes the token wizard", () => {
+    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, token_wizard: true });
+    expect(landingPath()).toBe(ROUTE_PATHS.TOKENS_WIZARD);
+  });
+
+  it("falls back to the tokens page for a regular admin", () => {
+    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, role: "admin", token_wizard: false });
+    expect(landingPath()).toBe(ROUTE_PATHS.TOKENS);
+  });
+});
+
+describe("loginGuard", () => {
+  const runGuard = () =>
+    TestBed.runInInjectionContext(() => loginGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot));
+  let authMock: MockAuthService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: AuthService, useClass: MockAuthService },
+        MockLocalService,
+        MockNotificationService
+      ]
+    });
+    authMock = TestBed.inject(AuthService) as unknown as MockAuthService;
+  });
+
+  it("allows the login route when not authenticated", () => {
+    authMock.isAuthenticated.set(false);
+    expect(runGuard()).toBe(true);
+  });
+
+  it("redirects authenticated users to their landing page", () => {
+    authMock.isAuthenticated.set(true);
+    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, role: "admin" });
+
+    const result = runGuard();
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(TestBed.inject(Router).serializeUrl(result as UrlTree)).toBe(ROUTE_PATHS.TOKENS);
   });
 });

--- a/privacyidea/static_new/src/app/guards/auth.guard.spec.ts
+++ b/privacyidea/static_new/src/app/guards/auth.guard.spec.ts
@@ -180,13 +180,19 @@ describe("resolveLandingPath", () => {
 
   const landingPath = () => resolveLandingPath(authMock as unknown as AuthServiceInterface);
 
-  it("prioritizes the token wizard", () => {
-    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, token_wizard: true });
+  it("sends a self-service user with the token wizard enabled to the token wizard", () => {
+    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, role: "user", token_wizard: true });
     expect(landingPath()).toBe(ROUTE_PATHS.TOKENS_WIZARD);
   });
 
   it("falls back to the tokens page for a regular admin", () => {
     authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, role: "admin", token_wizard: false });
+    expect(landingPath()).toBe(ROUTE_PATHS.TOKENS);
+  });
+
+  it("does NOT send a non-self-service user to a wizard route even when a wizard is enabled", () => {
+    // Wizard routes exist only for self-service; routing an admin there would loop via '**'.
+    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, role: "admin", token_wizard: true });
     expect(landingPath()).toBe(ROUTE_PATHS.TOKENS);
   });
 });

--- a/privacyidea/static_new/src/app/guards/auth.guard.ts
+++ b/privacyidea/static_new/src/app/guards/auth.guard.ts
@@ -17,12 +17,46 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { inject, Injectable } from "@angular/core";
-import { CanActivate, CanActivateChild, CanMatchFn, Router } from "@angular/router";
+import { CanActivate, CanActivateChild, CanActivateFn, CanMatchFn, Router } from "@angular/router";
+import { ROUTE_PATHS } from "@app/route_paths";
 import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { NotificationService, NotificationServiceInterface } from "@services/notification/notification.service";
 
 export const adminMatch: CanMatchFn = () => inject(AuthService).role() === "admin";
 export const selfServiceMatch: CanMatchFn = () => inject(AuthService).role() === "user";
+
+/**
+ * Resolve the route an authenticated user should land on. Mirrors the post-login
+ * navigation: wizards first, then tokens or containers depending on role and permissions.
+ */
+export function resolveLandingPath(authService: AuthServiceInterface): string {
+  if (authService.tokenWizard()) {
+    return ROUTE_PATHS.TOKENS_WIZARD;
+  }
+  if (authService.containerWizard().enabled) {
+    return ROUTE_PATHS.CONTAINERS_WIZARD;
+  }
+  if (authService.role() === "user" || authService.anyTokenActionAllowed()) {
+    return ROUTE_PATHS.TOKENS;
+  }
+  if (authService.anyContainerActionAllowed()) {
+    return ROUTE_PATHS.CONTAINERS;
+  }
+  return ROUTE_PATHS.TOKENS;
+}
+
+/**
+ * Keeps authenticated users off the login page: when a session is already active (e.g.
+ * restored after a full reload from switching the UI language), redirect to the landing
+ * page instead of showing the login form.
+ */
+export const loginGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  if (!authService.isAuthenticated()) {
+    return true;
+  }
+  return inject(Router).parseUrl(resolveLandingPath(authService));
+};
 
 @Injectable({
   providedIn: "root"

--- a/privacyidea/static_new/src/app/guards/auth.guard.ts
+++ b/privacyidea/static_new/src/app/guards/auth.guard.ts
@@ -30,13 +30,19 @@ export const selfServiceMatch: CanMatchFn = () => inject(AuthService).role() ===
  * navigation: wizards first, then tokens or containers depending on role and permissions.
  */
 export function resolveLandingPath(authService: AuthServiceInterface): string {
-  if (authService.tokenWizard()) {
-    return ROUTE_PATHS.TOKENS_WIZARD;
+  // The wizard routes live only in the self-service route tree (selfServiceMatch), so only a
+  // self-service user may be sent there. Directing any other role to a wizard path produces a
+  // URL with no matching route -> '**' -> /login -> loginGuard -> the same path -> redirect loop.
+  if (authService.role() === "user") {
+    if (authService.tokenWizard()) {
+      return ROUTE_PATHS.TOKENS_WIZARD;
+    }
+    if (authService.containerWizard().enabled) {
+      return ROUTE_PATHS.CONTAINERS_WIZARD;
+    }
+    return ROUTE_PATHS.TOKENS;
   }
-  if (authService.containerWizard().enabled) {
-    return ROUTE_PATHS.CONTAINERS_WIZARD;
-  }
-  if (authService.role() === "user" || authService.anyTokenActionAllowed()) {
+  if (authService.anyTokenActionAllowed()) {
     return ROUTE_PATHS.TOKENS;
   }
   if (authService.anyContainerActionAllowed()) {

--- a/privacyidea/static_new/src/app/services/auth/auth.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/auth/auth.service.spec.ts
@@ -22,6 +22,7 @@ import { provideHttpClient } from "@angular/common/http";
 import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
 import { Router } from "@angular/router";
 import { AppComponent } from "@app/app.component";
+import { AUTH_DATA_STORAGE_KEY, BEARER_TOKEN_STORAGE_KEY } from "@core/constants";
 import { LocalService } from "@services/local/local.service";
 import { NotificationService } from "@services/notification/notification.service";
 import { VersioningService } from "@services/version/version.service";
@@ -490,6 +491,51 @@ describe("AuthService", () => {
         rights: ["totp_2step=allow", "totp_2step"]
       } as unknown as AuthData);
       expect(authService.check2Step("totp")).toBe("allow");
+    });
+  });
+
+  describe("session rehydration (restoreSession)", () => {
+    const makeJwt = (expSecondsFromNow: number): string => {
+      const payload = {
+        username: "admin",
+        realm: "",
+        nonce: "",
+        role: "admin",
+        authtype: "",
+        exp: Math.floor(Date.now() / 1000) + expSecondsFromNow,
+        rights: []
+      };
+      return `h.${btoa(JSON.stringify(payload))}.s`;
+    };
+
+    const restore = () => (authService as unknown as { restoreSession: () => void }).restoreSession();
+
+    it("restores an active session from a valid stored token and auth data", () => {
+      mockLocal.saveData(BEARER_TOKEN_STORAGE_KEY, makeJwt(3600));
+      mockLocal.saveData(AUTH_DATA_STORAGE_KEY, JSON.stringify({ token: "t", role: "admin", username: "admin" }));
+      restore();
+      expect(authService.isAuthenticated()).toBe(true);
+      expect(authService.role()).toBe("admin");
+    });
+
+    it("does not restore and clears storage when the token is expired", () => {
+      mockLocal.saveData(BEARER_TOKEN_STORAGE_KEY, makeJwt(-3600));
+      mockLocal.saveData(AUTH_DATA_STORAGE_KEY, JSON.stringify({ token: "t" }));
+      restore();
+      expect(authService.isAuthenticated()).toBe(false);
+      expect(mockLocal.removeData).toHaveBeenCalledWith(BEARER_TOKEN_STORAGE_KEY);
+      expect(mockLocal.removeData).toHaveBeenCalledWith(AUTH_DATA_STORAGE_KEY);
+    });
+
+    it("stays unauthenticated when no token is stored", () => {
+      restore();
+      expect(authService.isAuthenticated()).toBe(false);
+    });
+
+    it("stays unauthenticated when the token is valid but auth data is missing", () => {
+      mockLocal.saveData(BEARER_TOKEN_STORAGE_KEY, makeJwt(3600));
+      restore();
+      expect(authService.isAuthenticated()).toBe(false);
     });
   });
 });

--- a/privacyidea/static_new/src/app/services/auth/auth.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/auth/auth.service.spec.ts
@@ -395,6 +395,19 @@ describe("AuthService", () => {
     expect(authService.jwtData()).toMatchObject(payload);
     expect(authService.isAuthenticated()).toBe(true);
 
+    // The JWT is persisted on its own; the stored auth data must not duplicate the token
+    // or any JWT claim (token, rights, role, username, realm), but keeps the UI config.
+    expect(mockLocal.saveData).toHaveBeenCalledWith(BEARER_TOKEN_STORAGE_KEY, jwt);
+    const authDataCall = (mockLocal.saveData as jest.Mock).mock.calls.find((c) => c[0] === AUTH_DATA_STORAGE_KEY);
+    const persisted = JSON.parse(authDataCall![1]);
+    expect(persisted.token).toBeUndefined();
+    expect(persisted.rights).toBeUndefined();
+    expect(persisted.role).toBeUndefined();
+    expect(persisted.username).toBeUndefined();
+    expect(persisted.realm).toBeUndefined();
+    expect(persisted.menus).toEqual([]);
+    expect(persisted.default_tokentype).toBe("hotp");
+
     sub.unsubscribe();
   });
 

--- a/privacyidea/static_new/src/app/services/auth/auth.service.ts
+++ b/privacyidea/static_new/src/app/services/auth/auth.service.ts
@@ -346,6 +346,18 @@ export class AuthService implements AuthServiceInterface {
    * The token and the auth data are restored only while the JWT is still valid; an
    * expired or corrupt session is cleared instead.
    */
+  /**
+   * Strip the fields that the bearer token already carries before persisting the auth data.
+   * The token (stored separately) is the source of truth for identity and rights via the
+   * decoded JWT, so the token string and the JWT claims (rights, role, username, realm) are
+   * not duplicated into storage; everything that remains is UI/policy config not in the JWT.
+   */
+  private persistableAuthData(authData: AuthData): Omit<AuthData, "token" | "rights" | "role" | "username" | "realm"> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { token, rights, role, username, realm, ...rest } = authData;
+    return rest;
+  }
+
   private restoreSession(): void {
     const token = this.localService.getData(BEARER_TOKEN_STORAGE_KEY);
     if (!token) {
@@ -393,7 +405,7 @@ export class AuthService implements AuthServiceInterface {
             this.authData.set(value);
             this.jwtData.set(this.decodeJwtPayload(value.token));
             this.localService.saveData(BEARER_TOKEN_STORAGE_KEY, value.token);
-            this.localService.saveData(AUTH_DATA_STORAGE_KEY, JSON.stringify(value));
+            this.localService.saveData(AUTH_DATA_STORAGE_KEY, JSON.stringify(this.persistableAuthData(value)));
           }
         }),
         catchError((error) => {

--- a/privacyidea/static_new/src/app/services/auth/auth.service.ts
+++ b/privacyidea/static_new/src/app/services/auth/auth.service.ts
@@ -22,7 +22,7 @@ import { Injectable, Signal, WritableSignal, computed, inject, signal } from "@a
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
 import { PiResponse } from "@app/app.component";
-import { BEARER_TOKEN_STORAGE_KEY } from "@core/constants";
+import { AUTH_DATA_STORAGE_KEY, BEARER_TOKEN_STORAGE_KEY } from "@core/constants";
 import { environment } from "@env/environment";
 import { PolicyAction } from "@services/auth/policy-actions";
 import { LocalService, LocalServiceInterface } from "@services/local/local.service";
@@ -336,6 +336,40 @@ export class AuthService implements AuthServiceInterface {
   );
   readonly isSelfServiceUser = computed(() => this.role() === "user");
 
+  constructor() {
+    this.restoreSession();
+  }
+
+  /**
+   * Rehydrate the session from storage on bootstrap so a full page reload (e.g. switching
+   * the UI language, which loads a different locale bundle) does not drop an active login.
+   * The token and the auth data are restored only while the JWT is still valid; an
+   * expired or corrupt session is cleared instead.
+   */
+  private restoreSession(): void {
+    const token = this.localService.getData(BEARER_TOKEN_STORAGE_KEY);
+    if (!token) {
+      return;
+    }
+    const jwt = this.decodeJwtPayload(token);
+    if (!jwt || (jwt.exp && jwt.exp * 1000 <= Date.now())) {
+      this.localService.removeData(BEARER_TOKEN_STORAGE_KEY);
+      this.localService.removeData(AUTH_DATA_STORAGE_KEY);
+      return;
+    }
+    const storedAuthData = this.localService.getData(AUTH_DATA_STORAGE_KEY);
+    if (!storedAuthData) {
+      return;
+    }
+    try {
+      this.authData.set(JSON.parse(storedAuthData) as AuthData);
+      this.jwtData.set(jwt);
+      this.authenticationAccepted.set(true);
+    } catch {
+      this.localService.removeData(AUTH_DATA_STORAGE_KEY);
+    }
+  }
+
   getHeaders(): HttpHeaders {
     return new HttpHeaders({
       "PI-Authorization": this.localService.getData(BEARER_TOKEN_STORAGE_KEY) || ""
@@ -359,6 +393,7 @@ export class AuthService implements AuthServiceInterface {
             this.authData.set(value);
             this.jwtData.set(this.decodeJwtPayload(value.token));
             this.localService.saveData(BEARER_TOKEN_STORAGE_KEY, value.token);
+            this.localService.saveData(AUTH_DATA_STORAGE_KEY, JSON.stringify(value));
           }
         }),
         catchError((error) => {
@@ -376,6 +411,7 @@ export class AuthService implements AuthServiceInterface {
     this.authData.set(null);
     this.jwtData.set(null);
     this.localService.removeData(BEARER_TOKEN_STORAGE_KEY);
+    this.localService.removeData(AUTH_DATA_STORAGE_KEY);
     this.authenticationAccepted.set(false);
     this.router.navigate(["login"]);
   }

--- a/privacyidea/static_new/src/app/services/auth/auth.service.ts
+++ b/privacyidea/static_new/src/app/services/auth/auth.service.ts
@@ -364,13 +364,16 @@ export class AuthService implements AuthServiceInterface {
       return;
     }
     const jwt = this.decodeJwtPayload(token);
-    if (!jwt || (jwt.exp && jwt.exp * 1000 <= Date.now())) {
-      this.localService.removeData(BEARER_TOKEN_STORAGE_KEY);
-      this.localService.removeData(AUTH_DATA_STORAGE_KEY);
+    // Treat a missing/zero exp as expired: such a token cannot establish a valid session.
+    if (!jwt || !jwt.exp || jwt.exp * 1000 <= Date.now()) {
+      this.clearStoredSession();
       return;
     }
     const storedAuthData = this.localService.getData(AUTH_DATA_STORAGE_KEY);
     if (!storedAuthData) {
+      // A token without its auth data cannot be restored; clear it so getHeaders() does not
+      // keep sending a bearer token for a session the UI considers logged out.
+      this.clearStoredSession();
       return;
     }
     try {
@@ -378,8 +381,13 @@ export class AuthService implements AuthServiceInterface {
       this.jwtData.set(jwt);
       this.authenticationAccepted.set(true);
     } catch {
-      this.localService.removeData(AUTH_DATA_STORAGE_KEY);
+      this.clearStoredSession();
     }
+  }
+
+  private clearStoredSession(): void {
+    this.localService.removeData(BEARER_TOKEN_STORAGE_KEY);
+    this.localService.removeData(AUTH_DATA_STORAGE_KEY);
   }
 
   getHeaders(): HttpHeaders {
@@ -422,8 +430,7 @@ export class AuthService implements AuthServiceInterface {
     this.dialog.closeAll();
     this.authData.set(null);
     this.jwtData.set(null);
-    this.localService.removeData(BEARER_TOKEN_STORAGE_KEY);
-    this.localService.removeData(AUTH_DATA_STORAGE_KEY);
+    this.clearStoredSession();
     this.authenticationAccepted.set(false);
     this.router.navigate(["login"]);
   }

--- a/privacyidea/static_new/src/app/services/auth/auth.service.ts
+++ b/privacyidea/static_new/src/app/services/auth/auth.service.ts
@@ -161,14 +161,17 @@ export interface WebAuthnLoginParams {
  * Imported `PasskeyCheckParams` from `validate.service` would create a
  * cycle, so callers pass the structurally compatible shape directly.
  */
-export type AuthenticateParams = PasswordLoginParams | WebAuthnLoginParams | {
-  transaction_id: string;
-  credential_id: string;
-  authenticatorData: string;
-  clientDataJSON: string;
-  signature: string;
-  userHandle: string;
-};
+export type AuthenticateParams =
+  | PasswordLoginParams
+  | WebAuthnLoginParams
+  | {
+      transaction_id: string;
+      credential_id: string;
+      authenticatorData: string;
+      clientDataJSON: string;
+      signature: string;
+      userHandle: string;
+    };
 
 export interface AuthServiceInterface {
   // Properties
@@ -341,12 +344,6 @@ export class AuthService implements AuthServiceInterface {
   }
 
   /**
-   * Rehydrate the session from storage on bootstrap so a full page reload (e.g. switching
-   * the UI language, which loads a different locale bundle) does not drop an active login.
-   * The token and the auth data are restored only while the JWT is still valid; an
-   * expired or corrupt session is cleared instead.
-   */
-  /**
    * Strip the fields that the bearer token already carries before persisting the auth data.
    * The token (stored separately) is the source of truth for identity and rights via the
    * decoded JWT, so the token string and the JWT claims (rights, role, username, realm) are
@@ -358,6 +355,12 @@ export class AuthService implements AuthServiceInterface {
     return rest;
   }
 
+  /**
+   * Rehydrate the session from storage on bootstrap so a full page reload (e.g. switching
+   * the UI language, which loads a different locale bundle) does not drop an active login.
+   * The token and the auth data are restored only while the JWT is still valid; an
+   * expired or corrupt session is cleared instead.
+   */
   private restoreSession(): void {
     const token = this.localService.getData(BEARER_TOKEN_STORAGE_KEY);
     if (!token) {

--- a/privacyidea/static_new/src/app/services/welcome/welcome-dialog.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/welcome/welcome-dialog.service.spec.ts
@@ -39,30 +39,28 @@ describe("WelcomeDialogService", () => {
     authMock = TestBed.inject(AuthService) as unknown as MockAuthService;
   });
 
-  it("opens dialog when authenticated and not explicitly hidden by status===3", () => {
-    authMock.isAuthenticated.set(true);
-    authMock.authData.set({
-      ...MockAuthService.MOCK_AUTH_DATA,
-      hide_welcome: false,
-      subscription_status: 2
-    });
+  it("opens dialog on an interactive login (auth transitions to true after init)", () => {
+    authMock.isAuthenticated.set(false);
     const service = TestBed.inject(WelcomeDialogService);
+
+    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, hide_welcome: false });
+    authMock.isAuthenticated.set(true);
     TestBed.tick();
 
     expect(service.opened()).toBe(true);
+    expect(dialogMock.open).toHaveBeenCalled();
   });
 
-  it("does NOT open when hideWelcome is true and subscriptionStatus===3", () => {
-    authMock.isAuthenticated.set(true);
-    authMock.authData.set({
-      ...MockAuthService.MOCK_AUTH_DATA,
-      hide_welcome: true,
-      subscription_status: 3
-    });
+  it("does NOT open on login when hideWelcome is true", () => {
+    authMock.isAuthenticated.set(false);
     const service = TestBed.inject(WelcomeDialogService);
+
+    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, hide_welcome: true });
+    authMock.isAuthenticated.set(true);
     TestBed.tick();
 
     expect(service.opened()).toBe(false);
+    expect(dialogMock.open).not.toHaveBeenCalled();
   });
 
   it("does NOT open when not authenticated", () => {
@@ -71,5 +69,16 @@ describe("WelcomeDialogService", () => {
     TestBed.tick();
 
     expect(service.opened()).toBe(false);
+  });
+
+  it("does NOT re-open for a session already authenticated at startup (restored on reload)", () => {
+    // Authenticated before the service is constructed = a restored session, not a fresh login.
+    authMock.isAuthenticated.set(true);
+    authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, hide_welcome: false });
+    const service = TestBed.inject(WelcomeDialogService);
+    TestBed.tick();
+
+    expect(service.opened()).toBe(false);
+    expect(dialogMock.open).not.toHaveBeenCalled();
   });
 });

--- a/privacyidea/static_new/src/app/services/welcome/welcome-dialog.service.ts
+++ b/privacyidea/static_new/src/app/services/welcome/welcome-dialog.service.ts
@@ -26,13 +26,26 @@ export class WelcomeDialogService {
   private readonly dialog = inject(MatDialog);
   private readonly auth: AuthServiceInterface = inject(AuthService);
   readonly opened = signal<boolean>(false);
+  // Whether the welcome decision has already been made for the current authenticated session.
+  // Seeded from the bootstrap auth state so a session restored on a reload (e.g. a language
+  // switch) is not treated as a fresh login and does not re-open the dialog.
+  private welcomeHandled = false;
 
   constructor() {
+    this.welcomeHandled = this.auth.isAuthenticated();
     effect(() => {
       const isAuth = this.auth.isAuthenticated();
-      const hideWelcome = this.auth.hideWelcome();
-
-      if (isAuth && !hideWelcome) {
+      if (!isAuth) {
+        // Logged out: allow the dialog again on the next interactive login.
+        this.welcomeHandled = false;
+        this.opened.set(false);
+        return;
+      }
+      if (this.welcomeHandled) {
+        return;
+      }
+      this.welcomeHandled = true;
+      if (!this.auth.hideWelcome()) {
         this.opened.set(true);
         this.dialog.open(WelcomeDialogComponent, {
           disableClose: true,

--- a/privacyidea/static_new/src/locale/messages.cs.xlf
+++ b/privacyidea/static_new/src/locale/messages.cs.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Změnit jazyk</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.de.xlf
+++ b/privacyidea/static_new/src/locale/messages.de.xlf
@@ -16618,6 +16618,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Sprache ändern</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.es.xlf
+++ b/privacyidea/static_new/src/locale/messages.es.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Cambiar idioma</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.fr.xlf
+++ b/privacyidea/static_new/src/locale/messages.fr.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Changer de langue</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.it.xlf
+++ b/privacyidea/static_new/src/locale/messages.it.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Cambia lingua</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.nl.xlf
+++ b/privacyidea/static_new/src/locale/messages.nl.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Taal wijzigen</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.pt.xlf
+++ b/privacyidea/static_new/src/locale/messages.pt.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Alterar idioma</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.ru.xlf
+++ b/privacyidea/static_new/src/locale/messages.ru.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Изменить язык</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.ta.xlf
+++ b/privacyidea/static_new/src/locale/messages.ta.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>மொழியை மாற்று</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.tr.xlf
+++ b/privacyidea/static_new/src/locale/messages.tr.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Dili değiştir</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.uk.xlf
+++ b/privacyidea/static_new/src/locale/messages.uk.xlf
@@ -16618,6 +16618,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>Змінити мову</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/static_new/src/locale/messages.xlf
+++ b/privacyidea/static_new/src/locale/messages.xlf
@@ -7144,41 +7144,41 @@
         <source>Refresh Resources</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/layout/user-utils-panel/user-utils-panel.component.html</context>
-          <context context-type="linenumber">40,41</context>
+          <context context-type="linenumber">41,42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/layout/user-utils-panel/user-utils-panel.self-service.component.html</context>
-          <context context-type="linenumber">28,29</context>
+          <context context-type="linenumber">29,30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="947729324223651141" datatype="html">
         <source>Time until session expires</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/layout/user-utils-panel/user-utils-panel.component.html</context>
-          <context context-type="linenumber">53,54</context>
+          <context context-type="linenumber">54,55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/layout/user-utils-panel/user-utils-panel.self-service.component.html</context>
-          <context context-type="linenumber">52,53</context>
+          <context context-type="linenumber">53,54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3797778920049399855" datatype="html">
         <source>Logout</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/layout/user-utils-panel/user-utils-panel.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">60</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/layout/user-utils-panel/user-utils-panel.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/layout/user-utils-panel/user-utils-panel.self-service.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">36</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/layout/user-utils-panel/user-utils-panel.self-service.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">41</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.ts</context>
@@ -8284,6 +8284,17 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/token/token-details/token-details-actions/set-pin-action/set-pin-action.component.ts</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3607584482891376289" datatype="html">

--- a/privacyidea/static_new/src/locale/messages.zh-Hant.xlf
+++ b/privacyidea/static_new/src/locale/messages.zh-Hant.xlf
@@ -16629,6 +16629,18 @@
           <context context-type="linenumber">31,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1210069423269934042" datatype="html">
+        <source>Change language</source>
+        <target>變更語言</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/shared/language-switcher/language-switcher.component.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/privacyidea/webui/login.py
+++ b/privacyidea/webui/login.py
@@ -50,6 +50,10 @@ DEFAULT_THEME = "/static/contrib/css/bootstrap-theme.css"
 DEFAULT_LANGUAGE_LIST = ['en', 'de', 'nl', 'zh_Hant', 'fr', 'es', 'tr', 'cs',
                          'it', 'ta', 'pt', 'ru', 'uk']  #:
 
+# Cookie that records an explicit UI language choice (set by the WebUI language switcher).
+# It is consulted before the browser's Accept-Language header when resolving the locale.
+LOCALE_COOKIE_NAME = "pi_ui_locale"
+
 # Case-insensitive, separator-insensitive lookup: normalized key → canonical BCP 47 locale
 _LOCALE_CANONICAL = {lang.replace("_", "-").lower(): lang.replace("_", "-") for lang in DEFAULT_LANGUAGE_LIST}
 
@@ -74,6 +78,23 @@ def get_accepted_language():
     pi_lang_list = get_app_config_value("PI_PREFERRED_LANGUAGE", default=DEFAULT_LANGUAGE_LIST)
     # try to match the language from the users accept header the browser transmits.
     # (The best match wins)
+    return request.accept_languages.best_match(pi_lang_list, default=pi_lang_list[0])
+
+
+def get_preferred_language():
+    """Resolve the preferred UI locale: an explicit choice stored in the locale cookie
+    takes precedence, otherwise fall back to the browser's Accept-Language header and
+    finally the configured default. Returns a canonical locale code or None outside a
+    request context."""
+    if not request:
+        return None
+    pi_lang_list = get_app_config_value("PI_PREFERRED_LANGUAGE", default=DEFAULT_LANGUAGE_LIST)
+    # An explicit choice (set by the language switcher) wins over the browser preference.
+    cookie_locale = request.cookies.get(LOCALE_COOKIE_NAME)
+    if cookie_locale:
+        canonical = _canonical_locale(cookie_locale, pi_lang_list)
+        if canonical:
+            return canonical
     return request.accept_languages.best_match(pi_lang_list, default=pi_lang_list[0])
 
 
@@ -243,7 +264,7 @@ def single_page_application():
     if current_app.config.get("PI_UI_DEACTIVATED"):
         # Do not provide the UI
         return send_html(render_template("deactivated.html"))
-    locale = get_accepted_language()
+    locale = get_preferred_language()
     if locale and locale != "en":
         url_locale = locale.replace("_", "-")
         dist = os.path.join(current_app.static_folder, "dist", "privacyidea-webui", "browser", url_locale)


### PR DESCRIPTION

  Adds a UI language switcher to the new WebUI, makes the session survive the full-page reload it requires, and cleans up what gets persisted to browser storage.

  Features

  - Language switcher in the user-utils panel (next to the theme and refresh controls), available for both admin and self-service layouts. Lists all 13 locales by their
  native name (Deutsch, Français, 繁體中文, …) with the current one marked.
  - Selecting a language stores the choice in a pi_ui_locale cookie and navigates to that locale's compiled bundle, preserving the current page (route + query string), so
  you stay where you were instead of being sent back to a landing page.
  - The choice persists across reloads and deep links: the backend resolves the UI locale as cookie → Accept-Language header → default, on the / route and the SPA
  fallback.

  Fixes (exposed by the switcher's full reload)

  - Session no longer drops on reload. Previously only the bearer token was persisted, so any full reload (language switch or a plain F5) reset the in-memory auth state
  and bounced the user to the login page. The session is now rehydrated on bootstrap while the stored JWT is still valid.
  - Authenticated users are kept off the login page. A new route guard forwards an already-authenticated user from /login to their landing page, instead of showing the
  login form with a spurious "already logged in" warning.

  Storage cleanup

  - The persisted auth data no longer duplicates anything the JWT already carries (token, rights, role, username, realm). The bearer token remains the single source of
  truth for identity and rights; only UI/policy config (menus, page sizes, wizards, defaults, …) is stored alongside it. This removes redundant copies of the (potentially
  large) rights list and the token itself.

  Notes

  - UI translations are compiled per-locale at build time, so switching languages is inherently a full page load of a different bundle — the cookie is what lets the
  language-agnostic / redirect honor the user's choice.
  - The cookie is designed as a drop-in seam for a future per-user language setting (/user/settings): the precedence would simply become stored setting → cookie → 
  Accept-Language → default, with no rework to this code.

  Testing

  - Frontend unit suite green (incl. new tests for the switcher, route preservation, session rehydration, the login guard, and the storage dedup).
  - Production and development builds green; backend syntax-checked.

