### PR TITLE
Do not crash the SecureFormatter on a non-string log message

### DIFF
--- a/privacyidea/lib/log.py
+++ b/privacyidea/lib/log.py
@@ -97,6 +97,11 @@ DOCKER_LOGGING_CONFIG = {
 class SecureFormatter(Formatter):
 
     def format(self, record):
+        if not isinstance(record.msg, str):
+            # Logging allows any object as the message (log.info(exception) is common).
+            # Coerce it here, like logging.LogRecord.getMessage() would, so the string
+            # operations below can not fail on the message object.
+            record.msg = str(record.msg)
         if 's_line' in record.__dict__ and '_called' not in record.__dict__:
             # rotating file handler calls "format" to check for its length before
             # emitting the actual line

--- a/tests/test_lib_logging.py
+++ b/tests/test_lib_logging.py
@@ -18,8 +18,25 @@
 import logging
 import logging.config
 
-from privacyidea.lib.log import DEFAULT_LOGGING_CONFIG
+from privacyidea.lib.log import DEFAULT_LOGGING_CONFIG, SecureFormatter
 from privacyidea.lib.utils import parse_date
+
+
+def _record(msg, args=(), **extra):
+    record = logging.LogRecord("test", logging.INFO, "some_file.py", 1, msg, args, None)
+    record.__dict__.update(extra)
+    return record
+
+
+def test_log_formatter_non_string_message():
+    # A log call may pass any object as the message, e.g. log.info(exception)
+    formatter = SecureFormatter("%(message)s")
+    assert (formatter.format(_record(ValueError("boom\0bad")))
+            == "!!Log Entry Secured by SecureFormatter!! boom.bad")
+    # The caller location is appended to a non-string message as well
+    assert formatter.format(_record(RuntimeError("failed"), s_line=42)) == "failed (called from some_file.py:1)"
+    # A format string with arguments is still interpolated
+    assert formatter.format(_record("value is %s", ("x",))) == "value is x"
 
 
 def test_log_formatter(caplog, tmp_path):


### PR DESCRIPTION
### Problem

`logging` allows any object as the log message, and `log.info(exception)` is used in several places in the code base (for example `offline_info` in `privacyidea/api/lib/postpolicy.py`). `SecureFormatter.format()` called `record.msg.isprintable()` and `record.msg += ...` directly, so such a call raised inside the log handler:

```
--- Logging error ---
  File "privacyidea/lib/log.py", line 107, in format
    if not record.msg.isprintable():
AttributeError: 'PendingRollbackError' object has no attribute 'isprintable'
```

The result is that exactly those messages that report a problem are dropped instead of being written to the log, which makes the underlying error hard to find.

### Change

`SecureFormatter.format()` now coerces a non-string message with `str()` before touching it, which is what `logging.LogRecord.getMessage()` does as well. A format string with arguments is unaffected, since `str()` of a string is the string itself.

A test covers a non-printable character in an exception message, the caller-location suffix on a non-string message and the usual format-string-with-arguments case.