### PR TITLE
Read the subscription table at the same size as the widgets beside it

### DIFF
--- a/privacyidea/static_new/src/app/components/dashboard/widgets/subscriptions-widget/subscriptions-widget.component.scss
+++ b/privacyidea/static_new/src/app/components/dashboard/widgets/subscriptions-widget/subscriptions-widget.component.scss
@@ -70,10 +70,9 @@
   // column widths keep the extra columns inside the widget instead of widening the
   // table, and every cell stays one line high, so the two views are the same height.
   table-layout: fixed;
-  // The size the rest of the tables use (styles/table.scss), kept in rem so it still
-  // follows the browser's font size. The rows are dense through their padding and line
-  // height instead, which is what lets the compact view fit every component.
-  font-size: 0.875rem;
+  // No font size of its own: the other widgets' tables set none either, so this one reads
+  // at the same size as the widgets beside it. The rows are dense through their padding
+  // and line height instead, which is what lets the compact view fit every component.
 
   th,
   td {

--- a/privacyidea/static_new/src/app/components/dashboard/widgets/subscriptions-widget/subscriptions-widget.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/dashboard/widgets/subscriptions-widget/subscriptions-widget.component.spec.ts
@@ -139,7 +139,7 @@ describe("SubscriptionsWidgetComponent", () => {
     expect(SubscriptionsWidgetComponent.pinned).toBe(false);
     expect(SubscriptionsWidgetComponent.fixedPosition).toBeNull();
     // Opens tall enough for the compact view to show every component without scrolling.
-    expect(SubscriptionsWidgetComponent.defaultSize).toEqual({ cols: 8, rows: 10 });
+    expect(SubscriptionsWidgetComponent.defaultSize).toEqual({ cols: 8, rows: 11 });
     expect(SubscriptionsWidgetComponent.minSize.cols).toBeLessThan(SubscriptionsWidgetComponent.defaultSize.cols);
     expect(SubscriptionsWidgetComponent.maxSize.cols).toBeGreaterThan(SubscriptionsWidgetComponent.defaultSize.cols);
   });

--- a/privacyidea/static_new/src/app/components/dashboard/widgets/subscriptions-widget/subscriptions-widget.component.ts
+++ b/privacyidea/static_new/src/app/components/dashboard/widgets/subscriptions-widget/subscriptions-widget.component.ts
@@ -137,8 +137,9 @@ export class SubscriptionsWidgetComponent extends DashboardWidget implements OnI
   static override readonly titleLink = ROUTE_PATHS.SUBSCRIPTION;
   static override readonly titleLinkAction = "managesubscription";
   // The default is tall enough for the compact view to show every component without
-  // scrolling; widening it makes room for the detailed view's extra columns.
-  static override readonly defaultSize: WidgetSize = { cols: 8, rows: 10 };
+  // scrolling, at the row height the inherited font size gives; widening it makes room for
+  // the detailed view's extra columns.
+  static override readonly defaultSize: WidgetSize = { cols: 8, rows: 11 };
   static override readonly minSize: WidgetSize = { cols: 5, rows: 4 };
   static override readonly maxSize: WidgetSize = { cols: 16, rows: 16 };
 


### PR DESCRIPTION
Follow-up to #5389, which merged before this last commit made it in.

The subscriptions widget's table set a font size of its own (`0.85rem`) where the
other dashboard widgets' tables set none — they use the shared `widget.stat-table`
mixin, which specifies no size, and nothing above it does either (`html, body` sets
only `font-family`, and `mat.theme` is configured without a `typography` key). So
this one table read smaller than everything around it on the dashboard.

It now inherits the same size the sibling widgets do, and `defaultSize` goes from
`rows: 10` to `rows: 11` so the compact view still shows every component without a
scrollbar at that size: the taller tile gives roughly 425px of content against the
roughly 402px the 15 rows need.