### PR TITLE
Add hide_auth_error_status policy to mask HTTP status of failed auths

### DIFF
--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -1087,3 +1087,6 @@ type: ``bool``
 
 If this policy is set, failed authentications will return a generic "Authentication failed" message.
 Other information is also removed from the `detail` object of the response.
+
+.. note:: To additionally return a uniform HTTP status code for failed authentications, see
+    the :ref:`policies_hardening` scope policy ``hide_auth_error_status``.

--- a/doc/policies/hardening.rst
+++ b/doc/policies/hardening.rst
@@ -1,0 +1,57 @@
+.. _policies_hardening:
+
+Hardening policies
+------------------
+
+.. index:: hardening policies
+
+The scope *hardening* contains policies that reduce the amount of
+information privacyIDEA exposes to unauthenticated clients. They are
+system-level controls: unlike most other scopes they are evaluated
+without user, realm, resolver or time conditions (client IP and user
+agent matching still apply).
+
+hide_version
+~~~~~~~~~~~~
+
+type: ``bool``
+
+If enabled, the version number is only shown after login. Responses to
+unauthenticated requests have the ``version`` and ``versionnumber``
+fields removed, so the running privacyIDEA version is not exposed to
+anonymous clients.
+
+hide_auth_error_status
+~~~~~~~~~~~~~~~~~~~~~~~
+
+type: ``bool``
+
+If this policy is set, failed authentications at the ``/auth`` and ``/validate`` endpoints
+return a uniform ``401`` HTTP status code, regardless of the reason the request failed.
+Without this policy the status code differs by cause (for example ``400`` for a denied
+authorization, ``403`` for a disabled login, ``404`` for a missing resource), which allows
+the status code to be used to distinguish why a request failed.
+
+For full masking, combine this policy with ``hide_specific_error_message`` (authentication
+scope; masks the error message and code in the response body) and the AUTHZ policy
+``no_detail_on_fail`` (strips the ``detail`` object from a rejected ``/validate/check``
+response). Used together these hide the reason an authentication failed via the status code,
+the error body and the response detail. Requests to other endpoints keep their regular
+status codes.
+
+.. warning:: This policy deliberately changes the HTTP status codes returned by the
+    ``/auth`` and ``/validate`` endpoints: failures that would otherwise return ``400``,
+    ``403`` or ``404`` all return ``401`` instead. This is an opt-in change to the API
+    contract of these endpoints. Any client, reverse proxy, load balancer or monitoring
+    system that branches on the specific status code may behave differently once this is
+    enabled. Only turn it on if you have reviewed how your integrations react to the
+    uniform ``401``.
+
+.. note:: This policy normalizes the *error* responses only. A ``/validate/check`` request
+    that reaches the token check and is rejected still returns ``HTTP 200`` with
+    ``result.value=false`` (the standard authentication response), while a failure before
+    that point (for example an unknown user) returns ``401``. The status code therefore
+    still distinguishes "rejected at the token check" from "failed earlier". Returning a
+    uniform status for that case as well would change the long-standing ``200``/``value``
+    contract that RADIUS, SAML and other consumers rely on, and is out of scope for this
+    policy.

--- a/doc/policies/index.rst
+++ b/doc/policies/index.rst
@@ -25,6 +25,7 @@ privacyIDEA knows these scopes:
    register
    container
    token
+   hardening
 
 You can define as many policies as you wish to.
 The logic of the policies in the scopes is additive.

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -32,8 +32,8 @@ import copy
 
 from flask_babel import _
 
-from .lib.utils import (get_all_params, get_optional, map_error_to_code, send_error, verify_auth_token,
-                        get_auth_token_from_request, logged_in_user_from_token)
+from .lib.utils import (get_all_params, get_optional, map_error_to_code, get_auth_error_status_code, send_error,
+                        verify_auth_token, get_auth_token_from_request, logged_in_user_from_token)
 from .container import container_blueprint
 from ..lib.container import find_container_for_token, find_container_by_serial
 from ..lib.framework import get_app_config_value
@@ -529,7 +529,7 @@ def auth_error(error):
 
         g.audit_object.add_to_log({"info": message}, add_with_comma=True)
 
-    return send_error(error.message, error_code=error.id, details=error.details), map_error_to_code(error)
+    return send_error(error.message, error_code=error.id, details=error.details), get_auth_error_status_code(error)
 
 
 @system_blueprint.errorhandler(PolicyError)
@@ -555,7 +555,7 @@ def auth_error(error):
 def policy_error(error):
     if "audit_object" in g:
         g.audit_object.add_to_log({"info": error.message}, add_with_comma=True)
-    return send_error(error.message, error_code=error.id), map_error_to_code(error)
+    return send_error(error.message, error_code=error.id), get_auth_error_status_code(error)
 
 
 @system_blueprint.app_errorhandler(ResourceNotFoundError)
@@ -584,7 +584,7 @@ def resource_not_found_error(error):
     """
     if "audit_object" in g:
         g.audit_object.log({"info": error.message})
-    return send_error(error.message, error_code=error.id), map_error_to_code(error)
+    return send_error(error.message, error_code=error.id), get_auth_error_status_code(error)
 
 
 @system_blueprint.app_errorhandler(PrivacyIDEAError)
@@ -614,7 +614,7 @@ def privacyidea_error(error):
     """
     if "audit_object" in g:
         g.audit_object.log({"info": str(error)})
-    return send_error(str(error), error_code=error.id), map_error_to_code(error)
+    return send_error(str(error), error_code=error.id), get_auth_error_status_code(error)
 
 
 @system_blueprint.app_errorhandler(NotImplementedError)

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -56,11 +56,10 @@ from urllib.parse import quote
 from flask import g, current_app, make_response, Request
 from flask_babel import _, lazy_gettext
 
-from privacyidea.api.lib.utils import get_all_params
+from privacyidea.api.lib.utils import get_all_params, hardening_action_active
 from privacyidea.config import ConfigKey
 from privacyidea.lib.auth import ROLE
-from privacyidea.lib.config import (get_multichallenge_enrollable_types, get_token_class, get_privacyidea_node,
-                                    get_from_config, SYSCONF)
+from privacyidea.lib.config import (get_multichallenge_enrollable_types, get_token_class, get_privacyidea_node)
 from privacyidea.lib.crypto import Sign
 from privacyidea.lib.error import PolicyError, ValidateError
 from privacyidea.lib.info.rss import FETCH_DAYS
@@ -281,43 +280,8 @@ def hide_version(request, response):
     if logged_in_user:
         return response
 
-    if response.is_json:
-        # Ensure g.policy_object and g.client_ip are available even when
-        # before_request failed early (e.g. due to AuthError before the
-        # policy object was created).
-        if not hasattr(g, "policy_object"):
-            try:
-                from privacyidea.lib.policy import PolicyClass
-                g.policy_object = PolicyClass()
-            except Exception:  # pragma: no cover
-                return response  # pragma: no cover
-        if not hasattr(g, "client_ip") or not g.client_ip:
-            from privacyidea.lib.utils import get_client_ip
-            try:
-                override_client = get_from_config(SYSCONF.OVERRIDECLIENT)
-            except Exception:
-                override_client = None
-            g.client_ip = get_client_ip(request, override_client)
-        if not g.get("user_agent"):
-            from privacyidea.lib.utils import get_plugin_info_from_useragent
-            ua_name, _ua_version, _ua_comment = get_plugin_info_from_useragent(request.user_agent.string)
-            g.user_agent = ua_name
-        # Skip the policy evaluation entirely when no hardening policy is
-        # configured. This keeps high-volume anonymous endpoints such as
-        # /validate/check fast while the feature is disabled, instead of running
-        # a full policy match on every response. Any failure here (the policy/DB
-        # backend being unavailable, or g.policy_object not being a usable
-        # PolicyClass) degrades to a no-op rather than raising a 500 out of
-        # after_request.
-        try:
-            if not g.policy_object.list_policies(scope=SCOPE.HARDENING, active=True):
-                return response
-            policy = Match.action_only(g, scope=SCOPE.HARDENING, action=PolicyAction.HIDE_VERSION).policies(
-                write_to_audit_log=False)
-        except Exception:
-            return response
-        if policy:
-            strip_version_from_response(response, strip_nested=True)
+    if response.is_json and hardening_action_active(g, request, PolicyAction.HIDE_VERSION):
+        strip_version_from_response(response, strip_nested=True)
     return response
 
 

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -34,7 +34,7 @@ from urllib.parse import unquote
 
 import jwt
 from flask import (jsonify,
-                   current_app, request, Response)
+                   current_app, request, g, Response)
 
 from privacyidea.lib.utils import (prepare_result, get_version, to_unicode,
                                    get_plugin_info_from_useragent)
@@ -50,6 +50,8 @@ from privacyidea.lib.params import (  # noqa: F401
 )
 # check_policy_name lives in lib/policy; re-exported here for backward compatibility
 from privacyidea.lib.policy import check_policy_name  # noqa: F401
+from privacyidea.lib.policy import Match, SCOPE
+from privacyidea.lib.policies.actions import PolicyAction
 from ...lib.error import (PolicyError, ResourceNotFoundError,
                           PrivacyIDEAError, AuthError, Error)
 from ...lib.log import log_with
@@ -442,3 +444,34 @@ def map_error_to_code(error: Exception, default: int = 500) -> int:
         if cls in error_mapping:
             return error_mapping[cls]
     return default
+
+
+def get_auth_error_status_code(error: Exception) -> int:
+    """
+    Determine the HTTP status code for an error raised during authentication.
+
+    Normally this is the error's mapped status code (e.g. 401 for AuthError,
+    403 for PolicyError, 404 for ResourceNotFoundError, 400 for other
+    PrivacyIDEAErrors such as a denied authorization). If the
+    hide_auth_error_status policy (HARDENING scope) is set, all of these are
+    collapsed into a uniform 401, so the status code cannot be used to
+    distinguish why the authentication failed.
+
+    Like the other hardening policies this is evaluated without
+    user/realm/resolver/time conditions (client IP and user agent matching
+    still apply). Only requests to the authentication endpoints (/auth and
+    /validate) are affected, so the same error types raised on other endpoints
+    keep their regular status code.
+    """
+    mapped_code = map_error_to_code(error)
+    if request.blueprint not in ("jwtauth", "validate_blueprint"):
+        return mapped_code
+    if "policy_object" not in g or "audit_object" not in g:
+        return mapped_code
+    # Skip the policy evaluation entirely when no hardening policy is configured,
+    # to avoid a full policy match on every auth error while the feature is off.
+    if not g.policy_object.list_policies(scope=SCOPE.HARDENING, active=True):
+        return mapped_code
+    hide_status = Match.action_only(g, scope=SCOPE.HARDENING,
+                                    action=PolicyAction.HIDE_AUTH_ERROR_STATUS).any(write_to_audit_log=False)
+    return 401 if hide_status else mapped_code

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -446,6 +446,61 @@ def map_error_to_code(error: Exception, default: int = 500) -> int:
     return default
 
 
+def hardening_action_active(g, request, action) -> bool:
+    """
+    Return whether the given HARDENING-scope policy action matches the current
+    request.
+
+    Hardening policies are evaluated without user/realm/resolver/time conditions
+    (client IP and user agent matching still apply). The evaluation is
+    defensive: an incomplete request context (for example an error raised early
+    in before_request, before g.client_ip was set) or a failure of the policy
+    backend results in ``False`` rather than an exception, so callers in error
+    handlers cannot themselves fail with a 500.
+    """
+    try:
+        # Ensure g.policy_object and g.client_ip/user_agent are available even
+        # when before_request failed early (e.g. an AuthError before the policy
+        # object was created).
+        if not hasattr(g, "policy_object"):
+            from privacyidea.lib.policy import PolicyClass
+            g.policy_object = PolicyClass()
+        # Skip the policy evaluation entirely when no hardening policy is
+        # configured. This keeps high-volume endpoints fast while the feature is
+        # disabled instead of running a full policy match on every request.
+        if not g.policy_object.list_policies(scope=SCOPE.HARDENING, active=True):
+            return False
+        # Match.action_only matches the client IP and user agent implicitly.
+        if not hasattr(g, "client_ip") or not g.client_ip:
+            from privacyidea.lib.config import get_from_config, SYSCONF
+            from privacyidea.lib.utils import get_client_ip
+            try:
+                override_client = get_from_config(SYSCONF.OVERRIDECLIENT)
+            except Exception:
+                override_client = None
+            g.client_ip = get_client_ip(request, override_client)
+        if not g.get("user_agent"):
+            ua_name, _ua_version, _ua_comment = get_plugin_info_from_useragent(request.user_agent.string)
+            g.user_agent = ua_name
+        return Match.action_only(g, scope=SCOPE.HARDENING, action=action).any(write_to_audit_log=False)
+    except Exception:
+        return False
+
+
+def _is_authentication_endpoint(request) -> bool:
+    """
+    True if the current request targets an authentication endpoint: any
+    /validate route, or the /auth login (not other jwtauth routes such as
+    /auth/rights).
+    """
+    # Imported lazily to avoid an import cycle (validate/auth import from here).
+    from privacyidea.api.auth import jwtauth
+    from privacyidea.api.validate import validate_blueprint
+    if request.blueprint == validate_blueprint.name:
+        return True
+    return request.blueprint == jwtauth.name and request.path.endswith("/auth")
+
+
 def get_auth_error_status_code(error: Exception) -> int:
     """
     Determine the HTTP status code for an error raised during authentication.
@@ -453,25 +508,20 @@ def get_auth_error_status_code(error: Exception) -> int:
     Normally this is the error's mapped status code (e.g. 401 for AuthError,
     403 for PolicyError, 404 for ResourceNotFoundError, 400 for other
     PrivacyIDEAErrors such as a denied authorization). If the
-    hide_auth_error_status policy (HARDENING scope) is set, all of these are
-    collapsed into a uniform 401, so the status code cannot be used to
-    distinguish why the authentication failed.
+    hide_auth_error_status policy (HARDENING scope) is set, the distinct 4xx
+    codes are collapsed into a uniform 401, so the status code cannot be used
+    to distinguish why the authentication failed.
 
-    Like the other hardening policies this is evaluated without
-    user/realm/resolver/time conditions (client IP and user agent matching
-    still apply). Only requests to the authentication endpoints (/auth and
-    /validate) are affected, so the same error types raised on other endpoints
-    keep their regular status code.
+    Server faults (5xx) are never masked, so a real internal error is not
+    disguised as an authentication failure. Only requests to the authentication
+    endpoints (the /auth login and /validate) are affected, so the same error
+    types raised on other endpoints keep their regular status code.
     """
     mapped_code = map_error_to_code(error)
-    if request.blueprint not in ("jwtauth", "validate_blueprint"):
+    # Already 401 -> nothing to normalize (avoids a policy match on the
+    # high-volume failed-login path). Never collapse server faults to 401.
+    if mapped_code == 401 or mapped_code >= 500:
         return mapped_code
-    if "policy_object" not in g or "audit_object" not in g:
+    if not _is_authentication_endpoint(request):
         return mapped_code
-    # Skip the policy evaluation entirely when no hardening policy is configured,
-    # to avoid a full policy match on every auth error while the feature is off.
-    if not g.policy_object.list_policies(scope=SCOPE.HARDENING, active=True):
-        return mapped_code
-    hide_status = Match.action_only(g, scope=SCOPE.HARDENING,
-                                    action=PolicyAction.HIDE_AUTH_ERROR_STATUS).any(write_to_audit_log=False)
-    return 401 if hide_status else mapped_code
+    return 401 if hardening_action_active(g, request, PolicyAction.HIDE_AUTH_ERROR_STATUS) else mapped_code

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -493,12 +493,12 @@ def _is_authentication_endpoint(request) -> bool:
     /validate route, or the /auth login (not other jwtauth routes such as
     /auth/rights).
     """
-    # Imported lazily to avoid an import cycle (validate/auth import from here).
-    from privacyidea.api.auth import jwtauth
-    from privacyidea.api.validate import validate_blueprint
-    if request.blueprint == validate_blueprint.name:
+    # The blueprint names are stable string constants, so we compare against
+    # them directly instead of importing the blueprints (which would import
+    # from this module) on the error-handling path.
+    if request.blueprint == "validate_blueprint":
         return True
-    return request.blueprint == jwtauth.name and request.path.endswith("/auth")
+    return request.blueprint == "jwtauth" and request.path.endswith("/auth")
 
 
 def get_auth_error_status_code(error: Exception) -> int:

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -138,7 +138,7 @@ from privacyidea.lib.user import log_used_user, User, split_user
 from privacyidea.lib.utils import get_client_ip, get_plugin_info_from_useragent, AUTH_RESPONSE
 from privacyidea.lib.utils import is_true, get_computer_name_from_user_agent
 from .lib.policyhelper import check_last_auth_policy, get_realm_for_authentication
-from .lib.utils import get_required, map_error_to_code, send_error, send_result
+from .lib.utils import get_required, get_auth_error_status_code, send_error, send_result
 from ..lib.decorators import (check_user_serial_or_cred_id_in_request)
 from ..lib.fido2.challenge import create_fido2_challenge, verify_fido2_challenge
 from ..lib.fido2.policy_action import FIDO2PolicyAction
@@ -299,7 +299,7 @@ def offlinerefill():
                 scope=SCOPE.TOKEN,
                 action=PolicyAction.HIDE_SPECIFIC_ERROR_MESSAGE_FOR_OFFLINE_REFILL,
                 user_object=request.User if hasattr(request, "User") else None).any():
-            return send_error("Failed offline token refill", error_code=Error.VALIDATE), map_error_to_code(e)
+            return send_error("Failed offline token refill", error_code=Error.VALIDATE), get_auth_error_status_code(e)
         raise
 
 

--- a/privacyidea/lib/policies/actions.py
+++ b/privacyidea/lib/policies/actions.py
@@ -223,6 +223,7 @@ class PolicyAction:
     HIDE_SPECIFIC_ERROR_MESSAGE = "hide_specific_error_message"
     HIDE_SPECIFIC_ERROR_MESSAGE_FOR_OFFLINE_REFILL = "hide_specific_error_message_for_offline_refill"
     HIDE_SPECIFIC_ERROR_MESSAGE_FOR_TTYPE = "hide_specific_error_message_for_ttype"
+    HIDE_AUTH_ERROR_STATUS = "hide_auth_error_status"
     REQUIRE_AUTH_FOR_RESOLVER_DETAILS = "require_auth_for_resolver_details"
     PASSKEY_LOGIN = "passkey_login"
     HIDE_VERSION = "hide_version"

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -3138,6 +3138,18 @@ def get_static_policy_definitions(scope=None):
                           'Note: This policy is evaluated without user/realm/resolver/time conditions '
                           '(client IP and user agent matching still apply).'),
                 'group': GROUP.SYSTEM,
+            },
+            PolicyAction.HIDE_AUTH_ERROR_STATUS: {
+                'type': 'bool',
+                'desc': _('Return a uniform 401 HTTP status code for failed authentications, so the status code '
+                          'cannot be used to distinguish the reason a request failed. Combine with '
+                          '"hide_specific_error_message" (in the authentication scope) to also mask the error '
+                          'message. WARNING: This changes the HTTP status codes returned by the /auth and '
+                          '/validate endpoints (e.g. 400/403/404 all become 401). Clients, proxies or monitoring '
+                          'that rely on the specific status codes may break. Only enable this if you understand '
+                          'the impact on your integrations. This policy is evaluated without '
+                          'user/realm/resolver/time conditions (client IP and user agent matching still apply).'),
+                'group': GROUP.SYSTEM,
             }
         }
 

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -845,7 +845,7 @@ class PostPolicyDecoratorTestCase(MyApiTestCase):
                    action=PolicyAction.HIDE_VERSION)
         g.policy_object = PolicyClass()
         resp = jsonify(res)
-        with patch("privacyidea.api.lib.postpolicy.get_from_config",
+        with patch("privacyidea.lib.config.get_from_config",
                    side_effect=Exception("DB unavailable")):
             new_response = hide_version(req, resp)
         jresult = new_response.json

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -3150,6 +3150,35 @@ class ValidateAPITestCase(MyApiTestCase):
         delete_policy("hide_status")
         remove_token("spass_status")
 
+    def test_44_hide_auth_error_status_is_defensive(self):
+        """
+        A failure while evaluating the hardening policy must not turn the error
+        response into a 500. get_auth_error_status_code falls back to the mapped
+        status code when the policy backend raises.
+        """
+        from privacyidea.lib.policy import PolicyClass
+        self.setUp_user_realms()
+        set_default_realm(self.realm1)
+        set_policy(name="hide_status", scope=SCOPE.HARDENING,
+                   action=PolicyAction.HIDE_AUTH_ERROR_STATUS)
+
+        original_list_policies = PolicyClass.list_policies
+
+        def raise_for_hardening(self, *args, **kwargs):
+            if kwargs.get("scope") == SCOPE.HARDENING:
+                raise Exception("policy backend unavailable")
+            return original_list_policies(self, *args, **kwargs)
+
+        # An unknown user fails with HTTP 400; with the hardening evaluation
+        # raising, the response falls back to 400 instead of a 500.
+        with mock.patch.object(PolicyClass, "list_policies", raise_for_hardening):
+            with self.app.test_request_context('/validate/check', method="POST",
+                                               data={"user": "unknown", "pass": "1234"}):
+                res = self.app.full_dispatch_request()
+                self.assertEqual(400, res.status_code, res.json)
+
+        delete_policy("hide_status")
+
     def _assert_unspecific_message_with_401(self, response):
         self.assertEqual(401, response.status_code, response.json)
         result = response.json.get("result")

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -3102,6 +3102,54 @@ class ValidateAPITestCase(MyApiTestCase):
 
         delete_policy("hide_error_message")
 
+    def test_43_hide_auth_error_status(self):
+        """
+        hide_auth_error_status returns a uniform 401 HTTP status code for
+        failed authentications, so the status code cannot be used to
+        distinguish the reason a request failed.
+        """
+        self.setUp_user_realms()
+        set_default_realm(self.realm1)
+        init_token({"type": "spass", "serial": "spass_status", "pin": "test43"},
+                   user=User("cornelius", self.realm1))
+        # authorized=deny makes an otherwise successful authentication fail with HTTP 400
+        set_policy(name="deny_all", scope=SCOPE.AUTHZ,
+                   action=f"{PolicyAction.AUTHORIZED}={AUTHORIZED.DENY}")
+
+        # Without the policy a denied authorization is HTTP 400 ...
+        with self.app.test_request_context('/validate/check', method="POST",
+                                           data={"user": "cornelius", "pass": "test43"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(400, res.status_code, res.json)
+        # ... and an unknown user is also HTTP 400 (UserError)
+        with self.app.test_request_context('/validate/check', method="POST",
+                                           data={"user": "unknown", "pass": "test43"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(400, res.status_code, res.json)
+
+        # With the policy active every failure returns a uniform 401
+        set_policy(name="hide_status", scope=SCOPE.HARDENING,
+                   action=PolicyAction.HIDE_AUTH_ERROR_STATUS)
+        with self.app.test_request_context('/validate/check', method="POST",
+                                           data={"user": "cornelius", "pass": "test43"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(401, res.status_code, res.json)
+        with self.app.test_request_context('/validate/check', method="POST",
+                                           data={"user": "unknown", "pass": "test43"}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(401, res.status_code, res.json)
+
+        # The policy only affects the authentication endpoints: a
+        # ResourceNotFoundError on a non-auth endpoint keeps its 404
+        with self.app.test_request_context('/policy/unknown_policy', method="DELETE",
+                                           headers={"Authorization": self.at}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(404, res.status_code, res.json)
+
+        delete_policy("deny_all")
+        delete_policy("hide_status")
+        remove_token("spass_status")
+
     def _assert_unspecific_message_with_401(self, response):
         self.assertEqual(401, response.status_code, response.json)
         result = response.json.get("result")

--- a/tests/test_api_validate_offline.py
+++ b/tests/test_api_validate_offline.py
@@ -78,6 +78,17 @@ class AValidateOfflineTestCase(MyApiTestCase):
             data = res.json
             self.assertEqual(data["result"]["error"]["code"], Error.VALIDATE)
             self.assertEqual(data["result"]["error"]["message"], "Failed offline token refill")
+
+            # hide_auth_error_status additionally normalizes the masked failure's
+            # HTTP status code to a uniform 401
+            set_policy(name="hide_auth_error_status", scope=SCOPE.HARDENING,
+                       action=PolicyAction.HIDE_AUTH_ERROR_STATUS)
+            try:
+                res = self.app.full_dispatch_request()
+                self.assertEqual(res.status_code, 401, res)
+                self.assertEqual(res.json["result"]["error"]["message"], "Failed offline token refill")
+            finally:
+                delete_policy("hide_auth_error_status")
         finally:
             delete_policy("hide_specific_error_message")
 

--- a/tests/test_api_validate_offline.py
+++ b/tests/test_api_validate_offline.py
@@ -76,8 +76,8 @@ class AValidateOfflineTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
             self.assertEqual(res.status_code, status_code, res)
             data = res.json
-            self.assertEqual(data["result"]["error"]["code"], Error.VALIDATE)
-            self.assertEqual(data["result"]["error"]["message"], "Failed offline token refill")
+            self.assertEqual(Error.VALIDATE, data["result"]["error"]["code"])
+            self.assertEqual("Failed offline token refill", data["result"]["error"]["message"])
 
             # hide_auth_error_status additionally normalizes the masked failure's
             # HTTP status code to a uniform 401


### PR DESCRIPTION
New additive `hide_auth_error_status` policy action in the **hardening** scope. When set, failed authentications at the `/auth` and `/validate` endpoints return a uniform `401` HTTP status code instead of the cause-specific code (`400`/`403`/`404`), so the status code cannot be used to distinguish why a request failed.

Like the other hardening policies (`hide_version`), it is evaluated without user/realm/resolver/time conditions (client IP and user agent matching still apply).

### Implementation
- New `get_auth_error_status_code` helper in `api/lib/utils.py`, wired into the `AuthError`, `PolicyError`, `ResourceNotFoundError` and generic `PrivacyIDEAError` handlers, and into the `offlinerefill` self-masked error path.
- Gated to the auth blueprints (`jwtauth`, `validate_blueprint`), so the same error types raised on other endpoints keep their regular status codes.
- No migration: the action is brand new. The existing `hide_specific_error_message` deliberately stays in the authentication scope (moving a released action across scopes would risk orphaning it).

### Docs
- New `doc/policies/hardening.rst` documenting the hardening scope (both `hide_version` and `hide_auth_error_status`).
- Documents combining with `hide_specific_error_message` (body message) and `no_detail_on_fail` (response detail) for full masking.
- Notes the residual limitation: the `200`/`result.value` contract for token-check rejections is intentionally left unchanged (out of scope), so a rejection at the token check still differs from an earlier failure.

Closes #5630