### PR TITLE
CI: group GitHub Actions dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    # Bundle all action updates into a single PR so we only have to run the
+    # "branch must be up to date with master" merge dance once per week
+    # instead of once per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Python and npm dependencies are updated manually on our schedule.
   # Dependabot PRs for these ecosystems tend to fail CI and create noise


### PR DESCRIPTION
Dependabot opened a separate PR per action, and with the "branch must be up to date with master" merge requirement each one had to be rebased and re-run in sequence, making the weekly batch slow to clear.

Bundle all github-actions updates into a single grouped PR so the update/rebase/merge cycle only happens once per week.