### PR TITLE
Mark the authorization-scope setrealm action as deprecated

### DIFF
--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -2854,7 +2854,9 @@ def get_static_policy_definitions(scope=None):
                 'value': realms,
                 'desc': _('The Realm of the user is set to this very realm. '
                           'This is important if the user is not contained in '
-                          'the default realm and can not pass his realm.'),
+                          'the default realm and can not pass his realm.')
+                        + " <em>" + _("Deprecated since v3.14 - use the set_realm action in the "
+                                      "authentication scope, which takes precedence over this one.") + "</em>",
                 'group': GROUP.SETTING_ACTIONS,
             },
             PolicyAction.NODETAILSUCCESS: {


### PR DESCRIPTION
The `setrealm` action in the **authorization** scope has been superseded by `set_realm` in the **authentication** scope, but nothing said so where an admin would see it.

The supersession is already real in code — `set_realm` (authorization) at `api/lib/prepolicy.py:1005` only runs when no `SET_REALM` policy matched, so the old action silently does nothing once the new one is configured, and the new action's own description states it "takes precedence over the mangle and setrealm policies".

In the WebUI, though, an admin sees two similarly named actions in two scopes with no indication of which one is current, and the old one looks fully functional. This adds the deprecation marker in the same shape as the other deprecated actions in that scope (`no_detail_on_success`, `no_detail_on_fail`, `api_key_required`).

Description only — no behaviour change.

### Notes

- Labelled **v3.14**: the replacement shipped earlier (it exists as of `v3.13dev3`), but the deprecation is being declared now.
- The added text is wrapped in `_()` so it is translatable, following the `api_key_required` precedent rather than the untranslated `no_detail_on_*` one, since it names a replacement action.
- Watch out when reading the code: the constants differ only by an underscore — `SET_REALM` (authentication, current) versus `SETREALM` (authorization, legacy).

### Testing

- `tests/test_lib_policy.py` — 88 passed
- `tests/test_api_validate_authorization.py` — 7 passed

No test asserts on policy description strings; the existing ones reference `PolicyAction.SETREALM` by name only.
