### PR TITLE
unifying the source of the token resource

### DIFF
--- a/privacyidea/static_new/src/app/components/container/container-details/container-details.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-details/container-details.component.html
@@ -216,11 +216,9 @@
                   } @else {
                     <app-copyable [copyText]="element.value">
                       <a
-                        (click)="contentService.userSelected(element.value, element['user_realm'])"
-                        (keydown.enter)="contentService.userSelected(element.value, element['user_realm'])"
-                        (keydown.space)="
-                          $event.preventDefault(); contentService.userSelected(element.value, element['user_realm'])
-                        "
+                        (click)="contentService.userSelected(element.value, userRealm())"
+                        (keydown.enter)="contentService.userSelected(element.value, userRealm())"
+                        (keydown.space)="$event.preventDefault(); contentService.userSelected(element.value, userRealm())"
                         i18n-aria-label="{{ element.keyMap.label }} Link"
                         role="button"
                         tabindex="0">

--- a/privacyidea/static_new/src/app/components/container/container-details/container-details.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/container/container-details/container-details.component.spec.ts
@@ -441,6 +441,19 @@ describe("ContainerDetailsComponent", () => {
     expect(containerService.unassignUser).toHaveBeenCalledWith("Mock serial", "bob", "realmUser");
   });
 
+  it("userRealm reflects the assigned user's realm for the user link", () => {
+    component.containerDetails.set({
+      serial: "Mock serial",
+      states: [],
+      realms: [],
+      tokens: [],
+      type: "generic",
+      users: [{ user_realm: "themis", user_name: "alice", user_resolver: "res", user_id: "1" }]
+    } as unknown as ContainerDetailData);
+
+    expect(component.userRealm()).toBe("themis");
+  });
+
   describe("pending changes", () => {
     it("registers hasChanges in ngOnInit", () => {
       expect(pendingChangesService.registerHasChanges).toHaveBeenCalled();

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-user/token-details-user.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-user/token-details-user.component.html
@@ -72,9 +72,9 @@
                 } @else {
                   <app-copyable [copyText]="element.value">
                     <a
-                      (click)="contentService.userSelected(element.value, element['user_realm'])"
-                      (keydown.enter)="contentService.userSelected(element.value, element['user_realm'])"
-                      (keydown.space)="$event.preventDefault(); contentService.userSelected(element.value, element['user_realm'])"
+                      (click)="contentService.userSelected(element.value, userRealm())"
+                      (keydown.enter)="contentService.userSelected(element.value, userRealm())"
+                      (keydown.space)="$event.preventDefault(); contentService.userSelected(element.value, userRealm())"
                       i18n-aria-label="{{ element.keyMap.label }} Link"
                       role="button"
                       tabindex="0">

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-user/token-details-user.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-user/token-details-user.component.spec.ts
@@ -147,6 +147,11 @@ describe("TokenDetailsUserComponent", () => {
     expect((component as unknown as { userRealm: () => string }).userRealm()).toBe("themis");
   });
 
+  it("falls back to an empty userRealm when no user_realm row is present", () => {
+    component.userData.set([{ keyMap: { key: "username" }, value: "alice", isEditing: signal(false) }]);
+    expect((component as unknown as { userRealm: () => string }).userRealm()).toBe("");
+  });
+
   it("creates self service", () => {
     expect(selfComponent).toBeTruthy();
   });

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-user/token-details-user.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-user/token-details-user.component.spec.ts
@@ -139,6 +139,14 @@ describe("TokenDetailsUserComponent", () => {
     expect(component).toBeTruthy();
   });
 
+  it("derives userRealm from the user_realm row for the user link", () => {
+    component.userData.set([
+      { keyMap: { key: "username" }, value: "alice", isEditing: signal(false) },
+      { keyMap: { key: "user_realm" }, value: "themis", isEditing: signal(false) }
+    ]);
+    expect((component as unknown as { userRealm: () => string }).userRealm()).toBe("themis");
+  });
+
   it("creates self service", () => {
     expect(selfComponent).toBeTruthy();
   });

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-user/token-details-user.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-user/token-details-user.component.ts
@@ -70,6 +70,9 @@ export class TokenDetailsUserComponent {
   protected readonly contentService: ContentServiceInterface = inject(ContentService);
 
   @Input() userData = signal<EditableElement[]>([]);
+  protected readonly userRealm = computed(
+    () => (this.userData().find((detail) => detail.keyMap.key === "user_realm")?.value as string) ?? ""
+  );
   @Input() tokenSerial!: WritableSignal<string>;
   @Input() isEditingUser!: WritableSignal<boolean>;
   @Input() isEditingInfo!: WritableSignal<boolean>;

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details-container-table/user-details-container-table.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details-container-table/user-details-container-table.component.html
@@ -22,7 +22,7 @@
   i18n-aria-label>
   <div class="details-header">
     <h4 i18n>Containers of User</h4>
-    <h4 class="username-header">{{ userService.detailsUsername() }}</h4>
+    <h4 class="username-header">{{ userService.detailsUser().username }}</h4>
     <h4 class="margin-left--8">:</h4>
   </div>
   <div class="flex-row filter-paginator-container">

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details-container-table/user-details-container-table.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details-container-table/user-details-container-table.component.html
@@ -22,8 +22,8 @@
   i18n-aria-label>
   <div class="details-header">
     <h4 i18n>Containers of User</h4>
-    <h4 class="username-header">{{ userService.detailsUser().username }}</h4>
-    <h4 class="margin-left--8">:</h4>
+    <h4 class="username-header">&nbsp;{{ userService.detailsUser().username }}</h4>
+    <h4>:</h4>
   </div>
   <div class="flex-row filter-paginator-container">
     <mat-form-field

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details-token-table/user-details-token-table.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details-token-table/user-details-token-table.component.html
@@ -23,7 +23,7 @@
   <div class="flex-column">
     <div class="details-header">
       <h4 i18n>Tokens of User</h4>
-      <h4 class="username-header">{{ userService.detailsUsername() }}</h4>
+      <h4 class="username-header">{{ userService.detailsUser().username }}</h4>
       <h4 class="margin-left--8">:</h4>
     </div>
     <div class="flex-row filter-paginator-container">

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details-token-table/user-details-token-table.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details-token-table/user-details-token-table.component.html
@@ -23,8 +23,8 @@
   <div class="flex-column">
     <div class="details-header">
       <h4 i18n>Tokens of User</h4>
-      <h4 class="username-header">{{ userService.detailsUser().username }}</h4>
-      <h4 class="margin-left--8">:</h4>
+      <h4 class="username-header">&nbsp;{{ userService.detailsUser().username }}</h4>
+      <h4>:</h4>
     </div>
     <div class="flex-row filter-paginator-container">
       <mat-form-field

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details-token-table/user-details-token-table.component.ts
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details-token-table/user-details-token-table.component.ts
@@ -121,7 +121,6 @@ export class UserDetailsTokenTableComponent implements AfterViewInit {
   pageSizeOptions = this.tableUtilsService.pageSizeOptions;
 
   constructor() {
-    this.tokenService.userRealm.set(this.userService.selectedUserRealm());
     effect(() => {
       if (!this.userTokenData) {
         return;

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details.component.html
@@ -25,8 +25,8 @@
   <div class="details-header">
     <ng-container i18n>
       <h3>Details for User:</h3>
-      <app-copyable [copyText]="userService.detailsUsername()">
-        <h3 class="username-header">{{ userService.detailsUsername() }}</h3>
+      <app-copyable [copyText]="userService.detailsUser().username">
+        <h3 class="username-header">{{ userService.detailsUser().username }}</h3>
       </app-copyable>
       <h3>in Realm</h3>
       <app-copyable [copyText]="userService.selectedUserRealm()">

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details.component.spec.ts
@@ -232,6 +232,15 @@ describe("UserDetailsComponent", () => {
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("showUserAuditLog sets the audit filter to the current user", () => {
+    const auditServiceMock = TestBed.inject(AuditService) as unknown as MockAuditService;
+    userServiceMock.detailsUser.set({ username: "Alice", realm: "realm1" });
+
+    component.showUserAuditLog();
+
+    expect(auditServiceMock.auditFilter().value).toBe("user: Alice");
+  });
+
   it("assignUserToToken opens PIN dialog and assigns user to token, then reloads resources", () => {
     userServiceMock.detailsUser.set({ username: "Alice", realm: "realm1" });
     userServiceMock.selectedUserRealm.set("realm1");

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details.component.spec.ts
@@ -233,7 +233,7 @@ describe("UserDetailsComponent", () => {
   });
 
   it("assignUserToToken opens PIN dialog and assigns user to token, then reloads resources", () => {
-    userServiceMock.detailsUsername.set("Alice");
+    userServiceMock.detailsUser.set({ username: "Alice", realm: "realm1" });
     userServiceMock.selectedUserRealm.set("realm1");
 
     dialogServiceMock.openDialog = jest.fn().mockReturnValue({

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details.component.ts
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details.component.ts
@@ -342,7 +342,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
         this.tokenService
           .assignUser({
             tokenSerial: option["serial"],
-            username: this.userService.detailsUsername(),
+            username: this.userService.detailsUser().username,
             realm: this.userService.selectedUserRealm(),
             pin: pin
           })
@@ -365,7 +365,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
   }
 
   showUserAuditLog() {
-    this.auditService.auditFilter.set(new FilterValue({ value: `user: ${this.userService.detailsUsername()}` }));
+    this.auditService.auditFilter.set(new FilterValue({ value: `user: ${this.userService.detailsUser().username}` }));
   }
 
   editMode = signal(false);

--- a/privacyidea/static_new/src/app/components/user/user-table/user-table.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/user/user-table/user-table.component.spec.ts
@@ -75,6 +75,14 @@ describe("UserTableComponent", () => {
     expect(component).toBeTruthy();
   });
 
+  it("onClickUsername stores username and the selected realm", () => {
+    mockUserService.selectedUserRealm.set("themis");
+    component.onClickUsername({ username: "alice" } as never);
+
+    expect(mockUserService.detailsUser().username).toBe("alice");
+    expect(mockUserService.detailsUser().realm).toBe("themis");
+  });
+
   it("pageSizeOptions should add custom page size if not included in default options", () => {
     const defaultOptions = [5, 10, 25, 50];
     mockTableUtilsService.pageSizeOptions.set(defaultOptions);

--- a/privacyidea/static_new/src/app/components/user/user-table/user-table.component.ts
+++ b/privacyidea/static_new/src/app/components/user/user-table/user-table.component.ts
@@ -190,7 +190,7 @@ export class UserTableComponent {
   }
 
   onClickUsername(user: UserData): void {
-    this.userService.detailsUsername.set(user.username);
+    this.userService.detailsUser.set({ username: user.username, realm: this.userService.selectedUserRealm() });
   }
 
   onClickResolver(resolverName: string): void {

--- a/privacyidea/static_new/src/app/services/container/container.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/container/container.service.spec.ts
@@ -1107,7 +1107,7 @@ describe("ContainerService", () => {
     beforeEach(() => {
       authServiceMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, rights: ["container_list"] });
       userServiceMock = TestBed.inject(UserService) as unknown as MockUserService;
-      userServiceMock.detailsUsername.set("alice");
+      userServiceMock.detailsUser.set({ username: "alice", realm: "realm1" });
       userServiceMock.selectedUserRealm.set("realm1");
     });
 

--- a/privacyidea/static_new/src/app/services/container/container.service.ts
+++ b/privacyidea/static_new/src/app/services/container/container.service.ts
@@ -417,7 +417,7 @@ export class ContainerService implements ContainerServiceInterface {
     return this.containerRequest({
       no_token: 1,
       ...this.filterParams(),
-      ...(this.userService.detailsUsername() && { user: this.userService.detailsUsername() }),
+      ...(this.userService.detailsUser().username && { user: this.userService.detailsUser().username }),
       ...(this.userService.selectedUserRealm() && { realm: this.userService.selectedUserRealm() })
     });
   });

--- a/privacyidea/static_new/src/app/services/content/content.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/content/content.service.spec.ts
@@ -153,6 +153,14 @@ describe("ContentService", () => {
       expect(service.detailsUser().username).toBe("alice");
       expect(service.detailsUser().realm).toBe("themis");
     });
+
+    it("stores an empty realm when none is provided", () => {
+      emitNav("/tokens");
+      service.userSelected("alice", undefined as unknown as string);
+
+      expect(mockRouter.navigateByUrl).toHaveBeenCalledWith(ROUTE_PATHS.USERS_DETAILS + "/alice?realm=");
+      expect(service.detailsUser().realm).toBe("");
+    });
   });
 
   describe("containerSelected()", () => {

--- a/privacyidea/static_new/src/app/services/content/content.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/content/content.service.spec.ts
@@ -144,6 +144,17 @@ describe("ContentService", () => {
     });
   });
 
+  describe("userSelected()", () => {
+    it("navigates to user details and stores username and realm", () => {
+      emitNav("/tokens");
+      service.userSelected("alice", "themis");
+
+      expect(mockRouter.navigateByUrl).toHaveBeenCalledWith(ROUTE_PATHS.USERS_DETAILS + "/alice?realm=themis");
+      expect(service.detailsUser().username).toBe("alice");
+      expect(service.detailsUser().realm).toBe("themis");
+    });
+  });
+
   describe("containerSelected()", () => {
     it("navigates to container details and sets serial", async () => {
       emitNav("/tokens");

--- a/privacyidea/static_new/src/app/services/content/content.service.ts
+++ b/privacyidea/static_new/src/app/services/content/content.service.ts
@@ -22,8 +22,13 @@ import { NavigationEnd, Router } from "@angular/router";
 import { ROUTE_PATHS } from "@app/route_paths";
 import { filter, map, pairwise, startWith } from "rxjs";
 
+export interface DetailsUser {
+  username: string;
+  realm: string;
+}
+
 export interface ContentServiceInterface {
-  detailsUsername: WritableSignal<string>;
+  detailsUser: WritableSignal<DetailsUser>;
   router: Router;
   routeUrl: Signal<string>;
   previousUrl: Signal<string>;
@@ -84,7 +89,7 @@ export interface ContentServiceInterface {
 
 @Injectable()
 export class ContentService implements ContentServiceInterface {
-  detailsUsername = signal("");
+  detailsUser = signal<DetailsUser>({ username: "", realm: "" });
   router = inject(Router);
   private readonly _urlPair = toSignal(
     this.router.events.pipe(
@@ -228,7 +233,7 @@ export class ContentService implements ContentServiceInterface {
     this.router.navigateByUrl(
       ROUTE_PATHS.USERS_DETAILS + "/" + encodeURIComponent(username) + `?realm=${encodeURIComponent(realm ?? "")}`
     );
-    this.detailsUsername.set(username);
+    this.detailsUser.set({ username, realm: realm ?? "" });
   }
 
   machineResolverSelected(resolverName: string): void {

--- a/privacyidea/static_new/src/app/services/token/token.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/token/token.service.spec.ts
@@ -871,8 +871,7 @@ describe("TokenService", () => {
       const realm = "test-realm";
       const user = "alice";
       contentServiceMock.routeUrl.update(() => ROUTE_PATHS.USERS_DETAILS + "/" + user);
-      contentServiceMock.detailsUsername.set(user);
-      tokenService.userRealm.set(realm);
+      contentServiceMock.detailsUser.set({ username: user, realm });
       const mockBackend = TestBed.inject(HttpTestingController);
       TestBed.tick();
 

--- a/privacyidea/static_new/src/app/services/token/token.service.ts
+++ b/privacyidea/static_new/src/app/services/token/token.service.ts
@@ -31,7 +31,7 @@ import { SimpleConfirmationDialogComponent } from "@components/shared/dialog/con
 import { FilterValue } from "@core/models/filter_value/filter_value";
 import { environment } from "@env/environment";
 import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
-import { ContentService, ContentServiceInterface } from "@services/content/content.service";
+import { ContentService, ContentServiceInterface, DetailsUser } from "@services/content/content.service";
 import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
 import { NotificationService, NotificationServiceInterface } from "@services/notification/notification.service";
 import { RealmService, RealmServiceInterface } from "@services/realm/realm.service";
@@ -245,8 +245,7 @@ export interface TokenServiceInterface {
   tokenDetailResourceValue: Signal<Tokens | undefined>;
   tokenTypesResource: HttpResourceRef<PiResponse<Record<string, string>> | undefined>;
   userTokenResource: HttpResourceRef<PiResponse<Tokens> | undefined>;
-  detailsUsername: WritableSignal<string>;
-  userRealm: WritableSignal<string>;
+  detailsUser: WritableSignal<DetailsUser>;
   tokenTypeOptions: Signal<TokenType[]>;
   pageSize: WritableSignal<number>;
   tokenIsActive: WritableSignal<boolean>;
@@ -365,9 +364,8 @@ export class TokenService implements TokenServiceInterface {
   readonly hiddenApiFilter = hiddenApiFilter;
   readonly apiFilterKeyMap = apiFilterKeyMap;
   readonly maxDescriptionLength = 80;
-  readonly userRealm = signal("");
+  readonly detailsUser = this.contentService.detailsUser;
   readonly tokenSerial = this.contentService.tokenSerial;
-  readonly detailsUsername = this.contentService.detailsUsername;
   readonly stopPolling$ = new Subject<void>();
   readonly eventPageSize = signal(10);
 
@@ -533,7 +531,7 @@ export class TokenService implements TokenServiceInterface {
       url: this.tokenBaseUrl,
       method: "GET",
       headers: this.authService.getHeaders(),
-      params: { user: this.detailsUsername(), realm: this.userRealm() }
+      params: { user: this.detailsUser().username, realm: this.detailsUser().realm }
     };
   });
 

--- a/privacyidea/static_new/src/app/services/user/user.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.spec.ts
@@ -157,6 +157,12 @@ describe("UserService", () => {
     expect(userService.selectedUserRealm()).toBe("realm1");
   });
 
+  it("selectedUserRealm uses the opened user's realm on user details", () => {
+    contentServiceMock.onUserDetails = signal(true);
+    contentServiceMock.detailsUser.set({ username: "Alice", realm: "userRealm" });
+    expect(userService.selectedUserRealm()).toBe("userRealm");
+  });
+
   it("allUsernames exposes every user.username", () => {
     expect(userService.allUsernames()).toEqual(["Alice", "Bob", "Charlie"]);
   });

--- a/privacyidea/static_new/src/app/services/user/user.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.spec.ts
@@ -119,7 +119,7 @@ describe("UserService", () => {
     alice = buildUser("Alice");
     users = [alice, buildUser("Bob"), buildUser("Charlie")];
     userService.users.set(users);
-    userService.detailsUsername.set("Alice");
+    userService.detailsUser.set({ username: "Alice", realm: "" });
   });
 
   afterEach(() => {
@@ -215,7 +215,7 @@ describe("UserService", () => {
 
     it("deleteUserAttribute issues DELETE /user/attribute/<key>/<user>/<realm> with proper encoding", () => {
       realmService.realmOptions.set(["realm1", "r 1"]);
-      userService.detailsUsername.set("Alice Smith");
+      userService.detailsUser.set({ username: "Alice Smith", realm: "" });
       realmService.setDefaultRealm("r 1");
 
       const key = "department/role";
@@ -445,7 +445,7 @@ describe("UserService", () => {
       const realm = "test-realm";
       const user = "alice";
       contentServiceMock.routeUrl.update(() => ROUTE_PATHS.USERS_DETAILS + "/" + user);
-      userService.detailsUsername.set(user);
+      userService.detailsUser.set({ username: user, realm: "" });
       userService.selectedUserRealm.set(realm);
       const mockBackend = TestBed.inject(HttpTestingController);
       TestBed.tick();
@@ -467,7 +467,7 @@ describe("UserService", () => {
       const realm = "test-realm";
       const user = "alice";
       contentServiceMock.routeUrl.update(() => ROUTE_PATHS.USERS_DETAILS + "/" + user);
-      userService.detailsUsername.set(user);
+      userService.detailsUser.set({ username: user, realm: "" });
       userService.selectedUserRealm.set(realm);
       const mockBackend = TestBed.inject(HttpTestingController);
       TestBed.tick();
@@ -504,7 +504,7 @@ describe("UserService", () => {
     it("should not show previous user details when detailsUsername changes", async () => {
       const realm = "test-realm";
       contentServiceMock.routeUrl.update(() => ROUTE_PATHS.USERS_DETAILS + "/alice");
-      userService.detailsUsername.set("alice");
+      userService.detailsUser.set({ username: "alice", realm: "" });
       userService.selectedUserRealm.set(realm);
       const mockBackend = TestBed.inject(HttpTestingController);
       TestBed.tick();
@@ -519,7 +519,7 @@ describe("UserService", () => {
 
       // Switch to bob — while loading, user signal should NOT keep alice's data
       contentServiceMock.routeUrl.update(() => ROUTE_PATHS.USERS_DETAILS + "/bob");
-      userService.detailsUsername.set("bob");
+      userService.detailsUser.set({ username: "bob", realm: "" });
       TestBed.tick();
 
       // Before bob's response arrives, user should be reset to empty

--- a/privacyidea/static_new/src/app/services/user/user.service.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.ts
@@ -19,11 +19,10 @@
 import { HttpClient, httpResource, HttpResourceRef } from "@angular/common/http";
 import { computed, effect, inject, Injectable, linkedSignal, Signal, signal, WritableSignal } from "@angular/core";
 import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
-import { ContentService, ContentServiceInterface } from "@services/content/content.service";
+import { ContentService, ContentServiceInterface, DetailsUser } from "@services/content/content.service";
 import { RealmService, RealmServiceInterface } from "@services/realm/realm.service";
 import { TokenService, TokenServiceInterface } from "@services/token/token.service";
 
-import { Router } from "@angular/router";
 import { PiResponse } from "@app/app.component";
 import { ROUTE_PATHS } from "@app/route_paths";
 import { FilterValue } from "@core/models/filter_value/filter_value";
@@ -105,7 +104,7 @@ export interface UserServiceInterface {
   apiFilterOptions: string[];
   advancedApiFilterOptions: string[];
 
-  detailsUsername: WritableSignal<string>;
+  detailsUser: WritableSignal<DetailsUser>;
 
   setUserAttribute(key: string, value: string): Observable<PiResponse<number> | undefined>;
   deleteUserAttribute(key: string): Observable<PiResponse<number> | undefined>;
@@ -124,7 +123,6 @@ export class UserService implements UserServiceInterface {
   private readonly tokenService: TokenServiceInterface = inject(TokenService);
   private readonly authService: AuthServiceInterface = inject(AuthService);
   private readonly notificationService = inject(NotificationService);
-  private readonly router = inject(Router);
   private readonly http = inject(HttpClient);
 
   constructor() {
@@ -187,7 +185,7 @@ export class UserService implements UserServiceInterface {
       url: this.baseUrl + "editable_attributes/",
       method: "GET",
       headers: this.authService.getHeaders(),
-      params: { user: this.detailsUsername(), realm: this.selectedUserRealm() }
+      params: { user: this.detailsUser().username, realm: this.selectedUserRealm() }
     };
   });
 
@@ -223,11 +221,11 @@ export class UserService implements UserServiceInterface {
       url: this.baseUrl + "attribute",
       method: "GET",
       headers: this.authService.getHeaders(),
-      params: { user: this.detailsUsername(), realm: this.selectedUserRealm() }
+      params: { user: this.detailsUser().username, realm: this.selectedUserRealm() }
     };
   });
 
-  detailsUsername = this.contentService.detailsUsername;
+  detailsUser = this.contentService.detailsUser;
 
   apiUserFilter = signal(new FilterValue());
 
@@ -245,7 +243,7 @@ export class UserService implements UserServiceInterface {
   selectedUserRealm: WritableSignal<string> = linkedSignal({
     source: () => ({
       routeUrl: this.contentService.routeUrl(),
-      currentUrl: this.router.url,
+      detailsUserRealm: this.contentService.detailsUser().realm,
       defaultRealm: this.realmService.defaultRealm(),
       realmOptions: this.realmService.realmOptions(),
       selectedTokenType: this.tokenService.selectedTokenType(),
@@ -253,15 +251,10 @@ export class UserService implements UserServiceInterface {
       authRealm: this.authService.realm()
     }),
     computation: (source, previous): string => {
-      // On user details set realm from the URL query param if present
+      // On user details the realm of the opened user is the source of truth
       if (this.contentService.onUserDetails()) {
-        const qIndex = source.currentUrl.indexOf("?");
-        if (qIndex !== -1) {
-          const params = new URLSearchParams(source.currentUrl.substring(qIndex + 1));
-          const realm = params.get("realm") ?? "";
-          if (realm) {
-            return realm;
-          }
+        if (source.detailsUserRealm) {
+          return source.detailsUserRealm;
         }
         if (previous?.value) {
           return previous.value;
@@ -307,7 +300,7 @@ export class UserService implements UserServiceInterface {
       method: "GET",
       headers: this.authService.getHeaders(),
       params: {
-        ...(this.detailsUsername() && { user: this.detailsUsername() }),
+        ...(this.detailsUser().username && { user: this.detailsUser().username }),
         ...(this.selectedUserRealm() && { realm: this.selectedUserRealm() })
       }
     };
@@ -318,7 +311,7 @@ export class UserService implements UserServiceInterface {
       userRes: this.userResource.hasValue() ? this.userResource.value() : undefined,
       isLoading: this.userResource.isLoading(),
       error: this.userResource.error(),
-      detailsUsername: this.detailsUsername()
+      detailsUsername: this.detailsUser().username
     }),
     computation: (source, previous) => {
       const emptyDetails: UserData = {
@@ -473,7 +466,7 @@ export class UserService implements UserServiceInterface {
 
   setUserAttribute(key: string, value: string) {
     const params: Record<string, string> = {
-      user: this.detailsUsername(),
+      user: this.detailsUser().username,
       realm: this.selectedUserRealm(),
       key,
       value
@@ -494,7 +487,7 @@ export class UserService implements UserServiceInterface {
   }
 
   deleteUserAttribute(key: string) {
-    const username = this.detailsUsername();
+    const username = this.detailsUser().username;
     const realm = this.selectedUserRealm();
     const url =
       this.baseUrl +

--- a/privacyidea/static_new/src/testing/mock-services/mock-content-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-content-service.ts
@@ -23,7 +23,7 @@ import { ROUTE_PATHS } from "@app/route_paths";
 import { ContentServiceInterface } from "@services/content/content.service";
 
 export class MockContentService implements ContentServiceInterface {
-  detailsUsername = signal("");
+  detailsUser = signal({ username: "", realm: "" });
   router: Router = {} as Router;
   routeUrl = signal("");
   previousUrl = signal("");

--- a/privacyidea/static_new/src/testing/mock-services/mock-token-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-token-service.ts
@@ -90,8 +90,7 @@ export class MockTokenService implements TokenServiceInterface {
   readonly userTokenResource = new MockHttpResourceRef<PiResponse<Tokens> | undefined>(
     MockPiResponse.fromValue<Tokens>({ count: 0, current: 0, tokens: [] })
   );
-  detailsUsername = signal("");
-  userRealm = signal("");
+  detailsUser = signal({ username: "", realm: "" });
   tokenTypeOptions = signal<TokenType[]>([
     { key: "hotp", name: "HOTP", info: "", text: "HMAC-based One-Time Password" },
     { key: "totp", name: "TOTP", info: "", text: "Time-based One-Time Password" },

--- a/privacyidea/static_new/src/testing/mock-services/mock-user-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-user-service.ts
@@ -49,7 +49,7 @@ export class MockUserService implements UserServiceInterface {
     this.selectedUserRealm.set("");
   }
 
-  detailsUsername = signal("");
+  detailsUser = signal({ username: "", realm: "" });
 
   setUserAttribute = jest.fn().mockReturnValue(of({}));
   deleteUserAttribute = jest.fn().mockReturnValue(of({}));


### PR DESCRIPTION
This should always send the correct user realm to the API.