### PR TITLE
Keep repeated keys in the log redaction and share the repr redaction

### DIFF
--- a/privacyidea/lib/log.py
+++ b/privacyidea/lib/log.py
@@ -246,6 +246,24 @@ def is_sensitive_key(key) -> bool:
     """
     if not isinstance(key, str):
         return False
+    return _is_sensitive_key_name(key)
+
+
+# The cache is bounded on purpose: a caller can send arbitrary parameter names, and every distinct
+# name that reaches a DEBUG log line would otherwise become a permanent entry. The names that
+# actually occur are a small set which stays resident, while one-off names are evicted again.
+@functools.lru_cache(maxsize=4096)
+def _is_sensitive_key_name(key: str) -> bool:
+    """
+    Decide whether the value belonging to the name ``key`` has to be hidden from the log.
+
+    Separate from :py:func:`is_sensitive_key` so that the memoized function is only ever reached
+    with a hashable string, and so that the decision is computed once per distinct name: it runs
+    several regular expressions, and it is evaluated for every key of every decorated call.
+
+    :param key: A mapping key or parameter name
+    :return: True if the value must not be logged
+    """
     normalized_key = key.strip().lower()
     if normalized_key in INSENSITIVE_KEY_NAMES:
         return False
@@ -274,6 +292,25 @@ def _is_headers_like(value) -> bool:
     """
     return type(value).__name__ in ("Headers", "EnvironHeaders", "ImmutableTypeConversionDict",
                                     "CombinedMultiDict", "MultiDict", "ImmutableMultiDict")
+
+
+def _all_items(value):
+    """
+    Return the key/value pairs of a mapping, including the repeated keys.
+
+    A request may carry a key more than once - several ``X-Forwarded-For`` headers, a parameter
+    sent twice - but ``MultiDict.items()`` yields only the first value of each key. Ask for all of
+    them where the container supports it, so that the log does not drop the very values someone
+    raised the log level to look at. Containers without the keyword either cannot hold a repeated
+    key or already yield them all.
+
+    :param value: A mapping or header container
+    :return: An iterable of key/value pairs
+    """
+    try:
+        return value.items(multi=True)
+    except TypeError:
+        return value.items()
 
 
 def redact_url(url: str) -> str:
@@ -329,9 +366,14 @@ def redact(value, depth: int = 0, _path_ids: frozenset = frozenset()):
             return "<recursion>"
         _path_ids = _path_ids | {id(value)}
         try:
-            return {key: HIDDEN if is_sensitive_key(key) and is_sensitive_value(item)
-                    else redact(item, depth + 1, _path_ids)
-                    for key, item in value.items()}
+            collected = {}
+            for key, item in _all_items(value):
+                collected.setdefault(key, []).append(
+                    HIDDEN if is_sensitive_key(key) and is_sensitive_value(item)
+                    else redact(item, depth + 1, _path_ids))
+            # The result is a plain dict and can hold one value per key, so a key that occurred
+            # more than once keeps its values in a list instead of losing all but one.
+            return {key: items[0] if len(items) == 1 else items for key, items in collected.items()}
         except Exception:
             # Returning the original here would hand an unredacted object to the log line, which
             # then renders it through its repr. A container we failed to walk is a container whose
@@ -339,6 +381,28 @@ def redact(value, depth: int = 0, _path_ids: frozenset = frozenset()):
             # is also called from __repr__, which has no caller able to suppress the whole line.
             return "<redaction failed>"
     return value
+
+
+def redacted_attributes(obj) -> dict:
+    """
+    Render the instance attributes of ``obj`` for a ``__repr__``, with every secret replaced.
+
+    A repr ends up in the log like any other value, so it has to hide what a log line has to hide.
+    Both the token class and the token database model represent themselves this way, and they share
+    this function so that a change to the hiding rules cannot reach one of them but not the other.
+
+    :param obj: The object whose instance attributes are rendered
+    :return: A dictionary mapping the repr of every attribute name to the repr of its value
+    """
+    attributes = {}
+    for name, value in vars(obj).items():
+        if is_sensitive_key(name) and is_sensitive_value(value):
+            attributes[f"{name!r}"] = f"{HIDDEN!r}"
+        else:
+            # An attribute that is not sensitive itself can still carry a secret inside it,
+            # for example the enrollment key in init_details.
+            attributes[f"{name!r}"] = f"{redact(value)!r}"
+    return attributes
 
 
 class log_with:

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -108,7 +108,7 @@ from .config import (get_from_config, get_prepend_pin)
 from .decorators import check_token_locked
 from .error import (TokenAdminError,
                     ParameterError, ResourceNotFoundError)
-from .log import HIDDEN, is_sensitive_key, log_with, redact
+from .log import log_with, redacted_attributes
 from .policies.actions import PolicyAction
 from .policydecorators import libpolicy, auth_otppin, challenge_response_allowed
 from .user import (User)
@@ -1589,18 +1589,7 @@ class TokenClass:
         :return: token state as string representation
         :rtype:  string
         """
-        ldict = {}
-        for attr in self.__dict__:
-            key = f"{attr!r}"
-            if is_sensitive_key(attr):
-                val = f"{HIDDEN!r}"
-            else:
-                # An attribute that is not sensitive itself can still carry a secret inside it,
-                # for example the enrollment key in init_details.
-                val = f"{redact(getattr(self, attr))!r}"
-            ldict[key] = val
-        res = f"<{self.__class__!r} {ldict!r}>"
-        return res
+        return f"<{self.__class__!r} {redacted_attributes(self)!r}>"
 
     def get_init_detail(self, params=None, user=None):
         """

--- a/privacyidea/models/token.py
+++ b/privacyidea/models/token.py
@@ -30,7 +30,7 @@ from privacyidea.lib.crypto import (geturandom, encrypt, hexlify_and_unicode,
                                     pass_hash, encryptPin, decryptPin, hash,
                                     verify_pass_hash, SecretObj)
 from privacyidea.lib.error import ResourceNotFoundError
-from privacyidea.lib.log import HIDDEN, is_sensitive_key, log_with, redact
+from privacyidea.lib.log import log_with, redacted_attributes
 from privacyidea.lib.utils import convert_column_to_unicode
 from privacyidea.models import db
 from privacyidea.models.realm import Realm
@@ -396,16 +396,7 @@ class Token(MethodsMixin, db.Model):
         :return: token state as string representation
         :rtype:  str
         """
-        ldict = {}
-        for attr in self.__dict__:
-            key = f"{attr!r}"
-            if is_sensitive_key(attr):
-                val = f"{HIDDEN!r}"
-            else:
-                val = f"{redact(getattr(self, attr))!r}"
-            ldict[key] = val
-        res = f"<{self.__class__!r} {ldict!r}>"
-        return res
+        return f"<{self.__class__!r} {redacted_attributes(self)!r}>"
 
     def get_info(self):
         """

--- a/tests/test_lib_logging_redaction.py
+++ b/tests/test_lib_logging_redaction.py
@@ -23,7 +23,10 @@ import pytest
 
 from .base import MyApiTestCase
 
-from privacyidea.lib.log import is_sensitive_key, log_with, redact
+from werkzeug.datastructures import (CombinedMultiDict, EnvironHeaders, Headers,
+                                     ImmutableMultiDict, ImmutableTypeConversionDict, MultiDict)
+
+from privacyidea.lib.log import HIDDEN, is_sensitive_key, log_with, redact, redacted_attributes
 
 # Values that must never reach the log. They are deliberately unusual strings so that a single
 # substring check over the captured log output is enough to detect a leak.
@@ -125,6 +128,78 @@ class TestRedact:
         redacted = redact({"obj": Unpickleable(), "pin": TEST_PIN, "serial": "OATH0001"})
         assert redacted["pin"] == "HIDDEN"
         assert redacted["serial"] == "OATH0001"
+
+
+class TestRedactMultiValueContainers:
+    """
+    Tests for the werkzeug containers that carry more than one value per key.
+
+    The request headers and parameters arrive in these, so they are the containers the redaction
+    walks most often, and a key may legitimately appear several times in them.
+    """
+
+    @pytest.mark.parametrize("container_type", [Headers, MultiDict, ImmutableMultiDict])
+    def test_every_value_of_a_repeated_key_is_kept(self, container_type):
+        container = container_type([("X-Forwarded-For", "10.0.0.1"),
+                                    ("X-Forwarded-For", "10.0.0.2"),
+                                    ("Authorization", f"Bearer {TEST_SECRET}")])
+        redacted = redact(container)
+        assert redacted["X-Forwarded-For"] == ["10.0.0.1", "10.0.0.2"]
+        assert redacted["Authorization"] == HIDDEN
+
+    def test_every_value_of_a_repeated_key_is_kept_for_combined_multi_dict(self):
+        container = CombinedMultiDict([MultiDict([("pass", TEST_PASSWORD), ("realm", "realm1")]),
+                                       MultiDict([("realm", "realm2")])])
+        redacted = redact(container)
+        assert redacted["realm"] == ["realm1", "realm2"]
+        assert redacted["pass"] == HIDDEN
+
+    def test_a_single_value_is_not_wrapped_in_a_list(self):
+        # Only a repeated key needs a list, so the common case still reads like a plain mapping.
+        assert redact(MultiDict([("serial", "OATH0001")])) == {"serial": "OATH0001"}
+
+    @pytest.mark.parametrize("container_type", [Headers, EnvironHeaders, MultiDict,
+                                               ImmutableMultiDict, ImmutableTypeConversionDict])
+    def test_a_secret_is_hidden_in_every_container_in_use(self, container_type):
+        # _is_headers_like recognises these containers by class name, so a werkzeug release that
+        # renames or replaces one of them has to fail here instead of silently logging the header.
+        if container_type is EnvironHeaders:
+            container = EnvironHeaders({"HTTP_AUTHORIZATION": f"Bearer {TEST_SECRET}"})
+        else:
+            container = container_type([("Authorization", f"Bearer {TEST_SECRET}")])
+        redacted = redact(container)
+        assert redacted["Authorization"] == HIDDEN
+        assert_not_logged(str(redacted), [TEST_SECRET])
+
+
+class TestRedactedAttributes:
+    """
+    Tests for the attribute rendering that the token repr and the token model repr share.
+    """
+
+    class Token:
+        def __init__(self):
+            self.serial = "OATH0001"
+            self.pin = TEST_PIN
+            self.using_pin = True
+            self.init_details = {"otpkey": TEST_SECRET, "googleurl": "otpauth://..."}
+
+    def test_a_sensitive_attribute_is_hidden(self):
+        attributes = redacted_attributes(self.Token())
+        assert attributes["'pin'"] == f"{HIDDEN!r}"
+        assert attributes["'serial'"] == "'OATH0001'"
+
+    def test_a_secret_nested_in_an_attribute_is_hidden(self):
+        attributes = redacted_attributes(self.Token())
+        assert TEST_SECRET not in attributes["'init_details'"]
+        assert "googleurl" in attributes["'init_details'"]
+
+    def test_a_flag_under_a_sensitive_name_stays_readable(self):
+        # Same rule as for a mapping key: a switch is never a credential.
+        assert redacted_attributes(self.Token())["'using_pin'"] == "True"
+
+    def test_nothing_secret_survives_in_the_rendered_form(self):
+        assert_not_logged(str(redacted_attributes(self.Token())))
 
 
 class TestRedactionFailsClosed:


### PR DESCRIPTION
Follow-ups on the unreleased log redaction, found while reviewing it.

### Repeated keys were dropped

`redact()` rebuilt werkzeug multi-value containers via `items()`, which yields only the first value per key — so at DEBUG a request with several `X-Forwarded-For` headers or a parameter sent twice logged only one of them, hiding the very data someone raised the log level to look at:

```python
redact(MultiDict([("X-Forwarded-For", "10.0.0.1"), ("X-Forwarded-For", "10.0.0.2"), ("pass", "s3cret")]))
# before: {'X-Forwarded-For': '10.0.0.1', 'pass': 'HIDDEN'}
# after:  {'X-Forwarded-For': ['10.0.0.1', '10.0.0.2'], 'pass': 'HIDDEN'}
```

The new `_all_items()` asks for `items(multi=True)` and falls back to `items()` on `TypeError`. Each werkzeug container in use was probed to confirm the fallback is correct: `MultiDict`/`ImmutableMultiDict`/`CombinedMultiDict` need the keyword, `Headers`/`EnvironHeaders` reject it but `Headers.items()` already yields duplicates, and `ImmutableTypeConversionDict` is a plain dict subclass that cannot hold them. A key with a single value is not wrapped in a list, so ordinary mappings render exactly as before. The iterator is returned rather than consumed inside the `try`, so a container that fails mid-iteration still falls through to `<redaction failed>` instead of being walked twice.

### `is_sensitive_key` is memoized

It is a pure name-to-bool decision running several regular expressions, evaluated for every key of every decorated call. `is_sensitive_key` keeps the type guard and delegates to `_is_sensitive_key_name` under `lru_cache(maxsize=4096)`, so only hashable strings reach the cache and the bound caps what arbitrary caller-supplied parameter names can grow.

### One redaction loop instead of two

`TokenClass.__repr__` and `Token.__repr__` carried byte-identical hiding loops. Both exist to keep secrets out of a repr, so a change reaching one but not the other would leak. They now share `redacted_attributes()`. Two deliberate changes inside it:

- it applies `is_sensitive_value` as well, matching `redact()`'s dict path, so `using_pin=True` is readable instead of `HIDDEN`. A bool or `None` is never a credential, so nothing real is unhidden.
- it reads `vars(obj).items()` rather than `getattr` per name — equivalent for instance attributes, but it keeps a repr from invoking a descriptor on an ORM model.

The rendered format is unchanged; verified against a real HOTP token that the PIN does not appear and `key_enc`/`user_pin`/`so_pin` still render as `'HIDDEN'`.

### `_is_headers_like` coverage is pinned

`_is_headers_like` recognises header containers by class name, which is deliberate (an arbitrary object exposing `items` may run a query when called) but means a werkzeug rename would silently log `Authorization`/`Cookie`/`X-API-Key` unredacted. A new parametrised test asserts an `Authorization` header is hidden for each of the five types the allowlist names, so that fails loudly instead. The predicate itself is untouched.

### Tests

- `tests/test_lib_logging_redaction.py`: 71 pass, 12 new across `TestRedactMultiValueContainers` and `TestRedactedAttributes`
- also green: `test_lib_logging.py`, `test_lib_tokenclass.py`, `test_db_model.py`, `test_lib_radiusserver.py`, `test_lib_remembered_device.py`, `test_lib_tokens_radius.py`, `test_lib_smsprovider.py`, `test_api_validate_multichallenge_enroll.py`
- `ruff check privacyidea` clean