### PR TITLE
Fix event bindings in token rollover component

### DIFF
--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
@@ -17,8 +17,8 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  (close)="close()"
-  (onAction)="rolloverToken()"
+  (wrapperClose)="close()"
+  (actionTriggered)="rolloverToken()"
   [showCancelButton]="true"
   [title]="title()"
   [actions]="dialogActions()">


### PR DESCRIPTION
Update event bindings in the token rollover component to use the correct event names.