### PR TITLE
Report only actual deletions in pitokenjanitor delete_info and run the docker cron on UTC

### DIFF
--- a/deploy/docker/cron-runner.py
+++ b/deploy/docker/cron-runner.py
@@ -107,7 +107,7 @@ def hourly() -> Schedule:
 
 
 def daily_at(hour: int) -> Schedule:
-    return Schedule(lambda now: now.hour == hour and now.minute == 0, f"daily at {hour:02d}:00")
+    return Schedule(lambda now: now.hour == hour and now.minute == 0, f"daily at {hour:02d}:00 UTC")
 
 
 def every(interval_minutes: int) -> Schedule:
@@ -225,7 +225,11 @@ def main() -> None:
 
     last_minute = -1
     while True:
-        now = datetime.datetime.now()
+        # An hour-of-day schedule needs a clock that advances monotonically: in a timezone with
+        # daylight saving time the local 02:00 is skipped in spring and happens twice in autumn,
+        # so a daily task would be missed or run twice. The image ships no tzdata and therefore
+        # runs on UTC anyway - say so explicitly rather than depend on it.
+        now = datetime.datetime.now(datetime.timezone.utc)
         if now.minute != last_minute:
             last_minute = now.minute
             for task in TASKS:
@@ -233,7 +237,7 @@ def main() -> None:
                     run(task.build())
 
         # Sleep until just past the start of the next minute.
-        time.sleep(61 - datetime.datetime.now().second)
+        time.sleep(61 - datetime.datetime.now(datetime.timezone.utc).second)
 
 
 if __name__ == "__main__":

--- a/privacyidea/cli/pitokenjanitor/utils/findcontainer.py
+++ b/privacyidea/cli/pitokenjanitor/utils/findcontainer.py
@@ -168,8 +168,11 @@ def delete_info(ctx, key):
     for clist in ctx.obj['containers']:
         for container in clist:
             try:
-                container.delete_container_info(key=key)
-                click.echo(f"Deleted info {key} for container {container.serial}")
+                deleted = container.delete_container_info(key=key)
+                if deleted.get(key):
+                    click.echo(f"Deleted info {key} for container {container.serial}")
+                else:
+                    click.echo(f"Container {container.serial} has no info {key}")
             except PolicyError as e:
                 click.echo(f"Cannot delete info {key} for container {container.serial}: {e}")
 

--- a/tests/cli/test_cli_pitokenjanitor.py
+++ b/tests/cli/test_cli_pitokenjanitor.py
@@ -783,6 +783,20 @@ class TestPiTokenJanitorContainer:
             container = find_container_by_serial("C1")
             assert "key1" not in container.get_container_info_dict()
 
+    def test_container_delete_info_unknown_key(self, app, containers):
+        """
+        Tests that deleting an info key the container does not have is reported as such.
+        """
+        runner = app.test_cli_runner()
+        with app.app_context():
+            container = find_container_by_serial("C1")
+            assert "no_such_key" not in container.get_container_info_dict()
+
+        result = runner.invoke(findcontainer, ["--serial", "C1", "delete_info", "no_such_key"])
+        assert result.exit_code == 0
+        assert "Container C1 has no info no_such_key" in result.output
+        assert "Deleted info" not in result.output
+
     def test_container_set_description(self, app, containers):
         """
         Tests setting the description for a container.


### PR DESCRIPTION
Two unrelated small fixes found while reviewing unreleased code on master.

### `pitokenjanitor findcontainer delete_info`

`delete_container_info(key)` returns `{key: False}` (without raising) when the container has no info with that key, but the CLI echoed `Deleted info <key> …` for anything that did not raise — so a janitor run reported deletions that never happened. It now reads the returned map and says `Container <serial> has no info <key>` instead.

### `deploy/docker/cron-runner.py`

The scheduler compared a naive local clock (`datetime.now()`) against an hour of day. In a timezone that observes daylight saving time the local clock is not monotonic: `02:00` does not exist on the spring switch (a daily task is skipped) and occurs twice on the autumn switch (it runs twice). The image ships no tzdata and therefore already runs on UTC, so this makes that assumption explicit rather than incidental: both `now()` calls are UTC-aware, and `daily_at` describes itself as `daily at HH:00 UTC` in the startup banner.

### Tests

- new `test_container_delete_info_unknown_key` covers the CLI wording and asserts nothing claims a deletion
- `tests/cli/test_cli_pitokenjanitor.py` passes in full (42 tests)

The pre-existing `UP035` in `cron-runner.py` (`typing.Callable`) is left alone — CI's ruff lints `privacyidea/` only, and it is unrelated to this change.