### PR TITLE
Fix flaky test_07_reset_failcounter_failed_auth minute-boundary race

### DIFF
--- a/tests/test_lib_token_failcounter.py
+++ b/tests/test_lib_token_failcounter.py
@@ -263,6 +263,15 @@ class TokenFailCounterTestCase(MyTestCase):
         self.assertEqual(1, tok.get_failcount())
         self.assertIsNone(tok.get_tokeninfo(FAILCOUNTER_EXCEEDED))
 
+        # The checks below re-lock the token and expect it to *stay* locked.
+        # FAILCOUNTER_EXCEEDED is stored with minute precision (DATE_FORMAT), so
+        # with a 1-minute clear timeout a token that gets locked late within a
+        # wall-clock minute could be auto-cleared only seconds later, as soon as
+        # the minute rolls over - spuriously unlocking it. Use a clear timeout
+        # far larger than the test runtime so these assertions can't race a
+        # minute boundary.
+        set_privacyidea_config(FAILCOUNTER_CLEAR_TIMEOUT, 60)
+
         # after nine more invalid auth requests, the token is locked again
         for i in range(2, 11):
             res, reply = check_token_list([tok], "pin123456")


### PR DESCRIPTION
FAILCOUNTER_EXCEEDED is stored with minute precision (DATE_FORMAT '%Y-%m-%dT%H:%M%z'), and check_reset_failcount clears the failcounter once `now > failcounter_exceeded + timeout`. With the test's 1-minute clear timeout, a token that gets re-locked late within a wall-clock minute is auto-cleared only seconds later, as soon as the minute rolls over. The subsequent valid-OTP check then unexpectedly authenticates, so `assertFalse(res)` fails with "True is not false". This surfaced in the slow, heavily-parallel Redis job, where the few seconds between locking and the check are most likely to cross a minute boundary.

Raise the clear timeout far above the test runtime for the "stays locked" phase so the assertions can no longer race a minute boundary. The behaviour under test (locked -> stays locked while within timeout, then disabled when timeout is 0) is unchanged.