### PR TITLE
Record the user-agent policy semantics and the lockout risk it carries

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -180,6 +180,40 @@
   with a 400, because the request would otherwise be filtered by the realm and the resolver alone and return the tokens
   of other users.
 
+* **Policies with a User Agent condition are no longer dropped when no user agent is known.** Listing the policies
+  without a user agent - which is the case for `pi-manage config export`, for the configuration report of
+  `GET /system/documentation`, and for the internal check whether a scope contains any policy at all - previously
+  omitted every policy that carries a `User Agent` condition. Such a policy was therefore missing from a configuration
+  export (#5683), and a scope whose policies all carry a User Agent condition was treated as if it had no policies.
+  All of these now see the complete set of policies.
+
+  **This changes who is allowed what** in the `admin` and `user` scopes. Those scopes allow everything as long as they
+  contain no policy at all, and deny everything that is not explicitly granted as soon as they contain one. A scope
+  whose only policies carry a User Agent condition was therefore treated as empty and allowed everything; it now counts
+  as configured, and a request arriving with a different user agent is denied unless a policy grants the action to it.
+  For example, if your only `user` scope policy grants `enrollpin` limited to `privacyIDEA-WebUI`, users can still set
+  their PIN through the WebUI, but a request from another client is refused.
+
+  **WARNING**: in the `admin` scope this can lock you out. If **every** policy in your `admin` scope carries a User
+  Agent condition, then before the update administrators kept full rights no matter which client they used, and after
+  the update they only have the rights of the policies that match their user agent - none, if no policy names it. An
+  admin policy limited to, say, `privacyIDEA-CP` will leave you unable to administrate through the WebUI, including
+  unable to edit the very policy causing it.
+
+  **Before updating**, check your `admin` scope policies under *Config -> Policies* for a User Agent condition. If any
+  are present, make sure that at least one **active** `admin` policy grants your administrators their rights either
+  with no User Agent condition at all or with a condition that includes the client they administrate with
+  (`privacyIDEA-WebUI` for the WebUI). The same review applies to the `user` scope, where the consequence is users
+  losing self-service rights rather than a lockout.
+
+  If you are already locked out after the update, the policy can be disabled from the command line on the server, which
+  does not go through the policy check:
+
+      pi-manage config policy list
+      pi-manage config policy disable <name>
+
+  Installations that do not use the User Agent condition are unaffected.
+
 ## Update from 3.12 to 3.13
 
 * `enrollpin` right enforcement has been made stricter. If you try to enroll a token with a PIN but do not have the the

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -439,7 +439,11 @@ class PolicyClass:
             combination
         :param sort_by_priority: If true, sort the resulting list by priority, ascending
             by their policy numbers.
-        :param user_agent: The user agent of the request
+        :param user_agent: The user agent of the request. ``None`` returns the user-agent-restricted
+            policies as well, which is what a caller wants that dumps or counts the policies rather
+            than matching a request - an export, the configuration report, or the check whether a
+            scope is configured at all. Pass the empty string to match only the policies that carry
+            no user agent restriction.
         :return: list of policies
         :rtype: list of dicts
         """
@@ -3456,6 +3460,13 @@ class Match:
          * *either* if there are no active policies defined in the matched scope
          * *or* the action is explicitly allowed by a policy in the matched scope
 
+        Whether the scope is configured is decided by the scope alone: every
+        active policy of the scope counts, including one that is restricted to a
+        realm, a client or a user agent which does not match this request. So a
+        scope whose only policy is restricted to one user agent is a configured
+        scope, and a request from a different user agent is denied unless a
+        policy grants the action to it.
+
         This method is **fail-open**: it returns True when the whole scope is
         unconfigured. It is therefore only correct for *permission gates* -
         checks whose result is immediately used to deny an action (typically
@@ -3478,6 +3489,12 @@ class Match:
         :return: True or False
         """
         policies_defined = self.any(write_to_audit_log=write_to_audit_log)
+        # Whether the scope is configured at all is asked without any of the filters of the request:
+        # no realm, no user, no client IP and, by passing no user_agent, no user agent either. A
+        # policy that is restricted to a user agent still configures its scope, so it has to be
+        # counted here even when it does not match this request - otherwise defining nothing but
+        # user-agent-restricted policies in a scope would leave that scope wide open for every
+        # other user agent.
         policies_at_all = self._g.policy_object.list_policies(scope=self._match_kwargs["scope"], active=True)
         # The action is *allowed* if a matched policy explicitly mentions it (``policies_defined`` is non-empty)
         # or if no policies are defined in the given scope (``policies_at_all`` is empty)

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -2467,7 +2467,10 @@ class PolicyTestCase(MyTestCase):
         self.assertEqual(2, len(policies), policies)
         self.assertSetEqual({"policy-keycloak", "policy-no-agent"}, {policy["name"] for policy in policies})
 
-        # no user agent filter returns all policies (no filtering by user_agent)
+        # No user agent filter returns all policies, including the user-agent-restricted ones. This
+        # is what a caller needs that dumps or counts the policies instead of matching a request:
+        # the configuration export, the configuration report, and the check whether a scope has any
+        # policy at all.
         policies = P.list_policies(scope=SCOPE.AUTH)
         self.assertEqual(3, len(policies), policies)
         self.assertSetEqual({"policy-cp", "policy-keycloak", "policy-no-agent"},
@@ -3428,6 +3431,49 @@ class PolicyMatchTestCase(MyTestCase):
         token_corny.delete_token()
         token_hans.delete_token()
         token_no_user.delete_token()
+
+    def test_07_allowed_with_only_a_user_agent_restricted_policy(self):
+        # A policy restricted to one user agent configures its scope for every user agent: the
+        # action is allowed to the agent the policy names and denied to the others, instead of the
+        # scope counting as unconfigured and allowing everybody.
+        delete_all_policies()
+        set_policy(name="only-webui", scope=SCOPE.USER, action=PolicyAction.ENROLLPIN,
+                   user_agents="privacyIDEA-WebUI")
+        user = User("cornelius", self.realm1)
+
+        def user_match(user_agent):
+            g = FakeFlaskG()
+            g.client_ip = "127.0.0.1"
+            g.audit_object = mock.Mock()
+            g.audit_object.audit_data = {}
+            g.policy_object = PolicyClass()
+            g.user_agent = user_agent
+            return Match.user(g, scope=SCOPE.USER, action=PolicyAction.ENROLLPIN, user_object=user)
+
+        self.assertTrue(user_match("privacyIDEA-WebUI").allowed())
+        self.assertFalse(user_match("privacyIDEA-CP").allowed())
+        # The scope counts as configured no matter which agent asks
+        self.assertEqual(1, len(PolicyClass().list_policies(scope=SCOPE.USER, active=True)))
+
+        # The same for an admin policy: the agent it names keeps the action, the others lose it
+        delete_policy("only-webui")
+        set_policy(name="only-cp", scope=SCOPE.ADMIN, action=PolicyAction.DELETE,
+                   user_agents="privacyIDEA-CP")
+
+        def admin_match(user_agent):
+            g = FakeFlaskG()
+            g.client_ip = "127.0.0.1"
+            g.audit_object = mock.Mock()
+            g.audit_object.audit_data = {}
+            g.policy_object = PolicyClass()
+            g.user_agent = user_agent
+            g.logged_in_user = {"username": "admin", "realm": "", "role": ROLE.ADMIN}
+            return Match.admin(g, action=PolicyAction.DELETE)
+
+        self.assertTrue(admin_match("privacyIDEA-CP").allowed())
+        self.assertFalse(admin_match("privacyIDEA-WebUI").allowed())
+
+        delete_policy("only-cp")
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Follow-up on #5699 / #5683. No behaviour change — this records a behaviour change that already happened, pins it with a test, and warns about its consequence in the update notes.

### What #5699 changed, and what it changed beyond the issue

#5683 asked for `pi-manage config export` to dump the policies *"regardless of the runtime execution context"*, because the CLI has no user agent and every policy carrying a `User Agent` condition was silently dropped from the export. #5699 delivered that by making `list_policies(user_agent=None)` skip the user-agent filter entirely.

Three callers benefit, not just the reported one — all of them dump or count policies rather than matching a request:

- `cli/pimanage/pi_config.py` — `pi-manage config export` (the reported bug) and `pi-manage config policy list`
- `lib/policy.py` `export_policies`
- `api/system.py` — the configuration report behind `GET /system/documentation`

But a fourth kind of caller also stopped filtering: the `policies_at_all` probe in `Match.allowed()`, and the equivalent probes in `check_admin_tokenlist`, `ui_get_rights` and `ui_get_enroll_tokentypes`. That was not part of the issue.

### Why the probe change is right

`allowed()` is fail-open: it permits an action when the whole scope contains no policy. Under the old behaviour, a scope whose only policies carried a `User Agent` condition looked empty to that probe for every *other* user agent — so defining one user-agent-restricted admin policy, which an admin does in order to restrict something, left the entire admin scope permitting everything for every other client. The new behaviour counts such a policy, which is also consistent with the probe already ignoring the realm, user and client-IP filters.

So this is kept as it is. What was missing is that nothing said so, and nothing tested it.

### Changes

- `list_policies`: the `user_agent` parameter doc now states what `None` and `""` mean and which kind of caller wants which.
- `Match.allowed()`: a docstring paragraph stating that whether a scope counts as configured is decided by the scope alone — every active policy counts, including one restricted to a realm, client or user agent that does not match this request — plus a comment at the `policies_at_all` call recording why the filter is deliberately not applied there.
- `tests/test_lib_policy.py`: new `test_07_allowed_with_only_a_user_agent_restricted_policy` pins both scopes. A `scope=user` `enrollpin` policy limited to `privacyIDEA-WebUI` is allowed from the WebUI and denied from `privacyIDEA-CP`; a `scope=admin` `delete` policy limited to `privacyIDEA-CP` is allowed from CP and denied from the WebUI. The existing `list_policies` assertion for the unfiltered call now says *why* it returns everything.
- `READ_BEFORE_UPDATE.md`: an entry under *3.13 to 3.14*, led by the bugfix and followed by a `**WARNING**` about the lockout risk — if every policy in the `admin` scope carries a `User Agent` condition, administrators arriving with a different user agent lose the rights they had before the update, including the right to edit that policy. It gives the pre-update check, and the recovery path via `pi-manage config policy list` / `disable <name>`, which does not go through the policy check.

Worth noting for the last point: `pi-manage config policy list` calls `list_policies()` with no user agent, so before #5699 it would itself have hidden the very policy locking you out. The recovery instruction only works because of this fix.

### Tests

Green: `test_lib_policy.py` (89), `test_api_lib_policy.py` (35), `test_api_lib_policy_admin.py` + `test_api_lib_policy_actions.py` (26), `tests/cli/test_cli_pimanage.py` (41). `ruff check privacyidea` clean.
