### PR TITLE
CA: fix toggle enable / dry run for invalid policies

### DIFF
--- a/privacyidea/static_new/src/app/components/conditional-access/conditional-access.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/conditional-access/conditional-access.component.spec.ts
@@ -135,6 +135,12 @@ describe("ConditionalAccessComponent", () => {
     expect(policyServiceMock.enablePolicy).toHaveBeenCalledWith(1);
   });
 
+  it("should send only the new dry-run state on toggle", () => {
+    component.onToggleDryRun({ ...samplePolicy, dry_run: false });
+    expect(policyServiceMock.setDryRun).toHaveBeenCalledWith(1, true);
+    expect(policyServiceMock.savePolicy).not.toHaveBeenCalled();
+  });
+
   it("should join all stage thresholds for display", () => {
     const multiStage: LockoutPolicy = {
       ...samplePolicy,
@@ -271,8 +277,8 @@ describe("ConditionalAccessComponent", () => {
       component.policySelection.set([dryRunOff, dryRunOn]);
       component.toggleDryRunSelected();
       emitAction("toggle");
-      expect(policyServiceMock.savePolicy).toHaveBeenCalledWith(expect.objectContaining({ id: 1, dry_run: true }));
-      expect(policyServiceMock.savePolicy).toHaveBeenCalledWith(expect.objectContaining({ id: 2, dry_run: false }));
+      expect(policyServiceMock.setDryRun).toHaveBeenCalledWith(1, true);
+      expect(policyServiceMock.setDryRun).toHaveBeenCalledWith(2, false);
       expect(component.policySelection().length).toBe(0);
     });
 

--- a/privacyidea/static_new/src/app/components/conditional-access/conditional-access.component.ts
+++ b/privacyidea/static_new/src/app/components/conditional-access/conditional-access.component.ts
@@ -445,7 +445,7 @@ export class ConditionalAccessComponent implements OnDestroy {
           return;
         }
         selected.forEach((policy) =>
-          this.policyService.savePolicy({ ...policy, dry_run: this.resolveToggle(action, policy.dry_run) })
+          this.policyService.setDryRun(policy.id, this.resolveToggle(action, policy.dry_run))
         );
         this.policySelection.set([]);
       });
@@ -472,7 +472,7 @@ export class ConditionalAccessComponent implements OnDestroy {
   }
 
   onToggleDryRun(policy: LockoutPolicy): void {
-    this.policyService.savePolicy({ ...policy, dry_run: !policy.dry_run });
+    this.policyService.setDryRun(policy.id, !policy.dry_run);
   }
 
   onFilterInput(value: string): void {

--- a/privacyidea/static_new/src/app/services/conditional-access/conditional-access-policy.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/conditional-access/conditional-access-policy.service.spec.ts
@@ -534,6 +534,33 @@ describe("ConditionalAccessPolicyService", () => {
     });
   });
 
+  describe("setDryRun", () => {
+    it("should PATCH the dry-run flag alone, leaving the rest of the policy untouched", async () => {
+      const promise = service.setDryRun(1, true);
+      const req = httpMock.expectOne(`${service.baseUrl}/1`);
+      expect(req.request.method).toBe("PATCH");
+      expect(req.request.body).toEqual({ dry_run: true });
+      req.flush({});
+      await promise;
+    });
+
+    it("should PATCH dry-run off", async () => {
+      const promise = service.setDryRun(1, false);
+      const req = httpMock.expectOne(`${service.baseUrl}/1`);
+      expect(req.request.body).toEqual({ dry_run: false });
+      req.flush({});
+      await promise;
+    });
+
+    it("should notify on error", async () => {
+      const promise = service.setDryRun(1, true);
+      const req = httpMock.expectOne(`${service.baseUrl}/1`);
+      req.flush(null, { status: 500, statusText: "Internal Server Error" });
+      await promise;
+      expect(notificationServiceMock.error).toHaveBeenCalled();
+    });
+  });
+
   describe("reorderPolicies", () => {
     it("should PUT the id order to the order URL", async () => {
       const reload = jest.spyOn(service.policiesResource, "reload").mockImplementation(() => true);

--- a/privacyidea/static_new/src/app/services/conditional-access/conditional-access-policy.service.ts
+++ b/privacyidea/static_new/src/app/services/conditional-access/conditional-access-policy.service.ts
@@ -236,6 +236,8 @@ export interface ConditionalAccessPolicyServiceInterface {
   enablePolicy(id: number): Promise<void>;
 
   disablePolicy(id: number): Promise<void>;
+
+  setDryRun(id: number, dryRun: boolean): Promise<void>;
 }
 
 @Injectable()
@@ -514,26 +516,36 @@ export class ConditionalAccessPolicyService implements ConditionalAccessPolicySe
     }
   }
 
-  async enablePolicy(id: number): Promise<void> {
+  // Send the one flag rather than the whole policy: the backend validates only the fields it is
+  // given, so a policy carrying a value that is no longer valid - a deleted realm in a condition,
+  // say - can still be switched on and off instead of being frozen until it is repaired. It also
+  // cannot overwrite another admin's concurrent edit of the fields this toggle does not touch.
+  private async patchFlag(id: number, flag: { enabled: boolean } | { dry_run: boolean }, errorMessage: string) {
     const headers = this.authService.getHeaders();
     try {
-      await lastValueFrom(this.http.patch(`${this.baseUrl}/${id}`, { enabled: true }, { headers }));
-      this.policiesResource.reload();
+      await lastValueFrom(this.http.patch(`${this.baseUrl}/${id}`, flag, { headers }));
     } catch {
-      this.notificationService.error($localize`Failed to enable conditional-access policy.`);
-      this.policiesResource.reload();
+      this.notificationService.error(errorMessage);
     }
+    this.policiesResource.reload();
+  }
+
+  async enablePolicy(id: number): Promise<void> {
+    await this.patchFlag(id, { enabled: true }, $localize`Failed to enable conditional-access policy.`);
   }
 
   async disablePolicy(id: number): Promise<void> {
-    const headers = this.authService.getHeaders();
-    try {
-      await lastValueFrom(this.http.patch(`${this.baseUrl}/${id}`, { enabled: false }, { headers }));
-      this.policiesResource.reload();
-    } catch {
-      this.notificationService.error($localize`Failed to disable conditional-access policy.`);
-      this.policiesResource.reload();
-    }
+    await this.patchFlag(id, { enabled: false }, $localize`Failed to disable conditional-access policy.`);
+  }
+
+  async setDryRun(id: number, dryRun: boolean): Promise<void> {
+    await this.patchFlag(
+      id,
+      { dry_run: dryRun },
+      dryRun
+        ? $localize`Failed to switch the conditional-access policy to dry-run mode.`
+        : $localize`Failed to switch the conditional-access policy to enforcing mode.`
+    );
   }
 
   // Rearrange the evaluation order: the listed policies take the priority values this

--- a/privacyidea/static_new/src/testing/mock-services/mock-conditional-access-policy-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-conditional-access-policy-service.ts
@@ -109,5 +109,7 @@ export class MockConditionalAccessPolicyService implements ConditionalAccessPoli
 
   disablePolicy = jest.fn(async (): Promise<void> => Promise.resolve());
 
+  setDryRun = jest.fn(async (_id: number, _dryRun: boolean): Promise<void> => Promise.resolve());
+
   reorderPolicies = jest.fn(async (_: number[]): Promise<boolean> => Promise.resolve(true));
 }

--- a/privacyidea/static_new/src/testing/mock-services/mock-conditional-access-policy-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-conditional-access-policy-service.ts
@@ -109,7 +109,7 @@ export class MockConditionalAccessPolicyService implements ConditionalAccessPoli
 
   disablePolicy = jest.fn(async (): Promise<void> => Promise.resolve());
 
-  setDryRun = jest.fn(async (_id: number, _dryRun: boolean): Promise<void> => Promise.resolve());
+  setDryRun = jest.fn(async (_: number, __: boolean): Promise<void> => Promise.resolve());
 
   reorderPolicies = jest.fn(async (_: number[]): Promise<boolean> => Promise.resolve(true));
 }


### PR DESCRIPTION
Only send the enable / dry run value for the toggle to also work on invalid policy definitions