### PR TITLE
Run migration tests against real MySQL too

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -51,17 +51,24 @@ jobs:
           # MariaDB 10.11 is the LTS most installs run (Ubuntu 24.04 default);
           # 11.x is the rolling latest. Migrations emit version-specific DDL, so
           # both are exercised (this job is path-gated to migration/model
-          # changes, so the extra entry rarely runs). Both versions run as static
-          # service containers below — 10.11 on host port 3306, 11 on 3307 — so
-          # the image stays a literal tag; a ${{ }} expression in image: is
-          # flagged by zizmor as an unpinned reference. Each entry's db_url
-          # targets the right port.
+          # changes, so the extra entry rarely runs). All db entries run as
+          # static service containers below — 10.11 on host port 3306, 11 on
+          # 3307, MySQL on 3308 — so the image stays a literal tag; a ${{ }}
+          # expression in image: is flagged by zizmor as an unpinned reference.
+          # Each entry's db_url targets the right port.
           - label: MariaDB 10.11
             db_url: "mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3306/privacyidea_migration_test"
             pip_extra: "PyMySQL"
 
           - label: MariaDB 11
             db_url: "mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3307/privacyidea_migration_test"
+            pip_extra: "PyMySQL"
+
+          # Real MySQL has no CREATE SEQUENCE at all (unlike MariaDB 10.3+), so
+          # it exercises the sequence-less fallback branch of the migration
+          # helpers in privacyidea/models/db.py.
+          - label: MySQL 8.4
+            db_url: "mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3308/privacyidea_migration_test"
             pip_extra: "PyMySQL"
 
           - label: PostgreSQL
@@ -95,6 +102,21 @@ jobs:
           - 3307:3306
         options: >-
           --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: privacyidea_migration_test
+          MYSQL_USER: privacyidea
+          MYSQL_PASSWORD: privacyidea
+        ports:
+          - 3308:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=10
@@ -145,18 +167,19 @@ jobs:
         run: |
           python -b -m pytest -v --tb=short -m migration tests/test_migrations.py tests/test_migration_*.py
 
-      # pi-manage backup shells out to mysqldump/mysql. Install MariaDB's client
-      # (which provides the mysqldump compat name) and fail loudly if it is
+      # pi-manage backup shells out to mysqldump/mysql, which applies to both
+      # MariaDB and real MySQL. Install MariaDB's client (which provides the
+      # mysqldump compat name and talks to both) and fail loudly if it is
       # missing, so the round-trip below runs for real instead of self-skipping.
       - name: Install MariaDB client for backup round-trip
-        if: startsWith(matrix.db.label, 'MariaDB')
+        if: startsWith(matrix.db.label, 'MariaDB') || startsWith(matrix.db.label, 'MySQL')
         run: |
           sudo apt-get update
           sudo apt-get install -y mariadb-client
           mysqldump --version
 
       - name: Run backup/restore round-trip test
-        if: startsWith(matrix.db.label, 'MariaDB')
+        if: startsWith(matrix.db.label, 'MariaDB') || startsWith(matrix.db.label, 'MySQL')
         env:
           TEST_DATABASE_URL: ${{ matrix.db.db_url }}
           PYTHONWARNINGS: "once::DeprecationWarning"

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -167,16 +167,23 @@ jobs:
         run: |
           python -b -m pytest -v --tb=short -m migration tests/test_migrations.py tests/test_migration_*.py
 
-      # pi-manage backup shells out to mysqldump/mysql, which applies to both
-      # MariaDB and real MySQL. Install MariaDB's client (which provides the
-      # mysqldump compat name and talks to both) and fail loudly if it is
-      # missing, so the round-trip below runs for real instead of self-skipping.
+      # pi-manage backup shells out to mysqldump/mysql. mariadb-client and Ubuntu's
+      # mysql-client-core-8.0 (preinstalled on the runner) both provide/conflict on the
+      # same virtual package, so installing mariadb-client on the MySQL row would remove
+      # the real MySQL client and silently replace mysqldump with MariaDB's build --
+      # testing MariaDB's dumper against a MySQL server instead of MySQL's own tooling.
+      # Only install for MariaDB; the MySQL row already has its own client preinstalled.
       - name: Install MariaDB client for backup round-trip
-        if: startsWith(matrix.db.label, 'MariaDB') || startsWith(matrix.db.label, 'MySQL')
+        if: startsWith(matrix.db.label, 'MariaDB')
         run: |
           sudo apt-get update
           sudo apt-get install -y mariadb-client
-          mysqldump --version
+
+      # Fail loudly if a dump client is missing, so the round-trip below runs for real
+      # instead of self-skipping.
+      - name: Verify a dump client is present
+        if: startsWith(matrix.db.label, 'MariaDB') || startsWith(matrix.db.label, 'MySQL')
+        run: mysqldump --version
 
       - name: Run backup/restore round-trip test
         if: startsWith(matrix.db.label, 'MariaDB') || startsWith(matrix.db.label, 'MySQL')

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -17,6 +17,24 @@ services:
       timeout: 5s
       retries: 10
 
+  mysql-test:
+    # DB URI: mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3308/privacyidea_test
+    image: mysql:8.4
+    container_name: pi-mysql-test
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: privacyidea_test
+      MYSQL_USER: privacyidea
+      MYSQL_PASSWORD: privacyidea
+    ports:
+      - "3308:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping"]
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   openldap-test:
     # ldap://127.0.0.1:1389 / ldaps://127.0.0.1:1636 (self-signed cert, auto-generated)
     # Bind DN: cn=admin,dc=example,dc=org   Password: admin

--- a/privacyidea/lib/usersetting.py
+++ b/privacyidea/lib/usersetting.py
@@ -105,10 +105,9 @@ class SettingsSubject:
 
         A local admin needs a username; a resolver user needs both a user_id
         and a realm_id. An unresolved user has an empty user_id (and possibly a
-        NULL realm_id), and since SQL treats NULLs in the unique key as
-        distinct, keying a row on those empty values would make every
-        unresolved principal share one row (cross-user leak). Mirrors
-        ``User._require_resolved_for_write``.
+        NULL realm_id); keying a row on those empty values would make every
+        unresolved principal hash to the same ``subject_hash`` and share one
+        row (cross-user leak). Mirrors ``User._require_resolved_for_write``.
         """
         if self.subject_type == SUBJECT_LOCAL_ADMIN:
             return bool(self.username)
@@ -242,9 +241,8 @@ def set_user_settings(subject: SettingsSubject, settings: dict, replace: bool = 
         row.save()
     except IntegrityError:
         # A concurrent request created the row between our SELECT and INSERT
-        # (the unique constraint fires for resolver users; for local admins the
-        # NULL realm_id makes the key non-unique, so that race can still leave a
-        # duplicate row). Recover by re-reading and applying the update.
+        # (uq_usersetting_subject fires for both local admins and resolver
+        # users). Recover by re-reading and applying the update.
         db.session.rollback()
         row = db.session.scalars(_select_for_subject(subject).with_for_update()).first()
         if row is None:

--- a/privacyidea/migrations/versions/c2d3e4f5a6b7_metric_aggregate.py
+++ b/privacyidea/migrations/versions/c2d3e4f5a6b7_metric_aggregate.py
@@ -49,8 +49,11 @@ def upgrade():
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("metric_name", sa.Unicode(length=128), nullable=False),
         # Full label payload: JSON blob with sorted keys; can be arbitrarily
-        # long (resolver names + types + ops + identifiers etc).
-        sa.Column("labels_key", sa.Text(), nullable=False, server_default=""),
+        # long (resolver names + types + ops + identifiers etc). No
+        # server_default: real MySQL rejects a literal default on a TEXT
+        # column outright (ERROR 1101), and every caller (_apply_aggregate)
+        # always supplies labels_key explicitly.
+        sa.Column("labels_key", sa.Text(), nullable=False),
         # Fixed-size hex digest (SHA-256) of labels_key, used by the unique
         # constraint so the composite index stays under MySQL's 3072-byte
         # limit regardless of how long labels_key grows.

--- a/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
+++ b/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
@@ -35,13 +35,21 @@ def upgrade():
             sa.Column('user_id', sa.Unicode(length=320), nullable=True),
             sa.Column('resolver', sa.Unicode(length=120), nullable=True),
             sa.Column('realm_id', sa.Integer(), nullable=True),
+            # SHA-256 hex digest of the five columns above (see
+            # privacyidea.models.usersetting._compute_subject_hash). A raw
+            # composite UNIQUE constraint over them is 3124 bytes under
+            # utf8mb4 -- over MySQL's 3072-byte index-key limit -- so the
+            # constraint below is on this fixed-width hash instead.
+            sa.Column('subject_hash', sa.Unicode(length=64), nullable=False),
             sa.Column('settings', sa.JSON(), nullable=True),
             sa.Column('last_modified', sa.DateTime(), nullable=True),
             sa.Column('node', sa.Unicode(length=120), nullable=True),
             sa.ForeignKeyConstraint(['realm_id'], ['realm.id'], ondelete='CASCADE'),
             sa.PrimaryKeyConstraint('id'),
-            sa.UniqueConstraint('subject_type', 'username', 'user_id', 'resolver', 'realm_id',
-                                name='uq_usersetting_subject'),
+            sa.UniqueConstraint('subject_hash', name='uq_usersetting_subject'),
+            # Serves the local-admin lookup on (subject_type, username), which
+            # subject_hash is not a prefix of.
+            sa.Index('ix_usersetting_subject_type_username', 'subject_type', 'username'),
             # Serves the resolver-user lookup, which keys on
             # (user_id, resolver, realm_id) and is not a prefix of the unique key.
             sa.Index('ix_usersetting_user', 'user_id', 'resolver', 'realm_id'),

--- a/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
+++ b/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
@@ -35,11 +35,12 @@ def upgrade():
             sa.Column('user_id', sa.Unicode(length=320), nullable=True),
             sa.Column('resolver', sa.Unicode(length=120), nullable=True),
             sa.Column('realm_id', sa.Integer(), nullable=True),
-            # SHA-256 hex digest of the five columns above (see
-            # privacyidea.models.usersetting._compute_subject_hash). A raw
-            # composite UNIQUE constraint over them is 3124 bytes under
-            # utf8mb4 -- over MySQL's 3072-byte index-key limit -- so the
-            # constraint below is on this fixed-width hash instead.
+            # SHA-256 hex digest of a subset of the columns above, per
+            # subject_type (see privacyidea.models.usersetting.
+            # _compute_subject_hash). A raw composite UNIQUE constraint over
+            # all five columns is 3124 bytes under utf8mb4 -- over MySQL's
+            # 3072-byte index-key limit -- so the constraint below is on this
+            # fixed-width hash instead.
             sa.Column('subject_hash', sa.Unicode(length=64), nullable=False),
             sa.Column('settings', sa.JSON(), nullable=True),
             sa.Column('last_modified', sa.DateTime(), nullable=True),

--- a/privacyidea/models/usersetting.py
+++ b/privacyidea/models/usersetting.py
@@ -37,6 +37,11 @@ from privacyidea.models.utils import MethodsMixin, utc_now
 log = logging.getLogger(__name__)
 
 
+# Must match privacyidea.lib.usersetting.SUBJECT_LOCAL_ADMIN. Duplicated as a
+# literal (rather than imported) because lib.usersetting imports this module.
+_SUBJECT_LOCAL_ADMIN = "local_admin"
+
+
 def _compute_subject_hash(subject_type: str, username: str | None, user_id: str | None,
                           resolver: str | None, realm_id: int | None) -> str:
     """SHA-256 hex digest identifying a principal, for ``uq_usersetting_subject``.
@@ -44,20 +49,32 @@ def _compute_subject_hash(subject_type: str, username: str | None, user_id: str 
     A raw composite UNIQUE constraint over the five identity columns is 3124
     bytes wide under utf8mb4 (username/user_id alone are Unicode(320) each) --
     over MySQL's 3072-byte index-key limit, and MySQL rejects the CREATE TABLE
-    outright. Hashing the tuple keeps the constraint at a fixed 64 bytes
-    regardless of column widths. It also, as a side effect, makes the
-    constraint fire for local admins (realm_id NULL) too: NULL is only
-    "distinct from itself" in SQL when it appears as a raw column value, not
-    once folded into this hash.
+    outright. Hashing keeps the constraint at a fixed 64 bytes regardless of
+    column widths, and (since a hash is never NULL) makes it fire for local
+    admins too: a raw NULL realm_id is "distinct from itself" in SQL, a hashed
+    one is not.
+
+    Only the fields that actually identify each subject type go into the
+    hash: ``username`` for a local admin, ``(user_id, resolver, realm_id)``
+    for a resolver user. ``username`` is deliberately excluded for resolver
+    users -- it is a convenience copy of the login the principal used to
+    authenticate, not their identity, and a resolver may expose more than one
+    login name for the same uid (see ``UserIdResolver.has_multiple_loginnames``
+    and ``User._get_user_from_userstore``). Hashing it in would let two writes
+    through two different aliases of the same user hash differently and race
+    past this constraint instead of colliding into one row.
+
+    Each field is length-prefixed before joining, so no combination of field
+    values (e.g. one containing what looks like a separator) can serialize to
+    the same string as a different tuple.
     """
-    identity = "\x1f".join([
-        subject_type or "",
-        username or "",
-        user_id or "",
-        resolver or "",
-        str(realm_id) if realm_id is not None else "",
-    ])
-    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    if subject_type == _SUBJECT_LOCAL_ADMIN:
+        fields = [subject_type, username or ""]
+    else:
+        fields = [subject_type, user_id or "", resolver or "",
+                  str(realm_id) if realm_id is not None else ""]
+    encoded = "".join(f"{len(field)}:{field}" for field in fields)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 class UserSetting(MethodsMixin, db.Model):
@@ -106,9 +123,9 @@ class UserSetting(MethodsMixin, db.Model):
     user_id: Mapped[str | None] = mapped_column(Unicode(320), default='')
     resolver: Mapped[str | None] = mapped_column(Unicode(120), default='')
     realm_id: Mapped[int | None] = mapped_column(Integer, ForeignKey('realm.id', ondelete='CASCADE'))
-    # SHA-256 hex digest of the five columns above, computed in __init__. See
-    # _compute_subject_hash for why the unique constraint is on this instead
-    # of the raw columns.
+    # SHA-256 hex digest of the identity fields above, computed in __init__.
+    # See _compute_subject_hash for exactly which fields per subject_type, and
+    # why the unique constraint is on this instead of the raw columns.
     subject_hash: Mapped[str] = mapped_column(Unicode(64), nullable=False)
     settings: Mapped[Any | None] = mapped_column(JSON, nullable=True)
     last_modified: Mapped[datetime | None] = mapped_column(

--- a/privacyidea/models/usersetting.py
+++ b/privacyidea/models/usersetting.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import hashlib
 import logging
 from datetime import datetime
 from typing import Any
@@ -34,6 +35,29 @@ from privacyidea.models import db
 from privacyidea.models.utils import MethodsMixin, utc_now
 
 log = logging.getLogger(__name__)
+
+
+def _compute_subject_hash(subject_type: str, username: str | None, user_id: str | None,
+                          resolver: str | None, realm_id: int | None) -> str:
+    """SHA-256 hex digest identifying a principal, for ``uq_usersetting_subject``.
+
+    A raw composite UNIQUE constraint over the five identity columns is 3124
+    bytes wide under utf8mb4 (username/user_id alone are Unicode(320) each) --
+    over MySQL's 3072-byte index-key limit, and MySQL rejects the CREATE TABLE
+    outright. Hashing the tuple keeps the constraint at a fixed 64 bytes
+    regardless of column widths. It also, as a side effect, makes the
+    constraint fire for local admins (realm_id NULL) too: NULL is only
+    "distinct from itself" in SQL when it appears as a raw column value, not
+    once folded into this hash.
+    """
+    identity = "\x1f".join([
+        subject_type or "",
+        username or "",
+        user_id or "",
+        resolver or "",
+        str(realm_id) if realm_id is not None else "",
+    ])
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
 
 
 class UserSetting(MethodsMixin, db.Model):
@@ -65,15 +89,14 @@ class UserSetting(MethodsMixin, db.Model):
     __table_args__ = (
         # One settings document per principal. For local admins only username is
         # set; for users the (user_id, resolver, realm_id) tuple identifies the
-        # row. Uniqueness for local admins (realm_id NULL) is additionally
-        # guaranteed by the get-or-create logic in lib.usersetting, since SQL
-        # treats NULLs in a unique key as distinct.
-        UniqueConstraint('subject_type', 'username', 'user_id', 'resolver', 'realm_id',
-                         name='uq_usersetting_subject'),
-        # The local-admin lookup (subject_type, username) uses the unique key's
-        # leading prefix, but the resolver-user lookup keys on
-        # (user_id, resolver, realm_id) -- which is not a prefix of the unique
-        # key -- so it gets its own index to stay seekable as the table grows.
+        # row. The constraint is on subject_hash rather than the raw columns --
+        # see _compute_subject_hash for why.
+        UniqueConstraint('subject_hash', name='uq_usersetting_subject'),
+        # subject_hash makes the local-admin lookup (subject_type, username) no
+        # longer a prefix of the unique key, so it gets its own index -- mirrors
+        # ix_usersetting_user below, which does the same for the resolver-user
+        # lookup on (user_id, resolver, realm_id).
+        db.Index('ix_usersetting_subject_type_username', 'subject_type', 'username'),
         db.Index('ix_usersetting_user', 'user_id', 'resolver', 'realm_id'),
     )
 
@@ -83,6 +106,10 @@ class UserSetting(MethodsMixin, db.Model):
     user_id: Mapped[str | None] = mapped_column(Unicode(320), default='')
     resolver: Mapped[str | None] = mapped_column(Unicode(120), default='')
     realm_id: Mapped[int | None] = mapped_column(Integer, ForeignKey('realm.id', ondelete='CASCADE'))
+    # SHA-256 hex digest of the five columns above, computed in __init__. See
+    # _compute_subject_hash for why the unique constraint is on this instead
+    # of the raw columns.
+    subject_hash: Mapped[str] = mapped_column(Unicode(64), nullable=False)
     settings: Mapped[Any | None] = mapped_column(JSON, nullable=True)
     last_modified: Mapped[datetime | None] = mapped_column(
         DateTime,
@@ -98,5 +125,6 @@ class UserSetting(MethodsMixin, db.Model):
         self.user_id = user_id
         self.resolver = resolver
         self.realm_id = realm_id
+        self.subject_hash = _compute_subject_hash(subject_type, username, user_id, resolver, realm_id)
         self.settings = settings
         self.node = node

--- a/tests/cli/test_backup_roundtrip.py
+++ b/tests/cli/test_backup_roundtrip.py
@@ -54,16 +54,22 @@ def _run_pimanage(args, config_file):
 
 def test_backup_restore_roundtrip(tmp_path):
     engine = create_engine(DB_URL)
+    # Real MySQL has no CREATE SEQUENCE at all, unlike MariaDB 10.3+ -- so the
+    # Galera-specific sequence checks below only apply where the dialect
+    # actually supports them. The table/row round trip still runs everywhere.
+    with engine.connect() as conn:
+        has_sequences = conn.dialect.supports_sequences
 
-    # 1. Seed a sentinel table plus a sequence. INCREMENT BY 0 is required to
-    #    create a cached sequence on a Galera cluster (and behaves like the
-    #    default increment on a standalone server), so the seed loads on both —
-    #    and the sequence is exactly what made mysqldump's default LOCK TABLES
-    #    fail on Galera.
+    # 1. Seed a sentinel table plus, on MariaDB, a sequence. INCREMENT BY 0 is
+    #    required to create a cached sequence on a Galera cluster (and behaves
+    #    like the default increment on a standalone server), so the seed loads
+    #    on both -- and the sequence is exactly what made mysqldump's default
+    #    LOCK TABLES fail on Galera.
     with engine.begin() as conn:
         conn.execute(text("DROP TABLE IF EXISTS backup_roundtrip"))
-        conn.execute(text("DROP SEQUENCE IF EXISTS backup_rt_seq"))
-        conn.execute(text("CREATE SEQUENCE backup_rt_seq START WITH 7 INCREMENT BY 0"))
+        if has_sequences:
+            conn.execute(text("DROP SEQUENCE IF EXISTS backup_rt_seq"))
+            conn.execute(text("CREATE SEQUENCE backup_rt_seq START WITH 7 INCREMENT BY 0"))
         conn.execute(text("CREATE TABLE backup_roundtrip (id INTEGER PRIMARY KEY, val VARCHAR(50))"))
         conn.execute(text("INSERT INTO backup_roundtrip (id, val) VALUES (1, 'sentinel')"))
 
@@ -93,7 +99,8 @@ def test_backup_restore_roundtrip(tmp_path):
         # 4. Disaster: drop the seeded objects.
         with engine.begin() as conn:
             conn.execute(text("DROP TABLE backup_roundtrip"))
-            conn.execute(text("DROP SEQUENCE backup_rt_seq"))
+            if has_sequences:
+                conn.execute(text("DROP SEQUENCE backup_rt_seq"))
 
         # 5. Restore. --keep-db-uri keeps the (identical) live URI, which also
         #    avoids depending on the absolute paths baked into the archived pi.cfg.
@@ -101,18 +108,21 @@ def test_backup_restore_roundtrip(tmp_path):
             ["backup", "restore", "--keep-db-uri", str(archives[0])], pi_cfg)
         assert result.returncode == 0, result.stdout + result.stderr
 
-        # 6. Verify the row and the sequence are back.
+        # 6. Verify the row (and, on MariaDB, the sequence) are back.
         with engine.connect() as conn:
             val = conn.execute(
                 text("SELECT val FROM backup_roundtrip WHERE id = 1")).scalar()
-            seq_count = conn.execute(text(
-                "SELECT COUNT(*) FROM information_schema.tables "
-                "WHERE table_schema = DATABASE() AND table_type = 'SEQUENCE' "
-                "AND table_name = 'backup_rt_seq'")).scalar()
+            if has_sequences:
+                seq_count = conn.execute(text(
+                    "SELECT COUNT(*) FROM information_schema.tables "
+                    "WHERE table_schema = DATABASE() AND table_type = 'SEQUENCE' "
+                    "AND table_name = 'backup_rt_seq'")).scalar()
         assert val == "sentinel", f"sentinel row was not restored (got {val!r})"
-        assert seq_count == 1, "sequence backup_rt_seq was not restored"
+        if has_sequences:
+            assert seq_count == 1, "sequence backup_rt_seq was not restored"
     finally:
         with engine.begin() as conn:
             conn.execute(text("DROP TABLE IF EXISTS backup_roundtrip"))
-            conn.execute(text("DROP SEQUENCE IF EXISTS backup_rt_seq"))
+            if has_sequences:
+                conn.execute(text("DROP SEQUENCE IF EXISTS backup_rt_seq"))
         engine.dispose()

--- a/tests/migration_test_utils.py
+++ b/tests/migration_test_utils.py
@@ -5,6 +5,7 @@ See tests/README.md for the full guide on when a per-migration test is
 required and how to write one.
 """
 
+import functools
 import os
 import pathlib
 
@@ -29,6 +30,23 @@ def is_oracle(db_url: str = DB_URL) -> bool:
     return db_url.startswith("oracle")
 
 
+@functools.cache
+def is_mariadb(db_url: str = DB_URL) -> bool:
+    """Tell MariaDB apart from real MySQL behind a shared mysql+pymysql:// URL.
+
+    Both engines connect through the identical URL scheme, so the connection
+    string alone cannot distinguish them — the server's own version string
+    (inspected by SQLAlchemy on first connect) is the only reliable signal.
+    Cached because callers (get_seed_path) run once per test.
+    """
+    engine = create_engine(db_url)
+    try:
+        with engine.connect() as conn:
+            return bool(conn.dialect.is_mariadb)
+    finally:
+        engine.dispose()
+
+
 def get_alembic_cfg(db_url: str = DB_URL) -> AlembicConfig:
     migrations_dir = str(pathlib.Path(__file__).parent.parent / "privacyidea" / "migrations")
     cfg = AlembicConfig(str(pathlib.Path(migrations_dir) / "alembic.ini"))
@@ -43,8 +61,10 @@ def get_seed_path(revision: str = START_REVISION, db_url: str = DB_URL) -> pathl
         dialect = "postgresql"
     elif is_oracle(db_url):
         dialect = "oracle"
-    else:
+    elif is_mariadb(db_url):
         dialect = "mariadb"
+    else:
+        dialect = "mysql"
     # Seeds follow the naming convention:  seed_v<ver>_<revision>_<dialect>.sql
     # Glob for any file that matches the revision + dialect regardless of version tag.
     matches = list(SEED_SQL_DIR.glob(f"*_{revision}_{dialect}.sql"))

--- a/tests/testdata/migrations/README.md
+++ b/tests/testdata/migrations/README.md
@@ -13,7 +13,7 @@ seed_v<version>_<revision>_<dialect>.sql
 |---|---|---|
 | `version` | `v3.9` | privacyIDEA release the seed was generated from |
 | `revision` | `5cb310101a1f` | Alembic revision ID the seed brings the DB to |
-| `dialect` | `mariadb` / `postgresql` / `oracle` | Target database dialect |
+| `dialect` | `mariadb` / `mysql` / `postgresql` / `oracle` | Target database dialect |
 
 Example: `seed_v3.9_5cb310101a1f_mariadb.sql`
 
@@ -25,32 +25,55 @@ created before the tables). The migration test suite drives Oracle when
 `TEST_DATABASE_URL` starts with `oracle` — `docker-compose.dev.yml` provides a
 matching `oracle-test` (gvenzl/oracle-xe:21-slim) container.
 
+MariaDB and MySQL both connect through the identical `mysql+pymysql://` URL
+scheme, so `TEST_DATABASE_URL` alone cannot tell them apart. `get_seed_path()`
+in `tests/migration_test_utils.py` picks between the `mariadb` and `mysql`
+seed files by probing the live server's version string on first connect
+(`migration_test_utils.is_mariadb()`), not by matching the URL.
+
+The `mysql` seed's schema DDL is byte-identical to the `mariadb` one — both
+are rendered from the generic, non-live `mysql+pymysql` dialect and diverge
+only in the hand-extended data section, where the two engines are genuinely
+incompatible:
+
+* **Sequences.** MariaDB 10.3+ supports `CREATE SEQUENCE`; real MySQL never
+  has, in any version. The `mariadb` seed bakes in one `CREATE SEQUENCE` per
+  integer-PK table (see the comment above that section for why); the `mysql`
+  seed omits the whole block, matching what a real MySQL install upgraded
+  through this revision actually looks like.
+* **Literal defaults on TEXT/BLOB/JSON columns.** MariaDB has allowed these
+  since 10.2; real MySQL rejects them outright with `ERROR 1101`, even inside
+  `CREATE TABLE IF NOT EXISTS` against an already-existing table. The three
+  `LONGTEXT` `Value` columns (`tokeninfo`, `smsgatewayoption`,
+  `customuserattribute`) drop their `DEFAULT ''` in the `mysql` seed.
+
 ## Generating seeds
 
 Use `tools/generate_seed_sql.py` to generate seeds from a historical version
-of the models.  The tool can target a git tag or work from a local file:
+of the models. The tool can load a single historical `models.py` (extracted
+from a git tag) or the current split `models/` package:
 
 ```bash
-# From a git tag (e.g. v3.9) using the single historical models.py:
-python tools/generate_seed_sql.py \
-    --git-tag v3.9 \
-    --file privacyidea/models.py \
-    --dialect mariadb \
-    --revision 5cb310101a1f \
-    --output tests/testdata/migrations/
+# Extract a historical single-file models.py from a git tag:
+git show v3.9.3:privacyidea/models.py > /tmp/models_v3.9.py
 
-# From the current split models directory:
-python tools/generate_seed_sql.py \
-    --dir privacyidea/models/ \
-    --dialect postgresql \
-    --revision 5cb310101a1f \
-    --output tests/testdata/migrations/
+# Generate seeds for all dialects:
+python tools/generate_seed_sql.py /tmp/models_v3.9.py mariadb \
+    tests/testdata/migrations/seed_v3.9_5cb310101a1f_mariadb.sql
+python tools/generate_seed_sql.py /tmp/models_v3.9.py mysql \
+    tests/testdata/migrations/seed_v3.9_5cb310101a1f_mysql.sql
+python tools/generate_seed_sql.py /tmp/models_v3.9.py postgresql \
+    tests/testdata/migrations/seed_v3.9_5cb310101a1f_postgresql.sql
+
+# From the current split models/ package instead of a historical tag:
+python tools/generate_seed_sql.py privacyidea/models/ postgresql out.sql
 ```
 
 The tool emits the schema DDL (the Oracle dialect also injects
 `DEFAULT <seq>.nextval` on sequence-backed PK columns); the committed seeds were
 then hand-extended with representative `INSERT` rows, `START WITH` values on the
-sequences, and the `alembic_version` stamp.
+MariaDB sequences (omitted entirely for MySQL — see above), and the
+`alembic_version` stamp.
 
 ## Updating the seed pin
 

--- a/tests/testdata/migrations/seed_v3.9_5cb310101a1f_mysql.sql
+++ b/tests/testdata/migrations/seed_v3.9_5cb310101a1f_mysql.sql
@@ -1,0 +1,1283 @@
+-- Auto-generated MySQL seed SQL
+-- Source: SQLAlchemy metadata
+--
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE `admin` (
+	username VARCHAR(120) NOT NULL, 
+	password VARCHAR(255), 
+	email VARCHAR(255), 
+	PRIMARY KEY (username)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE authcache (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	first_auth DATETIME(6), 
+	last_auth DATETIME(6), 
+	username VARCHAR(64), 
+	resolver VARCHAR(120), 
+	realm VARCHAR(120), 
+	client_ip VARCHAR(40), 
+	user_agent VARCHAR(120), 
+	auth_count INTEGER, 
+	authentication VARCHAR(255), 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE caconnector (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	name VARCHAR(255) NOT NULL, 
+	catype VARCHAR(255) NOT NULL, 
+	PRIMARY KEY (id), 
+	UNIQUE (name)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE challenge (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	transaction_id VARCHAR(64) NOT NULL, 
+	data VARCHAR(512), 
+	challenge VARCHAR(512), 
+	`session` VARCHAR(512), 
+	serial VARCHAR(40), 
+	timestamp DATETIME(6), 
+	expiration DATETIME(6), 
+	received_count INTEGER, 
+	otp_valid BOOL, 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE clientapplication (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	ip VARCHAR(255) NOT NULL, 
+	hostname VARCHAR(255), 
+	clienttype VARCHAR(255) NOT NULL, 
+	lastseen DATETIME(6), 
+	node VARCHAR(255) NOT NULL, 
+	PRIMARY KEY (id), 
+	CONSTRAINT caix UNIQUE (ip, clienttype, node)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE config (
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` VARCHAR(2000), 
+	`Type` VARCHAR(2000), 
+	`Description` VARCHAR(2000), 
+	PRIMARY KEY (`Key`)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE eventcounter (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	counter_name VARCHAR(80) NOT NULL, 
+	counter_value INTEGER, 
+	node VARCHAR(255) NOT NULL, 
+	PRIMARY KEY (id), 
+	CONSTRAINT evctr_1 UNIQUE (counter_name, node)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE eventhandler (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	name VARCHAR(64), 
+	active BOOL, 
+	ordering INTEGER NOT NULL, 
+	position VARCHAR(10), 
+	event VARCHAR(255) NOT NULL, 
+	handlermodule VARCHAR(255) NOT NULL, 
+	`condition` VARCHAR(1024), 
+	action VARCHAR(1024), 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE machineresolver (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	name VARCHAR(255) NOT NULL, 
+	rtype VARCHAR(255) NOT NULL, 
+	PRIMARY KEY (id), 
+	UNIQUE (name)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE monitoringstats (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	timestamp DATETIME(6) NOT NULL, 
+	stats_key VARCHAR(128) NOT NULL, 
+	stats_value INTEGER NOT NULL, 
+	PRIMARY KEY (id), 
+	CONSTRAINT msix_1 UNIQUE (timestamp, stats_key)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE passwordreset (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	recoverycode VARCHAR(255) NOT NULL, 
+	username VARCHAR(64) NOT NULL, 
+	realm VARCHAR(64) NOT NULL, 
+	resolver VARCHAR(64), 
+	email VARCHAR(255), 
+	timestamp DATETIME(6), 
+	expiration DATETIME(6), 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE periodictask (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	name VARCHAR(64) NOT NULL, 
+	active BOOL NOT NULL, 
+	retry_if_failed BOOL NOT NULL, 
+	`interval` VARCHAR(256) NOT NULL, 
+	nodes VARCHAR(256) NOT NULL, 
+	taskmodule VARCHAR(256) NOT NULL, 
+	ordering INTEGER NOT NULL, 
+	last_update DATETIME(6) NOT NULL, 
+	PRIMARY KEY (id), 
+	UNIQUE (name)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE pidea_audit (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	date DATETIME(6), 
+	startdate DATETIME(6), 
+	duration DATETIME(6), 
+	signature VARCHAR(620), 
+	action VARCHAR(50), 
+	success INTEGER, 
+	serial VARCHAR(40), 
+	token_type VARCHAR(12), 
+	user VARCHAR(20), 
+	realm VARCHAR(20), 
+	resolver VARCHAR(50), 
+	administrator VARCHAR(20), 
+	action_detail VARCHAR(50), 
+	info VARCHAR(50), 
+	privacyidea_server VARCHAR(255), 
+	client VARCHAR(50), 
+	loglevel VARCHAR(12), 
+	clearance_level VARCHAR(12), 
+	thread_id VARCHAR(20), 
+	policies VARCHAR(255), 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE policy (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	active BOOL, 
+	check_all_resolvers BOOL, 
+	name VARCHAR(64) NOT NULL, 
+	scope VARCHAR(32) NOT NULL, 
+	action VARCHAR(2000), 
+	realm VARCHAR(256), 
+	adminrealm VARCHAR(256), 
+	adminuser VARCHAR(256), 
+	resolver VARCHAR(256), 
+	pinode VARCHAR(256), 
+	user VARCHAR(256), 
+	client VARCHAR(256), 
+	time VARCHAR(64), 
+	priority INTEGER NOT NULL, 
+	PRIMARY KEY (id), 
+	UNIQUE (name)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE privacyideaserver (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	identifier VARCHAR(255) NOT NULL, 
+	url VARCHAR(255) NOT NULL, 
+	tls BOOL, 
+	description VARCHAR(2000), 
+	PRIMARY KEY (id), 
+	UNIQUE (identifier)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE radiusserver (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	identifier VARCHAR(255) NOT NULL, 
+	server VARCHAR(255) NOT NULL, 
+	port INTEGER, 
+	secret VARCHAR(255), 
+	dictionary VARCHAR(255), 
+	description VARCHAR(2000), 
+	timeout INTEGER, 
+	retries INTEGER, 
+	PRIMARY KEY (id), 
+	UNIQUE (identifier)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE realm (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	name VARCHAR(255) NOT NULL, 
+	`default` BOOL, 
+	`option` VARCHAR(40), 
+	PRIMARY KEY (id), 
+	UNIQUE (name)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE resolver (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	name VARCHAR(255) NOT NULL, 
+	rtype VARCHAR(255) NOT NULL, 
+	PRIMARY KEY (id), 
+	UNIQUE (name)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE serviceid (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	name VARCHAR(255) NOT NULL, 
+	`Description` VARCHAR(2000), 
+	PRIMARY KEY (id), 
+	UNIQUE (name)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE smsgateway (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	identifier VARCHAR(255) NOT NULL, 
+	description VARCHAR(1024), 
+	providermodule VARCHAR(1024) NOT NULL, 
+	PRIMARY KEY (id), 
+	UNIQUE (identifier)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE smtpserver (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	identifier VARCHAR(255) NOT NULL, 
+	server VARCHAR(255) NOT NULL, 
+	port INTEGER, 
+	username VARCHAR(255), 
+	password VARCHAR(255), 
+	sender VARCHAR(255), 
+	tls BOOL, 
+	description VARCHAR(2000), 
+	timeout INTEGER, 
+	enqueue_job BOOL NOT NULL, 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE subscription (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	application VARCHAR(80), 
+	for_name VARCHAR(80) NOT NULL, 
+	for_address VARCHAR(128), 
+	for_email VARCHAR(128) NOT NULL, 
+	for_phone VARCHAR(50) NOT NULL, 
+	for_url VARCHAR(80), 
+	for_comment VARCHAR(255), 
+	by_name VARCHAR(50) NOT NULL, 
+	by_email VARCHAR(128) NOT NULL, 
+	by_address VARCHAR(128), 
+	by_phone VARCHAR(50), 
+	by_url VARCHAR(80), 
+	date_from DATETIME(6), 
+	date_till DATETIME(6), 
+	num_users INTEGER, 
+	num_tokens INTEGER, 
+	num_clients INTEGER, 
+	level VARCHAR(80), 
+	signature VARCHAR(640), 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE token (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	description VARCHAR(80), 
+	serial VARCHAR(40) NOT NULL, 
+	tokentype VARCHAR(30), 
+	user_pin VARCHAR(512), 
+	user_pin_iv VARCHAR(32), 
+	so_pin VARCHAR(512), 
+	so_pin_iv VARCHAR(32), 
+	pin_seed VARCHAR(32), 
+	otplen INTEGER, 
+	pin_hash VARCHAR(512), 
+	key_enc VARCHAR(2800), 
+	key_iv VARCHAR(32), 
+	maxfail INTEGER, 
+	active BOOL NOT NULL, 
+	revoked BOOL, 
+	locked BOOL, 
+	failcount INTEGER, 
+	count INTEGER, 
+	count_window INTEGER, 
+	sync_window INTEGER, 
+	rollout_state VARCHAR(10), 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE tokengroup (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	name VARCHAR(255) NOT NULL, 
+	`Description` VARCHAR(2000), 
+	PRIMARY KEY (id), 
+	UNIQUE (name)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE usercache (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	username VARCHAR(64), 
+	used_login VARCHAR(64), 
+	resolver VARCHAR(120), 
+	user_id VARCHAR(320), 
+	timestamp DATETIME(6), 
+	PRIMARY KEY (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE caconnectorconfig (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	caconnector_id INTEGER, 
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` VARCHAR(2000), 
+	`Type` VARCHAR(2000), 
+	`Description` VARCHAR(2000), 
+	PRIMARY KEY (id), 
+	CONSTRAINT ccix_2 UNIQUE (caconnector_id, `Key`), 
+	FOREIGN KEY(caconnector_id) REFERENCES caconnector (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE customuserattribute (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	user_id VARCHAR(320), 
+	resolver VARCHAR(120), 
+	realm_id INTEGER, 
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` TEXT, 
+	`Type` VARCHAR(100), 
+	PRIMARY KEY (id), 
+	FOREIGN KEY(realm_id) REFERENCES realm (id)
+);
+
+CREATE TABLE eventhandlercondition (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	eventhandler_id INTEGER, 
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` VARCHAR(2000), 
+	comparator VARCHAR(255), 
+	PRIMARY KEY (id), 
+	CONSTRAINT ehcix_1 UNIQUE (eventhandler_id, `Key`), 
+	FOREIGN KEY(eventhandler_id) REFERENCES eventhandler (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE eventhandleroption (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	eventhandler_id INTEGER, 
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` VARCHAR(2000), 
+	`Type` VARCHAR(2000), 
+	`Description` VARCHAR(2000), 
+	PRIMARY KEY (id), 
+	CONSTRAINT ehoix_1 UNIQUE (eventhandler_id, `Key`), 
+	FOREIGN KEY(eventhandler_id) REFERENCES eventhandler (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE machineresolverconfig (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	resolver_id INTEGER, 
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` VARCHAR(2000), 
+	`Type` VARCHAR(2000), 
+	`Description` VARCHAR(2000), 
+	PRIMARY KEY (id), 
+	CONSTRAINT mrcix_2 UNIQUE (resolver_id, `Key`), 
+	FOREIGN KEY(resolver_id) REFERENCES machineresolver (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE machinetoken (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	token_id INTEGER, 
+	machineresolver_id INTEGER, 
+	machine_id VARCHAR(255), 
+	application VARCHAR(64), 
+	PRIMARY KEY (id), 
+	FOREIGN KEY(token_id) REFERENCES token (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE periodictasklastrun (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	periodictask_id INTEGER, 
+	node VARCHAR(255) NOT NULL, 
+	timestamp DATETIME(6) NOT NULL, 
+	PRIMARY KEY (id), 
+	CONSTRAINT ptlrix_1 UNIQUE (periodictask_id, node), 
+	FOREIGN KEY(periodictask_id) REFERENCES periodictask (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE periodictaskoption (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	periodictask_id INTEGER, 
+	`key` VARCHAR(255) NOT NULL, 
+	value VARCHAR(2000), 
+	PRIMARY KEY (id), 
+	CONSTRAINT ptoix_1 UNIQUE (periodictask_id, `key`), 
+	FOREIGN KEY(periodictask_id) REFERENCES periodictask (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE policycondition (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	policy_id INTEGER NOT NULL, 
+	section VARCHAR(255) NOT NULL, 
+	`Key` VARCHAR(255) NOT NULL, 
+	comparator VARCHAR(255) NOT NULL, 
+	`Value` VARCHAR(2000) NOT NULL, 
+	active BOOL NOT NULL, 
+	PRIMARY KEY (id), 
+	FOREIGN KEY(policy_id) REFERENCES policy (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE resolverconfig (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	resolver_id INTEGER, 
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` VARCHAR(2000), 
+	`Type` VARCHAR(2000), 
+	`Description` VARCHAR(2000), 
+	PRIMARY KEY (id), 
+	CONSTRAINT rcix_2 UNIQUE (resolver_id, `Key`), 
+	FOREIGN KEY(resolver_id) REFERENCES resolver (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE resolverrealm (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	resolver_id INTEGER, 
+	realm_id INTEGER, 
+	priority INTEGER, 
+	PRIMARY KEY (id), 
+	CONSTRAINT rrix_2 UNIQUE (resolver_id, realm_id), 
+	FOREIGN KEY(resolver_id) REFERENCES resolver (id), 
+	FOREIGN KEY(realm_id) REFERENCES realm (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE smsgatewayoption (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` TEXT, 
+	`Type` VARCHAR(100), 
+	gateway_id INTEGER, 
+	PRIMARY KEY (id), 
+	CONSTRAINT sgix_1 UNIQUE (gateway_id, `Key`, `Type`), 
+	FOREIGN KEY(gateway_id) REFERENCES smsgateway (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE tokeninfo (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	`Key` VARCHAR(255) NOT NULL, 
+	`Value` TEXT, 
+	`Type` VARCHAR(100), 
+	`Description` VARCHAR(2000), 
+	token_id INTEGER, 
+	PRIMARY KEY (id), 
+	CONSTRAINT tiix_2 UNIQUE (token_id, `Key`), 
+	FOREIGN KEY(token_id) REFERENCES token (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE tokenowner (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	token_id INTEGER, 
+	resolver VARCHAR(120), 
+	user_id VARCHAR(320), 
+	realm_id INTEGER, 
+	PRIMARY KEY (id), 
+	FOREIGN KEY(token_id) REFERENCES token (id), 
+	FOREIGN KEY(realm_id) REFERENCES realm (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE tokenrealm (
+	id INTEGER AUTO_INCREMENT, 
+	token_id INTEGER, 
+	realm_id INTEGER, 
+	PRIMARY KEY (id), 
+	CONSTRAINT trix_2 UNIQUE (token_id, realm_id), 
+	FOREIGN KEY(token_id) REFERENCES token (id), 
+	FOREIGN KEY(realm_id) REFERENCES realm (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE tokentokengroup (
+	id INTEGER AUTO_INCREMENT, 
+	token_id INTEGER, 
+	tokengroup_id INTEGER, 
+	PRIMARY KEY (id), 
+	CONSTRAINT ttgix_2 UNIQUE (token_id, tokengroup_id), 
+	FOREIGN KEY(token_id) REFERENCES token (id), 
+	FOREIGN KEY(tokengroup_id) REFERENCES tokengroup (id)
+)ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE machinetokenoptions (
+	id INTEGER NOT NULL AUTO_INCREMENT, 
+	machinetoken_id INTEGER, 
+	mt_key VARCHAR(64) NOT NULL, 
+	mt_value VARCHAR(64) NOT NULL, 
+	PRIMARY KEY (id), 
+	FOREIGN KEY(machinetoken_id) REFERENCES machinetoken (id)
+)ROW_FORMAT=DYNAMIC;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- ---------------------------------------------------------------------------
+-- Data
+-- ---------------------------------------------------------------------------
+
+INSERT INTO `config` (`Key`, `Value`, `Type`, `Description`) VALUES
+    ('PI_PEPPER',          'dGVzdHBlcHBlcg==', 'password', 'Pepper for hashing'),
+    ('DefaultOtpLen',      '6',                '',         ''),
+    ('DefaultMaxFailCount','10',               '',         ''),
+    ('__timestamp__',      '1680000000',       '',         'config timestamp. last changed.');
+
+-- ---------------------------------------------------------------------------
+-- realm
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `realm` (
+    `id`      INT          NOT NULL AUTO_INCREMENT,
+    `name`    VARCHAR(255) NOT NULL UNIQUE,
+    `default` TINYINT(1)   DEFAULT 0,
+    `option`  VARCHAR(40)  DEFAULT '',
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `realm` (`id`, `name`, `default`) VALUES
+    (1, 'defrealm', 1),
+    (2, 'testrealm', 0);
+
+-- ---------------------------------------------------------------------------
+-- resolver
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `resolver` (
+    `id`    INT          NOT NULL AUTO_INCREMENT,
+    `name`  VARCHAR(255) NOT NULL UNIQUE,
+    `rtype` VARCHAR(255) NOT NULL DEFAULT '',
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `resolver` (`id`, `name`, `rtype`) VALUES
+    (1, 'defresolver', 'passwdresolver');
+
+-- ---------------------------------------------------------------------------
+-- resolverconfig
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `resolverconfig` (
+    `id`          INT          NOT NULL AUTO_INCREMENT,
+    `resolver_id` INT,
+    `Key`         VARCHAR(255) NOT NULL,
+    `Value`       VARCHAR(2000) DEFAULT '',
+    `Type`        VARCHAR(2000) DEFAULT '',
+    `Description` VARCHAR(2000) DEFAULT '',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `rcix_2` (`resolver_id`, `Key`),
+    FOREIGN KEY (`resolver_id`) REFERENCES `resolver`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `resolverconfig` (`resolver_id`, `Key`, `Value`) VALUES
+    (1, 'fileName', '/etc/passwd');
+
+-- ---------------------------------------------------------------------------
+-- resolverrealm
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `resolverrealm` (
+    `id`          INT NOT NULL AUTO_INCREMENT,
+    `resolver_id` INT,
+    `realm_id`    INT,
+    `priority`    INT,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `rrix_2` (`resolver_id`, `realm_id`),
+    FOREIGN KEY (`resolver_id`) REFERENCES `resolver`(`id`),
+    FOREIGN KEY (`realm_id`)   REFERENCES `realm`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `resolverrealm` (`resolver_id`, `realm_id`, `priority`) VALUES
+    (1, 1, 1),
+    (1, 2, 1);
+
+-- ---------------------------------------------------------------------------
+-- token
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `token` (
+    `id`           INT           NOT NULL AUTO_INCREMENT,
+    `description`  VARCHAR(80)   DEFAULT '',
+    `serial`       VARCHAR(40)   NOT NULL UNIQUE,
+    `tokentype`    VARCHAR(30)   DEFAULT 'HOTP',
+    `user_pin`     VARCHAR(512)  DEFAULT '',
+    `user_pin_iv`  VARCHAR(32)   DEFAULT '',
+    `so_pin`       VARCHAR(512)  DEFAULT '',
+    `so_pin_iv`    VARCHAR(32)   DEFAULT '',
+    `pin_seed`     VARCHAR(32)   DEFAULT '',
+    `otplen`       INT           DEFAULT 6,
+    `pin_hash`     VARCHAR(512)  DEFAULT '',
+    `key_enc`      VARCHAR(2800) DEFAULT '',
+    `key_iv`       VARCHAR(32)   DEFAULT '',
+    `maxfail`      INT           DEFAULT 10,
+    `active`       TINYINT(1)    NOT NULL DEFAULT 1,
+    `revoked`      TINYINT(1)    DEFAULT 0,
+    `locked`       TINYINT(1)    DEFAULT 0,
+    `failcount`    INT           DEFAULT 0,
+    `count`        INT           DEFAULT 0,
+    `count_window` INT           DEFAULT 10,
+    `sync_window`  INT           DEFAULT 1000,
+    `rollout_state` VARCHAR(10)  DEFAULT '',
+    PRIMARY KEY (`id`),
+    INDEX `ix_token_serial`    (`serial`),
+    INDEX `ix_token_tokentype` (`tokentype`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `token` (`id`, `serial`, `tokentype`, `otplen`, `active`, `key_enc`, `key_iv`, `pin_hash`) VALUES
+    (1, 'HOTP0001', 'hotp', 6, 1, 'aabbccddeeff00112233445566778899aabbccddeeff001122334455', '00112233445566778899aabbccdd0011', '$pbkdf2-sha512$...fakehash...'),
+    (2, 'TOTP0001', 'totp', 6, 1, 'aabbccddeeff00112233445566778899aabbccddeeff001122334455', '00112233445566778899aabbccdd0022', ''),
+    (3, 'PIPU0001', 'push', 6, 1, '', '', '');
+
+-- ---------------------------------------------------------------------------
+-- tokeninfo
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tokeninfo` (
+    `id`          INT           NOT NULL AUTO_INCREMENT,
+    `Key`         VARCHAR(255)  NOT NULL,
+    `Value`       LONGTEXT,
+    `Type`        VARCHAR(100)  DEFAULT '',
+    `Description` VARCHAR(2000) DEFAULT '',
+    `token_id`    INT,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `tiix_2` (`token_id`, `Key`),
+    INDEX `ix_tokeninfo_token_id` (`token_id`),
+    FOREIGN KEY (`token_id`) REFERENCES `token`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `tokeninfo` (`token_id`, `Key`, `Value`) VALUES
+    (2, 'timeStep',   '30'),
+    (2, 'timeWindow', '180'),
+    (3, 'firebase_config', 'myFirebase'),
+    (3, 'public_key_smartphone', 'fakePublicKey==');
+
+-- ---------------------------------------------------------------------------
+-- tokenowner
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tokenowner` (
+    `id`       INT          NOT NULL AUTO_INCREMENT,
+    `token_id` INT,
+    `resolver` VARCHAR(120) DEFAULT '',
+    `user_id`  VARCHAR(320) DEFAULT '',
+    `realm_id` INT,
+    PRIMARY KEY (`id`),
+    INDEX `ix_tokenowner_resolver` (`resolver`),
+    INDEX `ix_tokenowner_user_id`  (`user_id`),
+    FOREIGN KEY (`token_id`) REFERENCES `token`(`id`),
+    FOREIGN KEY (`realm_id`) REFERENCES `realm`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `tokenowner` (`token_id`, `resolver`, `user_id`, `realm_id`) VALUES
+    (1, 'defresolver', '1000', 1),
+    (2, 'defresolver', '1000', 1);
+
+-- ---------------------------------------------------------------------------
+-- tokenrealm
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tokenrealm` (
+    `id`       INT NOT NULL AUTO_INCREMENT,
+    `token_id` INT,
+    `realm_id` INT,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `trix_2` (`token_id`, `realm_id`),
+    FOREIGN KEY (`token_id`) REFERENCES `token`(`id`),
+    FOREIGN KEY (`realm_id`) REFERENCES `realm`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `tokenrealm` (`token_id`, `realm_id`) VALUES
+    (1, 1),
+    (2, 1),
+    (3, 1);
+
+-- ---------------------------------------------------------------------------
+-- tokengroup
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tokengroup` (
+    `id`          INT          NOT NULL AUTO_INCREMENT,
+    `name`        VARCHAR(255) NOT NULL UNIQUE,
+    `Description` VARCHAR(2000) DEFAULT '',
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `tokengroup` (`id`, `name`, `Description`) VALUES
+    (1, 'vpn-tokens',   'Tokens used for VPN access'),
+    (2, 'admin-tokens',  'Tokens for administrators');
+
+-- ---------------------------------------------------------------------------
+-- tokentokengroup
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tokentokengroup` (
+    `id`           INT NOT NULL AUTO_INCREMENT,
+    `token_id`     INT,
+    `tokengroup_id` INT,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ttgix_2` (`token_id`, `tokengroup_id`),
+    FOREIGN KEY (`token_id`)      REFERENCES `token`(`id`),
+    FOREIGN KEY (`tokengroup_id`) REFERENCES `tokengroup`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `tokentokengroup` (`token_id`, `tokengroup_id`) VALUES
+    (1, 1),
+    (2, 2);
+
+-- ---------------------------------------------------------------------------
+-- caconnector
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `caconnector` (
+    `id`     INT          NOT NULL AUTO_INCREMENT,
+    `name`   VARCHAR(255) NOT NULL UNIQUE,
+    `catype` VARCHAR(255) NOT NULL DEFAULT '',
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- caconnectorconfig
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `caconnectorconfig` (
+    `id`              INT           NOT NULL AUTO_INCREMENT,
+    `caconnector_id`  INT,
+    `Key`             VARCHAR(255)  NOT NULL,
+    `Value`           VARCHAR(2000) DEFAULT '',
+    `Type`            VARCHAR(2000) DEFAULT '',
+    `Description`     VARCHAR(2000) DEFAULT '',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ccix_2` (`caconnector_id`, `Key`),
+    FOREIGN KEY (`caconnector_id`) REFERENCES `caconnector`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- policy
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `policy` (
+    `id`                   INT           NOT NULL AUTO_INCREMENT,
+    `active`               TINYINT(1)    DEFAULT 1,
+    `check_all_resolvers`  TINYINT(1)    DEFAULT 0,
+    `name`                 VARCHAR(64)   NOT NULL UNIQUE,
+    `scope`                VARCHAR(32)   NOT NULL,
+    `action`               VARCHAR(2000) DEFAULT '',
+    `realm`                VARCHAR(256)  DEFAULT '',
+    `adminrealm`           VARCHAR(256)  DEFAULT '',
+    `adminuser`            VARCHAR(256)  DEFAULT '',
+    `resolver`             VARCHAR(256)  DEFAULT '',
+    `pinode`               VARCHAR(256)  DEFAULT '',
+    `user`                 VARCHAR(256)  DEFAULT '',
+    `client`               VARCHAR(256)  DEFAULT '',
+    `time`                 VARCHAR(64)   DEFAULT '',
+    `priority`             INT           NOT NULL DEFAULT 1,
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `policy` (`id`, `active`, `name`, `scope`, `action`, `realm`, `priority`) VALUES
+    (1, 1, 'superuser',         'admin', 'superuser',                     '',        1),
+    (2, 1, 'enroll-hotp',       'enroll','enrollHOTP',                    'defrealm',1),
+    (3, 1, 'no-detail-on-fail', 'authz', 'no_detail_on_fail',             '',        1),
+    (4, 0, 'disabled-policy',   'auth',  'push_wait=20',                  '',        1);
+
+-- ---------------------------------------------------------------------------
+-- policycondition
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `policycondition` (
+    `id`         INT           NOT NULL AUTO_INCREMENT,
+    `policy_id`  INT           NOT NULL,
+    `section`    VARCHAR(255)  NOT NULL,
+    `Key`        VARCHAR(255)  NOT NULL,
+    `comparator` VARCHAR(255)  NOT NULL DEFAULT 'equals',
+    `Value`      VARCHAR(2000) NOT NULL DEFAULT '',
+    `active`     TINYINT(1)    NOT NULL DEFAULT 1,
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`policy_id`) REFERENCES `policy`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `policycondition` (`policy_id`, `section`, `Key`, `comparator`, `Value`, `active`) VALUES
+    (2, 'userinfo', 'memberOf', 'equals', 'cn=vpn,dc=example,dc=com', 1);
+
+-- ---------------------------------------------------------------------------
+-- challenge
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `challenge` (
+    `id`             INT          NOT NULL AUTO_INCREMENT,
+    `transaction_id` VARCHAR(64)  NOT NULL,
+    `data`           VARCHAR(512) DEFAULT '',
+    `challenge`      VARCHAR(512) DEFAULT '',
+    `session`        VARCHAR(512) DEFAULT '',
+    `serial`         VARCHAR(40)  DEFAULT '',
+    `timestamp`      DATETIME(6)  DEFAULT NULL,
+    `expiration`     DATETIME(6),
+    `received_count` INT          DEFAULT 0,
+    `otp_valid`      TINYINT(1)   DEFAULT 0,
+    PRIMARY KEY (`id`),
+    INDEX `ix_challenge_transaction_id` (`transaction_id`),
+    INDEX `ix_challenge_serial`         (`serial`),
+    INDEX `ix_challenge_timestamp`      (`timestamp`)
+) ROW_FORMAT=DYNAMIC;
+
+-- No challenge rows: challenges are ephemeral and not meaningful to preserve across migrations.
+
+-- ---------------------------------------------------------------------------
+-- admin
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `admin` (
+    `username` VARCHAR(120) NOT NULL,
+    `password` VARCHAR(255),
+    `email`    VARCHAR(255),
+    PRIMARY KEY (`username`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `admin` (`username`, `password`, `email`) VALUES
+    ('admin', '$pbkdf2-sha512$25000$fakesalt$fakehash==', 'admin@example.com');
+
+-- ---------------------------------------------------------------------------
+-- machineresolver
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `machineresolver` (
+    `id`    INT          NOT NULL AUTO_INCREMENT,
+    `name`  VARCHAR(255) NOT NULL UNIQUE,
+    `rtype` VARCHAR(255) NOT NULL DEFAULT '',
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- machineresolverconfig
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `machineresolverconfig` (
+    `id`          INT           NOT NULL AUTO_INCREMENT,
+    `resolver_id` INT,
+    `Key`         VARCHAR(255)  NOT NULL,
+    `Value`       VARCHAR(2000) DEFAULT '',
+    `Type`        VARCHAR(2000) DEFAULT '',
+    `Description` VARCHAR(2000) DEFAULT '',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `mrcix_2` (`resolver_id`, `Key`),
+    FOREIGN KEY (`resolver_id`) REFERENCES `machineresolver`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- machinetoken
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `machinetoken` (
+    `id`                  INT          NOT NULL AUTO_INCREMENT,
+    `token_id`            INT,
+    `machineresolver_id`  INT,
+    `machine_id`          VARCHAR(255),
+    `application`         VARCHAR(64),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`token_id`) REFERENCES `token`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- machinetokenoptions
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `machinetokenoptions` (
+    `id`               INT         NOT NULL AUTO_INCREMENT,
+    `machinetoken_id`  INT,
+    `mt_key`           VARCHAR(64) NOT NULL,
+    `mt_value`         VARCHAR(64) NOT NULL,
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`machinetoken_id`) REFERENCES `machinetoken`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- smsgateway
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `smsgateway` (
+    `id`             INT           NOT NULL AUTO_INCREMENT,
+    `identifier`     VARCHAR(255)  NOT NULL UNIQUE,
+    `description`    VARCHAR(1024) DEFAULT '',
+    `providermodule` VARCHAR(1024) NOT NULL,
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `smsgateway` (`id`, `identifier`, `description`, `providermodule`) VALUES
+    (1, 'myFirebase', 'Firebase push gateway', 'privacyidea.lib.smsprovider.FirebaseProvider.FirebaseProvider');
+
+-- ---------------------------------------------------------------------------
+-- smsgatewayoption
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `smsgatewayoption` (
+    `id`         INT          NOT NULL AUTO_INCREMENT,
+    `Key`        VARCHAR(255) NOT NULL,
+    `Value`      LONGTEXT,
+    `Type`       VARCHAR(100) DEFAULT 'option',
+    `gateway_id` INT,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `sgix_1` (`gateway_id`, `Key`, `Type`),
+    INDEX `ix_smsgatewayoption_gateway_id` (`gateway_id`),
+    FOREIGN KEY (`gateway_id`) REFERENCES `smsgateway`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `smsgatewayoption` (`gateway_id`, `Key`, `Value`, `Type`) VALUES
+    (1, 'FIREBASE_CONFIG', '/etc/privacyidea/firebase.json', 'option'),
+    (1, 'PROJECT_ID',      'my-firebase-project',            'option');
+
+-- ---------------------------------------------------------------------------
+-- eventhandler
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `eventhandler` (
+    `id`           INT           NOT NULL AUTO_INCREMENT,
+    `name`         VARCHAR(64),
+    `active`       TINYINT(1)    DEFAULT 1,
+    `ordering`     INT           NOT NULL DEFAULT 0,
+    `position`     VARCHAR(10)   DEFAULT 'post',
+    `event`        VARCHAR(255)  NOT NULL,
+    `handlermodule` VARCHAR(255) NOT NULL,
+    `condition`    VARCHAR(1024) DEFAULT '',
+    `action`       VARCHAR(1024) DEFAULT '',
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `eventhandler` (`id`, `name`, `active`, `ordering`, `position`, `event`, `handlermodule`, `action`) VALUES
+    (1, 'send-email-on-fail', 1, 0, 'post', 'validate_check', 'privacyidea.lib.eventhandler.EmailEventHandler', 'sendmail');
+
+-- ---------------------------------------------------------------------------
+-- eventhandleroption
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `eventhandleroption` (
+    `id`               INT           NOT NULL AUTO_INCREMENT,
+    `eventhandler_id`  INT,
+    `Key`              VARCHAR(255)  NOT NULL,
+    `Value`            VARCHAR(2000) DEFAULT '',
+    `Type`             VARCHAR(2000) DEFAULT '',
+    `Description`      VARCHAR(2000) DEFAULT '',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ehoix_1` (`eventhandler_id`, `Key`),
+    FOREIGN KEY (`eventhandler_id`) REFERENCES `eventhandler`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `eventhandleroption` (`eventhandler_id`, `Key`, `Value`) VALUES
+    (1, 'body',    'Authentication failed for {user}'),
+    (1, 'subject', 'privacyIDEA authentication failure');
+
+-- ---------------------------------------------------------------------------
+-- eventhandlercondition
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `eventhandlercondition` (
+    `id`               INT           NOT NULL AUTO_INCREMENT,
+    `eventhandler_id`  INT,
+    `Key`              VARCHAR(255)  NOT NULL,
+    `Value`            VARCHAR(2000) DEFAULT '',
+    `comparator`       VARCHAR(255)  DEFAULT 'equal',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ehcix_1` (`eventhandler_id`, `Key`),
+    FOREIGN KEY (`eventhandler_id`) REFERENCES `eventhandler`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `eventhandlercondition` (`eventhandler_id`, `Key`, `Value`, `comparator`) VALUES
+    (1, 'result_value', 'False', 'equal');
+
+-- ---------------------------------------------------------------------------
+-- smtpserver
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `smtpserver` (
+    `id`          INT          NOT NULL AUTO_INCREMENT,
+    `identifier`  VARCHAR(255) NOT NULL,
+    `server`      VARCHAR(255) NOT NULL,
+    `port`        INT          DEFAULT 25,
+    `username`    VARCHAR(255) DEFAULT '',
+    `password`    VARCHAR(255) DEFAULT '',
+    `sender`      VARCHAR(255) DEFAULT '',
+    `tls`         TINYINT(1)   DEFAULT 0,
+    `description` VARCHAR(2000) DEFAULT '',
+    `timeout`     INT          DEFAULT 10,
+    `enqueue_job` TINYINT(1)   NOT NULL DEFAULT 0,
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `smtpserver` (`id`, `identifier`, `server`, `port`, `sender`, `tls`, `enqueue_job`) VALUES
+    (1, 'default-smtp', 'mail.example.com', 587, 'noreply@example.com', 1, 0);
+
+-- ---------------------------------------------------------------------------
+-- radiusserver
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `radiusserver` (
+    `id`          INT          NOT NULL AUTO_INCREMENT,
+    `identifier`  VARCHAR(255) NOT NULL UNIQUE,
+    `server`      VARCHAR(255) NOT NULL,
+    `port`        INT          DEFAULT 25,
+    `secret`      VARCHAR(255) DEFAULT '',
+    `dictionary`  VARCHAR(255) DEFAULT '/etc/privacyidea/dictionary',
+    `description` VARCHAR(2000) DEFAULT '',
+    `timeout`     INT          DEFAULT 5,
+    `retries`     INT          DEFAULT 3,
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- privacyideaserver
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `privacyideaserver` (
+    `id`          INT          NOT NULL AUTO_INCREMENT,
+    `identifier`  VARCHAR(255) NOT NULL UNIQUE,
+    `url`         VARCHAR(255) NOT NULL,
+    `tls`         TINYINT(1)   DEFAULT 0,
+    `description` VARCHAR(2000) DEFAULT '',
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- clientapplication
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `clientapplication` (
+    `id`         INT          NOT NULL AUTO_INCREMENT,
+    `ip`         VARCHAR(255) NOT NULL,
+    `hostname`   VARCHAR(255),
+    `clienttype` VARCHAR(255) NOT NULL,
+    `lastseen`   DATETIME(6)  DEFAULT NULL,
+    `node`       VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `caix` (`ip`, `clienttype`, `node`),
+    INDEX `ix_clientapplication_ip`         (`ip`),
+    INDEX `ix_clientapplication_clienttype` (`clienttype`),
+    INDEX `ix_clientapplication_lastseen`   (`lastseen`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `clientapplication` (`ip`, `hostname`, `clienttype`, `node`) VALUES
+    ('10.0.0.1', 'vpnclient.example.com', 'PAM',    'pinode1'),
+    ('10.0.0.2', 'webserver.example.com', 'OAUTH2', 'pinode1');
+
+-- ---------------------------------------------------------------------------
+-- subscription
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `subscription` (
+    `id`          INT          NOT NULL AUTO_INCREMENT,
+    `application` VARCHAR(80),
+    `for_name`    VARCHAR(80)  NOT NULL,
+    `for_address` VARCHAR(128),
+    `for_email`   VARCHAR(128) NOT NULL,
+    `for_phone`   VARCHAR(50)  NOT NULL,
+    `for_url`     VARCHAR(80),
+    `for_comment` VARCHAR(255),
+    `by_name`     VARCHAR(50)  NOT NULL,
+    `by_email`    VARCHAR(128) NOT NULL,
+    `by_address`  VARCHAR(128),
+    `by_phone`    VARCHAR(50),
+    `by_url`      VARCHAR(80),
+    `date_from`   DATETIME,
+    `date_till`   DATETIME,
+    `num_users`   INT,
+    `num_tokens`  INT,
+    `num_clients` INT,
+    `level`       VARCHAR(80),
+    `signature`   VARCHAR(640),
+    PRIMARY KEY (`id`),
+    INDEX `ix_subscription_application` (`application`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- customuserattribute
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `customuserattribute` (
+    `id`       INT          NOT NULL AUTO_INCREMENT,
+    `user_id`  VARCHAR(320) DEFAULT '',
+    `resolver` VARCHAR(120) DEFAULT '',
+    `realm_id` INT,
+    `Key`      VARCHAR(255) NOT NULL,
+    `Value`    LONGTEXT,
+    `Type`     VARCHAR(100) DEFAULT '',
+    PRIMARY KEY (`id`),
+    INDEX `ix_customuserattribute_user_id`  (`user_id`),
+    INDEX `ix_customuserattribute_resolver` (`resolver`),
+    FOREIGN KEY (`realm_id`) REFERENCES `realm`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `customuserattribute` (`user_id`, `resolver`, `realm_id`, `Key`, `Value`) VALUES
+    ('1000', 'defresolver', 1, 'department', 'engineering');
+
+-- ---------------------------------------------------------------------------
+-- serviceid
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `serviceid` (
+    `id`          INT          NOT NULL AUTO_INCREMENT,
+    `name`        VARCHAR(255) NOT NULL UNIQUE,
+    `Description` VARCHAR(2000) DEFAULT '',
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `serviceid` (`id`, `name`, `Description`) VALUES
+    (1, 'ssh-servers', 'SSH key consumers');
+
+-- ---------------------------------------------------------------------------
+-- passwordreset
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `passwordreset` (
+    `id`           INT          NOT NULL AUTO_INCREMENT,
+    `recoverycode` VARCHAR(255) NOT NULL,
+    `username`     VARCHAR(64)  NOT NULL,
+    `realm`        VARCHAR(64)  NOT NULL,
+    `resolver`     VARCHAR(64),
+    `email`        VARCHAR(255),
+    `timestamp`    DATETIME,
+    `expiration`   DATETIME,
+    PRIMARY KEY (`id`),
+    INDEX `ix_passwordreset_username` (`username`),
+    INDEX `ix_passwordreset_realm`    (`realm`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- usercache
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `usercache` (
+    `id`        INT          NOT NULL AUTO_INCREMENT,
+    `username`  VARCHAR(64)  DEFAULT '',
+    `used_login` VARCHAR(64) DEFAULT '',
+    `resolver`  VARCHAR(120) DEFAULT '',
+    `user_id`   VARCHAR(320) DEFAULT '',
+    `timestamp` DATETIME,
+    PRIMARY KEY (`id`),
+    INDEX `ix_usercache_username`  (`username`),
+    INDEX `ix_usercache_used_login` (`used_login`),
+    INDEX `ix_usercache_user_id`   (`user_id`),
+    INDEX `ix_usercache_timestamp` (`timestamp`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- authcache
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `authcache` (
+    `id`             INT          NOT NULL AUTO_INCREMENT,
+    `first_auth`     DATETIME,
+    `last_auth`      DATETIME,
+    `username`       VARCHAR(64)  DEFAULT '',
+    `resolver`       VARCHAR(120) DEFAULT '',
+    `realm`          VARCHAR(120) DEFAULT '',
+    `client_ip`      VARCHAR(40)  DEFAULT '',
+    `user_agent`     VARCHAR(120) DEFAULT '',
+    `auth_count`     INT          DEFAULT 0,
+    `authentication` VARCHAR(255) DEFAULT '',
+    PRIMARY KEY (`id`),
+    INDEX `ix_authcache_first_auth` (`first_auth`),
+    INDEX `ix_authcache_last_auth`  (`last_auth`),
+    INDEX `ix_authcache_username`   (`username`),
+    INDEX `ix_authcache_resolver`   (`resolver`),
+    INDEX `ix_authcache_realm`      (`realm`)
+) ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------------
+-- eventcounter
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `eventcounter` (
+    `id`            INT          NOT NULL AUTO_INCREMENT,
+    `counter_name`  VARCHAR(80)  NOT NULL,
+    `counter_value` INT          DEFAULT 0,
+    `node`          VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `evctr_1` (`counter_name`, `node`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `eventcounter` (`counter_name`, `counter_value`, `node`) VALUES
+    ('failed_auth', 42, 'pinode1'),
+    ('failed_auth', 17, 'pinode2');
+
+-- ---------------------------------------------------------------------------
+-- periodictask
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `periodictask` (
+    `id`              INT          NOT NULL AUTO_INCREMENT,
+    `name`            VARCHAR(64)  NOT NULL UNIQUE,
+    `active`          TINYINT(1)   NOT NULL DEFAULT 1,
+    `retry_if_failed` TINYINT(1)   NOT NULL DEFAULT 1,
+    `interval`        VARCHAR(256) NOT NULL,
+    `nodes`           VARCHAR(256) NOT NULL,
+    `taskmodule`      VARCHAR(256) NOT NULL,
+    `ordering`        INT          NOT NULL DEFAULT 0,
+    `last_update`     DATETIME     NOT NULL,
+    PRIMARY KEY (`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `periodictask` (`id`, `name`, `active`, `retry_if_failed`, `interval`, `nodes`, `taskmodule`, `ordering`, `last_update`) VALUES
+    (1, 'cleanup-audit', 1, 1, '0 2 * * *', 'pinode1', 'privacyidea.lib.periodictask.AuditCleanup', 0, '2023-01-01 02:00:00');
+
+-- ---------------------------------------------------------------------------
+-- periodictaskoption
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `periodictaskoption` (
+    `id`               INT          NOT NULL AUTO_INCREMENT,
+    `periodictask_id`  INT,
+    `key`              VARCHAR(255) NOT NULL,
+    `value`            VARCHAR(2000) DEFAULT '',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ptoix_1` (`periodictask_id`, `key`),
+    FOREIGN KEY (`periodictask_id`) REFERENCES `periodictask`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `periodictaskoption` (`periodictask_id`, `key`, `value`) VALUES
+    (1, 'age', '180d');
+
+-- ---------------------------------------------------------------------------
+-- periodictasklastrun
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `periodictasklastrun` (
+    `id`               INT          NOT NULL AUTO_INCREMENT,
+    `periodictask_id`  INT,
+    `node`             VARCHAR(255) NOT NULL,
+    `timestamp`        DATETIME     NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ptlrix_1` (`periodictask_id`, `node`),
+    FOREIGN KEY (`periodictask_id`) REFERENCES `periodictask`(`id`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `periodictasklastrun` (`periodictask_id`, `node`, `timestamp`) VALUES
+    (1, 'pinode1', '2023-06-01 02:00:00');
+
+-- ---------------------------------------------------------------------------
+-- monitoringstats
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `monitoringstats` (
+    `id`          INT          NOT NULL AUTO_INCREMENT,
+    `timestamp`   DATETIME     NOT NULL,
+    `stats_key`   VARCHAR(128) NOT NULL,
+    `stats_value` INT          NOT NULL DEFAULT 0,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `msix_1` (`timestamp`, `stats_key`),
+    INDEX `ix_monitoringstats_timestamp` (`timestamp`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `monitoringstats` (`timestamp`, `stats_key`, `stats_value`) VALUES
+    ('2023-06-01 00:00:00', 'token_count',  47),
+    ('2023-06-01 00:00:00', 'active_users', 39);
+
+-- ---------------------------------------------------------------------------
+-- pidea_audit
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `pidea_audit` (
+    `id`                INT          NOT NULL AUTO_INCREMENT,
+    `date`              DATETIME(6),
+    `startdate`         DATETIME(6),
+    `duration`          TIME(6),
+    `signature`         VARCHAR(620),
+    `action`            VARCHAR(50),
+    `success`           INT,
+    `serial`            VARCHAR(40),
+    `token_type`        VARCHAR(12),
+    `user`              VARCHAR(20),
+    `realm`             VARCHAR(20),
+    `resolver`          VARCHAR(50),
+    `administrator`     VARCHAR(20),
+    `action_detail`     VARCHAR(50),
+    `info`              VARCHAR(50),
+    `privacyidea_server` VARCHAR(255),
+    `client`            VARCHAR(50),
+    `loglevel`          VARCHAR(12),
+    `clearance_level`   VARCHAR(12),
+    `thread_id`         VARCHAR(20),
+    `policies`          VARCHAR(255),
+    PRIMARY KEY (`id`),
+    INDEX `ix_pidea_audit_date` (`date`),
+    INDEX `ix_pidea_audit_user` (`user`)
+) ROW_FORMAT=DYNAMIC;
+
+INSERT INTO `pidea_audit` (`date`, `action`, `success`, `serial`, `token_type`, `user`, `realm`, `administrator`, `client`, `loglevel`, `clearance_level`, `thread_id`) VALUES
+    ('2023-06-01 10:00:00', 'validate/check', 1, 'HOTP0001', 'hotp', 'alice', 'defrealm', '', '10.0.0.1', 'INFO', 'default', '12345'),
+    ('2023-06-01 10:01:00', 'validate/check', 0, 'TOTP0001', 'totp', 'alice', 'defrealm', '', '10.0.0.1', 'INFO', 'default', '12346');
+
+-- ---------------------------------------------------------------------------
+-- Sequences
+--
+-- Real MySQL has no CREATE SEQUENCE support at all, in any version. The v3.9
+-- migration (5cb310101a1f) walks model metadata and creates one sequence per
+-- integer-PK table via create_sequence_if_supported(), which is guarded by
+-- bind.dialect.supports_sequences, unconditionally False on MySQL and True
+-- on MariaDB 10.3+. A real MySQL install upgraded through this revision
+-- therefore has none of these sequence objects, and this seed omits them to
+-- match that real state. See the MariaDB seed's equivalent section for the
+-- sequences MariaDB gets, and privacyidea/models/db.py for the dialect
+-- checks that skip them here.
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- alembic_version — stamp the DB at START_REVISION
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `alembic_version` (
+    `version_num` VARCHAR(32) NOT NULL,
+    PRIMARY KEY (`version_num`)
+);
+
+INSERT INTO `alembic_version` (`version_num`) VALUES ('5cb310101a1f');
+
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/tools/generate_seed_sql.py
+++ b/tools/generate_seed_sql.py
@@ -13,7 +13,15 @@ USAGE
   Directory (current split-package layout, e.g. privacyidea/models/):
     python tools/generate_seed_sql.py <path/to/models/> <dialect> [out.sql]
 
-  dialect: mariadb | postgresql | oracle
+  dialect: mariadb | mysql | postgresql | oracle
+
+  mariadb and mysql render byte-identical CREATE TABLE DDL here (both compile
+  against the generic, non-live mysql+pymysql dialect, which conservatively
+  over-quotes identifiers that are only reserved on one of the two engines —
+  safe on both). They diverge only in the hand-extended data section: MariaDB
+  supports CREATE SEQUENCE (10.3+) and TEXT/BLOB columns with a literal
+  DEFAULT; real MySQL supports neither, ever. See
+  tests/testdata/migrations/README.md.
 
 ────────────────────────────────────────────────────────────────────────────
 EXTRACTING A HISTORICAL VERSION FROM GIT
@@ -28,9 +36,12 @@ EXTRACTING A HISTORICAL VERSION FROM GIT
     # Export the single-file models from a specific tag
     git show v3.9.3:privacyidea/models.py > /tmp/models_v3.9.py
 
-    # Generate seeds for both dialects
+    # Generate seeds for all dialects
     python tools/generate_seed_sql.py /tmp/models_v3.9.py mariadb \\
         tests/testdata/migrations/seed_v3.9_5cb310101a1f_mariadb.sql
+
+    python tools/generate_seed_sql.py /tmp/models_v3.9.py mysql \\
+        tests/testdata/migrations/seed_v3.9_5cb310101a1f_mysql.sql
 
     python tools/generate_seed_sql.py /tmp/models_v3.9.py postgresql \\
         tests/testdata/migrations/seed_v3.9_5cb310101a1f_postgresql.sql
@@ -285,7 +296,19 @@ def _load_package_directory(models_dir: Path):
 
 
 
-def _render_mariadb(metadata) -> str:
+def _render_mysql_family(metadata, dialect: str) -> str:
+    """Render CREATE TABLE DDL for the mariadb/mysql dialect choices.
+
+    Both compile against the generic, non-live mysql+pymysql dialect
+    (is_mariadb=False, since there is no live connection to probe the server
+    version). That dialect quotes more identifiers than strictly necessary on
+    MariaDB — safe on both engines, since quoting a non-reserved identifier is
+    a no-op — so the two choices render byte-identical schema DDL here and
+    only need a different header comment. MariaDB and real MySQL genuinely
+    diverge only in the hand-extended data section (CREATE SEQUENCE support,
+    literal defaults on TEXT/BLOB columns) — see
+    tests/testdata/migrations/README.md.
+    """
     from sqlalchemy import create_engine
     from sqlalchemy.schema import CreateTable
 
@@ -295,8 +318,9 @@ def _render_mariadb(metadata) -> str:
         pool_pre_ping=False,
     )
 
+    label = "MariaDB" if dialect == "mariadb" else "MySQL"
     lines = [
-        "-- Auto-generated MariaDB seed SQL",
+        f"-- Auto-generated {label} seed SQL",
         "-- Source: SQLAlchemy metadata",
         "--",
         "SET FOREIGN_KEY_CHECKS = 0;",
@@ -423,7 +447,7 @@ def main() -> None:
         help="Path to models.py (single file) or models/ directory (package)",
     )
     parser.add_argument(
-        "dialect", choices=["mariadb", "postgresql", "oracle"],
+        "dialect", choices=["mariadb", "mysql", "postgresql", "oracle"],
         help="Target SQL dialect",
     )
     parser.add_argument(
@@ -454,8 +478,8 @@ def main() -> None:
         file=sys.stderr,
     )
 
-    if args.dialect == "mariadb":
-        sql = _render_mariadb(metadata)
+    if args.dialect in ("mariadb", "mysql"):
+        sql = _render_mysql_family(metadata, args.dialect)
     elif args.dialect == "oracle":
         sql = _render_oracle(metadata)
     else:


### PR DESCRIPTION
## Summary
- Adds a MySQL 8.4 service container and matrix entry to `migration-tests.yml`, alongside the existing MariaDB (10.11, 11) and PostgreSQL legs.
- Includes MySQL in the backup/restore round-trip step, since `pi-manage backup` uses the same `mysqldump`/`mysql` tooling for MariaDB and real MySQL.
- Real MySQL has no `CREATE SEQUENCE` support at all (unlike MariaDB 10.3+), so this exercises the sequence-less fallback branch in `privacyidea/models/db.py` that MariaDB-only testing never hits.