### PR TITLE
Send the assigned user's realm as a container list filter

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -143,11 +143,12 @@
   is given without `user`, listing the containers of all users of that realm. Previously such a
   request returned an empty list, because the realm was only ever applied together with a resolved
   user id. Note that `realm` (the realm of the assigned user) and `container_realm` (the realm of the
-  container itself) are still two distinct filters. Two error cases that were silently answered with
-  an empty list now return an error, the same way `GET /token/` already does:
-  a `realm` that does not exist is rejected with a 404, and a `user` that can not be found in any
-  resolver of the realm with a 400. Scripts that pass a stale or misspelled realm or user name to
-  `GET /container/` and relied on getting a result need to be updated.
+  container itself) are still two distinct filters. A realm that does not exist matches nothing, like
+  any other filter value that does not exist. A `user` that can not be resolved to a user id is now
+  rejected with a 400 instead of being answered with an empty list, because the request would
+  otherwise be filtered by the realm and the resolver alone and return the containers of other users.
+  Scripts that pass a stale or misspelled user name to `GET /container/` and relied on getting an
+  empty result need to handle the error.
 
 ## Update from 3.12 to 3.13
 

--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -139,6 +139,16 @@
   returned a single string (e.g. `"dc01.example.test"`); it now returns a list
   (e.g. `["dc01.example.test"]`), consistent with the hosts resolver and the documented API.
 
+* **HTTP API change** - `GET /container/` now filters by the realm of the assigned user when `realm`
+  is given without `user`, listing the containers of all users of that realm. Previously such a
+  request returned an empty list, because the realm was only ever applied together with a resolved
+  user id. Note that `realm` (the realm of the assigned user) and `container_realm` (the realm of the
+  container itself) are still two distinct filters. Two error cases that were silently answered with
+  an empty list now return an error, the same way `GET /token/` already does:
+  a `realm` that does not exist is rejected with a 404, and a `user` that can not be found in any
+  resolver of the realm with a 400. Scripts that pass a stale or misspelled realm or user name to
+  `GET /container/` and relied on getting a result need to be updated.
+
 ## Update from 3.12 to 3.13
 
 * `enrollpin` right enforcement has been made stricter. If you try to enroll a token with a PIN but do not have the

--- a/privacyidea/api/container.py
+++ b/privacyidea/api/container.py
@@ -125,7 +125,8 @@ def list_containers():
 
     Requires authentication and the policy action ``container_list``.
 
-    :query user: filter by the username of an assigned user.
+    :query user: filter by the username of an assigned user. Combined with
+        ``realm`` and ``resolver`` to identify the user.
     :query container_serial: filter by container serial
         (case-insensitive, ``*`` wildcard).
     :query type: filter by container type (case-insensitive, ``*``
@@ -138,8 +139,14 @@ def list_containers():
         this serial (case-insensitive, ``*`` wildcard).
     :query template: filter by the name of the template the
         container was created from (case-sensitive, ``*`` wildcard).
-    :query container_realm: filter by realm (case-insensitive, ``*``
-        wildcard).
+    :query realm: filter by the realm of the assigned user (exact,
+        case-insensitive). May be given without ``user`` to list the
+        containers of all users of that realm. Not to be confused with
+        ``container_realm``: the realm of a user is always among the realms
+        of their container, but a container can be in further realms and
+        keeps the realm of a user that has been unassigned.
+    :query container_realm: filter by the realm of the container itself
+        (case-insensitive, ``*`` wildcard).
     :query description: filter by description (case-insensitive,
         ``*`` wildcard).
     :query resolver: filter by the resolver of the assigned user
@@ -164,6 +171,8 @@ def list_containers():
         entry.
     :status 200: paginated container list in ``result.value`` with
         ``containers``, ``count``, ``current``, ``next``, ``prev``.
+    :status 400: the ``user`` can not be found in any resolver of the realm.
+    :status 404: the ``realm`` does not exist.
     """
     param = request.all_data
     user = request.User

--- a/privacyidea/api/container.py
+++ b/privacyidea/api/container.py
@@ -141,7 +141,10 @@ def list_containers():
         container was created from (case-sensitive, ``*`` wildcard).
     :query realm: filter by the realm of the assigned user (exact,
         case-insensitive). May be given without ``user`` to list the
-        containers of all users of that realm. Not to be confused with
+        containers of all users of that realm; a realm that does not exist
+        matches nothing. Only assigned containers have an owner, hence this
+        filter never matches an unassigned container and combining it with
+        ``assigned=false`` yields an empty list. Not to be confused with
         ``container_realm``: the realm of a user is always among the realms
         of their container, but a container can be in further realms and
         keeps the realm of a user that has been unassigned.
@@ -171,8 +174,9 @@ def list_containers():
         entry.
     :status 200: paginated container list in ``result.value`` with
         ``containers``, ``count``, ``current``, ``next``, ``prev``.
-    :status 400: the ``user`` can not be found in any resolver of the realm.
-    :status 404: the ``realm`` does not exist.
+    :status 400: the ``user`` can not be found in any resolver of the
+        realm. Not raised when the ``realm`` itself does not exist — that
+        is answered with an empty list.
     """
     param = request.all_data
     user = request.User

--- a/privacyidea/lib/container.py
+++ b/privacyidea/lib/container.py
@@ -179,7 +179,10 @@ def _create_container_query(user: User = None, serial: str = None, ctype: str = 
     """
     Generates a sql query to filter containers by the given parameters.
 
-    :param user: container owner, optional
+    :param user: container owner, optional. The login name, the realm and the resolver of the user are
+        applied independently, hence a user object carrying only a realm or only a resolver lists the
+        containers of all users of that realm or resolver. Raises a UserError if a login name is given
+        that can not be resolved and a ResourceNotFoundError if the realm does not exist.
     :param serial: container serial (case-insensitive and allows '*' as wildcard), optional
     :param ctype: container type filter (case-insensitive and allows '*' as wildcard), optional
     :param ctype_exact: exact container type filter list (case-insensitive; matches any type in the list), optional.
@@ -209,15 +212,24 @@ def _create_container_query(user: User = None, serial: str = None, ctype: str = 
     stmt = select(TokenContainer)
     realm1 = aliased(Realm)
     if user:
-        stmt = stmt.join(TokenContainer.owners).where(TokenContainerOwner.user_id == user.uid)
+        if user.login and not user.resolver:
+            # A username was requested, but it can not be found in any resolver. Without this check, the
+            # query would only be filtered by the realm and return all containers of that realm.
+            raise UserError("The user can not be found in any resolver in this realm!")
+        # The realm, the resolver and the user id are applied independently, so that the containers of all
+        # users of a realm or resolver can be listed without specifying a username.
+        stmt = stmt.join(TokenContainer.owners)
         if user.realm:
             realm_db = db.session.execute(
                 select(realm1).where(func.lower(realm1.name) == user.realm.lower())
             ).scalar_one_or_none()
-            if realm_db:
-                stmt = stmt.where(TokenContainerOwner.realm_id == realm_db.id)
+            if not realm_db:
+                raise ResourceNotFoundError(f"Realm '{user.realm}' does not exist.")
+            stmt = stmt.where(TokenContainerOwner.realm_id == realm_db.id)
         if user.resolver:
             stmt = stmt.where(func.lower(TokenContainerOwner.resolver) == user.resolver.lower())
+        if user.uid:
+            stmt = stmt.where(TokenContainerOwner.user_id == user.uid)
 
     if serial and serial.strip("*"):
         if "*" in serial:
@@ -382,7 +394,10 @@ def get_all_containers(user: User = None, serial: str = None, ctype: str = None,
     the next or previous page. If page and pagesize are both smaller than 0, no pagination is used.
     The containers are filtered by the given parameters.
 
-    :param user: container owner, optional
+    :param user: container owner, optional. The login name, the realm and the resolver of the user are
+        applied independently, hence a user object carrying only a realm or only a resolver lists the
+        containers of all users of that realm or resolver. Raises a UserError if a login name is given
+        that can not be resolved and a ResourceNotFoundError if the realm does not exist.
     :param serial: container serial (case-insensitive and allows '*' as wildcard), optional
     :param ctype: container type filter (case-insensitive and allows '*' as wildcard), optional
     :param ctype_exact: exact container type filter list (case-insensitive; matches any type in the list), optional.

--- a/privacyidea/lib/container.py
+++ b/privacyidea/lib/container.py
@@ -179,10 +179,12 @@ def _create_container_query(user: User = None, serial: str = None, ctype: str = 
     """
     Generates a sql query to filter containers by the given parameters.
 
-    :param user: container owner, optional. The login name, the realm and the resolver of the user are
-        applied independently, hence a user object carrying only a realm or only a resolver lists the
-        containers of all users of that realm or resolver. Raises a UserError if a login name is given
-        that can not be resolved and a ResourceNotFoundError if the realm does not exist.
+    :param user: container owner, optional. The realm, the resolver and the user id of the user are applied
+        independently, hence a user object carrying only a realm lists the containers of all users of that
+        realm. Note that a user object with only a resolver is empty (User.is_empty ignores the resolver)
+        and therefore does not filter at all. Since only assigned containers have an owner, a user object
+        never matches an unassigned container, and neither does a realm that does not exist. Raises a
+        UserError if a login name is given that can not be resolved to a user id.
     :param serial: container serial (case-insensitive and allows '*' as wildcard), optional
     :param ctype: container type filter (case-insensitive and allows '*' as wildcard), optional
     :param ctype_exact: exact container type filter list (case-insensitive; matches any type in the list), optional.
@@ -212,24 +214,34 @@ def _create_container_query(user: User = None, serial: str = None, ctype: str = 
     stmt = select(TokenContainer)
     realm1 = aliased(Realm)
     if user:
-        if user.login and not user.resolver:
-            # A username was requested, but it can not be found in any resolver. Without this check, the
-            # query would only be filtered by the realm and return all containers of that realm.
-            raise UserError("The user can not be found in any resolver in this realm!")
-        # The realm, the resolver and the user id are applied independently, so that the containers of all
-        # users of a realm or resolver can be listed without specifying a username.
-        stmt = stmt.join(TokenContainer.owners)
+        realm_db = None
         if user.realm:
             realm_db = db.session.execute(
                 select(realm1).where(func.lower(realm1.name) == user.realm.lower())
             ).scalar_one_or_none()
-            if not realm_db:
-                raise ResourceNotFoundError(f"Realm '{user.realm}' does not exist.")
-            stmt = stmt.where(TokenContainerOwner.realm_id == realm_db.id)
-        if user.resolver:
-            stmt = stmt.where(func.lower(TokenContainerOwner.resolver) == user.resolver.lower())
-        if user.uid:
-            stmt = stmt.where(TokenContainerOwner.user_id == user.uid)
+        if user.realm and not realm_db:
+            # No user can be in a realm that does not exist: like every other filter, an unknown value
+            # matches nothing.
+            stmt = stmt.where(false())
+        else:
+            if user.login and not user.uid:
+                # A username was requested, but it can not be resolved to a user id: neither the realm nor
+                # the resolver of the user may be used as a fallback filter, because the query would then
+                # return the containers of all users of that realm or resolver.
+                raise UserError("The user can not be found in any resolver in this realm!")
+            # The realm, the resolver and the user id are applied independently, so that the containers of
+            # all users of a realm can be listed without specifying a username.
+            stmt = stmt.join(TokenContainer.owners)
+            if realm_db:
+                stmt = stmt.where(TokenContainerOwner.realm_id == realm_db.id)
+            if user.resolver:
+                if "*" in user.resolver:
+                    stmt = stmt.where(TokenContainerOwner.resolver.ilike(
+                        convert_wildcard_to_sql_like(user.resolver), escape=SQL_LIKE_ESCAPE))
+                else:
+                    stmt = stmt.where(func.lower(TokenContainerOwner.resolver) == user.resolver.lower())
+            if user.uid:
+                stmt = stmt.where(TokenContainerOwner.user_id == user.uid)
 
     if serial and serial.strip("*"):
         if "*" in serial:
@@ -394,10 +406,12 @@ def get_all_containers(user: User = None, serial: str = None, ctype: str = None,
     the next or previous page. If page and pagesize are both smaller than 0, no pagination is used.
     The containers are filtered by the given parameters.
 
-    :param user: container owner, optional. The login name, the realm and the resolver of the user are
-        applied independently, hence a user object carrying only a realm or only a resolver lists the
-        containers of all users of that realm or resolver. Raises a UserError if a login name is given
-        that can not be resolved and a ResourceNotFoundError if the realm does not exist.
+    :param user: container owner, optional. The realm, the resolver and the user id of the user are applied
+        independently, hence a user object carrying only a realm lists the containers of all users of that
+        realm. Note that a user object with only a resolver is empty (User.is_empty ignores the resolver)
+        and therefore does not filter at all. Since only assigned containers have an owner, a user object
+        never matches an unassigned container, and neither does a realm that does not exist. Raises a
+        UserError if a login name is given that can not be resolved to a user id.
     :param serial: container serial (case-insensitive and allows '*' as wildcard), optional
     :param ctype: container type filter (case-insensitive and allows '*' as wildcard), optional
     :param ctype_exact: exact container type filter list (case-insensitive; matches any type in the list), optional.

--- a/privacyidea/static_new/src/app/components/container/container-table/container-table.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-table/container-table.component.html
@@ -33,7 +33,8 @@
           <input
             #filterHTMLInputElement
             [appFilterAutocomplete]="filterKeywords"
-            (input)="containerService.handleFilterInput($event)"
+            (input)="onFilterInput($event)"
+            (keyup.enter)="containerService.handleFilterInput($event)"
             [value]="containerService.containerFilter().filterString"
             aria-label="Filter Input"
             i18n-aria-label
@@ -43,6 +44,13 @@
             placeholder="Example query: 'type: generic'" />
         </app-clearable-input>
         <mat-hint>{{ filterHint }}</mat-hint>
+        @if (showFilterHint()) {
+          <mat-hint
+            align="end"
+            i18n
+            >Press enter to apply the filter</mat-hint
+          >
+        }
       </mat-form-field>
       <button
         [matMenuTriggerFor]="advancedFilterMenu"

--- a/privacyidea/static_new/src/app/components/container/container-table/container-table.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/container/container-table/container-table.component.spec.ts
@@ -49,6 +49,7 @@ import {
 } from "@testing/mock-services";
 import { MockAuthService } from "@testing/mock-services/mock-auth-service";
 import { MockPiResponse } from "@testing/mock-services/mock-utils";
+import { FilterValue } from "@core/models/filter_value/filter_value";
 
 describe("ContainerTableComponent (Jest)", () => {
   let component: ContainerTableComponent;
@@ -163,6 +164,43 @@ describe("ContainerTableComponent (Jest)", () => {
       const result = component.sort();
       expect(result.active).toBe("type");
       expect(result.direction).toBe("asc");
+    });
+  });
+
+  describe("#onFilterInput", () => {
+    it("applies the filter while typing as long as no user or realm filter is used", () => {
+      const inputEvent = { target: { value: "type: generic" } } as unknown as Event;
+
+      component.onFilterInput(inputEvent);
+
+      expect(containerService.handleFilterInput).toHaveBeenCalledWith(inputEvent);
+    });
+
+    it("defers the user and the realm filter until the input is confirmed", () => {
+      component.onFilterInput({ target: { value: "user: alice" } } as unknown as Event);
+      expect(containerService.handleFilterInput).not.toHaveBeenCalled();
+
+      component.onFilterInput({ target: { value: "realm: realm1" } } as unknown as Event);
+      expect(containerService.handleFilterInput).not.toHaveBeenCalled();
+    });
+
+    it("hints that the filter has to be confirmed while a user filter is typed", () => {
+      component.onFilterInput({ target: { value: "user: alice" } } as unknown as Event);
+
+      expect(component.showFilterHint()).toBe(true);
+    });
+
+    it("does not hint once the typed filter is the applied one", () => {
+      containerService.containerFilter.set(new FilterValue({ value: "user: alice" }));
+      component.onFilterInput({ target: { value: "user: alice" } } as unknown as Event);
+
+      expect(component.showFilterHint()).toBe(false);
+    });
+
+    it("does not hint for a filter that is applied while typing", () => {
+      component.onFilterInput({ target: { value: "type: generic" } } as unknown as Event);
+
+      expect(component.showFilterHint()).toBe(false);
     });
   });
 

--- a/privacyidea/static_new/src/app/components/container/container-table/container-table.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-table/container-table.component.ts
@@ -142,6 +142,7 @@ export class ContainerTableComponent {
     states: "state",
     description: "description",
     user_name: "user",
+    user_realm: "realm",
     realms: "container_realm"
   } as const;
 

--- a/privacyidea/static_new/src/app/components/container/container-table/container-table.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-table/container-table.component.ts
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
-import { Component, ElementRef, ViewChild, WritableSignal, inject, linkedSignal } from "@angular/core";
+import { Component, ElementRef, ViewChild, WritableSignal, computed, inject, linkedSignal } from "@angular/core";
 import { MatPaginatorModule, PageEvent } from "@angular/material/paginator";
 import { Sort } from "@angular/material/sort";
 import { MatTableDataSource, MatTableModule } from "@angular/material/table";
@@ -95,6 +95,21 @@ export class ContainerTableComponent {
   readonly advancedApiFilter = this.containerService.advancedApiFilter;
   readonly filterKeywords = [...this.containerService.apiFilter, ...this.containerService.advancedApiFilter];
   readonly filterHint = inlineFilterHint();
+  // The `user` and `realm` filters are exact values that the backend resolves against the user store, so
+  // they are only applied when the input is confirmed with enter. All other filters are applied while typing.
+  protected readonly filterInputValue = linkedSignal({
+    source: () => this.containerService.containerFilter().filterString,
+    computation: (filterString) => filterString
+  });
+  protected readonly showFilterHint = computed(() => {
+    const current = this.filterInputValue().trim().toLowerCase();
+    const applied = this.containerService.containerFilter().filterString.trim().toLowerCase();
+
+    if (current !== applied) {
+      return /(^|\s)user:/.test(current) || /(^|\s)realm:/.test(current);
+    }
+    return false;
+  });
   containerSelection = this.containerService.containerSelection;
 
   pageSize = this.containerService.pageSize;
@@ -189,6 +204,17 @@ export class ContainerTableComponent {
 
   onSortEvent($event: Sort) {
     this.sort.set($event);
+  }
+
+  onFilterInput($event: Event) {
+    const input = $event.target as HTMLInputElement;
+    this.filterInputValue.set(input.value);
+    const value = input.value.toLowerCase();
+    const hasUser = /(^|\s)user:/.test(value);
+    const hasRealm = /(^|\s)realm:/.test(value);
+    if (!hasUser && !hasRealm) {
+      this.containerService.handleFilterInput($event);
+    }
   }
 
   toggleFilter(filterKeyword: string): void {

--- a/privacyidea/static_new/src/app/services/container/container.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/container/container.service.spec.ts
@@ -461,10 +461,16 @@ describe("ContainerService", () => {
       expect(containerService.containerFilter().filterMap.get("realm")).toBe("otherrealm");
     });
 
-    it("does not add a realm without a user filter", () => {
+    it("does not default the realm when no user filter is set", () => {
       containerService.handleFilterInput(filterInputEvent("type: generic"));
 
       expect(containerService.containerFilter().hasKey("realm")).toBe(false);
+    });
+
+    it("keeps a realm that is filtered without a user", () => {
+      containerService.handleFilterInput(filterInputEvent("realm: otherrealm"));
+
+      expect(containerService.containerFilter().filterMap.get("realm")).toBe("otherrealm");
     });
   });
 

--- a/privacyidea/static_new/src/app/services/container/container.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/container/container.service.spec.ts
@@ -446,6 +446,40 @@ describe("ContainerService", () => {
     expect(containerService.filterParams()).toEqual({ type_list: "smartphone,yubikey" });
   });
 
+  describe("handleFilterInput realm handling", () => {
+    const filterInputEvent = (value: string): Event => ({ target: { value } as HTMLInputElement }) as unknown as Event;
+
+    it("adds the default realm when filtering by user without a realm", () => {
+      containerService.handleFilterInput(filterInputEvent("user: alice"));
+
+      expect(containerService.containerFilter().filterMap.get("realm")).toBe("realm1");
+    });
+
+    it("keeps an explicitly given realm", () => {
+      containerService.handleFilterInput(filterInputEvent("user: alice realm: otherrealm"));
+
+      expect(containerService.containerFilter().filterMap.get("realm")).toBe("otherrealm");
+    });
+
+    it("does not add a realm without a user filter", () => {
+      containerService.handleFilterInput(filterInputEvent("type: generic"));
+
+      expect(containerService.containerFilter().hasKey("realm")).toBe(false);
+    });
+  });
+
+  it("filterParams sends user and realm as exact values", () => {
+    containerService.containerFilter.set(new FilterValue({ value: "user: alice realm: realm1" }));
+
+    expect(containerService.filterParams()).toEqual({ user: "alice", realm: "realm1" });
+  });
+
+  it("filterParams keeps realm and container_realm apart", () => {
+    containerService.containerFilter.set(new FilterValue({ value: "realm: realm1 container_realm: realm2" }));
+
+    expect(containerService.filterParams()).toEqual({ realm: "realm1", container_realm: "*realm2*" });
+  });
+
   it("pageSize falls back to 10 for invalid eventPageSize", () => {
     containerService.eventPageSize.set(-1);
     expect(containerService.pageSize()).toBe(10);

--- a/privacyidea/static_new/src/app/services/container/container.service.ts
+++ b/privacyidea/static_new/src/app/services/container/container.service.ts
@@ -479,8 +479,12 @@ export class ContainerService implements ContainerServiceInterface {
     return this.containerRequest({
       no_token: 1,
       ...this.filterParams(),
-      ...(this.userService.detailsUser().username && { user: this.userService.detailsUser().username }),
-      ...(this.userService.selectedUserRealm() && { realm: this.userService.selectedUserRealm() })
+      // The realm is only sent together with the username: on its own it filters for the containers of
+      // all users of that realm, which are not the containers of the user shown on the details page.
+      ...(this.userService.detailsUser().username && {
+        user: this.userService.detailsUser().username,
+        ...(this.userService.selectedUserRealm() && { realm: this.userService.selectedUserRealm() })
+      })
     });
   });
 

--- a/privacyidea/static_new/src/app/services/container/container.service.ts
+++ b/privacyidea/static_new/src/app/services/container/container.service.ts
@@ -37,10 +37,13 @@ import { UserService, UserServiceInterface } from "@services/user/user.service";
 import { StringUtils } from "@utils/string.utils";
 import { catchError, forkJoin, lastValueFrom, Observable, of, Subject, throwError } from "rxjs";
 
-const apiFilter = ["container_serial", "type", "description", "user", "container_realm", "state"];
+// `realm` is the realm of the assigned user: the backend resolves `user` together with `realm` into
+// the user object the container list is filtered by. `container_realm` is the realm of the container
+// itself and is a separate filter.
+const apiFilter = ["container_serial", "type", "description", "user", "realm", "container_realm", "state"];
 const advancedApiFilter = ["token_serial", "template", "assigned"];
 
-const exactMatchKeys = new Set(["user", "type", "state", "assigned"]);
+const exactMatchKeys = new Set(["user", "realm", "type", "state", "assigned"]);
 
 // Filter keywords, a single value maps to the `type` query param, multiple to `type_list`.
 // TODO(4.0.0): send a single list-only `types` param once the backend drops the type/type_list split.

--- a/tests/test_api_container_api.py
+++ b/tests/test_api_container_api.py
@@ -894,14 +894,30 @@ class APIContainer(APIContainerTest):
                 self.assertEqual("hans", container["users"][0]["user_name"])
                 self.assertEqual(self.realm1, container["users"][0]["user_realm"])
 
-            # A realm that does not exist is rejected
-            self.request_assert_error(404, '/container/', {"realm": "non_existing_realm", "pagesize": 100},
-                                      self.at, 'GET', error_code=Error.RESOURCE_NOT_FOUND)
+            # Combined with a wildcard resolver
+            result = self.request_assert_success('/container/',
+                                                 {"realm": self.realm1, "resolver": f"{self.resolvername1[:-1]}*",
+                                                  "pagesize": 100},
+                                                 self.at, 'GET')
+            self.assertIn(realm1_serial, {c["serial"] for c in result["result"]["value"]["containers"]})
+
+            # A realm that does not exist matches nothing
+            result = self.request_assert_success('/container/',
+                                                 {"realm": "non_existing_realm", "pagesize": 100},
+                                                 self.at, 'GET')
+            self.assertEqual(0, result["result"]["value"]["count"])
 
             # A username that can not be resolved is rejected
             self.request_assert_error(400, '/container/', {"user": "non_existing_user", "realm": self.realm1,
                                                           "pagesize": 100},
                                       self.at, 'GET', error_code=Error.USER)
+
+            # The realm is evaluated first, hence an unknown user in an unknown realm matches nothing
+            result = self.request_assert_success('/container/',
+                                                 {"user": "non_existing_user", "realm": "non_existing_realm",
+                                                  "pagesize": 100},
+                                                 self.at, 'GET')
+            self.assertEqual(0, result["result"]["value"]["count"])
         finally:
             delete_container_by_serial(realm1_serial)
             delete_container_by_serial(realm2_serial)

--- a/tests/test_api_container_api.py
+++ b/tests/test_api_container_api.py
@@ -845,6 +845,68 @@ class APIContainer(APIContainerTest):
             delete_container_by_serial(smartphone_serial)
             delete_container_by_serial(generic_serial)
 
+    def test_21d_get_all_containers_filter_by_user_realm(self):
+        # Arrange: two containers with owners in different realms. Other test methods in this class leave
+        # containers around, so we only assert on the serials created here.
+        self.setUp_user_realms()
+        self.setUp_user_realm2()
+        realm1_serial = init_container({"type": "generic"})["container_serial"]
+        find_container_by_serial(realm1_serial).add_user(User(login="hans", realm=self.realm1))
+        realm2_serial = init_container({"type": "generic"})["container_serial"]
+        find_container_by_serial(realm2_serial).add_user(User(login="cornelius", realm=self.realm2))
+        unassigned_serial = init_container({"type": "generic", "realm": self.realm1})["container_serial"]
+
+        try:
+            # The realm of the assigned user is filtered without a username
+            result = self.request_assert_success('/container/',
+                                                 {"realm": self.realm1, "pagesize": 100},
+                                                 self.at, 'GET')
+            serials = {c["serial"] for c in result["result"]["value"]["containers"]}
+            self.assertIn(realm1_serial, serials)
+            self.assertNotIn(realm2_serial, serials)
+            # A container in the realm without an owner is not a match
+            self.assertNotIn(unassigned_serial, serials)
+
+            # The realm is matched case-insensitive
+            result = self.request_assert_success('/container/',
+                                                 {"realm": self.realm1.upper(), "pagesize": 100},
+                                                 self.at, 'GET')
+            self.assertIn(realm1_serial, {c["serial"] for c in result["result"]["value"]["containers"]})
+
+            # container_realm matches the realm of the container itself, hence it also returns the
+            # container without an owner
+            result = self.request_assert_success('/container/',
+                                                 {"container_realm": self.realm1, "pagesize": 100},
+                                                 self.at, 'GET')
+            serials = {c["serial"] for c in result["result"]["value"]["containers"]}
+            self.assertIn(realm1_serial, serials)
+            self.assertIn(unassigned_serial, serials)
+
+            # Combined with a username: only the containers of that user in that realm
+            result = self.request_assert_success('/container/',
+                                                 {"user": "hans", "realm": self.realm1, "pagesize": 100},
+                                                 self.at, 'GET')
+            serials = {c["serial"] for c in result["result"]["value"]["containers"]}
+            self.assertIn(realm1_serial, serials)
+            self.assertNotIn(realm2_serial, serials)
+            self.assertNotIn(unassigned_serial, serials)
+            for container in result["result"]["value"]["containers"]:
+                self.assertEqual("hans", container["users"][0]["user_name"])
+                self.assertEqual(self.realm1, container["users"][0]["user_realm"])
+
+            # A realm that does not exist is rejected
+            self.request_assert_error(404, '/container/', {"realm": "non_existing_realm", "pagesize": 100},
+                                      self.at, 'GET', error_code=Error.RESOURCE_NOT_FOUND)
+
+            # A username that can not be resolved is rejected
+            self.request_assert_error(400, '/container/', {"user": "non_existing_user", "realm": self.realm1,
+                                                          "pagesize": 100},
+                                      self.at, 'GET', error_code=Error.USER)
+        finally:
+            delete_container_by_serial(realm1_serial)
+            delete_container_by_serial(realm2_serial)
+            delete_container_by_serial(unassigned_serial)
+
     def test_22_get_all_containers_paginate_invalid_params(self):
         init_container({"type": "generic", "description": "test container"})
 

--- a/tests/test_api_container_user.py
+++ b/tests/test_api_container_user.py
@@ -364,6 +364,37 @@ class APIContainerAuthorizationUser(APIContainerAuthorization):
             self.assertEqual(401, res.status_code, res.json)
         delete_policy("policy")
 
+    def test_17b_user_container_list_only_returns_own_containers(self):
+        # A user only sees their own containers, independent of the user parameters of the request.
+        self.setUp_user_realms()
+        set_policy("policy", scope=SCOPE.USER, action=PolicyAction.CONTAINER_LIST)
+        # A second resolver in the realm of the user, holding a different set of users
+        save_resolver({"resolver": "reso3", "type": "passwdresolver", "fileName": "tests/testdata/passwd"})
+        set_realm(self.realm1, [{"name": self.resolvername1}, {"name": "reso3"}])
+        # A container of another user in that second resolver
+        other_container_serial = init_container({"type": "generic"})["container_serial"]
+        assign_user(other_container_serial, User("daemon", self.realm1, "reso3"))
+        my_container_serial = init_container({"type": "generic"})["container_serial"]
+        assign_user(my_container_serial, User("selfservice", self.realm1, self.resolvername1))
+
+        try:
+            # The user does not exist in the second resolver, hence the request can not be resolved to a user
+            self.request_assert_error(400, '/container/', {"resolver": "reso3", "pagesize": 100},
+                                      self.at_user, 'GET', error_code=Error.USER)
+
+            # The user sees their own container, but never the one of the other user
+            result = self.request_assert_success('/container/', {"pagesize": 100}, self.at_user, 'GET')
+            serials = {c["serial"] for c in result["result"]["value"]["containers"]}
+            self.assertIn(my_container_serial, serials)
+            self.assertNotIn(other_container_serial, serials)
+            for container in result["result"]["value"]["containers"]:
+                self.assertEqual("selfservice", container["users"][0]["user_name"])
+        finally:
+            delete_container_by_serial(other_container_serial)
+            delete_container_by_serial(my_container_serial)
+            set_realm(self.realm1, [{"name": self.resolvername1}])
+            delete_policy("policy")
+
     def test_18_user_container_list_allowed(self):
         # Arrange
         self.setUp_user_realms()

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -882,18 +882,39 @@ class TokenContainerManagementTestCase(MyTestCase):
         self.assertEqual(1, len(container_data["containers"]))
         self.assertEqual(container_serials[2], container_data["containers"][0].serial)
 
-        # Filter by the resolver of the user only
+        # Filter by the realm and the resolver of the user
         container_data = get_all_containers(user=User(realm=self.realm1, resolver=self.resolvername1), pagesize=15)
         self.assertEqual(1, len(container_data["containers"]))
         self.assertEqual(container_serials[1], container_data["containers"][0].serial)
 
-        # Filter for a non-existing realm
-        self.assertRaises(ResourceNotFoundError, get_all_containers, user=User(realm="non_existing_realm"),
-                          pagesize=15)
+        # The resolver of the user allows wildcards, like the separate resolver filter does
+        container_data = get_all_containers(user=User(realm=self.realm1, resolver="resolver*"), pagesize=15)
+        self.assertEqual(1, len(container_data["containers"]))
+        self.assertEqual(container_serials[1], container_data["containers"][0].serial)
+
+        # A user object with only a resolver is empty and does not filter at all
+        all_containers = get_all_containers(pagesize=15)["containers"]
+        container_data = get_all_containers(user=User(resolver=self.resolvername1), pagesize=15)
+        self.assertEqual(len(all_containers), len(container_data["containers"]))
+
+        # A realm that does not exist matches nothing
+        container_data = get_all_containers(user=User(realm="non_existing_realm"), pagesize=15)
+        self.assertEqual(0, len(container_data["containers"]))
+
+        # The realm is evaluated first, hence an unresolvable user in a realm that does not exist also
+        # matches nothing instead of raising
+        container_data = get_all_containers(user=User(login="invalid", realm="non_existing_realm"), pagesize=15)
+        self.assertEqual(0, len(container_data["containers"]))
 
         # Filter for non-existing user
-        user_invalid = User(login="invalid", realm="random")
+        user_invalid = User(login="invalid", realm=self.realm1)
         self.assertRaises(UserError, get_all_containers, user=user_invalid, pagesize=15)
+
+        # A username that does not exist in the given resolver is rejected instead of being filtered by the
+        # realm and the resolver alone
+        user_unresolvable = User(login="invalid", realm=self.realm1, resolver=self.resolvername1)
+        self.assertFalse(user_unresolvable.uid)
+        self.assertRaises(UserError, get_all_containers, user=user_unresolvable, pagesize=15)
 
         # ---- assigned ----
         container_data = get_all_containers(assigned=True, pagesize=15)

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -872,10 +872,28 @@ class TokenContainerManagementTestCase(MyTestCase):
         container1_owner = container_data["containers"][0].get_users()[0]
         self.assertEqual(user_cornelius_1, container1_owner)
 
+        # Filter by the realm of the user only: lists the containers of all users of that realm
+        container_data = get_all_containers(user=User(realm=self.realm1), pagesize=15)
+        self.assertEqual(1, len(container_data["containers"]))
+        self.assertEqual(container_serials[1], container_data["containers"][0].serial)
+
+        # The realm of the user is matched case-insensitive
+        container_data = get_all_containers(user=User(realm=self.realm2.upper()), pagesize=15)
+        self.assertEqual(1, len(container_data["containers"]))
+        self.assertEqual(container_serials[2], container_data["containers"][0].serial)
+
+        # Filter by the resolver of the user only
+        container_data = get_all_containers(user=User(realm=self.realm1, resolver=self.resolvername1), pagesize=15)
+        self.assertEqual(1, len(container_data["containers"]))
+        self.assertEqual(container_serials[1], container_data["containers"][0].serial)
+
+        # Filter for a non-existing realm
+        self.assertRaises(ResourceNotFoundError, get_all_containers, user=User(realm="non_existing_realm"),
+                          pagesize=15)
+
         # Filter for non-existing user
         user_invalid = User(login="invalid", realm="random")
-        container_data = get_all_containers(user=user_invalid, pagesize=15)
-        self.assertEqual(0, len(container_data["containers"]))
+        self.assertRaises(UserError, get_all_containers, user=user_invalid, pagesize=15)
 
         # ---- assigned ----
         container_data = get_all_containers(assigned=True, pagesize=15)


### PR DESCRIPTION
handleFilterInput adds a realm entry when filtering by user, but realm was not part of apiFilter, so filterParams dropped it and it never reached the backend. Add realm as an exact-match filter key, distinct from container_realm, and map the user_realm column to it.