### PR TITLE
Fix hide_specific_error_message in auth_error decorator not stripping error code

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -79,7 +79,7 @@ from .serviceid import serviceid_blueprint
 from .healthcheck import healthz_blueprint
 from .info import info_blueprint
 from privacyidea.api.lib.postpolicy import postrequest, sign_response, hide_version
-from ..lib.error import (PrivacyIDEAError,
+from ..lib.error import (PrivacyIDEAError, Error,
                          AuthError, UserError,
                          PolicyError, ResourceNotFoundError)
 from privacyidea.lib.utils import get_client_ip, get_plugin_info_from_useragent, AUTH_RESPONSE
@@ -524,8 +524,12 @@ def auth_error(error):
                                       user_object=request.User if hasattr(request, 'User') else None).any()
             if hide_message:
                 error.message = _("Authentication failed.")
-                error.details["message"] = error.message
-                error.details.pop("loginmode", None)
+                # Remap to the generic AUTHENTICATE id, so a masked failure is
+                # indistinguishable from any other unspecified auth failure.
+                error.id = Error.AUTHENTICATE
+                # Replace the details completely, so future additions to the
+                # details cannot accidentally leak information either.
+                error.details = {"message": error.message}
 
         g.audit_object.add_to_log({"info": message}, add_with_comma=True)
 

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -12,7 +12,7 @@ from privacyidea.config import TestingConfig
 from privacyidea.lib.auth import create_db_admin
 from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib.config import set_privacyidea_config, SYSCONF
-from privacyidea.lib.error import ResourceNotFoundError
+from privacyidea.lib.error import ResourceNotFoundError, Error
 from privacyidea.lib.event import set_event, delete_event
 from privacyidea.lib.eventhandler.base import CONDITION
 from privacyidea.lib.policies.actions import PolicyAction
@@ -1301,7 +1301,7 @@ class AuthApiTestCase(MyApiTestCase):
         self.assertEqual(401, response.status_code, response)
         result = response.json.get("result")
         error = result.get("error")
-        self.assertEqual(4031, error.get("code"))
+        self.assertEqual(Error.AUTHENTICATE, error.get("code"))
         self.assertEqual("Authentication failed.", error.get("message"))
         self.assertEqual(2, len(error))
         detail = response.json.get("detail")

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -3106,7 +3106,7 @@ class ValidateAPITestCase(MyApiTestCase):
         self.assertEqual(401, response.status_code, response.json)
         result = response.json.get("result")
         error = result.get("error")
-        self.assertEqual(4031, error.get("code"))
+        self.assertEqual(Error.AUTHENTICATE, error.get("code"))
         self.assertEqual("Authentication failed.", error.get("message"))
         self.assertEqual(2, len(error))
         detail = response.json.get("detail")


### PR DESCRIPTION
With the hide_specific_error_message policy, the auth_error decorator only replaced the error message, but the error id and potentially other details were still in the error response. This meant it was still possible to probe for rate limits or other stuff.

Normalize the error id to the generic AUTHENTICATE (403) and completely replace the error details with a new clean dict so future additions can also not accidentally leak infos.