### PR TITLE
Prefill user and userrealm on enroll token and create container

### DIFF
--- a/privacyidea/static_new/src/app/components/external-services/ca-connectors/ca-connectors.component.ts
+++ b/privacyidea/static_new/src/app/components/external-services/ca-connectors/ca-connectors.component.ts
@@ -100,7 +100,6 @@ export class CaConnectorsComponent {
     }
   }
 
-
   isAllSelected(): boolean {
     const rows = this.caConnectorDataSource().data;
     return rows.length > 0 && this.selection().length === rows.length;
@@ -145,12 +144,13 @@ export class CaConnectorsComponent {
       .afterClosed()
       .subscribe((result) => {
         if (result) {
-          selected.forEach((row) => this.caConnectorService.deleteCaConnector(row.connectorname));
+          selected.forEach(
+            (row) => void this.caConnectorService.deleteCaConnector(row.connectorname).catch(() => undefined)
+          );
           this.selection.set([]);
         }
       });
   }
-
 
   onFilterInput(value: string): void {
     const trimmed = (value ?? "").trim();

--- a/privacyidea/static_new/src/app/components/external-services/privacyidea-servers/privacyidea-servers.component.ts
+++ b/privacyidea/static_new/src/app/components/external-services/privacyidea-servers/privacyidea-servers.component.ts
@@ -100,7 +100,6 @@ export class PrivacyideaServersComponent {
     }
   }
 
-
   isAllSelected(): boolean {
     const rows = this.privacyideaDataSource().data;
     return rows.length > 0 && this.selection().length === rows.length;
@@ -145,12 +144,13 @@ export class PrivacyideaServersComponent {
       .afterClosed()
       .subscribe((result) => {
         if (result) {
-          selected.forEach((row) => this.privacyideaServerService.deletePrivacyideaServer(row.identifier));
+          selected.forEach(
+            (row) => void this.privacyideaServerService.deletePrivacyideaServer(row.identifier).catch(() => undefined)
+          );
           this.selection.set([]);
         }
       });
   }
-
 
   onFilterInput(value: string): void {
     const trimmed = (value ?? "").trim();

--- a/privacyidea/static_new/src/app/components/external-services/radius-servers/radius-servers.component.ts
+++ b/privacyidea/static_new/src/app/components/external-services/radius-servers/radius-servers.component.ts
@@ -100,7 +100,6 @@ export class RadiusServersComponent {
     this.router.navigateByUrl(ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS_DETAILS + server.identifier);
   }
 
-
   isAllSelected(): boolean {
     const rows = this.radiusDataSource().data;
     return rows.length > 0 && this.selection().length === rows.length;
@@ -145,12 +144,11 @@ export class RadiusServersComponent {
       .afterClosed()
       .subscribe((result) => {
         if (result) {
-          selected.forEach((row) => this.radiusService.deleteRadiusServer(row.identifier));
+          selected.forEach((row) => void this.radiusService.deleteRadiusServer(row.identifier).catch(() => undefined));
           this.selection.set([]);
         }
       });
   }
-
 
   onFilterInput(value: string): void {
     const trimmed = (value ?? "").trim();

--- a/privacyidea/static_new/src/app/components/external-services/service-ids/service-ids.component.ts
+++ b/privacyidea/static_new/src/app/components/external-services/service-ids/service-ids.component.ts
@@ -93,7 +93,6 @@ export class ServiceIdsComponent {
     this.router.navigateByUrl(ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS_DETAILS + serviceId.servicename);
   }
 
-
   isAllSelected(): boolean {
     const rows = this.serviceIdDataSource().data;
     return rows.length > 0 && this.selection().length === rows.length;
@@ -138,12 +137,11 @@ export class ServiceIdsComponent {
       .afterClosed()
       .subscribe((result) => {
         if (result) {
-          selected.forEach((row) => this.serviceIdService.deleteServiceId(row.servicename));
+          selected.forEach((row) => void this.serviceIdService.deleteServiceId(row.servicename).catch(() => undefined));
           this.selection.set([]);
         }
       });
   }
-
 
   onFilterInput(value: string): void {
     const trimmed = (value ?? "").trim();

--- a/privacyidea/static_new/src/app/components/external-services/sms-gateways/sms-gateways.component.ts
+++ b/privacyidea/static_new/src/app/components/external-services/sms-gateways/sms-gateways.component.ts
@@ -141,7 +141,9 @@ export class SmsGatewaysComponent {
       .afterClosed()
       .subscribe((result) => {
         if (result) {
-          selected.forEach((gateway) => this.smsGatewayService.deleteSmsGateway(gateway.name));
+          selected.forEach(
+            (gateway) => void this.smsGatewayService.deleteSmsGateway(gateway.name).catch(() => undefined)
+          );
           this.selection.set([]);
         }
       });

--- a/privacyidea/static_new/src/app/components/external-services/smtp-servers/smtp-servers.component.ts
+++ b/privacyidea/static_new/src/app/components/external-services/smtp-servers/smtp-servers.component.ts
@@ -95,7 +95,6 @@ export class SmtpServersComponent {
     this.router.navigateByUrl(ROUTE_PATHS.EXTERNAL_SERVICES_SMTP_DETAILS + server.identifier);
   }
 
-
   isAllSelected(): boolean {
     const rows = this.smtpDataSource().data;
     return rows.length > 0 && this.selection().length === rows.length;
@@ -140,12 +139,11 @@ export class SmtpServersComponent {
       .afterClosed()
       .subscribe((result) => {
         if (result) {
-          selected.forEach((row) => this.smtpService.deleteSmtpServer(row.identifier));
+          selected.forEach((row) => void this.smtpService.deleteSmtpServer(row.identifier).catch(() => undefined));
           this.selection.set([]);
         }
       });
   }
-
 
   onFilterInput(value: string): void {
     const trimmed = (value ?? "").trim();

--- a/privacyidea/static_new/src/app/components/external-services/tokengroups/tokengroups.component.ts
+++ b/privacyidea/static_new/src/app/components/external-services/tokengroups/tokengroups.component.ts
@@ -95,7 +95,6 @@ export class TokengroupsComponent {
     this.router.navigateByUrl(ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS_DETAILS + group.groupname);
   }
 
-
   isAllSelected(): boolean {
     const rows = this.tokengroupDataSource().data;
     return rows.length > 0 && this.selection().length === rows.length;
@@ -140,12 +139,11 @@ export class TokengroupsComponent {
       .afterClosed()
       .subscribe((result) => {
         if (result) {
-          selected.forEach((row) => this.tokengroupService.deleteTokengroup(row.groupname));
+          selected.forEach((row) => void this.tokengroupService.deleteTokengroup(row.groupname).catch(() => undefined));
           this.selection.set([]);
         }
       });
   }
-
 
   onFilterInput(value: string): void {
     const trimmed = (value ?? "").trim();

--- a/privacyidea/static_new/src/app/components/layout/debug-notice/debug-notice.component.scss
+++ b/privacyidea/static_new/src/app/components/layout/debug-notice/debug-notice.component.scss
@@ -27,7 +27,7 @@ $corner-size-stacked: 132px;
   // Centred on the square, so the band's centre line runs across its diagonal.
   top: 24%;
   left: 24%;
-  background-color: var(--yellow-dark);
+  background-color: light-dark(var(--yellow-dark), var(--yellow-light-active));
   color: white;
   width: $band-width;
   padding: 4px 0;

--- a/privacyidea/static_new/src/app/components/layout/navigation-self-service/navigation-self-service-button/navigation-self-service-button.component.ts
+++ b/privacyidea/static_new/src/app/components/layout/navigation-self-service/navigation-self-service-button/navigation-self-service-button.component.ts
@@ -40,6 +40,6 @@ export class NavigationSelfServiceButtonComponent {
   matIconSize = input<"tile-icon-small" | "tile-icon-medium" | "tile-icon-large" | "tile-icon-x-large">();
   routePath = computed(() => this.key());
 
-  isSelected = computed(() => this.contentService.routeUrl() === this.key());
+  isSelected = computed(() => this.contentService.matchesPath(this.key()));
   protected readonly Boolean = Boolean;
 }

--- a/privacyidea/static_new/src/app/components/layout/navigation/navigation.component.html
+++ b/privacyidea/static_new/src/app/components/layout/navigation/navigation.component.html
@@ -170,7 +170,7 @@
   </button>
   <button
     type="button"
-    (click)="documentationService.openDocumentation(contentService.routeUrl())"
+    (click)="documentationService.openDocumentation(contentService.routePath())"
     aria-label="Documentation"
     i18n-aria-label
     class="nav-button docs-button-full">
@@ -179,7 +179,7 @@
   </button>
   <button
     mat-icon-button
-    (click)="documentationService.openDocumentation(contentService.routeUrl())"
+    (click)="documentationService.openDocumentation(contentService.routePath())"
     aria-label="Documentation"
     i18n-aria-label
     matTooltip="Documentation"
@@ -254,12 +254,12 @@
     appOverflowNav>
     <ng-container *ngTemplateOutlet="footerText"></ng-container>
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.TOKENS ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.onTokens() ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.TOKENS]">
       <mat-icon class="ms--shield-list"></mat-icon>
       <span i18n>Overview</span>
     </a>
-    @if (contentService.routeUrl().startsWith(ROUTE_PATHS.TOKENS_DETAILS)) {
+    @if (contentService.onTokenDetails()) {
       <a class="sub-nav-active">
         <span class="icon-badge">
           <mat-icon class="padding-right-4">shield</mat-icon>
@@ -268,7 +268,7 @@
         <span i18n>Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.TOKENS_ENROLLMENT) {
+    @if (contentService.onTokensEnrollment()) {
       <a class="sub-nav-active">
         <span class="icon-badge">
           <mat-icon class="padding-right-6">shield</mat-icon>
@@ -279,7 +279,7 @@
     }
     @if (authService.actionAllowed("importtokens")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.TOKENS_IMPORT ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.onTokensImport() ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.TOKENS_IMPORT]">
         <mat-icon>input</mat-icon>
         <span i18n>Import</span>
@@ -287,7 +287,7 @@
     }
     @if (authService.actionAllowed("getchallenges")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.TOKENS_CHALLENGES ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.onTokensChallenges() ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.TOKENS_CHALLENGES]">
         <mat-icon>cached</mat-icon>
         <span i18n>Challenges</span>
@@ -295,14 +295,14 @@
     }
     @if (authService.actionsAllowed(["machinelist", "manage_machine_tokens"])) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.TOKENS_APPLICATIONS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.onTokensApplications() ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.TOKENS_APPLICATIONS]">
         <mat-icon>now_widgets</mat-icon>
         <span i18n>Applications</span>
       </a>
     }
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.TOKENS_GET_SERIAL ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.onTokensGetSerial() ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.TOKENS_GET_SERIAL]">
       <mat-icon>policy</mat-icon>
       <span i18n>Find Token</span>
@@ -317,12 +317,12 @@
     appOverflowNav>
     <ng-container *ngTemplateOutlet="footerText"></ng-container>
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.CONTAINERS ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.onContainers() ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.CONTAINERS]">
       <mat-icon class="mdi--folder-list"></mat-icon>
       <span i18n>Overview</span>
     </a>
-    @if (contentService.routeUrl().startsWith(ROUTE_PATHS.CONTAINERS_DETAILS)) {
+    @if (contentService.onContainersDetails()) {
       <a class="sub-nav-active">
         <span class="icon-badge">
           <mat-icon class="padding-right-4">folder</mat-icon>
@@ -331,7 +331,7 @@
         <span i18n>Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.CONTAINERS_CREATE) {
+    @if (contentService.routePath() === ROUTE_PATHS.CONTAINERS_CREATE) {
       <a class="sub-nav-active">
         <span class="icon-badge">
           <mat-icon class="padding-right-6">folder</mat-icon>
@@ -348,13 +348,13 @@
         <span i18n>Templates</span>
       </a>
     }
-    @if (contentService.routeUrl().startsWith(ROUTE_PATHS.CONTAINERS_TEMPLATES_DETAILS)) {
+    @if (contentService.onContainersTemplatesDetails()) {
       <a class="sub-nav-active">
         <mat-icon>plagiarism</mat-icon>
         <span i18n>Template Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.CONTAINERS_TEMPLATES_CREATE) {
+    @if (contentService.onContainersTemplatesCreate()) {
       <a class="sub-nav-active">
         <mat-icon>note_add</mat-icon>
         <span i18n>Create Template</span>
@@ -370,7 +370,7 @@
     appOverflowNav>
     <ng-container *ngTemplateOutlet="footerText"></ng-container>
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.USERS ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.onUsers() ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.USERS]">
       <mat-icon class="ms--person-list"></mat-icon>
       <span i18n>Overview</span>
@@ -399,7 +399,7 @@
       </a>
     }
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.USERS_RESOLVERS ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.onUsersResolvers() ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.USERS_RESOLVERS]">
       <mat-icon class="ms--database"></mat-icon>
       <span i18n>Resolvers</span>
@@ -415,7 +415,7 @@
         <span i18n>Resolver Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.USERS_RESOLVERS_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.USERS_RESOLVERS_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -427,7 +427,7 @@
       </a>
     }
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.USERS_REALMS ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.onUserRealms() ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.USERS_REALMS]">
       <mat-icon>public</mat-icon>
       <span i18n>Realms</span>
@@ -442,7 +442,7 @@
     appOverflowNav>
     <ng-container *ngTemplateOutlet="footerText"></ng-container>
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.POLICIES ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.routePath() === ROUTE_PATHS.POLICIES ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.POLICIES]">
       <mat-icon>gavel</mat-icon>
       <span i18n>Overview</span>
@@ -456,7 +456,7 @@
         <span i18n>Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.POLICIES_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.POLICIES_NEW) {
       <a class="sub-nav-active">
         <span class="icon-badge">
           <mat-icon class="padding-right-6">gavel</mat-icon>
@@ -475,7 +475,7 @@
     appOverflowNav>
     <ng-container *ngTemplateOutlet="footerText"></ng-container>
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.SUBSCRIPTION ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.onSubscription() ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.SUBSCRIPTION]">
       <mat-icon>event_repeat</mat-icon>
       <span i18n>Overview</span>
@@ -491,7 +491,7 @@
     <ng-container *ngTemplateOutlet="footerText"></ng-container>
     @if (authService.actionAllowed("auditlog")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.AUDIT ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.onAudit() ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.AUDIT]">
         <mat-icon>list_alt</mat-icon>
         <span i18n>Log</span>
@@ -499,7 +499,7 @@
     }
     @if (authService.actionAllowed("clienttype")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.CLIENTS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.onClients() ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.CLIENTS]">
         <mat-icon>recent_actors</mat-icon>
         <span i18n>Known Clients</span>
@@ -516,21 +516,21 @@
     <ng-container *ngTemplateOutlet="footerText"></ng-container>
     @if (authService.actionAllowed("configread")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.CONFIGURATION_SYSTEM ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.onConfigurationSystem() ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.CONFIGURATION_SYSTEM]">
         <mat-icon>build</mat-icon>
         <span i18n>System</span>
       </a>
     }
     <a
-      [ngClass]="contentService.routeUrl() === ROUTE_PATHS.CONFIGURATION_TOKENTYPES ? 'sub-nav-active' : ''"
+      [ngClass]="contentService.onConfigurationTokenTypes() ? 'sub-nav-active' : ''"
       [routerLink]="[ROUTE_PATHS.CONFIGURATION_TOKENTYPES]">
       <mat-icon>safety_check</mat-icon>
       <span i18n>Tokentypes</span>
     </a>
     @if (authService.actionAllowed("machinelist")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.CONFIGURATION_MACHINES ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.CONFIGURATION_MACHINES ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.CONFIGURATION_MACHINES]">
         <mat-icon>point_of_sale</mat-icon>
         <span i18n>Machines</span>
@@ -549,7 +549,7 @@
     }
     @if (authService.actionAllowed("mresolverread")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.MACHINE_RESOLVER ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.MACHINE_RESOLVER ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.MACHINE_RESOLVER]">
         <mat-icon>lan</mat-icon>
         <span i18n>Machine Resolver</span>
@@ -566,7 +566,7 @@
         <span i18n>Machine Resolver Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.MACHINE_RESOLVER_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.MACHINE_RESOLVER_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -579,7 +579,7 @@
     }
     @if (authService.actionAllowed("eventhandling_read")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.EVENTS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.EVENTS ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.EVENTS]">
         <mat-icon>flag</mat-icon>
         <span i18n>Events</span>
@@ -596,7 +596,7 @@
         <span i18n>Event Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.EVENTS_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.EVENTS_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -609,7 +609,7 @@
     }
     @if (authService.actionAllowed("periodictask_read")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS]">
         <mat-icon>event_repeat</mat-icon>
         <span i18n>Periodic Tasks</span>
@@ -626,7 +626,7 @@
         <span i18n>Periodic Task Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -648,7 +648,7 @@
     <ng-container *ngTemplateOutlet="footerText"></ng-container>
     @if (authService.actionAllowed("smtpserver_read")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMTP ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_SMTP ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.EXTERNAL_SERVICES_SMTP]">
         <mat-icon>email</mat-icon>
         <span i18n>SMTP Servers</span>
@@ -665,7 +665,7 @@
         <span i18n>SMTP Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMTP_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_SMTP_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -678,7 +678,7 @@
     }
     @if (authService.actionAllowed("radiusserver_read")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS]">
         <mat-icon>vpn_lock</mat-icon>
         <span i18n>RADIUS Servers</span>
@@ -695,7 +695,7 @@
         <span i18n>RADIUS Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -708,7 +708,7 @@
     }
     @if (authService.actionAllowed("smtpserver_read")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_SMS ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.EXTERNAL_SERVICES_SMS]">
         <mat-icon>sms</mat-icon>
         <span i18n>SMS Gateways</span>
@@ -725,7 +725,7 @@
         <span i18n>SMS Gateway Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMS_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_SMS_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -738,7 +738,7 @@
     }
     @if (authService.actionAllowed("caconnectorread")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS]">
         <mat-icon>assured_workload</mat-icon>
         <span i18n>CA Connectors</span>
@@ -755,7 +755,7 @@
         <span i18n>CA Connector Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -768,7 +768,7 @@
     }
     @if (authService.actionAllowed("privacyideaserver_read")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA]">
         <mat-icon class="mdi--pi-logo"></mat-icon>
         <span i18n>PrivacyIDEA Servers</span>
@@ -785,7 +785,7 @@
         <span i18n>PrivacyIDEA Server Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -798,7 +798,7 @@
     }
     @if (authService.actionAllowed("tokengroup_list")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS]">
         <mat-icon>local_police</mat-icon>
         <span i18n>Tokengroups</span>
@@ -815,7 +815,7 @@
         <span i18n>Tokengroup Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>
@@ -828,7 +828,7 @@
     }
     @if (authService.actionAllowed("serviceid_list")) {
       <a
-        [ngClass]="contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS ? 'sub-nav-active' : ''"
+        [ngClass]="contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS ? 'sub-nav-active' : ''"
         [routerLink]="[ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS]">
         <mat-icon>storage</mat-icon>
         <span i18n>Service IDs</span>
@@ -845,7 +845,7 @@
         <span i18n>Service ID Details</span>
       </a>
     }
-    @if (contentService.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS_NEW) {
+    @if (contentService.routePath() === ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS_NEW) {
       <a
         class="sub-nav-active"
         data-overflow-child>

--- a/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.component.ts
+++ b/privacyidea/static_new/src/app/components/layout/user-utils-panel/user-utils-panel.component.ts
@@ -216,7 +216,7 @@ export class UserUtilsPanelComponent {
       return;
     }
 
-    switch (this.contentService.routeUrl()) {
+    switch (this.contentService.routePath()) {
       case ROUTE_PATHS.TOKENS:
         this.tokenService.tokenResource.reload();
         break;

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details.component.spec.ts
@@ -252,24 +252,26 @@ describe("UserDetailsComponent", () => {
     expect(reloadTokenSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("enrollNewToken sets the user selection filter and navigates to token enrollment", () => {
+  it("enrollNewToken navigates to token enrollment with the user as query parameters", () => {
     userServiceMock.detailsUser.set({ username: "Alice", realm: "realm1" });
-    const navigateSpy = jest.spyOn(component["router"], "navigateByUrl").mockResolvedValue(true);
+    const navigateSpy = jest.spyOn(component["router"], "navigate").mockResolvedValue(true);
 
     component.enrollNewToken();
 
-    expect(userServiceMock.selectionFilter()).toBe("Alice");
-    expect(navigateSpy).toHaveBeenCalledWith(ROUTE_PATHS.TOKENS_ENROLLMENT);
+    expect(navigateSpy).toHaveBeenCalledWith([ROUTE_PATHS.TOKENS_ENROLLMENT], {
+      queryParams: { realm: "realm1", user: "Alice" }
+    });
   });
 
-  it("createNewContainer sets the user selection filter and navigates to container create", () => {
+  it("createNewContainer navigates to container create with the user as query parameters", () => {
     userServiceMock.detailsUser.set({ username: "Alice", realm: "realm1" });
-    const navigateSpy = jest.spyOn(component["router"], "navigateByUrl").mockResolvedValue(true);
+    const navigateSpy = jest.spyOn(component["router"], "navigate").mockResolvedValue(true);
 
     component.createNewContainer();
 
-    expect(userServiceMock.selectionFilter()).toBe("Alice");
-    expect(navigateSpy).toHaveBeenCalledWith(ROUTE_PATHS.CONTAINERS_CREATE);
+    expect(navigateSpy).toHaveBeenCalledWith([ROUTE_PATHS.CONTAINERS_CREATE], {
+      queryParams: { realm: "realm1", user: "Alice" }
+    });
   });
 
   it("detailsEntries lists the user data attributes and excludes the editable flag", () => {

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details.component.ts
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details.component.ts
@@ -316,15 +316,21 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
   }
 
   enrollNewToken() {
-    this.userService.selectedUserRealm.set(this.userService.detailsUser().realm);
-    this.userService.selectionFilter.set(this.userService.detailsUser().username);
-    this.router.navigateByUrl(ROUTE_PATHS.TOKENS_ENROLLMENT).then();
+    const detailsUser = this.userService.detailsUser();
+    this.router
+      .navigate([ROUTE_PATHS.TOKENS_ENROLLMENT], {
+        queryParams: { realm: detailsUser.realm, user: detailsUser.username }
+      })
+      .then();
   }
 
   createNewContainer() {
-    this.userService.selectedUserRealm.set(this.userService.detailsUser().realm);
-    this.userService.selectionFilter.set(this.userService.detailsUser().username);
-    this.router.navigateByUrl(ROUTE_PATHS.CONTAINERS_CREATE).then();
+    const detailsUser = this.userService.detailsUser();
+    this.router
+      .navigate([ROUTE_PATHS.CONTAINERS_CREATE], {
+        queryParams: { realm: detailsUser.realm, user: detailsUser.username }
+      })
+      .then();
   }
 
   showUserAuditLog() {

--- a/privacyidea/static_new/src/app/services/clients/clients.service.ts
+++ b/privacyidea/static_new/src/app/services/clients/clients.service.ts
@@ -19,7 +19,6 @@
 import { httpResource, HttpResourceRef } from "@angular/common/http";
 import { effect, inject, Injectable, signal } from "@angular/core";
 import { PiResponse } from "@app/app.component";
-import { ROUTE_PATHS } from "@app/route_paths";
 import { environment } from "@env/environment";
 import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
@@ -53,7 +52,7 @@ export class ClientsService implements ClientsServiceInterface {
     if (!this.authService.actionAllowed("clienttype")) {
       return undefined;
     }
-    if (!this.autocompleteRequested() && this.contentService.routeUrl() !== ROUTE_PATHS.CLIENTS) {
+    if (!this.autocompleteRequested() && !this.contentService.onClients()) {
       return undefined;
     }
     return {

--- a/privacyidea/static_new/src/app/services/container/container.service.ts
+++ b/privacyidea/static_new/src/app/services/container/container.service.ts
@@ -43,6 +43,11 @@ import { catchError, forkJoin, lastValueFrom, Observable, of, Subject, throwErro
 const apiFilter = ["container_serial", "type", "description", "user", "realm", "container_realm", "state"];
 const advancedApiFilter = ["token_serial", "template", "assigned"];
 
+// `realm` is the realm of the assigned user (it builds the endpoint's user object), not the container's
+// own realm, which is `container_realm`. It is only ever set implicitly to scope a `user:` filter, so it
+// stays out of `apiFilter` and is not offered as a keyword.
+const hiddenApiFilter = ["realm"];
+
 const exactMatchKeys = new Set(["user", "realm", "type", "state", "assigned"]);
 
 // Filter keywords, a single value maps to the `type` query param, multiple to `type_list`.
@@ -408,7 +413,7 @@ export class ContainerService implements ContainerServiceInterface {
   });
 
   filterParams = computed<Record<string, string>>(() => {
-    const allowed = [...this.apiFilter, ...this.advancedApiFilter];
+    const allowed = [...this.apiFilter, ...this.advancedApiFilter, ...hiddenApiFilter];
     const plainKeys = exactMatchKeys;
 
     const filterMap = this.containerFilter().filterMap;
@@ -1008,6 +1013,7 @@ export class ContainerService implements ContainerServiceInterface {
     const input = $event.target as HTMLInputElement;
     let newFilter = this.containerFilter().copyWith({ value: input.value });
 
+    // A username is only unique within a realm, so scope a bare `user:` filter to the default realm.
     if (newFilter.hasKey("user") && !newFilter.hasKey("realm")) {
       const defaultRealm = this.realmService.defaultRealm();
       if (defaultRealm) {

--- a/privacyidea/static_new/src/app/services/content/content.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/content/content.service.spec.ts
@@ -75,6 +75,25 @@ describe("ContentService", () => {
     expect(service.routeUrl()).toBe("/second");
   });
 
+  it("parses queryParams from the current route", () => {
+    expect(service.queryParams()).toEqual({});
+
+    emitNav(ROUTE_PATHS.TOKENS_ENROLLMENT + "?realm=defrealm&user=root");
+    expect(service.queryParams()).toEqual({ realm: "defrealm", user: "root" });
+
+    emitNav(ROUTE_PATHS.TOKENS_ENROLLMENT);
+    expect(service.queryParams()).toEqual({});
+  });
+
+  it("route checks match the base path even with query parameters", () => {
+    emitNav(ROUTE_PATHS.TOKENS_ENROLLMENT + "?realm=defrealm&user=root");
+    expect(service.onTokensEnrollment()).toBe(true);
+    expect(service.onTokens()).toBe(false);
+
+    emitNav(ROUTE_PATHS.CONTAINERS_CREATE + "?user=root");
+    expect(service.onContainersCreate()).toBe(true);
+  });
+
   it("onTokenEnrollmentLikely is true for enrollment related routes", () => {
     expect(service.onTokenEnrollmentLikely()).toBe(false);
 

--- a/privacyidea/static_new/src/app/services/content/content.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/content/content.service.spec.ts
@@ -97,11 +97,11 @@ describe("ContentService", () => {
   describe("route flags", () => {
     // Every flag with the URLs it has to recognize. Each URL is checked twice: bare, and with query
     // parameters appended, because navigation now carries the realm/user selection in the query string.
-    const routeFlagCases: ReadonlyArray<{
+    const routeFlagCases: readonly {
       name: string;
       read: (service: ContentService) => boolean;
       urls: string[];
-    }> = [
+    }[] = [
       { name: "onLogin", read: (s) => s.onLogin(), urls: [ROUTE_PATHS.LOGIN] },
       { name: "onAudit", read: (s) => s.onAudit(), urls: [ROUTE_PATHS.AUDIT] },
       { name: "onClients", read: (s) => s.onClients(), urls: [ROUTE_PATHS.CLIENTS] },

--- a/privacyidea/static_new/src/app/services/content/content.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/content/content.service.spec.ts
@@ -94,6 +94,189 @@ describe("ContentService", () => {
     expect(service.onContainersCreate()).toBe(true);
   });
 
+  describe("route flags", () => {
+    // Every flag with the URLs it has to recognize. Each URL is checked twice: bare, and with query
+    // parameters appended, because navigation now carries the realm/user selection in the query string.
+    const routeFlagCases: ReadonlyArray<{
+      name: string;
+      read: (service: ContentService) => boolean;
+      urls: string[];
+    }> = [
+      { name: "onLogin", read: (s) => s.onLogin(), urls: [ROUTE_PATHS.LOGIN] },
+      { name: "onAudit", read: (s) => s.onAudit(), urls: [ROUTE_PATHS.AUDIT] },
+      { name: "onClients", read: (s) => s.onClients(), urls: [ROUTE_PATHS.CLIENTS] },
+      { name: "onTokens", read: (s) => s.onTokens(), urls: [ROUTE_PATHS.TOKENS] },
+      { name: "onUsers", read: (s) => s.onUsers(), urls: [ROUTE_PATHS.USERS] },
+      {
+        name: "onPolicies",
+        read: (s) => s.onPolicies(),
+        urls: [ROUTE_PATHS.POLICIES, ROUTE_PATHS.POLICIES_NEW, ROUTE_PATHS.POLICIES_DETAILS + "pol1"]
+      },
+      { name: "onTokenDetails", read: (s) => s.onTokenDetails(), urls: [ROUTE_PATHS.TOKENS_DETAILS + "SER1"] },
+      { name: "onUserDetails", read: (s) => s.onUserDetails(), urls: [ROUTE_PATHS.USERS_DETAILS + "/alice"] },
+      {
+        name: "onUserDetailsSelfService",
+        read: (s) => s.onUserDetailsSelfService(),
+        urls: [ROUTE_PATHS.USERS_DETAILS]
+      },
+      { name: "onUserRealms", read: (s) => s.onUserRealms(), urls: [ROUTE_PATHS.USERS_REALMS] },
+      { name: "onUsersResolvers", read: (s) => s.onUsersResolvers(), urls: [ROUTE_PATHS.USERS_RESOLVERS] },
+      { name: "onTokensEnrollment", read: (s) => s.onTokensEnrollment(), urls: [ROUTE_PATHS.TOKENS_ENROLLMENT] },
+      { name: "onTokensChallenges", read: (s) => s.onTokensChallenges(), urls: [ROUTE_PATHS.TOKENS_CHALLENGES] },
+      { name: "onTokensApplications", read: (s) => s.onTokensApplications(), urls: [ROUTE_PATHS.TOKENS_APPLICATIONS] },
+      { name: "onTokensGetSerial", read: (s) => s.onTokensGetSerial(), urls: [ROUTE_PATHS.TOKENS_GET_SERIAL] },
+      { name: "onTokensImport", read: (s) => s.onTokensImport(), urls: [ROUTE_PATHS.TOKENS_IMPORT] },
+      { name: "onTokensAssignToken", read: (s) => s.onTokensAssignToken(), urls: [ROUTE_PATHS.TOKENS_ASSIGN_TOKEN] },
+      { name: "onTokensWizard", read: (s) => s.onTokensWizard(), urls: [ROUTE_PATHS.TOKENS_WIZARD] },
+      {
+        name: "onAnyTokensRoute",
+        read: (s) => s.onAnyTokensRoute(),
+        urls: [ROUTE_PATHS.TOKENS, ROUTE_PATHS.TOKENS_ENROLLMENT]
+      },
+      {
+        name: "onAnyUsersRoute",
+        read: (s) => s.onAnyUsersRoute(),
+        urls: [ROUTE_PATHS.USERS, ROUTE_PATHS.USERS_REALMS]
+      },
+      { name: "onContainers", read: (s) => s.onContainers(), urls: [ROUTE_PATHS.CONTAINERS] },
+      {
+        name: "onContainersCreate",
+        read: (s) => s.onContainersCreate(),
+        urls: [ROUTE_PATHS.CONTAINERS_CREATE, ROUTE_PATHS.CONTAINERS_WIZARD]
+      },
+      { name: "onContainersWizard", read: (s) => s.onContainersWizard(), urls: [ROUTE_PATHS.CONTAINERS_WIZARD] },
+      {
+        name: "onContainersDetails",
+        read: (s) => s.onContainersDetails(),
+        urls: [ROUTE_PATHS.CONTAINERS_DETAILS + "CONT1"]
+      },
+      {
+        name: "onAnyContainerTemplatesRoute",
+        read: (s) => s.onAnyContainerTemplatesRoute(),
+        urls: [
+          ROUTE_PATHS.CONTAINERS_TEMPLATES,
+          ROUTE_PATHS.CONTAINERS_TEMPLATES_CREATE,
+          ROUTE_PATHS.CONTAINERS_TEMPLATES_DETAILS + "myTemplate"
+        ]
+      },
+      {
+        name: "onEvents",
+        read: (s) => s.onEvents(),
+        urls: [ROUTE_PATHS.EVENTS, ROUTE_PATHS.EVENTS_NEW, ROUTE_PATHS.EVENTS_DETAILS + "1"]
+      },
+      {
+        name: "onConfigurationSystem",
+        read: (s) => s.onConfigurationSystem(),
+        urls: [ROUTE_PATHS.CONFIGURATION_SYSTEM]
+      },
+      {
+        name: "onConfigurationTokenTypes",
+        read: (s) => s.onConfigurationTokenTypes(),
+        urls: [ROUTE_PATHS.CONFIGURATION_TOKENTYPES]
+      },
+      {
+        name: "onConfigurationMachines",
+        read: (s) => s.onConfigurationMachines(),
+        urls: [ROUTE_PATHS.CONFIGURATION_MACHINES, ROUTE_PATHS.CONFIGURATION_MACHINES_DETAILS + "host1"]
+      },
+      {
+        name: "onConfigurationPeriodicTasks",
+        read: (s) => s.onConfigurationPeriodicTasks(),
+        urls: [
+          ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS,
+          ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS_NEW,
+          ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS_DETAILS + "1"
+        ]
+      },
+      { name: "onSubscription", read: (s) => s.onSubscription(), urls: [ROUTE_PATHS.SUBSCRIPTION] },
+      {
+        name: "onMachineResolver",
+        read: (s) => s.onMachineResolver(),
+        urls: [
+          ROUTE_PATHS.MACHINE_RESOLVER,
+          ROUTE_PATHS.MACHINE_RESOLVER_NEW,
+          ROUTE_PATHS.MACHINE_RESOLVER_DETAILS + "hosts1"
+        ]
+      },
+      {
+        name: "onExternalSmtp",
+        read: (s) => s.onExternalSmtp(),
+        urls: [
+          ROUTE_PATHS.EXTERNAL_SERVICES_SMTP,
+          ROUTE_PATHS.EXTERNAL_SERVICES_SMTP_NEW,
+          ROUTE_PATHS.EXTERNAL_SERVICES_SMTP_DETAILS + "mailer"
+        ]
+      },
+      {
+        name: "onExternalRadius",
+        read: (s) => s.onExternalRadius(),
+        urls: [
+          ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS,
+          ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS_NEW,
+          ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS_DETAILS + "radius1"
+        ]
+      },
+      {
+        name: "onExternalSms",
+        read: (s) => s.onExternalSms(),
+        urls: [
+          ROUTE_PATHS.EXTERNAL_SERVICES_SMS,
+          ROUTE_PATHS.EXTERNAL_SERVICES_SMS_NEW,
+          ROUTE_PATHS.EXTERNAL_SERVICES_SMS_DETAILS + "gateway1"
+        ]
+      },
+      {
+        name: "onExternalCaConnectors",
+        read: (s) => s.onExternalCaConnectors(),
+        urls: [
+          ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS,
+          ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS_NEW,
+          ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS_DETAILS + "ca1"
+        ]
+      },
+      {
+        name: "onExternalPrivacyIdea",
+        read: (s) => s.onExternalPrivacyIdea(),
+        urls: [
+          ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA,
+          ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA_NEW,
+          ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA_DETAILS + "pi1"
+        ]
+      },
+      {
+        name: "onExternalTokenGroups",
+        read: (s) => s.onExternalTokenGroups(),
+        urls: [
+          ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS,
+          ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS_NEW,
+          ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS_DETAILS + "group1"
+        ]
+      },
+      {
+        name: "onExternalServiceIds",
+        read: (s) => s.onExternalServiceIds(),
+        urls: [
+          ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS,
+          ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS_NEW,
+          ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS_DETAILS + "service1"
+        ]
+      }
+    ];
+
+    it.each(routeFlagCases)("$name matches its routes with and without query parameters", ({ read, urls }) => {
+      emitNav("/somewhere-else");
+      expect(read(service)).toBe(false);
+
+      for (const url of urls) {
+        emitNav(url);
+        expect(read(service)).toBe(true);
+
+        emitNav(url + "?realm=defrealm&user=root");
+        expect(read(service)).toBe(true);
+      }
+    });
+  });
+
   it("onTokenEnrollmentLikely is true for enrollment related routes", () => {
     expect(service.onTokenEnrollmentLikely()).toBe(false);
 

--- a/privacyidea/static_new/src/app/services/content/content.service.ts
+++ b/privacyidea/static_new/src/app/services/content/content.service.ts
@@ -32,6 +32,7 @@ export interface ContentServiceInterface {
   router: Router;
   routeUrl: Signal<string>;
   previousUrl: Signal<string>;
+  queryParams: Signal<Record<string, string>>;
   tokenSerial: WritableSignal<string>;
   containerSerial: WritableSignal<string>;
 
@@ -101,6 +102,18 @@ export class ContentService implements ContentServiceInterface {
   );
   readonly routeUrl = computed(() => this._urlPair()[1]);
   readonly previousUrl = computed(() => this._urlPair()[0]);
+  readonly queryParams = computed<Record<string, string>>(() => {
+    const url = this.routeUrl();
+    const queryIndex = url.indexOf("?");
+    if (queryIndex < 0) {
+      return {};
+    }
+    const params: Record<string, string> = {};
+    new URLSearchParams(url.slice(queryIndex + 1)).forEach((value, key) => {
+      params[key] = value;
+    });
+    return params;
+  });
   tokenSerial = signal("");
   containerSerial: WritableSignal<string> = linkedSignal({
     source: this.routeUrl,
@@ -111,116 +124,121 @@ export class ContentService implements ContentServiceInterface {
       return "";
     }
   });
-  onLogin = computed(() => this.routeUrl() === ROUTE_PATHS.LOGIN);
-  onAudit = computed(() => this.routeUrl() === ROUTE_PATHS.AUDIT);
-  onClients = computed(() => this.routeUrl() === ROUTE_PATHS.CLIENTS);
-  onTokens = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS);
-  onUsers = computed(() => this.routeUrl() === ROUTE_PATHS.USERS);
+  onLogin = computed(() => this.matchesPath(ROUTE_PATHS.LOGIN));
+  onAudit = computed(() => this.matchesPath(ROUTE_PATHS.AUDIT));
+  onClients = computed(() => this.matchesPath(ROUTE_PATHS.CLIENTS));
+  onTokens = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS));
+  onUsers = computed(() => this.matchesPath(ROUTE_PATHS.USERS));
   onPolicies = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.POLICIES));
   onTokenDetails = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.TOKENS_DETAILS));
   onUserDetails = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.USERS_DETAILS + "/"));
-  onUserDetailsSelfService = computed(() => this.routeUrl() === ROUTE_PATHS.USERS_DETAILS);
-  onUserRealms = computed(() => this.routeUrl() === ROUTE_PATHS.USERS_REALMS);
-  onTokensEnrollment = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_ENROLLMENT);
+  onUserDetailsSelfService = computed(() => this.matchesPath(ROUTE_PATHS.USERS_DETAILS));
+  onUserRealms = computed(() => this.matchesPath(ROUTE_PATHS.USERS_REALMS));
+  onTokensEnrollment = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_ENROLLMENT));
   onTokenEnrollmentLikely = computed(
     () =>
       // allow token details for rollover
       this.onTokensEnrollment() || this.onTokenDetails() || this.onTokensWizard() || this.onAnyContainerTemplatesRoute()
   );
-  onTokensChallenges = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_CHALLENGES);
-  onTokensApplications = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_APPLICATIONS);
-  onTokensGetSerial = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_GET_SERIAL);
-  onTokensImport = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_IMPORT);
-  onContainers = computed(() => this.routeUrl() === ROUTE_PATHS.CONTAINERS);
-  onContainersCreate = computed(() =>
-    [ROUTE_PATHS.CONTAINERS_CREATE, ROUTE_PATHS.CONTAINERS_WIZARD].includes(this.routeUrl())
+  onTokensChallenges = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_CHALLENGES));
+  onTokensApplications = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_APPLICATIONS));
+  onTokensGetSerial = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_GET_SERIAL));
+  onTokensImport = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_IMPORT));
+  onContainers = computed(() => this.matchesPath(ROUTE_PATHS.CONTAINERS));
+  onContainersCreate = computed(
+    () => this.matchesPath(ROUTE_PATHS.CONTAINERS_CREATE) || this.matchesPath(ROUTE_PATHS.CONTAINERS_WIZARD)
   );
   onContainersDetails = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.CONTAINERS_DETAILS));
-  onTokensAssignToken = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_ASSIGN_TOKEN);
-  onTokensWizard = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_WIZARD);
-  onContainersWizard = computed(() => this.routeUrl() === ROUTE_PATHS.CONTAINERS_WIZARD);
+  onTokensAssignToken = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_ASSIGN_TOKEN));
+  onTokensWizard = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_WIZARD));
+  onContainersWizard = computed(() => this.matchesPath(ROUTE_PATHS.CONTAINERS_WIZARD));
   onAnyTokensRoute = computed(
-    () => this.routeUrl() === ROUTE_PATHS.TOKENS || this.routeUrl().startsWith(ROUTE_PATHS.TOKENS + "/")
+    () => this.matchesPath(ROUTE_PATHS.TOKENS) || this.routeUrl().startsWith(ROUTE_PATHS.TOKENS + "/")
   );
   onAnyUsersRoute = computed(
-    () => this.routeUrl() === ROUTE_PATHS.USERS || this.routeUrl().startsWith(ROUTE_PATHS.USERS + "/")
+    () => this.matchesPath(ROUTE_PATHS.USERS) || this.routeUrl().startsWith(ROUTE_PATHS.USERS + "/")
   );
-  onContainersTemplates = computed(() => this.routeUrl() === ROUTE_PATHS.CONTAINERS_TEMPLATES);
-  onContainersTemplatesCreate = computed(() => this.routeUrl() === ROUTE_PATHS.CONTAINERS_TEMPLATES_CREATE);
+  onContainersTemplates = computed(() => this.matchesPath(ROUTE_PATHS.CONTAINERS_TEMPLATES));
+  onContainersTemplatesCreate = computed(() => this.matchesPath(ROUTE_PATHS.CONTAINERS_TEMPLATES_CREATE));
   onContainersTemplatesDetails = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.CONTAINERS_TEMPLATES_DETAILS));
   onAnyContainerTemplatesRoute = computed(
     () => this.onContainersTemplates() || this.onContainersTemplatesCreate() || this.onContainersTemplatesDetails()
   );
   onEvents = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.EVENTS ||
-      this.routeUrl() === ROUTE_PATHS.EVENTS_NEW ||
+      this.matchesPath(ROUTE_PATHS.EVENTS) ||
+      this.matchesPath(ROUTE_PATHS.EVENTS_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.EVENTS_DETAILS)
   );
-  onConfigurationSystem = computed(() => this.routeUrl() === ROUTE_PATHS.CONFIGURATION_SYSTEM);
-  onConfigurationTokenTypes = computed(() => this.routeUrl() === ROUTE_PATHS.CONFIGURATION_TOKENTYPES);
+  onConfigurationSystem = computed(() => this.matchesPath(ROUTE_PATHS.CONFIGURATION_SYSTEM));
+  onConfigurationTokenTypes = computed(() => this.matchesPath(ROUTE_PATHS.CONFIGURATION_TOKENTYPES));
   onConfigurationMachines = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.CONFIGURATION_MACHINES ||
+      this.matchesPath(ROUTE_PATHS.CONFIGURATION_MACHINES) ||
       this.routeUrl().startsWith(ROUTE_PATHS.CONFIGURATION_MACHINES_DETAILS)
   );
 
   onExternalSmtp = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMTP ||
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMTP_NEW ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SMTP) ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SMTP_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.EXTERNAL_SERVICES_SMTP_DETAILS)
   );
   onExternalRadius = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS ||
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS_NEW ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS) ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS_DETAILS)
   );
   onExternalSms = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMS ||
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMS_NEW ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SMS) ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SMS_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.EXTERNAL_SERVICES_SMS_DETAILS)
   );
   onExternalCaConnectors = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS ||
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS_NEW ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS) ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS_DETAILS)
   );
   onExternalPrivacyIdea = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA ||
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA_NEW ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA) ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA_DETAILS)
   );
   onExternalTokenGroups = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS ||
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS_NEW ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS) ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS_DETAILS)
   );
   onExternalServiceIds = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS ||
-      this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS_NEW ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS) ||
+      this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS_DETAILS)
   );
-  onUsersResolvers = computed(() => this.routeUrl() === ROUTE_PATHS.USERS_RESOLVERS);
+  onUsersResolvers = computed(() => this.matchesPath(ROUTE_PATHS.USERS_RESOLVERS));
   onConfigurationPeriodicTasks = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS ||
-      this.routeUrl() === ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS_NEW ||
+      this.matchesPath(ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS) ||
+      this.matchesPath(ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS_DETAILS)
   );
-  onSubscription = computed(() => this.routeUrl() === ROUTE_PATHS.SUBSCRIPTION);
+  onSubscription = computed(() => this.matchesPath(ROUTE_PATHS.SUBSCRIPTION));
   onMachineResolver = computed(
     () =>
-      this.routeUrl() === ROUTE_PATHS.MACHINE_RESOLVER ||
-      this.routeUrl() === ROUTE_PATHS.MACHINE_RESOLVER_NEW ||
+      this.matchesPath(ROUTE_PATHS.MACHINE_RESOLVER) ||
+      this.matchesPath(ROUTE_PATHS.MACHINE_RESOLVER_NEW) ||
       this.routeUrl().startsWith(ROUTE_PATHS.MACHINE_RESOLVER_DETAILS)
   );
+
+  private matchesPath(path: string): boolean {
+    const url = this.routeUrl();
+    return url === path || url.startsWith(path + "?");
+  }
 
   tokenSelected(serial: string): void {
     this.router.navigateByUrl(ROUTE_PATHS.TOKENS_DETAILS + encodeURIComponent(serial));

--- a/privacyidea/static_new/src/app/services/content/content.service.ts
+++ b/privacyidea/static_new/src/app/services/content/content.service.ts
@@ -31,6 +31,7 @@ export interface ContentServiceInterface {
   detailsUser: WritableSignal<DetailsUser>;
   router: Router;
   routeUrl: Signal<string>;
+  routePath: Signal<string>;
   previousUrl: Signal<string>;
   queryParams: Signal<Record<string, string>>;
   tokenSerial: WritableSignal<string>;
@@ -81,6 +82,7 @@ export interface ContentServiceInterface {
   onSubscription: Signal<boolean>;
   onMachineResolver: Signal<boolean>;
 
+  matchesPath: (path: string) => boolean;
   tokenSelected: (serial: string) => void;
   navigateContainerDetails: (containerSerial: string) => void;
   userSelected: (username: string, realm: string) => void;
@@ -101,6 +103,7 @@ export class ContentService implements ContentServiceInterface {
     { initialValue: [this.router.url, this.router.url] as const }
   );
   readonly routeUrl = computed(() => this._urlPair()[1]);
+  readonly routePath = computed(() => this.routeUrl().split(/[?#]/)[0]);
   readonly previousUrl = computed(() => this._urlPair()[0]);
   readonly queryParams = computed<Record<string, string>>(() => {
     const url = this.routeUrl();
@@ -109,7 +112,7 @@ export class ContentService implements ContentServiceInterface {
       return {};
     }
     const params: Record<string, string> = {};
-    new URLSearchParams(url.slice(queryIndex + 1)).forEach((value, key) => {
+    new URLSearchParams(url.slice(queryIndex + 1).split("#")[0]).forEach((value, key) => {
       params[key] = value;
     });
     return params;
@@ -235,9 +238,8 @@ export class ContentService implements ContentServiceInterface {
       this.routeUrl().startsWith(ROUTE_PATHS.MACHINE_RESOLVER_DETAILS)
   );
 
-  private matchesPath(path: string): boolean {
-    const url = this.routeUrl();
-    return url === path || url.startsWith(path + "?");
+  matchesPath(path: string): boolean {
+    return this.routePath() === path;
   }
 
   tokenSelected(serial: string): void {

--- a/privacyidea/static_new/src/app/services/realm/realm.service.ts
+++ b/privacyidea/static_new/src/app/services/realm/realm.service.ts
@@ -72,6 +72,7 @@ export interface RealmServiceInterface {
   adminRealmOptions: Signal<string[]>;
   defaultRealmResource: HttpResourceRef<PiResponse<Realms> | undefined>;
   defaultRealm: Signal<string>;
+  defaultRealmResolved: Signal<boolean>;
 
   createRealm(
     realm: string,
@@ -185,6 +186,10 @@ export class RealmService implements RealmServiceInterface {
     }
     return defaultRealm;
   });
+
+  // False while the default realm request is still in flight, so consumers can
+  // avoid latching onto a provisional realm before the real default is known.
+  defaultRealmResolved = computed<boolean>(() => !this.defaultRealmResource.isLoading());
 
   constructor() {
     effect(() => {

--- a/privacyidea/static_new/src/app/services/user/user.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.spec.ts
@@ -142,6 +142,37 @@ describe("UserService", () => {
     expect(userService.selectedUserRealm()).toBe("realm1");
   });
 
+  it("seeds selectedUserRealm and selectionFilter from query parameters on navigation", () => {
+    realmService.realmOptions.set(["realm1", "defrealm"]);
+    contentServiceMock.queryParams.set({ realm: "defrealm", user: "root" });
+    contentServiceMock.routeUrl.set(ROUTE_PATHS.TOKENS_ENROLLMENT);
+
+    expect(userService.selectedUserRealm()).toBe("defrealm");
+    expect(userService.selectionUsernameFilter()).toBe("root");
+  });
+
+  it("keeps the seeded user selection when the realm changes on the same route", () => {
+    realmService.realmOptions.set(["realm1", "defrealm"]);
+    contentServiceMock.queryParams.set({ realm: "defrealm", user: "root" });
+    contentServiceMock.routeUrl.set(ROUTE_PATHS.TOKENS_ENROLLMENT);
+    expect(userService.selectionUsernameFilter()).toBe("root");
+
+    userService.selectionFilter.set("bob");
+    userService.selectedUserRealm.set("realm1");
+    expect(userService.selectionUsernameFilter()).toBe("bob");
+  });
+
+  it("resets the selection filter when navigating away without query parameters", () => {
+    realmService.realmOptions.set(["realm1", "defrealm"]);
+    contentServiceMock.queryParams.set({ realm: "defrealm", user: "root" });
+    contentServiceMock.routeUrl.set(ROUTE_PATHS.TOKENS_ENROLLMENT);
+    expect(userService.selectionUsernameFilter()).toBe("root");
+
+    contentServiceMock.queryParams.set({});
+    contentServiceMock.routeUrl.set(ROUTE_PATHS.TOKENS);
+    expect(userService.selectionUsernameFilter()).toBe("");
+  });
+
   it("selectedUserRealm should expose empty string if no realmOptions are available", () => {
     realmService.realmOptions.set([]);
     expect(userService.selectedUserRealm()).toBe("");

--- a/privacyidea/static_new/src/app/services/user/user.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.spec.ts
@@ -23,7 +23,7 @@ import { TestBed } from "@angular/core/testing";
 import { provideRouter, Router } from "@angular/router";
 import { AuthService } from "@services/auth/auth.service";
 import { ContentService } from "@services/content/content.service";
-import { RealmService } from "@services/realm/realm.service";
+import { Realms, RealmService } from "@services/realm/realm.service";
 import { TokenDetails, Tokens, TokenService } from "@services/token/token.service";
 import { EditUserData, UserAttributePolicy, UserData, UserService } from "./user.service";
 
@@ -142,6 +142,20 @@ describe("UserService", () => {
   it("selectedUserRealm should expose first realm if no default realm is set", () => {
     realmService.realmOptions.set(["realm1", "realm2"]);
     expect(userService.selectedUserRealm()).toBe("realm1");
+  });
+
+  it("selectedUserRealm switches to the default realm when it resolves after the realm options", () => {
+    contentServiceMock.routeUrl.set(ROUTE_PATHS.USERS);
+    realmService.defaultRealmResource.isLoading.set(true);
+    realmService.defaultRealmResource.set(MockPiResponse.fromValue<Realms>({}));
+    realmService.realmOptions.set(["aRealm", "zRealm"]);
+    expect(userService.selectedUserRealm()).toBe("aRealm");
+
+    realmService.defaultRealmResource.set(
+      MockPiResponse.fromValue<Realms>({ zRealm: { default: true, id: 1, option: "", resolver: [] } })
+    );
+    realmService.defaultRealmResource.isLoading.set(false);
+    expect(userService.selectedUserRealm()).toBe("zRealm");
   });
 
   it("seeds selectedUserRealm and selectionFilter from query parameters on navigation", () => {

--- a/privacyidea/static_new/src/app/services/user/user.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.spec.ts
@@ -18,14 +18,16 @@
  **/
 import { provideHttpClient } from "@angular/common/http";
 import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
+import { provideLocationMocks } from "@angular/common/testing";
 import { TestBed } from "@angular/core/testing";
+import { provideRouter, Router } from "@angular/router";
 import { AuthService } from "@services/auth/auth.service";
 import { ContentService } from "@services/content/content.service";
 import { RealmService } from "@services/realm/realm.service";
 import { TokenDetails, Tokens, TokenService } from "@services/token/token.service";
 import { EditUserData, UserAttributePolicy, UserData, UserService } from "./user.service";
 
-import { signal } from "@angular/core";
+import { Component, signal } from "@angular/core";
 import { PiResponse } from "@app/app.component";
 import { FilterValue } from "@core/models/filter_value/filter_value";
 import { ROUTE_PATHS } from "@app/route_paths";
@@ -171,6 +173,36 @@ describe("UserService", () => {
     contentServiceMock.queryParams.set({});
     contentServiceMock.routeUrl.set(ROUTE_PATHS.TOKENS);
     expect(userService.selectionUsernameFilter()).toBe("");
+  });
+
+  it("ignores a query realm that is not in the realms the user may see", () => {
+    realmService.realmOptions.set(["realm1", "defrealm"]);
+    contentServiceMock.queryParams.set({ realm: "hiddenRealm", user: "root" });
+    contentServiceMock.routeUrl.set(ROUTE_PATHS.TOKENS_ENROLLMENT);
+
+    expect(userService.selectedUserRealm()).toBe("realm1");
+  });
+
+  it("keeps a manually chosen realm when the token type changes on the same route", () => {
+    const tokenService = TestBed.inject(TokenService) as unknown as MockTokenService;
+    realmService.realmOptions.set(["realm1", "defrealm"]);
+    contentServiceMock.queryParams.set({ realm: "defrealm", user: "root" });
+    contentServiceMock.routeUrl.set(ROUTE_PATHS.TOKENS_ENROLLMENT);
+    expect(userService.selectedUserRealm()).toBe("defrealm");
+
+    userService.selectedUserRealm.set("realm1");
+    tokenService.selectedTokenType.update((type) => ({ ...type, key: "totp" }));
+
+    expect(userService.selectedUserRealm()).toBe("realm1");
+  });
+
+  it("selectedUserRealm uses the own realm of a self service user", () => {
+    realmService.realmOptions.set(["realm1", "defrealm"]);
+    authServiceMock.role.set("user");
+    authServiceMock.realm.set("selfRealm");
+    contentServiceMock.routeUrl.set(ROUTE_PATHS.TOKENS_ENROLLMENT);
+
+    expect(userService.selectedUserRealm()).toBe("selfRealm");
   });
 
   it("selectedUserRealm should expose empty string if no realmOptions are available", () => {
@@ -771,5 +803,87 @@ describe("UserService", () => {
       expect(resultValue).toBe(false);
       expect(notificationServiceMock.error).toHaveBeenCalledWith("Failed to delete user fail-user. fail");
     });
+  });
+});
+
+@Component({ template: "" })
+class RouteStubComponent {}
+
+// The details page hands the opened user to the enrollment and container pages through the query
+// string (UserDetailsComponent.enrollNewToken / createNewContainer). These scenarios drive the whole
+// round trip through the real Router and ContentService instead of a route mock.
+describe("UserService user prefill from the route", () => {
+  let router: Router;
+  let contentService: ContentService;
+  let userService: UserService;
+  let realmService: MockRealmService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([{ path: "**", component: RouteStubComponent }]),
+        provideLocationMocks(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ContentService,
+        UserService,
+        { provide: RealmService, useClass: MockRealmService },
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: TokenService, useClass: MockTokenService },
+        { provide: NotificationService, useClass: MockNotificationService },
+        MockLocalService
+      ]
+    });
+
+    router = TestBed.inject(Router);
+    contentService = TestBed.inject(ContentService);
+    userService = TestBed.inject(UserService);
+    realmService = TestBed.inject(RealmService) as unknown as MockRealmService;
+    httpMock = TestBed.inject(HttpTestingController);
+    realmService.realmOptions.set(["realm1", "defrealm"]);
+  });
+
+  afterEach(() => {
+    // The user details route starts the user resources; their payloads do not matter for routing.
+    httpMock.match(() => true).forEach((request) => request.flush({}));
+    httpMock.verify();
+  });
+
+  it("carries the opened user from the details route into the enrollment route", async () => {
+    await router.navigate([ROUTE_PATHS.USERS_DETAILS, "alice"], { queryParams: { realm: "defrealm" } });
+    contentService.detailsUser.set({ username: "alice", realm: "defrealm" });
+    expect(contentService.onUserDetails()).toBe(true);
+    expect(userService.selectedUserRealm()).toBe("defrealm");
+
+    await router.navigate([ROUTE_PATHS.TOKENS_ENROLLMENT], { queryParams: { realm: "defrealm", user: "alice" } });
+
+    expect(contentService.routeUrl()).toBe(ROUTE_PATHS.TOKENS_ENROLLMENT + "?realm=defrealm&user=alice");
+    expect(contentService.onTokensEnrollment()).toBe(true);
+    expect(userService.selectedUserRealm()).toBe("defrealm");
+    expect(userService.selectionUsernameFilter()).toBe("alice");
+  });
+
+  it("carries the opened user into the container create route and drops it on the next navigation", async () => {
+    await router.navigate([ROUTE_PATHS.CONTAINERS_CREATE], { queryParams: { realm: "defrealm", user: "alice" } });
+
+    expect(contentService.onContainersCreate()).toBe(true);
+    expect(userService.selectedUserRealm()).toBe("defrealm");
+    expect(userService.selectionUsernameFilter()).toBe("alice");
+
+    await router.navigate([ROUTE_PATHS.TOKENS]);
+
+    expect(userService.selectionUsernameFilter()).toBe("");
+  });
+
+  it("keeps a user picked on the enrollment page instead of restoring the one from the query string", async () => {
+    await router.navigate([ROUTE_PATHS.TOKENS_ENROLLMENT], { queryParams: { realm: "defrealm", user: "alice" } });
+    expect(userService.selectionUsernameFilter()).toBe("alice");
+
+    userService.selectionFilter.set("bob");
+    userService.selectedUserRealm.set("realm1");
+
+    expect(userService.selectionUsernameFilter()).toBe("bob");
   });
 });

--- a/privacyidea/static_new/src/app/services/user/user.service.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.ts
@@ -360,16 +360,13 @@ export class UserService implements UserServiceInterface {
       queryUser: this.contentService.queryParams()["user"] ?? ""
     }),
     computation: (source, previous) => {
-      if (source.queryUser) {
-        if (source.routeUrl !== previous?.source.routeUrl) {
-          return source.queryUser;
-        }
-        if (previous !== undefined) {
-          return previous.value;
-        }
-        return source.queryUser;
+      if (!source.queryUser) {
+        return "";
       }
-      return "";
+      // A navigation seeds the selection from the query parameter, while a selection made afterwards
+      // on the same route wins over it.
+      const sameRoute = previous !== undefined && previous.source.routeUrl === source.routeUrl;
+      return sameRoute ? previous.value : source.queryUser;
     }
   });
 

--- a/privacyidea/static_new/src/app/services/user/user.service.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.ts
@@ -316,12 +316,15 @@ export class UserService implements UserServiceInterface {
       detailsUserRealm: this.contentService.detailsUser().realm,
       defaultRealm: this.realmService.defaultRealm(),
       realmOptions: this.realmService.realmOptions(),
+      defaultRealmResolved: this.realmService.defaultRealmResolved(),
       selectedTokenType: this.tokenService.selectedTokenType(),
       authRole: this.authService.role(),
       authRealm: this.authService.realm()
     }),
     computation: (source, previous): string => {
-      const previousRealm = previous?.value;
+      // The previous value is only trustworthy if the default realm was already
+      // known when it was picked, otherwise it may be a provisional first option.
+      const previousRealm = previous?.source.defaultRealmResolved ? previous.value : "";
       const routeChanged = source.routeUrl !== previous?.source.routeUrl;
       const fallbackRealm = previousRealm || this.defaultRealm();
       // On user details the realm of the opened user is the source of truth

--- a/privacyidea/static_new/src/app/services/user/user.service.ts
+++ b/privacyidea/static_new/src/app/services/user/user.service.ts
@@ -303,6 +303,7 @@ export class UserService implements UserServiceInterface {
   selectedUserRealm: WritableSignal<string> = linkedSignal({
     source: () => ({
       routeUrl: this.contentService.routeUrl(),
+      queryRealm: this.contentService.queryParams()["realm"] ?? "",
       detailsUserRealm: this.contentService.detailsUser().realm,
       defaultRealm: this.realmService.defaultRealm(),
       realmOptions: this.realmService.realmOptions(),
@@ -311,30 +312,56 @@ export class UserService implements UserServiceInterface {
       authRealm: this.authService.realm()
     }),
     computation: (source, previous): string => {
+      const previousRealm = previous?.value;
+      const routeChanged = source.routeUrl !== previous?.source.routeUrl;
+      const fallbackRealm = previousRealm || this.defaultRealm();
       // On user details the realm of the opened user is the source of truth
       if (this.contentService.onUserDetails()) {
-        if (source.detailsUserRealm) {
-          return source.detailsUserRealm;
-        }
-        if (previous?.value) {
-          return previous.value;
-        }
-      } else if (source.routeUrl.startsWith(ROUTE_PATHS.USERS) && previous?.value) {
-        return previous.value;
+        return source.detailsUserRealm || fallbackRealm;
       }
-      let defaultRealm = source.defaultRealm;
-      if (!this.realmService.realmOptions().includes(defaultRealm)) {
-        // user is not allowed to see the default realm
-        defaultRealm = "";
+      if (source.queryRealm) {
+        const realm = routeChanged ? source.queryRealm : fallbackRealm;
+        if (source.realmOptions.length > 0 && !source.realmOptions.includes(realm)) {
+          return this.defaultRealm();
+        }
+        return realm;
       }
-      const realm = source.authRole === "user" ? source.authRealm : defaultRealm;
-      return realm || source.realmOptions[0] || "";
+      if (source.routeUrl.startsWith(ROUTE_PATHS.USERS)) {
+        return fallbackRealm;
+      }
+      return this.defaultRealm();
     }
   });
 
-  selectionFilter = linkedSignal<{ realm: string; routeUrl: string }, UserData | string>({
-    source: () => ({ realm: this.selectedUserRealm(), routeUrl: this.contentService.routeUrl() }),
-    computation: () => ""
+  private defaultRealm(): string {
+    const options = this.realmService.realmOptions();
+    let defaultRealm = this.realmService.defaultRealm();
+    if (!options.includes(defaultRealm)) {
+      // user is not allowed to see the default realm
+      defaultRealm = "";
+    }
+    const realm = this.authService.role() === "user" ? this.authService.realm() : defaultRealm;
+    return realm || options[0] || "";
+  }
+
+  selectionFilter = linkedSignal<{ realm: string; routeUrl: string; queryUser: string }, UserData | string>({
+    source: () => ({
+      realm: this.selectedUserRealm(),
+      routeUrl: this.contentService.routeUrl(),
+      queryUser: this.contentService.queryParams()["user"] ?? ""
+    }),
+    computation: (source, previous) => {
+      if (source.queryUser) {
+        if (source.routeUrl !== previous?.source.routeUrl) {
+          return source.queryUser;
+        }
+        if (previous !== undefined) {
+          return previous.value;
+        }
+        return source.queryUser;
+      }
+      return "";
+    }
   });
 
   selectionUsernameFilter = computed<string>(() => {

--- a/privacyidea/static_new/src/testing/mock-services/mock-content-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-content-service.ts
@@ -26,6 +26,7 @@ export class MockContentService implements ContentServiceInterface {
   detailsUser = signal({ username: "", realm: "" });
   router: Router = {} as Router;
   routeUrl = signal("");
+  routePath = computed(() => this.routeUrl().split(/[?#]/)[0]);
   previousUrl = signal("");
   queryParams = signal<Record<string, string>>({});
   tokenSerial = signal("");
@@ -89,9 +90,8 @@ export class MockContentService implements ContentServiceInterface {
   onSubscription = computed(() => this.matchesPath(ROUTE_PATHS.SUBSCRIPTION));
   onMachineResolver = computed(() => this.matchesPath(ROUTE_PATHS.MACHINE_RESOLVER));
 
-  private matchesPath(path: string): boolean {
-    const url = this.routeUrl();
-    return url === path || url.startsWith(path + "?");
+  matchesPath(path: string): boolean {
+    return this.routePath() === path;
   }
 
   tokenSelected = jest.fn();

--- a/privacyidea/static_new/src/testing/mock-services/mock-content-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-content-service.ts
@@ -27,43 +27,44 @@ export class MockContentService implements ContentServiceInterface {
   router: Router = {} as Router;
   routeUrl = signal("");
   previousUrl = signal("");
+  queryParams = signal<Record<string, string>>({});
   tokenSerial = signal("");
   containerSerial = signal("");
   machineResolver = signal("");
 
-  onLogin = computed(() => this.routeUrl() === ROUTE_PATHS.LOGIN);
-  onAudit = computed(() => this.routeUrl() === ROUTE_PATHS.AUDIT);
-  onClients = computed(() => this.routeUrl() === ROUTE_PATHS.CLIENTS);
-  onTokens = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS);
-  onUsers = computed(() => this.routeUrl() === ROUTE_PATHS.USERS);
-  onPolicies = computed(() => this.routeUrl() === ROUTE_PATHS.POLICIES);
+  onLogin = computed(() => this.matchesPath(ROUTE_PATHS.LOGIN));
+  onAudit = computed(() => this.matchesPath(ROUTE_PATHS.AUDIT));
+  onClients = computed(() => this.matchesPath(ROUTE_PATHS.CLIENTS));
+  onTokens = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS));
+  onUsers = computed(() => this.matchesPath(ROUTE_PATHS.USERS));
+  onPolicies = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.POLICIES));
   onTokenDetails = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.TOKENS_DETAILS));
   onUserDetails = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.USERS_DETAILS + "/"));
-  onUserDetailsSelfService = computed(() => this.routeUrl() === ROUTE_PATHS.USERS_DETAILS);
-  onUserRealms = computed(() => this.routeUrl() === ROUTE_PATHS.USERS_REALMS);
-  onTokensEnrollment = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_ENROLLMENT);
+  onUserDetailsSelfService = computed(() => this.matchesPath(ROUTE_PATHS.USERS_DETAILS));
+  onUserRealms = computed(() => this.matchesPath(ROUTE_PATHS.USERS_REALMS));
+  onTokensEnrollment = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_ENROLLMENT));
   onTokenEnrollmentLikely = signal(false);
-  onTokensChallenges = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_CHALLENGES);
-  onTokensApplications = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_APPLICATIONS);
-  onTokensGetSerial = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_GET_SERIAL);
-  onTokensImport = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_IMPORT);
-  onContainers = computed(() => this.routeUrl() === ROUTE_PATHS.CONTAINERS);
-  onContainersCreate = computed(() =>
-    [ROUTE_PATHS.CONTAINERS_CREATE, ROUTE_PATHS.CONTAINERS_WIZARD].includes(this.routeUrl())
+  onTokensChallenges = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_CHALLENGES));
+  onTokensApplications = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_APPLICATIONS));
+  onTokensGetSerial = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_GET_SERIAL));
+  onTokensImport = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_IMPORT));
+  onContainers = computed(() => this.matchesPath(ROUTE_PATHS.CONTAINERS));
+  onContainersCreate = computed(
+    () => this.matchesPath(ROUTE_PATHS.CONTAINERS_CREATE) || this.matchesPath(ROUTE_PATHS.CONTAINERS_WIZARD)
   );
   onContainersDetails = computed(() => this.routeUrl().startsWith(ROUTE_PATHS.CONTAINERS_DETAILS));
-  onTokensAssignToken = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_ASSIGN_TOKEN);
-  onTokensWizard = computed(() => this.routeUrl() === ROUTE_PATHS.TOKENS_WIZARD);
-  onContainersWizard = computed(() => this.routeUrl() === ROUTE_PATHS.CONTAINERS_WIZARD);
+  onTokensAssignToken = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_ASSIGN_TOKEN));
+  onTokensWizard = computed(() => this.matchesPath(ROUTE_PATHS.TOKENS_WIZARD));
+  onContainersWizard = computed(() => this.matchesPath(ROUTE_PATHS.CONTAINERS_WIZARD));
   onAnyTokensRoute = computed(
-    () => this.routeUrl() === ROUTE_PATHS.TOKENS || this.routeUrl().startsWith(ROUTE_PATHS.TOKENS + "/")
+    () => this.matchesPath(ROUTE_PATHS.TOKENS) || this.routeUrl().startsWith(ROUTE_PATHS.TOKENS + "/")
   );
   onAnyUsersRoute = computed(
-    () => this.routeUrl() === ROUTE_PATHS.USERS || this.routeUrl().startsWith(ROUTE_PATHS.USERS + "/")
+    () => this.matchesPath(ROUTE_PATHS.USERS) || this.routeUrl().startsWith(ROUTE_PATHS.USERS + "/")
   );
-  onContainersTemplates: Signal<boolean> = computed(() => this.routeUrl() === ROUTE_PATHS.CONTAINERS_TEMPLATES);
-  onContainersTemplatesCreate: Signal<boolean> = computed(
-    () => this.routeUrl() === ROUTE_PATHS.CONTAINERS_TEMPLATES_CREATE
+  onContainersTemplates: Signal<boolean> = computed(() => this.matchesPath(ROUTE_PATHS.CONTAINERS_TEMPLATES));
+  onContainersTemplatesCreate: Signal<boolean> = computed(() =>
+    this.matchesPath(ROUTE_PATHS.CONTAINERS_TEMPLATES_CREATE)
   );
   onContainersTemplatesDetails: Signal<boolean> = computed(() =>
     this.routeUrl().startsWith(ROUTE_PATHS.CONTAINERS_TEMPLATES_DETAILS)
@@ -71,22 +72,27 @@ export class MockContentService implements ContentServiceInterface {
   onAnyContainerTemplatesRoute = computed(
     () => this.onContainersTemplates() || this.onContainersTemplatesCreate() || this.onContainersTemplatesDetails()
   );
-  onEvents = computed(() => this.routeUrl() === ROUTE_PATHS.EVENTS);
-  onConfigurationSystem: Signal<boolean> = computed(() => this.routeUrl() === ROUTE_PATHS.CONFIGURATION_SYSTEM);
-  onConfigurationTokenTypes: Signal<boolean> = computed(() => this.routeUrl() === ROUTE_PATHS.CONFIGURATION_TOKENTYPES);
-  onConfigurationMachines = computed(() => this.routeUrl() === ROUTE_PATHS.CONFIGURATION_MACHINES);
+  onEvents = computed(() => this.matchesPath(ROUTE_PATHS.EVENTS));
+  onConfigurationSystem: Signal<boolean> = computed(() => this.matchesPath(ROUTE_PATHS.CONFIGURATION_SYSTEM));
+  onConfigurationTokenTypes: Signal<boolean> = computed(() => this.matchesPath(ROUTE_PATHS.CONFIGURATION_TOKENTYPES));
+  onConfigurationMachines = computed(() => this.matchesPath(ROUTE_PATHS.CONFIGURATION_MACHINES));
 
-  onExternalSmtp = computed(() => this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMTP);
-  onExternalRadius = computed(() => this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS);
-  onExternalSms = computed(() => this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SMS);
-  onExternalCaConnectors = computed(() => this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS);
-  onExternalPrivacyIdea = computed(() => this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA);
-  onExternalTokenGroups = computed(() => this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS);
-  onExternalServiceIds = computed(() => this.routeUrl() === ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS);
-  onUsersResolvers = computed(() => this.routeUrl() === ROUTE_PATHS.USERS_RESOLVERS);
-  onConfigurationPeriodicTasks = computed(() => this.routeUrl() === ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS);
-  onSubscription = computed(() => this.routeUrl() === ROUTE_PATHS.SUBSCRIPTION);
-  onMachineResolver = computed(() => this.routeUrl() === ROUTE_PATHS.MACHINE_RESOLVER);
+  onExternalSmtp = computed(() => this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SMTP));
+  onExternalRadius = computed(() => this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_RADIUS));
+  onExternalSms = computed(() => this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SMS));
+  onExternalCaConnectors = computed(() => this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_CA_CONNECTORS));
+  onExternalPrivacyIdea = computed(() => this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_PRIVACYIDEA));
+  onExternalTokenGroups = computed(() => this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_TOKENGROUPS));
+  onExternalServiceIds = computed(() => this.matchesPath(ROUTE_PATHS.EXTERNAL_SERVICES_SERVICE_IDS));
+  onUsersResolvers = computed(() => this.matchesPath(ROUTE_PATHS.USERS_RESOLVERS));
+  onConfigurationPeriodicTasks = computed(() => this.matchesPath(ROUTE_PATHS.CONFIGURATION_PERIODIC_TASKS));
+  onSubscription = computed(() => this.matchesPath(ROUTE_PATHS.SUBSCRIPTION));
+  onMachineResolver = computed(() => this.matchesPath(ROUTE_PATHS.MACHINE_RESOLVER));
+
+  private matchesPath(path: string): boolean {
+    const url = this.routeUrl();
+    return url === path || url.startsWith(path + "?");
+  }
 
   tokenSelected = jest.fn();
   navigateContainerDetails = jest.fn();

--- a/privacyidea/static_new/src/testing/mock-services/mock-realm-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-realm-service.ts
@@ -32,6 +32,8 @@ export class MockRealmService implements RealmServiceInterface {
     return data ? (Object.keys(data)[0] ?? "") : "";
   });
 
+  defaultRealmResolved: Signal<boolean> = computed(() => !this.defaultRealmResource.isLoading());
+
   createRealm = jest
     .fn()
     .mockImplementation((realm: string, nodeId: string, resolvers: { name: string; priority?: number | null }[]) => {

--- a/privacyidea/static_new/src/testing/mock-services/mock-utils.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-utils.ts
@@ -75,7 +75,7 @@ export class MockHttpResourceRef<T> implements HttpResourceRef<T> {
 
   status: Signal<ResourceStatus> = signal("resolved");
   error = signal<Error | undefined>(undefined);
-  isLoading: Signal<boolean> = signal(false);
+  isLoading: WritableSignal<boolean> = signal(false);
   reload = jest.fn().mockReturnValue(true);
 
 }


### PR DESCRIPTION
Enrolling a token and creating a container from user details now sends the realm and user information via query parameters, e.g. "enrollment?realm=defrealm&user=root".
This allows us to send information from one page to another without using a list of exceptions on every computed signal.