### PR TITLE
Add biometric protection policies for Push enrollment

### DIFF
--- a/doc/policies/enrollment.rst
+++ b/doc/policies/enrollment.rst
@@ -951,3 +951,26 @@ This policy can be used to force the privacyIDEA Authenticator App to secure the
 biometric. If you select any, the token can be unlocked with both.
 
 .. note:: This needs the privacyIDEA Authenticator app 4.6.1 or higher.
+
+push_app_biometric_level
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+type: ``string``
+
+For Push tokens, this policy requests either any system biometric (``any``) or
+a strong biometric (``strong``) from a supporting Authenticator App. It only
+refines ``push_app_force_unlock=biometric``; older applications ignore the
+additional enrollment parameter.
+
+push_app_invalidate_on_biometric_change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+type: ``string``
+
+For Push tokens, this policy asks a supporting Authenticator App to protect the
+Push key so that a change to the enrolled biometrics invalidates it. Set it to
+``true`` to bind the key to the current biometric enrollment or explicitly set
+it to ``false`` to opt out. If the policy is not configured, the enrollment URL
+does not contain this parameter, allowing supporting applications to apply their
+own fail-safe default. Once the application detects an invalidated key, the
+token must be enrolled again.

--- a/privacyidea/api/lib/policyhelper.py
+++ b/privacyidea/api/lib/policyhelper.py
@@ -33,7 +33,7 @@ from privacyidea.lib.policies.actions import PolicyAction
 from privacyidea.lib.policies.conditions import ConditionSection
 from privacyidea.lib.policy import Match, SCOPE
 from privacyidea.lib.realm import realm_is_defined
-from privacyidea.lib.tokens.push_types import PushAction
+from privacyidea.lib.tokens.push_types import PushAction, PushBiometricLevel
 from privacyidea.lib.token import get_tokens_from_serial_or_user, get_token_owner
 from privacyidea.lib.tokenclass import TokenClass
 from privacyidea.lib.user import User
@@ -146,6 +146,35 @@ def get_pushtoken_add_config(g, params=None, user_obj=None):
     use_pia_scheme = Match.user(g, scope=SCOPE.ENROLL, action=PushAction.USE_PIA_SCHEME,
                                 user_object=user).allowed()
     params[PushAction.USE_PIA_SCHEME] = use_pia_scheme
+
+    biometric_level = Match.user(
+        g,
+        scope=SCOPE.ENROLL,
+        action=PushAction.APP_BIOMETRIC_LEVEL,
+        user_object=user,
+    ).action_values(unique=True)
+    if len(biometric_level) == 1:
+        level = next(iter(biometric_level))
+        allowed_levels = {item.value for item in PushBiometricLevel}
+        if level not in allowed_levels:
+            raise PolicyError(
+                f"Invalid value for {PushAction.APP_BIOMETRIC_LEVEL}: {level}"
+            )
+        params[PushAction.APP_BIOMETRIC_LEVEL] = level
+
+    invalidate_on_change = Match.user(
+        g,
+        scope=SCOPE.ENROLL,
+        action=PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE,
+        user_object=user,
+    ).action_values(unique=True)
+    if len(invalidate_on_change) == 1:
+        value = next(iter(invalidate_on_change))
+        if value not in {"true", "false"}:
+            raise PolicyError(
+                f"Invalid value for {PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE}: {value}"
+            )
+        params[PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE] = value
     return params
 
 

--- a/privacyidea/lib/tokens/push_types.py
+++ b/privacyidea/lib/tokens/push_types.py
@@ -9,6 +9,14 @@ class PushMode(str, Enum):
     REQUIRE_PRESENCE = "require_presence"
     CODE_TO_PHONE = "code_to_phone"
 
+
+class PushBiometricLevel(str, Enum):
+    """Minimum biometric assurance requested from the authenticator app."""
+
+    ANY = "any"
+    STRONG = "strong"
+
+
 # Length of the short display code for code_to_phone mode.
 # The security does not lie in this code; it's only used so the client
 # knows the smartphone has completed its confirmation.
@@ -67,6 +75,8 @@ class PushAction:
     PRESENCE_NUM_OPTIONS = "push_presence_num_options"
     USE_PIA_SCHEME = "push_use_pia_scheme"
     CHALLENGE_TEXT = "push_challenge_text"
+    APP_BIOMETRIC_LEVEL = "push_app_biometric_level"
+    APP_INVALIDATE_ON_BIOMETRIC_CHANGE = "push_app_invalidate_on_biometric_change"
 
 
 class PushAllowPolling:

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -71,7 +71,7 @@ from privacyidea.lib.token import get_one_token, init_token, create_challenge
 from privacyidea.lib.tokenclass import (TokenClass, AuthenticationMode, ClientMode,
                                         ChallengeSession, CHALLENGE_REFUSAL_STATUS)
 from privacyidea.lib.tokenrolloutstate import RolloutState
-from privacyidea.lib.tokens.push_types import (PushMode, PushPresenceOptions,
+from privacyidea.lib.tokens.push_types import (PushMode, PushPresenceOptions, PushBiometricLevel,
                                                PushAction, PushAllowPolling,
                                                PushDeclineReason, PushCapability,
                                                CODE_TO_PHONE_DISPLAY_CODE_LENGTH)
@@ -499,6 +499,20 @@ class PushTokenClass(TokenClass):
                                          'be unlocked with pin or biometric. This needs the privacyIDEA '
                                          'Authenticator app 4.6.1 or higher.')
                            },
+                           PushAction.APP_BIOMETRIC_LEVEL: {
+                               'type': 'str',
+                               'value': [level.value for level in PushBiometricLevel],
+                               'group': "PUSH",
+                               'desc': _('Select whether the Authenticator App may use any system biometric '
+                                         'or must require a strong biometric for this Push token.')
+                           },
+                           PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE: {
+                               'type': 'str',
+                               'value': ['true', 'false'],
+                               'group': "PUSH",
+                               'desc': _('Require the Authenticator App to invalidate the protected Push key '
+                                         'when the biometric enrollment changes.')
+                           },
                            PushAction.USE_PIA_SCHEME: {
                                'type': 'bool',
                                'desc': _("Use the privacyIDEA app URL scheme 'pia' in the enroll URL for push tokens "
@@ -714,6 +728,19 @@ class PushTokenClass(TokenClass):
                 extra_data.update({'pin': True})
             if params.get(PolicyAction.APP_FORCE_UNLOCK):
                 extra_data.update({'app_force_unlock': params.get(PolicyAction.APP_FORCE_UNLOCK)})
+            biometric_level = policy_params.get(PushAction.APP_BIOMETRIC_LEVEL)
+            if biometric_level:
+                extra_data['app_biometric_level'] = biometric_level
+            if PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE in policy_params:
+                invalidate_on_change = str(
+                    policy_params[PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE]
+                ).lower()
+                if invalidate_on_change not in {'true', 'false'}:
+                    raise ParameterError(
+                        f"Invalid value for {PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE}: "
+                        f"{invalidate_on_change}"
+                    )
+                extra_data['app_invalidate_on_biometric_change'] = invalidate_on_change
 
             # Get scheme to use
             pia_scheme = policy_params.get(PushAction.USE_PIA_SCHEME, False)

--- a/tests/test_api_lib_policy_enroll.py
+++ b/tests/test_api_lib_policy_enroll.py
@@ -1385,6 +1385,8 @@ class PrePolicyEnrollTestCase(PrePolicyHelperMixin, MyApiTestCase):
         self.assertEqual("10", policies.get(PushAction.TTL))
         self.assertEqual("1", policies.get(PushAction.SSL_VERIFY))
         self.assertFalse(policies.get(PushAction.USE_PIA_SCHEME))
+        self.assertIsNone(policies.get(PushAction.APP_BIOMETRIC_LEVEL))
+        self.assertIsNone(policies.get(PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE))
 
         # the request tries to inject a rogue value, but we assure sslverify=1
         g.policy_object = PolicyClass()
@@ -1413,10 +1415,50 @@ class PrePolicyEnrollTestCase(PrePolicyHelperMixin, MyApiTestCase):
         pushtoken_add_config(req, "init")
         self.assertTrue(g.policies.get(PushAction.USE_PIA_SCHEME))
 
+        set_policy(
+            "push_biometric_security",
+            scope=SCOPE.ENROLL,
+            action=(
+                f"{PushAction.APP_BIOMETRIC_LEVEL}=strong,"
+                f"{PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE}=true"
+            ),
+        )
+        req.all_data = {"type": "push"}
+        g.policies = {}
+        pushtoken_add_config(req, "init")
+        self.assertEqual("strong", g.policies.get(PushAction.APP_BIOMETRIC_LEVEL))
+        self.assertEqual(
+            "true",
+            g.policies.get(PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE),
+        )
+
+        delete_policy("push_biometric_security")
+        set_policy(
+            "push_biometric_no_invalidation",
+            scope=SCOPE.ENROLL,
+            action=f"{PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE}=false",
+        )
+        g.policies = {}
+        pushtoken_add_config(req, "init")
+        self.assertEqual(
+            "false",
+            g.policies.get(PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE),
+        )
+
+        delete_policy("push_biometric_no_invalidation")
+        set_policy(
+            "push_biometric_invalid",
+            scope=SCOPE.ENROLL,
+            action=f"{PushAction.APP_BIOMETRIC_LEVEL}=unsupported",
+        )
+        g.policies = {}
+        self.assertRaises(PolicyError, pushtoken_add_config, req, "init")
+
         # finally delete policy
         delete_policy("push_pol")
         delete_policy("push_pol2")
         delete_policy("pia_scheme")
+        delete_policy("push_biometric_invalid")
 
     def test_24_push_wait_policy(self):
 

--- a/tests/test_api_policy.py
+++ b/tests/test_api_policy.py
@@ -12,6 +12,7 @@ from privacyidea.lib.policies.conditions import ConditionSection, ConditionHandl
 from privacyidea.lib.policy import (set_policy, SCOPE, delete_policy,
                                     rename_policy, get_policies)
 from privacyidea.lib.token import init_token, remove_token
+from privacyidea.lib.tokens.push_types import PushAction
 from privacyidea.lib.user import User
 from privacyidea.lib.utils.compare import PrimaryComparators
 from privacyidea.models import db, NodeName
@@ -225,6 +226,56 @@ class APIPolicyTestCase(MyApiTestCase):
         self.assertTrue(policy.get("user_case_insensitive"), policy)
 
         delete_policy("polci")
+
+    def test_01bb_set_push_biometric_policy_controls(self):
+        policy_name = "push_biometric_controls"
+        with self.app.test_request_context(
+            f"/policy/{policy_name}",
+            method="POST",
+            data={
+                "scope": SCOPE.ENROLL,
+                "action": (
+                    f"{PushAction.APP_BIOMETRIC_LEVEL}=strong,"
+                    f"{PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE}=true"
+                ),
+            },
+            headers={"Authorization": self.at},
+        ):
+            response = self.app.full_dispatch_request()
+            self.assertEqual(200, response.status_code, response)
+
+        policy = get_policies(name=policy_name)[0]
+        self.assertEqual(
+            "strong",
+            policy["action"][PushAction.APP_BIOMETRIC_LEVEL],
+        )
+        self.assertEqual(
+            "true",
+            policy["action"][PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE]
+        )
+
+        with self.app.test_request_context(
+            f"/policy/{policy_name}",
+            method="POST",
+            data={
+                "scope": SCOPE.ENROLL,
+                "action": (
+                    f"{PushAction.APP_BIOMETRIC_LEVEL}=any,"
+                    f"{PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE}=false"
+                ),
+            },
+            headers={"Authorization": self.at},
+        ):
+            response = self.app.full_dispatch_request()
+            self.assertEqual(200, response.status_code, response)
+
+        policy = get_policies(name=policy_name)[0]
+        self.assertEqual("any", policy["action"][PushAction.APP_BIOMETRIC_LEVEL])
+        self.assertEqual(
+            "false",
+            policy["action"][PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE],
+        )
+        delete_policy(policy_name)
 
     def test_01c_set_policy_active(self):
         policy_name = "policy_inactive"

--- a/tests/test_api_ttype.py
+++ b/tests/test_api_ttype.py
@@ -473,6 +473,41 @@ class TtypePushAPITestCase(MyApiTestCase):
         # remove the policy
         delete_policy("push1")
 
+    def test_03a_api_enroll_push_with_biometric_policy_controls(self):
+        self.authenticate()
+        set_policy(
+            "push_biometric_controls",
+            scope=SCOPE.ENROLL,
+            action=(
+                f"{PushAction.FIREBASE_CONFIG}={POLL_ONLY},"
+                f"{PushAction.REGISTRATION_URL}={REGISTRATION_URL},"
+                f"push_{PolicyAction.APP_FORCE_UNLOCK}=biometric,"
+                f"{PushAction.APP_BIOMETRIC_LEVEL}=strong,"
+                f"{PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE}=true"
+            ),
+        )
+
+        serial = None
+        try:
+            with self.app.test_request_context(
+                "/token/init",
+                method="POST",
+                data={"type": "push", "genkey": 1},
+                headers={"Authorization": self.at},
+            ):
+                response = self.app.full_dispatch_request()
+                self.assertEqual(response.status_code, 200, response)
+                detail = response.json["detail"]
+                serial = detail["serial"]
+                push_url = detail["pushurl"]["value"]
+                self.assertIn("app_force_unlock=biometric", push_url)
+                self.assertIn("app_biometric_level=strong", push_url)
+                self.assertIn("app_invalidate_on_biometric_change=true", push_url)
+        finally:
+            if serial:
+                remove_token(serial)
+            delete_policy("push_biometric_controls")
+
     def test_04_api_poll_declined_chal(self):
         self.setUp_user_realms()
         # create FireBase Service and policies

--- a/tests/test_lib_tokens_push.py
+++ b/tests/test_lib_tokens_push.py
@@ -140,6 +140,19 @@ class PushTokenTestCase(MyTestCase):
         self.assertEqual([x for x in PushPresenceOptions.__members__],
                          token.get_class_info(key="policy")[SCOPE.AUTH][PushAction.PRESENCE_OPTIONS]["value"],
                          token.get_class_info())
+        enroll_policy = token.get_class_info(key="policy")[SCOPE.ENROLL]
+        self.assertEqual(
+            ["any", "strong"],
+            enroll_policy[PushAction.APP_BIOMETRIC_LEVEL]["value"],
+        )
+        self.assertEqual(
+            "str",
+            enroll_policy[PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE]["type"],
+        )
+        self.assertEqual(
+            ["true", "false"],
+            enroll_policy[PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE]["value"],
+        )
 
         # Test to do the 2nd step, although the token is not yet in clientwait
         self.assertRaises(ParameterError, token.update, {"otpkey": "1234", "pubkey": "1234", "serial": self.serial1})
@@ -223,6 +236,51 @@ class PushTokenTestCase(MyTestCase):
                                                             PushAction.REGISTRATION_URL: "https://privacyidea.com/enroll"},
                                                PolicyAction.APP_FORCE_UNLOCK: "pin"})
         self.assertIn('app_force_unlock=pin', detail["pushurl"]["value"])
+        remove_token(token.get_serial())
+
+    def test_01b_enroll_with_biometric_key_policies(self):
+        token_param = {"type": "push", "genkey": 1}
+        token_param.update(FB_CONFIG_VALS)
+        token = init_token(param=token_param)
+        detail = token.get_init_detail(
+            params={
+                "policies": {
+                    PushAction.FIREBASE_CONFIG: POLL_ONLY,
+                    PushAction.REGISTRATION_URL: (
+                        "https://privacyidea.com/enroll"
+                    ),
+                    PushAction.APP_BIOMETRIC_LEVEL: "strong",
+                    PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE: "true",
+                },
+                PolicyAction.APP_FORCE_UNLOCK: "biometric",
+            }
+        )
+        push_url = detail["pushurl"]["value"]
+        self.assertIn("app_force_unlock=biometric", push_url)
+        self.assertIn("app_biometric_level=strong", push_url)
+        self.assertIn("app_invalidate_on_biometric_change=true", push_url)
+        remove_token(token.get_serial())
+
+    def test_01c_enroll_with_any_biometric_without_invalidation(self):
+        token_param = {"type": "push", "genkey": 1}
+        token_param.update(FB_CONFIG_VALS)
+        token = init_token(param=token_param)
+        detail = token.get_init_detail(
+            params={
+                "policies": {
+                    PushAction.FIREBASE_CONFIG: POLL_ONLY,
+                    PushAction.REGISTRATION_URL: (
+                        "https://privacyidea.com/enroll"
+                    ),
+                    PushAction.APP_BIOMETRIC_LEVEL: "any",
+                    PushAction.APP_INVALIDATE_ON_BIOMETRIC_CHANGE: "false",
+                },
+                PolicyAction.APP_FORCE_UNLOCK: "biometric",
+            }
+        )
+        push_url = detail["pushurl"]["value"]
+        self.assertIn("app_biometric_level=any", push_url)
+        self.assertIn("app_invalidate_on_biometric_change=false", push_url)
         remove_token(token.get_serial())
 
     def test_02a_lib_enroll(self):


### PR DESCRIPTION
## Summary

Add two optional Push enrollment policy actions:

- `push_app_biometric_level=any|strong`
- `push_app_invalidate_on_biometric_change=true|false`

The selected values are added to the Push enrollment URL as
`app_biometric_level` and `app_invalidate_on_biometric_change`, allowing a
supporting authenticator app to select the required biometric class and bind
the Push key to the current biometric enrollment.

## Motivation

`push_app_force_unlock=biometric` specifies that the app should request
biometric authentication, but it does not describe the required biometric
strength or whether a change to the enrolled biometrics should invalidate the
existing Push key. These are separate security decisions and need separate
policy controls.

## Behavior

- `strong` requests strong biometric authentication from supporting clients.
- `any` permits the client to use any biometric accepted by the platform.
- `true` requests binding the Push key to the current biometric enrollment.
- `false` explicitly opts out of enrollment-change invalidation.
- If either policy is not configured, its parameter is omitted from the
  enrollment URL. Existing deployments therefore retain their current server
  behavior, and supporting clients may apply their own default.

The invalidation action is represented as a string enum rather than a boolean
policy action so that an unset policy remains distinguishable from an explicit
`false` value.

## Validation

- policy definition and policy helper tests
- REST policy create, update, read, and delete coverage
- Push enrollment API coverage for generated QR parameters
- Push token enrollment coverage for `strong/true` and `any/false`

Six focused regression tests pass. The changed Python modules also pass syntax
compilation after rebasing onto the current `master`.
