### PR TITLE
Allow a small tolerance on the frontend patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -44,7 +44,14 @@ coverage:
       frontend:
         flags:
           - frontend
+        # `target: auto` requires the patch to be covered as well as the flag
+        # already is. With a small patch that bar has no tolerance: at ~85%
+        # flag coverage a six-line patch fails on a single uncovered line,
+        # which is usually a guard clause or an error branch rather than
+        # untested logic. The threshold allows that much slack while the
+        # target keeps new frontend code at the level of the existing code.
         target: auto
+        threshold: 5%
 
 flag_management:
   default_rules:


### PR DESCRIPTION
## What

Adds `threshold: 5%` to the `codecov/patch/frontend` status. No other status changes.

## Why

The frontend patch status uses `target: auto`, which requires a patch to be covered as
well as the frontend flag already is (currently ~85%). For a small patch that bar has no
tolerance: at 85% a six-line patch fails on a single uncovered line, and that line is
usually a guard clause or an error branch rather than untested logic.

This came up on #5730, where the status failed on two uncovered lines in a diff of about
a dozen measurable frontend lines. The gate was doing its job there — the lines really
were untested, because the component specs exercise `MockEventService` rather than the
real service — but the same arithmetic fails patches that have nothing meaningful left
to test.

`target: auto` is kept, so new frontend code still has to match the level of the existing
code. Only the tolerance changes.

## Why not raise the target instead

Raising the frontend patch target above the flag average would push coverage up, but it
is not needed: the frontend flag has gone from 81.2% to 85.3% over the last two months on
its own, so new Angular code is already landing well above the flag average.

## Open question for review

The same brittleness applies to the backend patch status (at 92.9%, a 13-line patch fails
on one uncovered line), but I left it at `target: auto` with no threshold, because the
discussion that prompted this was about the frontend. Adding the same two lines to the
backend status is a reasonable follow-up if you want the two treated the same — say so and
I will include it here rather than in a second PR.

## Verification

`codecov.yml` was checked against `https://codecov.io/validate`, which reports `Valid!`
and echoes the parsed status as `patch.frontend.threshold: 5.0`.