### PR TITLE
Treat an empty list of allowed realms as no realm instead of every realm

### DIFF
--- a/privacyidea/lib/container.py
+++ b/privacyidea/lib/container.py
@@ -193,7 +193,8 @@ def _create_container_query(user: User = None, serial: str = None, ctype: str = 
     :param token_serial: serial of a token which is assigned to the container (case-insensitive and allows '*' as
         wildcard), optional
     :param realm: realm name to filter by (case-insensitive and allows '*' as wildcard), optional
-    :param allowed_realms: list of realms the user is allowed to see (None if all realms are allowed), optional
+    :param allowed_realms: list of realms the user is allowed to see (None if all realms are allowed and an
+        empty list if none is), optional.
         If realms and allowed_realms are given, the intersection of both lists is used. If there is no intersection, no
         container is returned.
     :param template: The name of the template the container was created with (case-sensitive and allows '*' as
@@ -288,7 +289,9 @@ def _create_container_query(user: User = None, serial: str = None, ctype: str = 
 
     # Use separate alias for each join to avoid conflicts
     realm_alias_allowed = aliased(Realm)
-    if allowed_realms:
+    # An empty list means the caller is allowed no realm at all, which is not the same as None
+    # ("every realm"): it has to match nothing rather than lift the restriction.
+    if allowed_realms is not None:
         allowed_realms = [r.lower() for r in allowed_realms]
         stmt = stmt.join(TokenContainer.realms.of_type(realm_alias_allowed), isouter=True).where(
             func.lower(realm_alias_allowed.name).in_(allowed_realms)
@@ -419,7 +422,8 @@ def get_all_containers(user: User = None, serial: str = None, ctype: str = None,
     :param token_serial: serial of a token which is assigned to the container (case-insensitive and allows '*'
         as wildcard), optional
     :param realm: name of the realm the container is assigned to (case-insensitive and allows '*' as wildcard), optional
-    :param allowed_realms: list of realms the user is allowed to see (None if all realms are allowed), optional
+    :param allowed_realms: list of realms the user is allowed to see (None if all realms are allowed and an
+        empty list if none is), optional.
         If realms and allowed_realms are given, the intersection of both lists is used. If there is no intersection, no
         container is returned.
     :param template: The name of the template the container was created with (case-sensitive and allows '*' as wildcard)
@@ -1139,7 +1143,8 @@ def set_container_realms(serial: str, realms: list[str],
 
     :param serial: serial of the container
     :param realms: requested realms as list of str
-    :param allowed_realms: realms the caller is allowed to manage, or None if all realms are allowed
+    :param allowed_realms: realms the caller is allowed to manage, None if all realms are allowed and an empty
+        list if none is
     :return: a :class:`ContainerRealmsResult` describing which realms are attached, and which requested
         realms could not be added, were removed, or could not be removed
     """
@@ -1147,8 +1152,9 @@ def set_container_realms(serial: str, realms: list[str],
     requested = {realm for realm in realms if realm}
     old_realms = {realm.name for realm in container.realms}
 
-    if allowed_realms:
+    if allowed_realms is not None:
         # Only manage realms the caller is allowed to: keep existing realms outside their scope untouched.
+        # An empty list is a caller allowed no realm at all, so nothing is added and nothing removed.
         target = (requested & set(allowed_realms)) | (old_realms - set(allowed_realms))
     else:
         target = requested
@@ -1168,16 +1174,18 @@ def add_container_realms(serial: str, realms: list[str], allowed_realms: list[st
 
     :param serial: serial of the container
     :param realms: new realms as list of str
-    :param allowed_realms: A list of realms the admin is allowed to set, optional
+    :param allowed_realms: A list of realms the admin is allowed to set, None if all realms are allowed and an
+        empty list if none is
     :returns: Dictionary in the format {realm: success}, the entry 'deleted' indicates whether existing realms were
               deleted.
     """
     container = find_container_by_serial(serial)
 
-    # Check if admin is allowed to set the realms
+    # Check if admin is allowed to set the realms. An empty list is a caller allowed no realm at
+    # all, so no realm is added and every requested realm is reported as failed.
     matching_realms = realms
     res_failed = {}
-    if allowed_realms:
+    if allowed_realms is not None:
         matching_realms = list(set(realms).intersection(allowed_realms))
         excluded_realms = list(set(realms) - set(matching_realms))
         if len(excluded_realms) > 0:
@@ -1202,7 +1210,7 @@ def get_container_realms(serial: str) -> list[str]:
 
 
 def create_container_dict(container_list: list[TokenContainerClass], no_token: bool = False, user: User = None,
-                          logged_in_user_role: str = 'user', allowed_token_realms: list[str] | None = [],
+                          logged_in_user_role: str = 'user', allowed_token_realms: list[str] | None = None,
                           hide_token_info: list[str] = None, hide_container_info: list[str] = None) -> list[dict]:
     """
     Create a dictionary for each container in the list.
@@ -1213,7 +1221,8 @@ def create_container_dict(container_list: list[TokenContainerClass], no_token: b
     :param no_token: If True, the token information is not included
     :param user: The user object requesting the containers
     :param logged_in_user_role: The role of the logged-in user ('admin' or 'user')
-    :param allowed_token_realms: A list of realms the admin is allowed to see tokens from
+    :param allowed_token_realms: A list of realms the admin is allowed to see tokens from, None if
+        the admin is allowed to see all of them and an empty list if the admin is allowed none
     :param hide_token_info: List of token info keys to hide in the response, optional
     :param hide_container_info: List of container info keys to hide in the response, optional
     :return: List of container dictionaries

--- a/privacyidea/lib/token/attributes.py
+++ b/privacyidea/lib/token/attributes.py
@@ -45,7 +45,8 @@ def set_realms(serial: str, realms: list | None = None, add: bool = False,
     :type realms: list
     :param add: if the realms should be added and not replaced
     :type add: bool
-    :param allowed_realms: A list of realms, that the admin is allowed to manage
+    :param allowed_realms: A list of realms, that the admin is allowed to manage, None if all realms are
+        allowed and an empty list if none is
     """
     realms = realms or []
     corrected_realms = []
@@ -61,7 +62,9 @@ def set_realms(serial: str, realms: list | None = None, add: bool = False,
     old_realms = token.get_realms()
 
     matching_realms = corrected_realms
-    if allowed_realms:
+    # An empty list is an admin allowed no realm at all, which is not the same as None ("every
+    # realm"): no realm is set and none of the existing ones is removed.
+    if allowed_realms is not None:
         matching_realms = list(set(corrected_realms).intersection(allowed_realms))
         excluded_realms = list(set(corrected_realms) - set(matching_realms))
         if len(excluded_realms) > 0:

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -568,6 +568,20 @@ class TokenTestCase(MyTestCase):
         token_realm_db = db.session.execute(stmt).one_or_none()
         self.assertIsNone(token_realm_db)
 
+    def test_16a_set_realms_with_no_allowed_realm(self):
+        # An empty list of allowed realms is an admin allowed no realm at all, which is not the
+        # same as None ("every realm"): no realm is set and the existing ones are kept.
+        self.setUp_user_realm2()
+        serial = "NOALLOWEDREALM01"
+        init_token({"serial": serial, "otpkey": self.otpkey})
+        set_realms(serial, [self.realm1])
+        self.assertEqual([self.realm1], get_realms_of_token(serial))
+
+        set_realms(serial, [self.realm2], allowed_realms=[])
+
+        self.assertEqual([self.realm1], get_realms_of_token(serial))
+        remove_token(serial=serial)
+
     def test_17_set_defaults(self):
         serial = "SETTOKEN"
         tokenobject = init_token({"serial": serial,

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -380,6 +380,24 @@ class TokenContainerManagementTestCase(MyTestCase):
         container_realms = [realm.name for realm in container.realms]
         self.assertEqual(0, len(container_realms))
 
+    def test_19a_set_realms_with_no_allowed_realm(self):
+        # An empty list of allowed realms is a caller allowed no realm at all, which is not the
+        # same as None ("every realm"): no realm is attached and none of the existing ones removed.
+        self.setUp_user_realms()
+        self.setUp_user_realm2()
+        container_serial = init_container({"type": "generic"})["container_serial"]
+        container = find_container_by_serial(container_serial)
+        set_container_realms(container_serial, [self.realm1], None)
+
+        result = set_container_realms(container_serial, [self.realm2], [])
+
+        self.assertListEqual([self.realm1], result.attached)
+        self.assertListEqual([self.realm2], result.not_added)
+        self.assertListEqual([], result.removed)
+        self.assertListEqual([self.realm1], result.not_removed)
+        self.assertFalse(result.success)
+        self.assertListEqual([self.realm1], [realm.name for realm in container.realms])
+
     def test_20_add_realms(self):
         self.setUp_user_realms()
         self.setUp_user_realm2()
@@ -421,6 +439,15 @@ class TokenContainerManagementTestCase(MyTestCase):
         result = add_container_realms(container_serial, None, None)
         self.assertFalse(result['deleted'])
         container_realms = [realm.name for realm in container.realms]
+        self.assertEqual(2, len(container_realms))
+
+        # An empty list of allowed realms is a caller allowed no realm at all, which is not the
+        # same as None ("every realm"): nothing is added and the request is reported as failed.
+        self.setUp_user_realm3()
+        result = add_container_realms(container_serial, [self.realm3], [])
+        self.assertFalse(result[self.realm3])
+        container_realms = [realm.name for realm in container.realms]
+        self.assertNotIn(self.realm3, container_realms)
         self.assertEqual(2, len(container_realms))
 
     def test_21_assign_unassign_user(self):
@@ -863,6 +890,12 @@ class TokenContainerManagementTestCase(MyTestCase):
         container_data = get_all_containers(allowed_realms=["realm1"], realm="realm2", pagesize=15)
         self.assertEqual(1, len(container_data["containers"]))
         self.assertEqual(container_serials[1], container_data["containers"][0].serial)
+
+        # An empty list of allowed realms is a caller allowed no realm at all, which is not the
+        # same as None ("every realm"): it has to match nothing instead of lifting the restriction.
+        container_data = get_all_containers(allowed_realms=[], pagesize=15)
+        self.assertEqual(0, len(container_data["containers"]))
+        self.assertEqual(0, container_data["count"])
 
         # ---- user ----
         # Filter by user (same username and resolver, but different realms)


### PR DESCRIPTION
`check_admin_tokenlist` (`api/lib/prepolicy.py:1269-1279`) reports the realms an admin may manage in three states, as its own docstring says:

- `None` — every realm
- `["realm1"]` — these realms
- `[]` — no realm at all (admin policies exist, but none matched)

Four consumers tested that value for truthiness and therefore collapsed the third state into the first: an admin allowed *no* realm took the unrestricted branch. `lib/token/query.py:125` and `:426` already test for `None` correctly; these four now match it.

| site | with `[]` before | with `[]` after |
|---|---|---|
| `lib/container.py` `_create_container_query` | no realm filter — every container is listed | matches nothing |
| `lib/container.py` `set_container_realms` | any requested realm can be attached | keeps the existing realms, requested ones reported as `not_added` |
| `lib/container.py` `add_container_realms` | any realm can be added | nothing added, request reported as failed |
| `lib/token/attributes.py` `set_realms` | any realm can be set | token keeps its existing realms |

The container query is the one that matters most: it is a listing scope, the same failure class as #5689.

Each `[]` outcome above falls out of the existing arithmetic — no other logic changed. The three states are now documented on all five functions, so the next caller does not have to infer them.

### Also: a mutable default that meant the wrong thing

`create_container_dict(..., allowed_token_realms: list[str] | None = [])` defaulted to an empty list, which flows into `convert_token_objects_to_dicts(allowed_realms=...)` — and that already uses `is not None`. Under the convention this PR makes uniform, that default reads as "no realms allowed" and would reduce every token in the response to its serial. It is harmless today only because its single caller (`api/container.py:228`) always passes the value explicitly. Changed to `None`.

### Deliberately not changed

`api/container.py:354` — `if user_role == "admin" and allowed_realms:` looks like the same pattern but guards `allowed_realms[0]`, so testing for `None` there would turn `[]` into an `IndexError`. If `[]` should block container creation, that belongs to the policy gate rather than to this line.

### Reachability

`[]` is producible, but at each of these endpoints `check_base_action` / `check_container_action` runs first and raises a `PolicyError` in the same situation, so no live path was demonstrated. The two gates do feed `Match` different inputs, though — `check_base_action` passes realm/user/resolver while `check_admin_tokenlist` passes serial/container_serial — so a divergence is not ruled out. This is defence in depth and one consistent convention across the realm-scoping consumers, not a fix for a proven hole.

### Tests

Three cases added to the existing realm tests: `get_all_containers(allowed_realms=[])` returns nothing; `set_container_realms` and `add_container_realms` with `[]` change nothing and report the request as failed; the token `set_realms` with `[]` keeps the token's realm.

Green: `test_lib_tokencontainer.py` (86), `test_lib_token.py` (78), `test_api_container.py` + `test_api_container_user.py` + `test_api_container_helpdesk.py` (125), `test_api_lib_policy_admin.py` + `test_api_token.py` (100). `ruff check privacyidea` clean.
