### PR TITLE
Added "Cancel" and "Retry" buttons to token enrollment dialogs

### DIFF
--- a/privacyidea/static_new/src/app/components/audit/audit-download-dialog/audit-download-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/audit/audit-download-dialog/audit-download-dialog.component.html
@@ -1,6 +1,5 @@
 <app-dialog-wrapper
   (actionTriggered)="onAction($event)"
-  (wrapperClose)="close()"
   [actions]="[action]"
   i18n-title="@@DialogTitleDownloadAuditLog"
   title="Download Audit Log">

--- a/privacyidea/static_new/src/app/components/audit/audit-download-dialog/audit-download-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/audit/audit-download-dialog/audit-download-dialog.component.html
@@ -2,7 +2,6 @@
   (actionTriggered)="onAction($event)"
   (wrapperClose)="close()"
   [actions]="[action]"
-  [showCancelButton]="true"
   i18n-title="@@DialogTitleDownloadAuditLog"
   title="Download Audit Log">
   <div>

--- a/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.html
@@ -20,6 +20,7 @@
   title="Container Successfully Created"
   i18n-title
   [actions]="dialogActions()"
+  [showCloseButton]="false"
   (actionTriggered)="onDialogAction($event)">
   <div class="progress-header">
     <span

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.html
@@ -18,7 +18,6 @@
 -->
 <app-dialog-wrapper
   [title]="dialogTitle"
-  [showCancelButton]="true"
   (wrapperClose)="close()">
   <mat-dialog-content>
     <div class="flex-row gap-16">

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.html
@@ -17,8 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  [title]="dialogTitle"
-  (wrapperClose)="close()">
+  [title]="dialogTitle">
   <mat-dialog-content>
     <div class="flex-row gap-16">
       @if (data()?.response?.result?.value?.container_url?.img) {

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.html
@@ -19,6 +19,7 @@
 <app-dialog-wrapper
   [title]="data.rollover ? 'Container Rollover' : 'Register Container'"
   [actions]="[getAction()]"
+  [showCloseButton]="false"
   (wrapperClose)="close()"
   (actionTriggered)="onAction($event)">
   <mat-dialog-content>

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.html
@@ -20,7 +20,6 @@
   [title]="data.rollover ? 'Container Rollover' : 'Register Container'"
   [actions]="[getAction()]"
   [showCloseButton]="false"
-  (wrapperClose)="close()"
   (actionTriggered)="onAction($event)">
   <mat-dialog-content>
     <app-container-registration-config

--- a/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.html
@@ -20,7 +20,6 @@
 <app-dialog-wrapper
   title="Copy Container Template"
   i18n-title
-  [showCancelButton]="true"
   [handleCloseExternally]="true"
   (wrapperClose)="close()"
   [actions]="actions()"

--- a/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.html
@@ -20,10 +20,10 @@
 <app-dialog-wrapper
   title="Copy Container Template"
   i18n-title
-  [handleCloseExternally]="true"
-  (wrapperClose)="close()"
   [actions]="actions()"
-  (actionTriggered)="onAction($event)">
+  [handleCloseExternally]="true"
+  (actionTriggered)="onAction($event)"
+  (wrapperClose)="close()">
   <div class="flex-column">
     <p i18n>
       Please enter a unique name for the new copy of <b>{{ data }}</b

--- a/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.spec.ts
@@ -28,6 +28,7 @@ import { PendingChangesService } from "@services/pending-changes/pending-changes
 import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
 import { MockDialogService, MockPendingChangesService } from "@testing/mock-services";
 import { MockContainerTemplateService } from "@testing/mock-services/mock-container-template-service";
+import { SaveAndExitDialogComponent } from "@components/shared/dialog/save-and-exit-dialog/save-and-exit-dialog.component";
 import { ContainerTemplateCopyDialogComponent } from "./container-template-copy-dialog.component";
 
 describe("ContainerTemplateCopyDialogComponent", () => {
@@ -72,6 +73,37 @@ describe("ContainerTemplateCopyDialogComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("closing with unsaved changes", () => {
+    const clickCloseButton = () => {
+      const closeButton: HTMLButtonElement = fixture.nativeElement.querySelector(".pi-dialog-footer button");
+      expect(closeButton.textContent?.trim()).toBe("Cancel");
+      closeButton.click();
+      fixture.detectChanges();
+    };
+
+    it("asks before discarding an edited name instead of closing right away", () => {
+      const dialogService = TestBed.inject(DialogService) as unknown as MockDialogService;
+      component.editName("RenamedTemplate");
+      fixture.detectChanges();
+
+      clickCloseButton();
+
+      expect(dialogService.openDialogAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ component: SaveAndExitDialogComponent })
+      );
+      expect(dialogRefMock.close).not.toHaveBeenCalled();
+    });
+
+    it("closes without asking when nothing was edited", () => {
+      const dialogService = TestBed.inject(DialogService) as unknown as MockDialogService;
+
+      clickCloseButton();
+
+      expect(dialogService.openDialogAsync).not.toHaveBeenCalled();
+      expect(dialogRefMock.close).toHaveBeenCalled();
+    });
   });
 
   it("should initialize with the name from MAT_DIALOG_DATA", () => {

--- a/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-delete-dialog/container-template-delete-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-delete-dialog/container-template-delete-dialog.component.html
@@ -19,7 +19,6 @@
 <app-dialog-wrapper
   title="Delete Container Template"
   i18n-title
-  [showCancelButton]="true"
   [actions]="actions()"
   (actionTriggered)="onAction($event)">
   <div class="delete-confirmation-container">

--- a/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-delete-dialog/container-template-delete-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-delete-dialog/container-template-delete-dialog.component.spec.ts
@@ -108,7 +108,7 @@ describe("ContainerTemplateDeleteDialogComponent", () => {
       const wrapper = fixture.debugElement.query(By.directive(DialogWrapperComponent)).componentInstance;
 
       const showCancelValue =
-        typeof wrapper.showCancelButton === "function" ? wrapper.showCancelButton() : wrapper.showCancelButton;
+        typeof wrapper.showCloseButton === "function" ? wrapper.showCloseButton() : wrapper.showCloseButton;
 
       const actionsValue = typeof wrapper.actions === "function" ? wrapper.actions() : wrapper.actions;
 

--- a/privacyidea/static_new/src/app/components/policies/dialogs/copy-policy-dialog/copy-policy-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/policies/dialogs/copy-policy-dialog/copy-policy-dialog.component.html
@@ -1,6 +1,5 @@
 <app-dialog-wrapper
   title="Copy Policy" i18n-title
-  (wrapperClose)="close()"
   [actions]="actions()"
   [showCloseButton]="false"
   (actionTriggered)="onAction($event)">

--- a/privacyidea/static_new/src/app/components/policies/dialogs/copy-policy-dialog/copy-policy-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/policies/dialogs/copy-policy-dialog/copy-policy-dialog.component.html
@@ -2,6 +2,7 @@
   title="Copy Policy" i18n-title
   (wrapperClose)="close()"
   [actions]="actions()"
+  [showCloseButton]="false"
   (actionTriggered)="onAction($event)">
   <div class="dialog-content">
     <p i18n>Please enter a unique name for the copied policy.</p>

--- a/privacyidea/static_new/src/app/components/shared/dialog/confirmation-dialog/confirmation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/confirmation-dialog/confirmation-dialog.component.html
@@ -20,7 +20,6 @@
   [title]="data.title"
   (wrapperClose)="close()"
   [actions]="actions"
-  [showCancelButton]="true"
   (actionTriggered)="onAction($event)">
   <div class="margin-right-16">
     <p i18n>

--- a/privacyidea/static_new/src/app/components/shared/dialog/confirmation-dialog/confirmation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/confirmation-dialog/confirmation-dialog.component.html
@@ -18,7 +18,6 @@
 -->
 <app-dialog-wrapper
   [title]="data.title"
-  (wrapperClose)="close()"
   [actions]="actions"
   (actionTriggered)="onAction($event)">
   <div class="margin-right-16">

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.html
@@ -12,9 +12,9 @@
       <ng-content></ng-content>
     </div>
   </mat-dialog-content>
-  @if (showCancelButton() || actions().length > 0) {
+  @if (showCloseButton() || actions().length > 0) {
     <div class="pi-dialog-footer">
-      @if (showCancelButton()) {
+      @if (showCloseButton()) {
         <button
           [attr.cdkFocusInitial]="cancelButtonPrimary() || null"
           class="action-button-secondary button-width-s"

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
@@ -37,7 +37,7 @@ describe("DialogWrapperComponent", () => {
     fixture = TestBed.createComponent(DialogWrapperComponent<DialogAction[]>);
     component = fixture.componentInstance;
     nativeElement = fixture.nativeElement;
-    fixture.componentRef.setInput("showCancelButton", true);
+    fixture.componentRef.setInput("showCloseButton", true);
     fixture.componentRef.setInput("title", "Test Title");
     fixture.componentRef.setInput("actions", [
       { value: "confirm", label: "Confirm", type: "confirm", primary: true },
@@ -65,15 +65,15 @@ describe("DialogWrapperComponent", () => {
     expect(iconEl?.textContent).toBe("test_icon");
   });
 
-  it("should show the close button when showCancelButton is true", () => {
+  it("should show the close button when showCloseButton is true", () => {
     const buttons = nativeElement.querySelectorAll(".pi-dialog-footer button");
     const closeButton = Array.from(buttons).find((btn) => btn.textContent?.trim() === "Cancel");
     expect(closeButton?.textContent?.trim()).toBe("Cancel");
     expect(closeButton).toBeTruthy();
   });
 
-  it("should not show the close button when showCancelButton is false", () => {
-    fixture.componentRef.setInput("showCancelButton", false);
+  it("should not show the close button when showCloseButton is false", () => {
+    fixture.componentRef.setInput("showCloseButton", false);
     fixture.detectChanges();
     const buttons = nativeElement.querySelectorAll(".pi-dialog-footer button");
     const closeButton = Array.from(buttons).find((btn) => btn.textContent?.trim() === "Close");
@@ -135,18 +135,18 @@ describe("DialogWrapperComponent", () => {
     const fixtureWrapper = TestBed.createComponent(DialogWrapperComponent);
     fixtureWrapper.componentRef.setInput("title", "Error Test");
     fixtureWrapper.componentRef.setInput("actions", []);
-    fixtureWrapper.componentRef.setInput("showCancelButton", false);
+    fixtureWrapper.componentRef.setInput("showCloseButton", false);
 
     expect(() => fixtureWrapper.detectChanges()).toThrow("Dialog must have at least one action or a cancel button.");
   });
 
   it("should display the custom cancel button label", () => {
-    fixture.componentRef.setInput("showCancelButton", true);
+    fixture.componentRef.setInput("showCloseButton", true);
     fixture.componentRef.setInput("cancelButtonLabel", "Discard Changes");
     fixture.detectChanges();
 
     const buttons = nativeElement.querySelectorAll(".pi-dialog-footer button");
-    // The cancel button is always the first button when showCancelButton is true
+    // The cancel button is always the first button when showCloseButton is true
     const cancelButton = buttons[0];
 
     expect(cancelButton?.textContent?.trim()).toBe("Discard Changes");

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
@@ -27,6 +27,7 @@ describe("DialogWrapperComponent", () => {
   let component: DialogWrapperComponent<DialogAction[]>;
   let fixture: ComponentFixture<DialogWrapperComponent<DialogAction[]>>;
   let nativeElement: HTMLElement;
+  let dialogRef: MockMatDialogRef<unknown, unknown>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -37,6 +38,7 @@ describe("DialogWrapperComponent", () => {
     fixture = TestBed.createComponent(DialogWrapperComponent<DialogAction[]>);
     component = fixture.componentInstance;
     nativeElement = fixture.nativeElement;
+    dialogRef = TestBed.inject(MatDialogRef) as unknown as MockMatDialogRef<unknown, unknown>;
     fixture.componentRef.setInput("showCloseButton", true);
     fixture.componentRef.setInput("title", "Test Title");
     fixture.componentRef.setInput("actions", [
@@ -50,6 +52,45 @@ describe("DialogWrapperComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("shows the close button without the caller opting in", () => {
+    const defaultFixture = TestBed.createComponent(DialogWrapperComponent<DialogAction[]>);
+    defaultFixture.componentRef.setInput("title", "Defaults");
+    defaultFixture.detectChanges();
+
+    const buttons: HTMLButtonElement[] = Array.from(
+      defaultFixture.nativeElement.querySelectorAll(".pi-dialog-footer button")
+    );
+    expect(buttons.map((button) => button.textContent?.trim())).toEqual(["Cancel"]);
+  });
+
+  it("hides the close button when the caller opts out", () => {
+    fixture.componentRef.setInput("showCloseButton", false);
+    fixture.detectChanges();
+
+    const buttons: HTMLButtonElement[] = Array.from(nativeElement.querySelectorAll(".pi-dialog-footer button"));
+    expect(buttons.map((button) => button.textContent?.trim())).not.toContain("Cancel");
+  });
+
+  it("closes the dialog itself by default", () => {
+    const buttons: HTMLButtonElement[] = Array.from(nativeElement.querySelectorAll(".pi-dialog-footer button"));
+    buttons[0].click();
+
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it("hands the close over to the parent when handleCloseExternally is set", () => {
+    const wrapperClose = jest.fn();
+    component.wrapperClose.subscribe(wrapperClose);
+    fixture.componentRef.setInput("handleCloseExternally", true);
+    fixture.detectChanges();
+
+    const buttons: HTMLButtonElement[] = Array.from(nativeElement.querySelectorAll(".pi-dialog-footer button"));
+    buttons[0].click();
+
+    expect(wrapperClose).toHaveBeenCalled();
+    expect(dialogRef.close).not.toHaveBeenCalled();
   });
 
   it("should display the title", () => {

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
@@ -137,7 +137,7 @@ describe("DialogWrapperComponent", () => {
     fixtureWrapper.componentRef.setInput("actions", []);
     fixtureWrapper.componentRef.setInput("showCloseButton", false);
 
-    expect(() => fixtureWrapper.detectChanges()).toThrow("Dialog must have at least one action or a cancel button.");
+    expect(() => fixtureWrapper.detectChanges()).toThrow("Dialog must have at least one action or a close button.");
   });
 
   it("should display the custom cancel button label", () => {

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.ts
@@ -65,7 +65,7 @@ export class DialogWrapperComponent<R = unknown> implements OnInit {
   ngOnInit() {
     assert(
       this.actions().length !== 0 || this.showCloseButton(),
-      "Dialog must have at least one action or a cancel button."
+      "Dialog must have at least one action or a close button."
     );
   }
 }

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.ts
@@ -38,7 +38,7 @@ export class DialogWrapperComponent<R = unknown> implements OnInit {
 
   title = input.required<string>();
   icon = input<string>();
-  showCancelButton = input<boolean>(false);
+  showCloseButton = input<boolean>(true);
   // Empty by default so the template falls back to the translated <div i18n>Cancel</div>.
   // A hardcoded "Cancel" here would bypass i18n and always render in English.
   cancelButtonLabel = input<string>("");
@@ -64,7 +64,7 @@ export class DialogWrapperComponent<R = unknown> implements OnInit {
 
   ngOnInit() {
     assert(
-      this.actions().length !== 0 || this.showCancelButton(),
+      this.actions().length !== 0 || this.showCloseButton(),
       "Dialog must have at least one action or a cancel button."
     );
   }

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.html
@@ -1,0 +1,25 @@
+<!--
+ (c) NetKnights GmbH 2026,  https://netknights.it
+
+ This code is free software; you can redistribute it and/or
+ modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ as published by the Free Software Foundation; either
+ version 3 of the License, or any later version.
+
+ This code is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+
+ You should have received a copy of the GNU Affero General Public
+ License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<app-dialog-wrapper
+  (actionTriggered)="onAction($event)"
+  (wrapperClose)="close()"
+  [actions]="actions"
+  [title]="data.title">
+  <p class="max-width-600">{{ data.message }}</p>
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.html
@@ -18,7 +18,6 @@
 -->
 <app-dialog-wrapper
   (actionTriggered)="onAction($event)"
-  (wrapperClose)="close()"
   [actions]="actions"
   [title]="data.title">
   <p class="max-width-600">{{ data.message }}</p>

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.scss
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.scss
@@ -1,0 +1,1 @@
+@use "styles";

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
+import {
+  MessageConfirmationDialogComponent,
+  MessageConfirmationDialogData
+} from "./message-confirmation-dialog.component";
+
+describe("MessageConfirmationDialogComponent", () => {
+  let component: MessageConfirmationDialogComponent;
+  let fixture: ComponentFixture<MessageConfirmationDialogComponent>;
+  let dialogRef: MockMatDialogRef<MessageConfirmationDialogComponent, boolean>;
+
+  const setup = async (data: Partial<MessageConfirmationDialogData> = {}) => {
+    TestBed.resetTestingModule();
+    dialogRef = new MockMatDialogRef<MessageConfirmationDialogComponent, boolean>();
+
+    await TestBed.configureTestingModule({
+      imports: [MessageConfirmationDialogComponent],
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            title: "Cancel Enrollment",
+            message: "The enrollment can still be completed as soon as the device is online again.",
+            confirmAction: { type: "destruct", label: "Delete", value: true },
+            ...data
+          }
+        },
+        { provide: MatDialogRef, useValue: dialogRef }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MessageConfirmationDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  const footerButtons = (): HTMLButtonElement[] =>
+    Array.from(fixture.nativeElement.querySelectorAll(".pi-dialog-footer button"));
+
+  it("should create", async () => {
+    await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it("renders the title and the plain message without a generated question", async () => {
+    await setup();
+
+    expect(fixture.nativeElement.textContent).toContain("Cancel Enrollment");
+    expect(fixture.nativeElement.textContent).toContain(
+      "The enrollment can still be completed as soon as the device is online again."
+    );
+    expect(fixture.nativeElement.textContent).not.toContain("Are you sure");
+    expect(fixture.nativeElement.querySelector("ul")).toBeNull();
+  });
+
+  it("shows the confirm action next to the close button and marks it primary", async () => {
+    await setup();
+
+    expect(footerButtons().map((button) => button.textContent?.trim())).toEqual(["Cancel", "Delete"]);
+    expect(component.actions[0].primary).toBe(true);
+  });
+
+  it("keeps an explicit primary flag from the caller", async () => {
+    await setup({ confirmAction: { type: "confirm", label: "Proceed", value: true, primary: false } });
+
+    expect(component.actions[0].primary).toBe(false);
+  });
+
+  it("closes with true when the confirm action is triggered", async () => {
+    await setup();
+
+    component.onAction(true);
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it("closes without a result when the dialog is dismissed", async () => {
+    await setup();
+
+    footerButtons()[0].click();
+
+    expect(dialogRef.close).toHaveBeenCalled();
+    expect(dialogRef.close.mock.calls[0][0]).toBeUndefined();
+  });
+});

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.ts
@@ -1,0 +1,46 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+
+import { Component } from "@angular/core";
+import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
+import { DialogAction } from "@models/dialog";
+
+export interface MessageConfirmationDialogData {
+  title: string;
+  message: string;
+  confirmAction: DialogAction<true>;
+}
+
+@Component({
+  selector: "app-message-confirmation-dialog",
+  imports: [DialogWrapperComponent],
+  templateUrl: "./message-confirmation-dialog.component.html",
+  styleUrl: "./message-confirmation-dialog.component.scss"
+})
+export class MessageConfirmationDialogComponent extends AbstractDialogComponent<
+  MessageConfirmationDialogData,
+  boolean
+> {
+  actions: DialogAction<boolean>[] = [{ ...this.data.confirmAction, primary: this.data.confirmAction.primary ?? true }];
+
+  onAction(value: boolean): void {
+    this.close(value);
+  }
+}

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-dialog/message-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-dialog/message-dialog.component.html
@@ -19,8 +19,7 @@
 
 <app-dialog-wrapper
   [title]="data.title || 'Information'"
-  [icon]="data.icon"
-  (wrapperClose)="close()">
+  [icon]="data.icon">
   <mat-dialog-content>
     <div class="text-center">
       @for (text of data.texts; track text) {

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-dialog/message-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-dialog/message-dialog.component.html
@@ -20,7 +20,6 @@
 <app-dialog-wrapper
   [title]="data.title || 'Information'"
   [icon]="data.icon"
-  [showCancelButton]="true"
   (wrapperClose)="close()">
   <mat-dialog-content>
     <div class="text-center">

--- a/privacyidea/static_new/src/app/components/shared/dialog/save-and-exit-dialog/save-and-exit-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/save-and-exit-dialog/save-and-exit-dialog.component.html
@@ -1,6 +1,5 @@
 <app-dialog-wrapper
   [title]="title()"
-  [showCancelButton]="true"
   [actions]="actions()"
   (actionTriggered)="onAction($event)">
   <p>{{ message() }}</p>

--- a/privacyidea/static_new/src/app/components/token/resync-otp-token-dialog/resync-otp-token-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/resync-otp-token-dialog/resync-otp-token-dialog.component.html
@@ -19,7 +19,6 @@
 
 <app-dialog-wrapper
   [title]="data ? 'Token Resync Successful' : 'Token Resync Failed'"
-  [showCancelButton]="true"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@closeButtonLabel"
   (wrapperClose)="close()">

--- a/privacyidea/static_new/src/app/components/token/resync-otp-token-dialog/resync-otp-token-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/resync-otp-token-dialog/resync-otp-token-dialog.component.html
@@ -20,8 +20,7 @@
 <app-dialog-wrapper
   [title]="data ? 'Token Resync Successful' : 'Token Resync Failed'"
   cancelButtonLabel="Close"
-  i18n-cancelButtonLabel="@@closeButtonLabel"
-  (wrapperClose)="close()">
+  i18n-cancelButtonLabel="@@closeButtonLabel">
   <mat-dialog-content>
     <div class="text-center">
       @if (data) {

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/lost-token/lost-token.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/lost-token/lost-token.component.html
@@ -17,7 +17,6 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  (wrapperClose)="close()"
   (actionTriggered)="onCloseAction()"
   [showCloseButton]="false"
   [actions]="[closeAction]"

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/lost-token/lost-token.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/lost-token/lost-token.component.html
@@ -19,7 +19,7 @@
 <app-dialog-wrapper
   (wrapperClose)="close()"
   (actionTriggered)="onCloseAction()"
-  [showCancelButton]="false"
+  [showCloseButton]="false"
   [actions]="[closeAction]"
   [title]="dialogTitle()">
   <div class="lost-content">

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
@@ -17,7 +17,6 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  (wrapperClose)="close()"
   (actionTriggered)="rolloverToken()"
   [title]="title()"
   [actions]="dialogActions()">

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
@@ -19,7 +19,6 @@
 <app-dialog-wrapper
   (wrapperClose)="close()"
   (actionTriggered)="rolloverToken()"
-  [showCancelButton]="true"
   [title]="title()"
   [actions]="dialogActions()">
   <div>

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.spec.ts
@@ -155,7 +155,8 @@ describe("TokenRolloverComponent", () => {
 
       expect(dialogService.openDialog).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ response: enrollResponse })
+          data: expect.objectContaining({ response: enrollResponse }),
+          configOverride: { autoFocus: "input", disableClose: true }
         })
       );
       expect(verifySpy).toHaveBeenCalledWith(completeResponse);
@@ -209,7 +210,8 @@ describe("TokenRolloverComponent", () => {
 
       expect(dialogService.openDialog).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ response: enrollResponse })
+          data: expect.objectContaining({ response: enrollResponse }),
+          configOverride: { autoFocus: "input", disableClose: true }
         })
       );
       expect(finalizeSpy).toHaveBeenCalledWith(verifiedResponse);

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.ts
@@ -160,7 +160,8 @@ export class TokenRolloverComponent extends AbstractDialogComponent<
 
     const dialogRef = this.dialogService.openDialog({
       component: TokenCompleteEnrollmentComponent,
-      data: this.enrolledDialogData()
+      data: this.enrolledDialogData(),
+      configOverride: { autoFocus: "input", disableClose: true }
     });
     dialogRef.afterClosed().subscribe((result) => {
       this.tokenService.tokenDetailResource.reload();
@@ -192,7 +193,8 @@ export class TokenRolloverComponent extends AbstractDialogComponent<
     // Open verify dialog
     const dialogRef = this.dialogService.openDialog({
       component: TokenVerifyEnrollmentComponent,
-      data: this.enrolledDialogData()
+      data: this.enrolledDialogData(),
+      configOverride: { autoFocus: "input", disableClose: true }
     });
     dialogRef.afterClosed().subscribe((result) => {
       this.tokenService.tokenDetailResource.reload();

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.ts
@@ -26,6 +26,7 @@ import { EnrollTokenTypeSwitchComponent } from "@components/shared/enroll-token-
 import { TokenCompleteEnrollmentComponent } from "@components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component";
 import { TokenEnrollmentLastStepDialogComponent } from "@components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component";
 import { TokenVerifyEnrollmentComponent } from "@components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component";
+import { ENROLLMENT_CANCELLED } from "@components/token/token-enrollment/token-enrollment.constants";
 import { DialogAction } from "@models/dialog";
 import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
 import { NotificationService, NotificationServiceInterface } from "@services/notification/notification.service";
@@ -135,7 +136,8 @@ export class TokenRolloverComponent extends AbstractDialogComponent<
     // Complete rollover
     // Push, passkey, webauthn (TODO: maybe we can integrate this into the complete enrollment dialog component)
     if (strategy.onEnrollmentResponse && enrollmentResponse) {
-      enrollmentResponse = await strategy.onEnrollmentResponse(enrollmentResponse, enrollmentArgs.data);
+      const stepResult = await strategy.onEnrollmentResponse(enrollmentResponse, enrollmentArgs.data);
+      enrollmentResponse = stepResult === ENROLLMENT_CANCELLED ? null : stepResult;
     }
 
     // two step enrollment + handles further enrollment steps (verify + success dialog)
@@ -162,7 +164,7 @@ export class TokenRolloverComponent extends AbstractDialogComponent<
     });
     dialogRef.afterClosed().subscribe((result) => {
       this.tokenService.tokenDetailResource.reload();
-      if (result) {
+      if (result && result !== ENROLLMENT_CANCELLED) {
         this.enrollResponse.set(result);
         this.enrolledDialogData.set({
           ...this.enrolledDialogData()!,
@@ -194,7 +196,7 @@ export class TokenRolloverComponent extends AbstractDialogComponent<
     });
     dialogRef.afterClosed().subscribe((result) => {
       this.tokenService.tokenDetailResource.reload();
-      if (result) {
+      if (result && result !== ENROLLMENT_CANCELLED) {
         this.enrollResponse.set(result);
         this._handleEnrollmentResponse(result);
       }

--- a/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-hotp-machine-attach-dialog/token-hotp-machine-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-hotp-machine-attach-dialog/token-hotp-machine-attach-dialog.component.html
@@ -22,7 +22,6 @@
   i18n-title
   (actionTriggered)="onAction($event)"
   [actions]="[assignAction]"
-  [showCancelButton]="true"
   (wrapperClose)="close()">
   <!-- number input field for countForm and roundsForm -->
   <mat-form-field

--- a/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-hotp-machine-attach-dialog/token-hotp-machine-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-hotp-machine-attach-dialog/token-hotp-machine-attach-dialog.component.html
@@ -21,8 +21,7 @@
   title="Attach Offline Machine"
   i18n-title
   (actionTriggered)="onAction($event)"
-  [actions]="[assignAction]"
-  (wrapperClose)="close()">
+  [actions]="[assignAction]">
   <!-- number input field for countForm and roundsForm -->
   <mat-form-field
     appearance="fill"

--- a/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-ssh-machine-attach-dialog/token-ssh-machine-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-ssh-machine-attach-dialog/token-ssh-machine-attach-dialog.component.html
@@ -20,7 +20,6 @@
 <app-dialog-wrapper
   title="Assign SSH Machine"
   i18n-title
-  (wrapperClose)="close()"
   (actionTriggered)="onAction($event)"
   [actions]="[assignAction]">
   <mat-form-field

--- a/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-ssh-machine-attach-dialog/token-ssh-machine-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-ssh-machine-attach-dialog/token-ssh-machine-attach-dialog.component.html
@@ -22,8 +22,7 @@
   i18n-title
   (wrapperClose)="close()"
   (actionTriggered)="onAction($event)"
-  [actions]="[assignAction]"
-  [showCancelButton]="true">
+  [actions]="[assignAction]">
   <mat-form-field
     appearance="fill"
     class="input-width-l">

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-passkey/enroll-passkey.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-passkey/enroll-passkey.component.spec.ts
@@ -21,12 +21,14 @@ import { provideHttpClient } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { EnrollmentResponse, TokenEnrollmentData } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { ENROLLMENT_CANCELLED } from "@components/token/token-enrollment/token-enrollment.constants";
 import { Base64Service } from "@services/base64/base64.service";
+import { AuthService } from "@services/auth/auth.service";
 import { DialogService } from "@services/dialog/dialog.service";
 import { NotificationService } from "@services/notification/notification.service";
 import { TokenService } from "@services/token/token.service";
-import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
 import { MockBase64Service, MockNotificationService, MockTokenService } from "@testing/mock-services";
+import { MockAuthService } from "@testing/mock-services/mock-auth-service";
 import { MockDialogService } from "@testing/mock-services/mock-dialog-service";
 import { lastValueFrom, of, throwError } from "rxjs";
 import { EnrollPasskeyComponent } from "./enroll-passkey.component";
@@ -59,6 +61,7 @@ describe("EnrollPasskeyComponent", () => {
         provideHttpClientTesting(),
         { provide: TokenService, useClass: MockTokenService },
         { provide: DialogService, useClass: MockDialogService },
+        { provide: AuthService, useClass: MockAuthService },
         { provide: Base64Service, useClass: MockBase64Service },
         { provide: NotificationService, useClass: MockNotificationService }
       ]
@@ -134,9 +137,6 @@ describe("EnrollPasskeyComponent", () => {
     } as unknown as TokenEnrollmentData;
     const args = component.buildEnrollmentArgs(initData);
     expect(args).not.toBeNull();
-    const dialogRefMock = new MockMatDialogRef();
-    dialogRefMock.afterClosed.mockReturnValue(of(true));
-    dialogService.openDialog.mockReturnValue(dialogRefMock);
     tokenService.enrollToken.mockReturnValueOnce(lastValueFrom(of(initResp)));
     const initResponse = await tokenService.enrollToken(args);
     const res = await component.onEnrollmentResponse(initResponse, args!.data);
@@ -148,7 +148,7 @@ describe("EnrollPasskeyComponent", () => {
     expect(b64.bytesToBase64).toHaveBeenCalled();
 
     expect(res).toStrictEqual(finalResp);
-    expect(res?.detail.serial).toBe("S-1");
+    expect((res as EnrollmentResponse).detail.serial).toBe("S-1");
 
     // After the happy path completes the strategy clears its reopenDialog signal back to undefined.
     expect(component.reopenDialog()).toBeUndefined();
@@ -164,9 +164,7 @@ describe("EnrollPasskeyComponent", () => {
     const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs));
     const finalResponse = component.onEnrollmentResponse(initResponse as EnrollmentResponse, enrollmentArgs!.data);
     await expect(finalResponse).rejects.toThrow(/Invalid server response/i);
-    expect(notif.error).toHaveBeenCalledWith(
-      "Failed to initiate Passkey registration: Invalid server response."
-    );
+    expect(notif.error).toHaveBeenCalledWith("Failed to initiate Passkey registration: Invalid server response.");
     expect(dialogService.openDialog).not.toHaveBeenCalled();
   });
 
@@ -210,7 +208,7 @@ describe("EnrollPasskeyComponent", () => {
     const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs));
     const finalResponse = component.onEnrollmentResponse(initResponse as EnrollmentResponse, enrollmentArgs!.data);
 
-    await expect(finalResponse).rejects.toThrow();
+    await expect(finalResponse).resolves.toBe(ENROLLMENT_CANCELLED);
 
     expect(notif.error).toHaveBeenCalledWith(
       "Error during final Passkey registration step. Attempting to clean up token."
@@ -255,7 +253,9 @@ describe("EnrollPasskeyComponent", () => {
 
     const finalize = (serial: string) => ({ detail: { serial } });
 
-    tokenService.enrollToken.mockReturnValueOnce(of(passkeyInit("S-1", "tx-1"))).mockReturnValueOnce(of(finalize("S-1")));
+    tokenService.enrollToken
+      .mockReturnValueOnce(of(passkeyInit("S-1", "tx-1")))
+      .mockReturnValueOnce(of(finalize("S-1")));
 
     const enrollmentArgs = component.buildEnrollmentArgs({} as TokenEnrollmentData);
     const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs));
@@ -268,5 +268,80 @@ describe("EnrollPasskeyComponent", () => {
 
     // strategy.reopenDialog is cleared once the flow finalizes successfully.
     expect(component.reopenDialog()).toBeUndefined();
+  });
+
+  describe("cancelling the enrollment", () => {
+    let authService: MockAuthService;
+
+    beforeEach(() => {
+      authService = TestBed.inject(AuthService) as unknown as MockAuthService;
+    });
+
+    const passkeyInitResponse = () =>
+      ({
+        detail: {
+          serial: "S-CANCEL",
+          transaction_id: "tx",
+          passkey_registration: {
+            rp: { name: "Example", id: "example.com" },
+            user: { id: "AA", name: "alice", displayName: "Alice" },
+            challenge: "AAAA",
+            pubKeyCredParams: [],
+            excludeCredentials: [],
+            authenticatorSelection: {},
+            timeout: 10000,
+            extensions: {},
+            attestation: "none"
+          }
+        }
+      }) as unknown as EnrollmentResponse;
+
+    const startPendingRegistration = async () => {
+      // The browser prompt never settles, so the dialog stays open until the user acts on it.
+      setNavigatorCredentials({ create: jest.fn().mockReturnValue(new Promise(() => undefined)) });
+      tokenService.enrollToken.mockReturnValue(of(passkeyInitResponse()));
+      const enrollmentArgs = component.buildEnrollmentArgs({} as TokenEnrollmentData);
+      const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs));
+      const pending = component.onEnrollmentResponse(initResponse as EnrollmentResponse, enrollmentArgs!.data);
+      await Promise.resolve();
+      // Wrapped so that awaiting the helper does not await the enrollment itself.
+      return { pending };
+    };
+
+    const dialogData = () => dialogService.openDialog.mock.calls[0][0].data;
+
+    it("replaces the close button with cancel when deletion is allowed", async () => {
+      authService.actionAllowed.mockImplementation((action: string) => action === "delete");
+
+      const { pending } = await startPendingRegistration();
+
+      expect(dialogData()).toEqual(expect.objectContaining({ showCancelButton: true, showCloseButton: false }));
+
+      component.currentStepOneRef?.close();
+      await pending;
+    });
+
+    it("keeps the close button without the delete right", async () => {
+      authService.actionAllowed.mockReturnValue(false);
+
+      const { pending } = await startPendingRegistration();
+
+      expect(dialogData()).toEqual(expect.objectContaining({ showCancelButton: false, showCloseButton: true }));
+
+      component.currentStepOneRef?.close();
+      await pending;
+    });
+
+    it("reports the cancellation and drops the reopen action", async () => {
+      authService.actionAllowed.mockImplementation((action: string) => action === "delete");
+
+      const { pending } = await startPendingRegistration();
+      expect(component.reopenDialog()).toBeDefined();
+
+      component.currentStepOneRef?.close(ENROLLMENT_CANCELLED);
+
+      expect(await pending).toBe(ENROLLMENT_CANCELLED);
+      expect(component.reopenDialog()).toBeUndefined();
+    });
   });
 });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-passkey/enroll-passkey.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-passkey/enroll-passkey.component.ts
@@ -31,11 +31,11 @@ import {
   PasskeyFinalizeData
 } from "@app/mappers/token-api-payload/passkey-token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
 import {
   TokenEnrollmentFirstStepDialogComponent,
   TokenEnrollmentFirstStepDialogData
 } from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
-import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
 import {
   ENROLLMENT_CANCELLED,
   EnrollmentStepResult
@@ -113,9 +113,10 @@ export class EnrollPasskeyComponent extends EnrollTokenBase<PasskeyEnrollmentDat
     enrollmentResponse: EnrollmentResponse;
   }): Promise<EnrollmentStepResult> {
     const dialogRef = this.openStepOneDialog(args);
+    const dialogClosed = lastValueFrom(dialogRef.afterClosed());
     void this.attemptRegistration(args);
 
-    const dialogResult = await lastValueFrom(dialogRef.afterClosed());
+    const dialogResult = await dialogClosed;
     if (dialogResult === ENROLLMENT_CANCELLED) {
       this.reopenDialog.set(undefined);
       return ENROLLMENT_CANCELLED;

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-passkey/enroll-passkey.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-passkey/enroll-passkey.component.ts
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 
-import { Component, forwardRef, inject } from "@angular/core";
+import { Component, forwardRef, inject, signal } from "@angular/core";
 import { MatDialogRef } from "@angular/material/dialog";
 import {
   EnrollmentResponse,
@@ -31,11 +31,16 @@ import {
   PasskeyFinalizeData
 } from "@app/mappers/token-api-payload/passkey-token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
-import { TokenEnrollmentFirstStepDialogComponent } from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
 import {
-  EnrollmentArgs,
-  EnrollTokenBase
-} from "@components/token/token-enrollment/enroll-token-base";
+  TokenEnrollmentFirstStepDialogComponent,
+  TokenEnrollmentFirstStepDialogData
+} from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
+import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
+import {
+  ENROLLMENT_CANCELLED,
+  EnrollmentStepResult
+} from "@components/token/token-enrollment/token-enrollment.constants";
+import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { Base64Service, Base64ServiceInterface } from "@services/base64/base64.service";
 import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
 import { NotificationService, NotificationServiceInterface } from "@services/notification/notification.service";
@@ -48,9 +53,7 @@ import { lastValueFrom } from "rxjs";
   imports: [],
   templateUrl: "./enroll-passkey.component.html",
   styleUrl: "./enroll-passkey.component.scss",
-  providers: [
-    { provide: EnrollTokenBase, useExisting: forwardRef(() => EnrollPasskeyComponent) }
-  ]
+  providers: [{ provide: EnrollTokenBase, useExisting: forwardRef(() => EnrollPasskeyComponent) }]
 })
 export class EnrollPasskeyComponent extends EnrollTokenBase<PasskeyEnrollmentData> {
   protected readonly enrollmentMapper: PasskeyApiPayloadMapper = inject(PasskeyApiPayloadMapper);
@@ -59,8 +62,14 @@ export class EnrollPasskeyComponent extends EnrollTokenBase<PasskeyEnrollmentDat
   protected readonly tokenService: TokenServiceInterface = inject(TokenService);
   protected readonly base64Service: Base64ServiceInterface = inject(Base64Service);
   protected readonly dialogService: DialogServiceInterface = inject(DialogService);
+  protected readonly authService: AuthServiceInterface = inject(AuthService);
 
-  currentStepOneRef?: MatDialogRef<AbstractDialogComponent, boolean>;
+  currentStepOneRef?: MatDialogRef<
+    AbstractDialogComponent<TokenEnrollmentFirstStepDialogData, EnrollmentStepResult>,
+    EnrollmentStepResult
+  >;
+
+  readonly registrationFailed = signal(false);
 
   buildEnrollmentArgs(basicEnrollmentData: TokenEnrollmentData): EnrollmentArgs<PasskeyEnrollmentData> | null {
     if (!navigator.credentials?.create) {
@@ -83,71 +92,82 @@ export class EnrollPasskeyComponent extends EnrollTokenBase<PasskeyEnrollmentDat
   override async onEnrollmentResponse(
     enrollmentResponse: EnrollmentResponse,
     enrollmentInitData: TokenEnrollmentData
-  ): Promise<EnrollmentResponse | null> {
-    let passkeyEnrollmentInitData: PasskeyEnrollmentData;
+  ): Promise<EnrollmentStepResult> {
     if (enrollmentInitData.type !== "passkey") {
       console.warn("Received enrollment data is not of type 'passkey'. Cannot proceed with Passkey enrollment.");
       return null;
-    } else {
-      passkeyEnrollmentInitData = enrollmentInitData as PasskeyEnrollmentData;
     }
-    const detail = enrollmentResponse.detail;
-    const passkeyRegOptions = detail?.passkey_registration;
-    if (!passkeyRegOptions) {
+    if (!enrollmentResponse.detail?.passkey_registration) {
       this.notificationService.error($localize`Failed to initiate Passkey registration: Invalid server response.`);
       throw new Error("Invalid server response for Passkey initiation.");
     }
-    this.openStepOneDialog({
-      enrollmentInitData: passkeyEnrollmentInitData as PasskeyEnrollmentData,
+
+    return this.runRegistration({
+      enrollmentInitData: enrollmentInitData as PasskeyEnrollmentData,
       enrollmentResponse
     });
-    const publicKeyCred = await this.readPublicKeyCred(enrollmentResponse);
-    if (publicKeyCred === null) {
-      return null;
+  }
+
+  private async runRegistration(args: {
+    enrollmentInitData: PasskeyEnrollmentData;
+    enrollmentResponse: EnrollmentResponse;
+  }): Promise<EnrollmentStepResult> {
+    const dialogRef = this.openStepOneDialog(args);
+    void this.attemptRegistration(args);
+
+    const dialogResult = await lastValueFrom(dialogRef.afterClosed());
+    if (dialogResult === ENROLLMENT_CANCELLED) {
+      this.reopenDialog.set(undefined);
+      return ENROLLMENT_CANCELLED;
     }
-    const resposeLastStep = await this.finalizeEnrollment({
-      enrollmentInitData: passkeyEnrollmentInitData as PasskeyEnrollmentData,
-      enrollmentResponse,
-      publicKeyCred
-    });
-    return resposeLastStep;
+    return dialogResult ?? null;
+  }
+
+  private async attemptRegistration(args: {
+    enrollmentInitData: PasskeyEnrollmentData;
+    enrollmentResponse: EnrollmentResponse;
+  }): Promise<void> {
+    const dialogRef = this.currentStepOneRef;
+    this.registrationFailed.set(false);
+
+    const publicKeyCred = await this.readPublicKeyCred(args.enrollmentResponse);
+    if (!publicKeyCred || (dialogRef && !this.dialogService.isDialogOpen(dialogRef))) {
+      this.registrationFailed.set(true);
+      return;
+    }
+
+    const responseLastStep = await this.finalizeEnrollment({ ...args, publicKeyCred }).catch(() => null);
+    dialogRef?.close(responseLastStep ?? ENROLLMENT_CANCELLED);
   }
 
   openStepOneDialog(args: {
     enrollmentInitData: PasskeyEnrollmentData;
     enrollmentResponse: EnrollmentResponse;
-  }): MatDialogRef<AbstractDialogComponent, boolean> {
+  }): MatDialogRef<
+    AbstractDialogComponent<TokenEnrollmentFirstStepDialogData, EnrollmentStepResult>,
+    EnrollmentStepResult
+  > {
     const { enrollmentInitData, enrollmentResponse } = args;
+    const showCancelButton = !enrollmentInitData.rollover && this.authService.actionAllowed("delete");
 
     this.reopenDialog.set(async () => {
       if (this.currentStepOneRef && this.dialogService.isDialogOpen(this.currentStepOneRef)) {
         return null;
       }
-      this.currentStepOneRef = this.dialogService.openDialog({
-        component: TokenEnrollmentFirstStepDialogComponent,
-        data: { enrollmentResponse }
-      });
-      const publicKeyCred = await this.readPublicKeyCred(enrollmentResponse);
-      if (publicKeyCred === null) {
-        return null;
-      }
-      const resposeLastStep = await this.finalizeEnrollment({
-        enrollmentInitData,
-        enrollmentResponse,
-        publicKeyCred
-      });
-      return resposeLastStep;
+      return this.runRegistration(args);
     });
 
     this.currentStepOneRef = this.dialogService.openDialog({
       component: TokenEnrollmentFirstStepDialogComponent,
-      data: { enrollmentResponse }
+      data: {
+        enrollmentResponse,
+        showCancelButton,
+        showCloseButton: !showCancelButton,
+        registrationFailed: this.registrationFailed.asReadonly(),
+        onRetry: () => void this.attemptRegistration(args)
+      }
     });
     return this.currentStepOneRef;
-  }
-
-  closeStepOneDialog(): void {
-    this.currentStepOneRef?.close();
   }
 
   private async readPublicKeyCred(responseStepOne: EnrollmentResponse): Promise<PublicKeyCredential | null> {
@@ -180,11 +200,10 @@ export class EnrollPasskeyComponent extends EnrollTokenBase<PasskeyEnrollmentDat
     const publicKeyCred = await navigator.credentials
       .create({ publicKey: publicKeyOptions })
       .catch((browserOrCredentialError) => {
-        this.notificationService.error($localize`Passkey credential creation failed: ${browserOrCredentialError.message}`);
+        this.notificationService.error(
+          $localize`Passkey credential creation failed: ${browserOrCredentialError.message}`
+        );
         return null;
-      })
-      .finally(() => {
-        this.closeStepOneDialog();
       });
     return publicKeyCred as PublicKeyCredential | null;
   }
@@ -219,7 +238,9 @@ export class EnrollPasskeyComponent extends EnrollTokenBase<PasskeyEnrollmentDat
       })
     )
       .catch(async (errorStep3) => {
-        this.notificationService.error($localize`Error during final Passkey registration step. Attempting to clean up token.`);
+        this.notificationService.error(
+          $localize`Error during final Passkey registration step. Attempting to clean up token.`
+        );
         await lastValueFrom(this.tokenService.deleteToken(detail.serial)).catch(() => {
           this.notificationService.error(
             $localize`Failed to delete token ${detail.serial} after registration error. Please check manually.`

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-passkey/enroll-passkey.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-passkey/enroll-passkey.component.ts
@@ -148,7 +148,7 @@ export class EnrollPasskeyComponent extends EnrollTokenBase<PasskeyEnrollmentDat
     EnrollmentStepResult
   > {
     const { enrollmentInitData, enrollmentResponse } = args;
-    const showCancelButton = !enrollmentInitData.rollover && this.authService.actionAllowed("delete");
+    const canCancel = !enrollmentInitData.rollover && this.authService.actionAllowed("delete");
 
     this.reopenDialog.set(async () => {
       if (this.currentStepOneRef && this.dialogService.isDialogOpen(this.currentStepOneRef)) {
@@ -161,8 +161,8 @@ export class EnrollPasskeyComponent extends EnrollTokenBase<PasskeyEnrollmentDat
       component: TokenEnrollmentFirstStepDialogComponent,
       data: {
         enrollmentResponse,
-        showCancelButton,
-        showCloseButton: !showCancelButton,
+        showCancelButton: canCancel,
+        showCloseButton: !canCancel,
         registrationFailed: this.registrationFailed.asReadonly(),
         onRetry: () => void this.attemptRegistration(args)
       }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.spec.ts
@@ -138,6 +138,25 @@ describe("EnrollPushComponent", () => {
     expect(component.pollResponse()).toBeUndefined();
   });
 
+  it("opens the first-step dialog so it cannot be dismissed by clicking outside of it", async () => {
+    const initResp = makeInitResp("S-1");
+    const pollResp = makePollResp("enrolled");
+
+    tokenService.enrollToken.mockReturnValue(of(initResp));
+    tokenService.pollTokenRolloutState.mockReturnValue(of(pollResp));
+
+    const enrollmentArgs = component.buildEnrollmentArgs({} as TokenEnrollmentData);
+    const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
+
+    await component.onEnrollmentResponse(initResponse as EnrollmentResponse);
+
+    expect(dialogService.openDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configOverride: { disableClose: true }
+      })
+    );
+  });
+
   it("keeps dialog open when rollout_state is clientwait", async () => {
     const pollResp = makePollResp("clientwait");
     tokenService.enrollToken.mockReturnValue(of(makeInitResp()));

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.spec.ts
@@ -28,9 +28,12 @@ import {
 } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { PushApiPayloadMapper } from "@app/mappers/token-api-payload/push-token-api-payload.mapper";
 import { EnrollTokenBase, ReopenDialogAction } from "@components/token/token-enrollment/enroll-token-base";
+import { ENROLLMENT_CANCELLED } from "@components/token/token-enrollment/token-enrollment.constants";
+import { AuthService } from "@services/auth/auth.service";
 import { DialogService } from "@services/dialog/dialog.service";
 import { TokenDetails, Tokens, TokenService } from "@services/token/token.service";
 import { MockTokenService } from "@testing/mock-services";
+import { MockAuthService } from "@testing/mock-services/mock-auth-service";
 import { MockDialogService } from "@testing/mock-services/mock-dialog-service";
 import { lastValueFrom, of, throwError } from "rxjs";
 import { EnrollPushComponent } from "./enroll-push.component";
@@ -67,6 +70,7 @@ describe("EnrollPushComponent", () => {
   let component: EnrollPushComponent;
   let tokenService: jest.Mocked<MockTokenService>;
   let dialogService: MockDialogService;
+  let authService: MockAuthService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -76,7 +80,8 @@ describe("EnrollPushComponent", () => {
         provideHttpClientTesting(),
         { provide: TokenService, useClass: MockTokenService },
         { provide: DialogService, useClass: MockDialogService },
-        { provide: PushApiPayloadMapper, useClass: DummyPushApiPayloadMapper }
+        { provide: PushApiPayloadMapper, useClass: DummyPushApiPayloadMapper },
+        { provide: AuthService, useClass: MockAuthService }
       ]
     }).compileComponents();
 
@@ -84,6 +89,7 @@ describe("EnrollPushComponent", () => {
     component = fixture.componentInstance;
     tokenService = TestBed.inject(TokenService) as unknown as jest.Mocked<MockTokenService>;
     dialogService = TestBed.inject(DialogService) as unknown as MockDialogService;
+    authService = TestBed.inject(AuthService) as unknown as MockAuthService;
     fixture.detectChanges();
   });
 
@@ -140,11 +146,16 @@ describe("EnrollPushComponent", () => {
     const enrollmentArgs = component.buildEnrollmentArgs({} as TokenEnrollmentData);
     const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
 
-    await component.onEnrollmentResponse(initResponse as EnrollmentResponse);
+    const finalResponsePromise = component.onEnrollmentResponse(initResponse as EnrollmentResponse);
+    await Promise.resolve();
     fixture.detectChanges();
 
     expect(dialogService.openDialog).toHaveBeenCalled();
     expect(component.pollResponse()).toEqual(pollResp);
+
+    // The rollout is still pending, so the dialog stays open until the user closes it.
+    component.firstStepDialogRef?.close();
+    expect(await finalResponsePromise).toBeNull();
   });
 
   it("strategy.reopenDialog exposes a Promise callback that re-triggers polling when dialog is not open", async () => {
@@ -200,13 +211,17 @@ describe("EnrollPushComponent", () => {
     const enrollmentArgs = component.buildEnrollmentArgs({} as TokenEnrollmentData);
     const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
 
-    await component.onEnrollmentResponse(initResponse as EnrollmentResponse);
+    const finalResponsePromise = component.onEnrollmentResponse(initResponse as EnrollmentResponse);
+    await Promise.resolve();
     fixture.detectChanges();
 
     const reopenFn = component.reopenDialog() as ReopenDialogAction | undefined;
     expect(await reopenFn!()).toBeNull();
     expect(dialogService.isDialogOpen).toHaveBeenCalledWith(component.firstStepDialogRef);
     expect(tokenService.pollTokenRolloutState).toHaveBeenCalledTimes(1);
+
+    component.firstStepDialogRef?.close();
+    await finalResponsePromise;
   });
 
   it("falls back to the rollout_state of the init response when the poll response carries no token", async () => {
@@ -252,5 +267,82 @@ describe("EnrollPushComponent", () => {
     await fixture.whenStable();
 
     expect(tokenService.stopPolling).toHaveBeenCalled();
+  });
+
+  describe("cancelling the rollout", () => {
+    const startPendingRollout = async (serial = "S-C") => {
+      tokenService.enrollToken.mockReturnValue(of(makeInitResp(serial)));
+      tokenService.pollTokenRolloutState.mockReturnValue(of(makePollResp("clientwait")));
+
+      const enrollmentArgs = component.buildEnrollmentArgs({} as TokenEnrollmentData);
+      const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
+      const pending = component.onEnrollmentResponse(initResponse as EnrollmentResponse);
+      await Promise.resolve();
+      // Wrapped so that awaiting the helper does not await the enrollment itself.
+      return { pending };
+    };
+
+    const dialogData = () => dialogService.openDialog.mock.calls[0][0].data;
+
+    it("lets the dialog offer a cancel button with a push specific confirmation", async () => {
+      authService.actionAllowed.mockImplementation((action: string) => action === "delete");
+
+      const { pending } = await startPendingRollout();
+
+      expect(dialogData()).toEqual(
+        expect.objectContaining({
+          showCancelButton: true,
+          showCloseButton: true,
+          cancelConfirmationMessage: expect.stringContaining("QR code")
+        })
+      );
+
+      component.firstStepDialogRef?.close();
+      await pending;
+    });
+
+    it("hides the cancel button without the delete right", async () => {
+      authService.actionAllowed.mockReturnValue(false);
+
+      const { pending } = await startPendingRollout();
+
+      expect(dialogData()).toEqual(expect.objectContaining({ showCancelButton: false, showCloseButton: true }));
+
+      component.firstStepDialogRef?.close();
+      await pending;
+    });
+
+    it("never offers to cancel a rollover", async () => {
+      authService.actionAllowed.mockImplementation((action: string) => action === "delete");
+      tokenService.enrollToken.mockReturnValue(of(makeInitResp("S-R")));
+      tokenService.pollTokenRolloutState.mockReturnValue(of(makePollResp("clientwait")));
+
+      const enrollmentArgs = component.buildEnrollmentArgs({} as TokenEnrollmentData);
+      const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
+      const pending = component.onEnrollmentResponse(
+        initResponse as EnrollmentResponse,
+        {
+          type: "push",
+          rollover: true
+        } as TokenEnrollmentData
+      );
+      await Promise.resolve();
+
+      expect(dialogData()).toEqual(expect.objectContaining({ showCancelButton: false }));
+
+      component.firstStepDialogRef?.close();
+      await pending;
+    });
+
+    it("reports the cancellation and drops the reopen action", async () => {
+      const { pending } = await startPendingRollout();
+      expect(component.reopenDialog()).toBeDefined();
+
+      component.firstStepDialogRef?.close(ENROLLMENT_CANCELLED);
+
+      expect(await pending).toBe(ENROLLMENT_CANCELLED);
+      expect(component.reopenDialog()).toBeUndefined();
+      expect(tokenService.stopPolling).toHaveBeenCalled();
+    });
   });
 });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.ts
@@ -132,6 +132,8 @@ export class EnrollPushComponent extends EnrollTokenBase<PushEnrollmentData> {
     AbstractDialogComponent<TokenEnrollmentFirstStepDialogData, EnrollmentStepResult>,
     EnrollmentStepResult
   > {
+    const canCancel = !rollover && this.authService.actionAllowed("delete");
+
     this.reopenDialog.set(async () => {
       if (this.firstStepDialogRef && this.dialogService.isDialogOpen(this.firstStepDialogRef)) {
         return null;
@@ -143,8 +145,9 @@ export class EnrollPushComponent extends EnrollTokenBase<PushEnrollmentData> {
       component: TokenEnrollmentFirstStepDialogComponent,
       data: {
         enrollmentResponse,
-        showCancelButton: !rollover && this.authService.actionAllowed("delete"),
-        showCloseButton: true
+        showCancelButton: canCancel,
+        showCloseButton: true,
+        cancelConfirmationMessage: $localize`When canceling the rollout the token will be deleted even when the QR code was scanned.`
       }
     });
   }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.ts
@@ -23,18 +23,18 @@ import { PiResponse } from "@app/app.component";
 import { EnrollmentResponse, TokenEnrollmentData } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { PushApiPayloadMapper, PushEnrollmentData } from "@app/mappers/token-api-payload/push-token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
 import {
   TokenEnrollmentFirstStepDialogComponent,
   TokenEnrollmentFirstStepDialogData
 } from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
-import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
 import {
   ENROLLMENT_CANCELLED,
   EnrollmentStepResult
 } from "@components/token/token-enrollment/token-enrollment.constants";
 import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
-import { TokenService, TokenServiceInterface, Tokens } from "@services/token/token.service";
+import { Tokens, TokenService, TokenServiceInterface } from "@services/token/token.service";
 import { lastValueFrom } from "rxjs";
 
 @Component({
@@ -90,8 +90,10 @@ export class EnrollPushComponent extends EnrollTokenBase<PushEnrollmentData> {
   ): Promise<EnrollmentStepResult> {
     const dialogRef = this._openStepOneDialog(initResponse, rollover);
     this.firstStepDialogRef = dialogRef;
+    const dialogClosed = lastValueFrom(dialogRef.afterClosed());
 
     let lastPollResponse: PiResponse<Tokens> | undefined;
+    let pollingFailed = false;
     this.tokenService.pollTokenRolloutState({ tokenSerial: initResponse.detail.serial, initDelay }).subscribe({
       next: (pollResponse) => {
         lastPollResponse = pollResponse;
@@ -100,16 +102,22 @@ export class EnrollPushComponent extends EnrollTokenBase<PushEnrollmentData> {
           dialogRef.close();
         }
       },
-      error: () => dialogRef.close()
+      error: () => {
+        pollingFailed = true;
+        dialogRef.close();
+      }
     });
 
-    const dialogResult = await lastValueFrom(dialogRef.afterClosed());
+    const dialogResult = await dialogClosed;
     this.tokenService.stopPolling();
     this.pollResponse.set(undefined);
 
     if (dialogResult === ENROLLMENT_CANCELLED) {
       this.reopenDialog.set(undefined);
       return ENROLLMENT_CANCELLED;
+    }
+    if (pollingFailed) {
+      return null;
     }
 
     const rolloutState = lastPollResponse?.result?.value?.tokens[0].rollout_state ?? initResponse.detail.rollout_state;

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.ts
@@ -20,17 +20,19 @@
 import { Component, forwardRef, inject, signal } from "@angular/core";
 import { MatDialogRef } from "@angular/material/dialog";
 import { PiResponse } from "@app/app.component";
-import {
-  EnrollmentResponse,
-  TokenEnrollmentData
-} from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { EnrollmentResponse, TokenEnrollmentData } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { PushApiPayloadMapper, PushEnrollmentData } from "@app/mappers/token-api-payload/push-token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
-import { TokenEnrollmentFirstStepDialogComponent } from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
 import {
-  EnrollmentArgs,
-  EnrollTokenBase
-} from "@components/token/token-enrollment/enroll-token-base";
+  TokenEnrollmentFirstStepDialogComponent,
+  TokenEnrollmentFirstStepDialogData
+} from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
+import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
+import {
+  ENROLLMENT_CANCELLED,
+  EnrollmentStepResult
+} from "@components/token/token-enrollment/token-enrollment.constants";
+import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
 import { TokenService, TokenServiceInterface, Tokens } from "@services/token/token.service";
 import { lastValueFrom } from "rxjs";
@@ -41,20 +43,22 @@ import { lastValueFrom } from "rxjs";
   imports: [],
   templateUrl: "./enroll-push.component.html",
   styleUrl: "./enroll-push.component.scss",
-  providers: [
-    { provide: EnrollTokenBase, useExisting: forwardRef(() => EnrollPushComponent) }
-  ]
+  providers: [{ provide: EnrollTokenBase, useExisting: forwardRef(() => EnrollPushComponent) }]
 })
 export class EnrollPushComponent extends EnrollTokenBase<PushEnrollmentData> {
   protected readonly tokenService: TokenServiceInterface = inject(TokenService);
   protected readonly dialogService: DialogServiceInterface = inject(DialogService);
   protected readonly enrollmentMapper: PushApiPayloadMapper = inject(PushApiPayloadMapper);
+  protected readonly authService: AuthServiceInterface = inject(AuthService);
 
   pollResponse = signal<PiResponse<Tokens> | undefined>(undefined);
 
   text = this.tokenService.tokenTypeOptions().find((type) => type.key === "push")?.text;
 
-  firstStepDialogRef: MatDialogRef<AbstractDialogComponent, boolean> | null = null;
+  firstStepDialogRef: MatDialogRef<
+    AbstractDialogComponent<TokenEnrollmentFirstStepDialogData, EnrollmentStepResult>,
+    EnrollmentStepResult
+  > | null = null;
 
   override readonly showEnrollDataInLastStep: boolean = false;
 
@@ -69,17 +73,46 @@ export class EnrollPushComponent extends EnrollTokenBase<PushEnrollmentData> {
     };
   }
 
-  override async onEnrollmentResponse(initResponse: EnrollmentResponse): Promise<EnrollmentResponse | null> {
+  override async onEnrollmentResponse(
+    initResponse: EnrollmentResponse,
+    enrollmentData?: TokenEnrollmentData
+  ): Promise<EnrollmentStepResult> {
     if (!initResponse) {
       return null;
     }
-    const pollResponse = await this.pollTokenRolloutState(initResponse, 5000).catch(() => {
-      return null;
+    return this.awaitRolloutState(initResponse, 5000, enrollmentData?.rollover ?? false);
+  }
+
+  private async awaitRolloutState(
+    initResponse: EnrollmentResponse,
+    initDelay: number,
+    rollover: boolean
+  ): Promise<EnrollmentStepResult> {
+    const dialogRef = this._openStepOneDialog(initResponse, rollover);
+    this.firstStepDialogRef = dialogRef;
+
+    let lastPollResponse: PiResponse<Tokens> | undefined;
+    this.tokenService.pollTokenRolloutState({ tokenSerial: initResponse.detail.serial, initDelay }).subscribe({
+      next: (pollResponse) => {
+        lastPollResponse = pollResponse;
+        this.pollResponse.set(pollResponse);
+        if (pollResponse.result?.value?.tokens[0].rollout_state !== "clientwait") {
+          dialogRef.close();
+        }
+      },
+      error: () => dialogRef.close()
     });
-    if (!pollResponse) {
-      return null;
+
+    const dialogResult = await lastValueFrom(dialogRef.afterClosed());
+    this.tokenService.stopPolling();
+    this.pollResponse.set(undefined);
+
+    if (dialogResult === ENROLLMENT_CANCELLED) {
+      this.reopenDialog.set(undefined);
+      return ENROLLMENT_CANCELLED;
     }
-    const rolloutState = pollResponse.result?.value?.tokens[0].rollout_state ?? initResponse.detail.rollout_state;
+
+    const rolloutState = lastPollResponse?.result?.value?.tokens[0].rollout_state ?? initResponse.detail.rollout_state;
     if (rolloutState === "clientwait") {
       return null;
     }
@@ -92,46 +125,27 @@ export class EnrollPushComponent extends EnrollTokenBase<PushEnrollmentData> {
     };
   }
 
-  private pollTokenRolloutState = (
-    initResponse: EnrollmentResponse,
-    initDelay: number
-  ): Promise<PiResponse<Tokens>> => {
-    this.firstStepDialogRef = this._openStepOneDialog(initResponse);
-    this.firstStepDialogRef.afterClosed().subscribe(() => {
-      this.tokenService.stopPolling();
-      this.pollResponse.set(undefined);
-    });
-    const observable = this.tokenService.pollTokenRolloutState({
-      tokenSerial: initResponse.detail.serial,
-      initDelay
-    });
-    observable.subscribe({
-      next: (pollResponse) => {
-        this.pollResponse.set(pollResponse);
-        if (pollResponse.result?.value?.tokens[0].rollout_state !== "clientwait") {
-          this.firstStepDialogRef?.close(true);
-        }
-      }
-    });
-    return lastValueFrom(observable);
-  };
-
-  private _openStepOneDialog(enrollmentResponse: EnrollmentResponse): MatDialogRef<AbstractDialogComponent, boolean> {
+  private _openStepOneDialog(
+    enrollmentResponse: EnrollmentResponse,
+    rollover: boolean
+  ): MatDialogRef<
+    AbstractDialogComponent<TokenEnrollmentFirstStepDialogData, EnrollmentStepResult>,
+    EnrollmentStepResult
+  > {
     this.reopenDialog.set(async () => {
       if (this.firstStepDialogRef && this.dialogService.isDialogOpen(this.firstStepDialogRef)) {
         return null;
       }
-
-      const pollResponse = await this.pollTokenRolloutState(enrollmentResponse, 0);
-      return {
-        ...enrollmentResponse,
-        detail: { ...enrollmentResponse.detail, rollout_state: pollResponse.result?.value?.tokens[0].rollout_state }
-      };
+      return this.awaitRolloutState(enrollmentResponse, 0, rollover);
     });
 
     return this.dialogService.openDialog({
       component: TokenEnrollmentFirstStepDialogComponent,
-      data: { enrollmentResponse }
+      data: {
+        enrollmentResponse,
+        showCancelButton: !rollover && this.authService.actionAllowed("delete"),
+        showCloseButton: true
+      }
     });
   }
 }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-push/enroll-push.component.ts
@@ -156,7 +156,8 @@ export class EnrollPushComponent extends EnrollTokenBase<PushEnrollmentData> {
         showCancelButton: canCancel,
         showCloseButton: true,
         cancelConfirmationMessage: $localize`When canceling the rollout the token will be deleted even when the QR code was scanned.`
-      }
+      },
+      configOverride: { disableClose: true }
     });
   }
 }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-token-base.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-token-base.ts
@@ -23,6 +23,7 @@ import {
   TokenApiPayloadMapper,
   TokenEnrollmentData
 } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { EnrollmentStepResult } from "@components/token/token-enrollment/token-enrollment.constants";
 import { Observable } from "rxjs";
 
 export interface EnrollmentArgs<T extends TokenEnrollmentData> {
@@ -30,7 +31,7 @@ export interface EnrollmentArgs<T extends TokenEnrollmentData> {
   mapper: TokenApiPayloadMapper<T>;
 }
 
-export type ReopenDialogAction = () => Promise<EnrollmentResponse | null> | Observable<EnrollmentResponse | null>;
+export type ReopenDialogAction = () => Promise<EnrollmentStepResult> | Observable<EnrollmentStepResult>;
 
 // Abstract class so it can be used as a DI token via
 // `{ provide: EnrollTokenBase, useExisting: forwardRef(() => MyEnrollComponent) }`.
@@ -39,7 +40,7 @@ export type ReopenDialogAction = () => Promise<EnrollmentResponse | null> | Obse
 export abstract class EnrollTokenBase<T extends TokenEnrollmentData = TokenEnrollmentData> {
   abstract buildEnrollmentArgs(basic: TokenEnrollmentData): EnrollmentArgs<T> | null;
 
-  onEnrollmentResponse?(response: EnrollmentResponse, data: TokenEnrollmentData): Promise<EnrollmentResponse | null>;
+  onEnrollmentResponse?(response: EnrollmentResponse, data: TokenEnrollmentData): Promise<EnrollmentStepResult>;
 
   readonly showEnrollDataInLastStep: boolean = true;
 

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component.spec.ts
@@ -28,9 +28,12 @@ import {
 } from "@app/mappers/token-api-payload/webauthn-token-api-payload.mapper";
 import { EnrollWebauthnComponent } from "@components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component";
 import { Base64Service } from "@services/base64/base64.service";
+import { ENROLLMENT_CANCELLED } from "@components/token/token-enrollment/token-enrollment.constants";
+import { AuthService } from "@services/auth/auth.service";
 import { DialogService } from "@services/dialog/dialog.service";
 import { NotificationService } from "@services/notification/notification.service";
 import { TokenService } from "@services/token/token.service";
+import { MockAuthService } from "@testing/mock-services/mock-auth-service";
 import { MockDialogService } from "@testing/mock-services/mock-dialog-service";
 import { lastValueFrom, of, throwError } from "rxjs";
 
@@ -66,7 +69,8 @@ const makePublicKeyCredential = () => {
     type: "public-key",
     authenticatorAttachment: "platform",
     response: { attestationObject, clientDataJSON },
-    getClientExtensionResults: () => ({ credProps: { rk: true } })
+    getClientExtensionResults: () => ({ credProps: { rk: true } }),
+    toJSON: jest.fn()
   } as PublicKeyCredential;
 };
 
@@ -83,7 +87,10 @@ describe("EnrollWebauthnComponent", () => {
 
   const setNavigatorCreate = (impl: () => Promise<PublicKeyCredential>) => {
     (navigator as { credentials: CredentialsContainer }).credentials = {
-      create: jest.fn().mockImplementation(impl)
+      create: jest.fn().mockImplementation(impl),
+      get: jest.fn(),
+      preventSilentAccess: jest.fn(),
+      store: jest.fn()
     } as CredentialsContainer;
   };
 
@@ -109,7 +116,8 @@ describe("EnrollWebauthnComponent", () => {
         { provide: Base64Service, useValue: base64 },
         { provide: WebAuthnApiPayloadMapper, useValue: {} },
         { provide: WebAuthnFinalizeApiPayloadMapper, useValue: {} },
-        { provide: DialogService, useClass: MockDialogService }
+        { provide: DialogService, useClass: MockDialogService },
+        { provide: AuthService, useClass: MockAuthService }
       ]
     }).compileComponents();
 
@@ -122,6 +130,17 @@ describe("EnrollWebauthnComponent", () => {
     fixture.detectChanges();
     await Promise.resolve();
     fixture.detectChanges();
+  };
+
+  /**
+   * A failed attempt keeps the first step dialog open so the user can retry or cancel.
+   * The enrollment promise therefore only settles once the dialog is closed.
+   */
+  const closeDialogAfterFailedAttempt = async () => {
+    for (let i = 0; i < 20 && !component.registrationFailed(); i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    component.stepOneDialogRef?.close();
   };
 
   it("should create", async () => {
@@ -144,7 +163,9 @@ describe("EnrollWebauthnComponent", () => {
 
   it("should notify when init response missing detail", async () => {
     setNavigatorCreate(async () => makePublicKeyCredential());
-    tokenService.enrollToken.mockReturnValue(of({ detail: undefined, type: "webauthn" } as unknown as EnrollmentResponse));
+    tokenService.enrollToken.mockReturnValue(
+      of({ detail: undefined, type: "webauthn" } as unknown as EnrollmentResponse)
+    );
     await detectChangesStable();
     const enrollmentArgs = component.buildEnrollmentArgs(BASIC);
     const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
@@ -192,6 +213,7 @@ describe("EnrollWebauthnComponent", () => {
       enrollmentArgs!.data
     );
     expect(finalResponse).toBeNull();
+    expect(dialogServiceMock.openDialog).not.toHaveBeenCalled();
     expect(notification.warning).toHaveBeenCalledWith(
       "Invalid transaction ID or serial number in enrollment detail for finalization."
     );
@@ -206,10 +228,12 @@ describe("EnrollWebauthnComponent", () => {
     await detectChangesStable();
     const enrollmentArgs = component.buildEnrollmentArgs(BASIC);
     const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
-    const finalResponse = await component.onEnrollmentResponse(
+    const finalResponsePromise = component.onEnrollmentResponse(
       initResponse as EnrollmentResponse,
       enrollmentArgs!.data
     );
+    await closeDialogAfterFailedAttempt();
+    const finalResponse = await finalResponsePromise;
     expect(dialogServiceMock.openDialog).toHaveBeenCalled();
     expect(finalResponse).toBeNull();
     expect(notification.error).toHaveBeenCalledWith("WebAuthn credential creation failed: blocked");
@@ -244,17 +268,22 @@ describe("EnrollWebauthnComponent", () => {
     await detectChangesStable();
     const enrollmentArgs = component.buildEnrollmentArgs(BASIC);
     const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
-    const finalResponse = await component.onEnrollmentResponse(
+    const finalResponsePromise = component.onEnrollmentResponse(
       initResponse as EnrollmentResponse,
       enrollmentArgs!.data
     );
+    await closeDialogAfterFailedAttempt();
+    const finalResponse = await finalResponsePromise;
     expect(finalResponse).toBeNull();
     expect(notification.error).toHaveBeenCalledWith("WebAuthn finalization failed: finalize-fail");
   });
 
   it("buildEnrollmentArgs returns the webauthn payload and mapper", async () => {
     (navigator as { credentials: CredentialsContainer }).credentials = {
-      create: jest.fn().mockResolvedValue(makePublicKeyCredential())
+      create: jest.fn().mockResolvedValue(makePublicKeyCredential()),
+      get: jest.fn(),
+      preventSilentAccess: jest.fn(),
+      store: jest.fn()
     } as CredentialsContainer;
     await detectChangesStable();
 
@@ -263,6 +292,62 @@ describe("EnrollWebauthnComponent", () => {
     expect(enrollmentArgs).toEqual({
       data: { realm: "default", type: "webauthn", user: "alice" },
       mapper: expect.any(Object)
+    });
+  });
+
+  describe("cancelling the enrollment", () => {
+    let authService: MockAuthService;
+
+    beforeEach(() => {
+      authService = TestBed.inject(AuthService) as unknown as MockAuthService;
+    });
+
+    const startPendingRegistration = async () => {
+      // The browser prompt never settles, so the dialog stays open until the user acts on it.
+      setNavigatorCreate(() => new Promise<PublicKeyCredential>(() => undefined));
+      tokenService.enrollToken.mockReturnValue(of(makeEnrollInitResponse()));
+      const enrollmentArgs = component.buildEnrollmentArgs(BASIC);
+      const initResponse = await lastValueFrom(tokenService.enrollToken(enrollmentArgs!));
+      const pending = component.onEnrollmentResponse(initResponse as EnrollmentResponse, enrollmentArgs!.data);
+      await Promise.resolve();
+      // Wrapped so that awaiting the helper does not await the enrollment itself.
+      return { pending };
+    };
+
+    const dialogData = () => dialogServiceMock.openDialog.mock.calls[0][0].data;
+
+    it("replaces the close button with cancel when deletion is allowed", async () => {
+      authService.actionAllowed.mockImplementation((action: string) => action === "delete");
+
+      const { pending } = await startPendingRegistration();
+
+      expect(dialogData()).toEqual(expect.objectContaining({ showCancelButton: true, showCloseButton: false }));
+
+      component.stepOneDialogRef?.close();
+      await pending;
+    });
+
+    it("keeps the close button without the delete right", async () => {
+      authService.actionAllowed.mockReturnValue(false);
+
+      const { pending } = await startPendingRegistration();
+
+      expect(dialogData()).toEqual(expect.objectContaining({ showCancelButton: false, showCloseButton: true }));
+
+      component.stepOneDialogRef?.close();
+      await pending;
+    });
+
+    it("reports the cancellation and drops the reopen action", async () => {
+      authService.actionAllowed.mockImplementation((action: string) => action === "delete");
+
+      const { pending } = await startPendingRegistration();
+      expect(component.reopenDialog()).toBeDefined();
+
+      component.stepOneDialogRef?.close(ENROLLMENT_CANCELLED);
+
+      expect(await pending).toBe(ENROLLMENT_CANCELLED);
+      expect(component.reopenDialog()).toBeUndefined();
     });
   });
 });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component.ts
@@ -17,12 +17,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 
-import { Component, forwardRef, inject } from "@angular/core";
+import { Component, forwardRef, inject, signal } from "@angular/core";
 import { MatDialogRef } from "@angular/material/dialog";
-import {
-  EnrollmentResponse,
-  TokenEnrollmentData
-} from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { EnrollmentResponse, TokenEnrollmentData } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import {
   WebAuthnApiPayloadMapper,
   WebAuthnEnrollmentData,
@@ -31,16 +28,21 @@ import {
   WebauthnFinalizeData
 } from "@app/mappers/token-api-payload/webauthn-token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
-import { TokenEnrollmentFirstStepDialogComponent } from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
 import {
-  EnrollmentArgs,
-  EnrollTokenBase
-} from "@components/token/token-enrollment/enroll-token-base";
+  TokenEnrollmentFirstStepDialogComponent,
+  TokenEnrollmentFirstStepDialogData
+} from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
+import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
+import {
+  ENROLLMENT_CANCELLED,
+  EnrollmentStepResult
+} from "@components/token/token-enrollment/token-enrollment.constants";
+import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { Base64Service, Base64ServiceInterface } from "@services/base64/base64.service";
 import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
 import { NotificationService, NotificationServiceInterface } from "@services/notification/notification.service";
 import { TokenService, TokenServiceInterface } from "@services/token/token.service";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, lastValueFrom } from "rxjs";
 
 @Component({
   selector: "app-enroll-webauthn",
@@ -48,9 +50,7 @@ import { firstValueFrom } from "rxjs";
   imports: [],
   templateUrl: "./enroll-webauthn.component.html",
   styleUrl: "./enroll-webauthn.component.scss",
-  providers: [
-    { provide: EnrollTokenBase, useExisting: forwardRef(() => EnrollWebauthnComponent) }
-  ]
+  providers: [{ provide: EnrollTokenBase, useExisting: forwardRef(() => EnrollWebauthnComponent) }]
 })
 export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentData> {
   protected readonly enrollmentMapper: WebAuthnApiPayloadMapper = inject(WebAuthnApiPayloadMapper);
@@ -59,8 +59,14 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
   protected readonly tokenService: TokenServiceInterface = inject(TokenService);
   protected readonly base64Service: Base64ServiceInterface = inject(Base64Service);
   protected readonly dialogService: DialogServiceInterface = inject(DialogService);
+  protected readonly authService: AuthServiceInterface = inject(AuthService);
 
-  stepOneDialogRef: MatDialogRef<AbstractDialogComponent, boolean> | null = null;
+  stepOneDialogRef: MatDialogRef<
+    AbstractDialogComponent<TokenEnrollmentFirstStepDialogData, EnrollmentStepResult>,
+    EnrollmentStepResult
+  > | null = null;
+
+  readonly registrationFailed = signal(false);
 
   buildEnrollmentArgs(basicEnrollmentData: TokenEnrollmentData): EnrollmentArgs<WebAuthnEnrollmentData> | null {
     if (!navigator.credentials?.create) {
@@ -83,7 +89,7 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
   override async onEnrollmentResponse(
     enrollmentResponse: EnrollmentResponse,
     enrollmentData: TokenEnrollmentData
-  ): Promise<EnrollmentResponse | null> {
+  ): Promise<EnrollmentStepResult> {
     if (!enrollmentResponse?.detail) {
       this.notificationService.error(
         $localize`Failed to initiate WebAuthn registration: Invalid server response or missing details.`
@@ -98,25 +104,47 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
       console.warn("Received enrollment data is not of type 'webauthn'. Cannot proceed with WebAuthn enrollment.");
       return null;
     }
-    const webauthnEnrollmentResponse = enrollmentResponse as WebauthnEnrollmentResponse;
-    const webauthnEnrollmentData = enrollmentData as WebAuthnEnrollmentData;
 
-    this.openStepOneDialog({
-      webauthnEnrollmentData,
-      webauthnEnrollmentResponse: webauthnEnrollmentResponse
+    return this.runRegistration({
+      webauthnEnrollmentData: enrollmentData as WebAuthnEnrollmentData,
+      webauthnEnrollmentResponse: enrollmentResponse as WebauthnEnrollmentResponse
     });
+  }
 
-    const responseLastStep = await this.finalizeEnrollment({
-      webauthnEnrollmentData,
-      webauthnEnrollmentResponse: webauthnEnrollmentResponse
-    });
+  private async runRegistration(args: {
+    webauthnEnrollmentData: WebAuthnEnrollmentData;
+    webauthnEnrollmentResponse: WebauthnEnrollmentResponse;
+  }): Promise<EnrollmentStepResult> {
+    const dialogRef = this.openStepOneDialog(args);
+    void this.attemptRegistration(args);
 
-    if (!responseLastStep) {
-      this.closeStepOneDialog();
-      return null;
+    const dialogResult = await lastValueFrom(dialogRef.afterClosed());
+    if (dialogResult === ENROLLMENT_CANCELLED) {
+      this.reopenDialog.set(undefined);
+      return ENROLLMENT_CANCELLED;
+    }
+    return dialogResult ?? null;
+  }
+
+  private async attemptRegistration(args: {
+    webauthnEnrollmentData: WebAuthnEnrollmentData;
+    webauthnEnrollmentResponse: WebauthnEnrollmentResponse;
+  }): Promise<void> {
+    const dialogRef = this.stepOneDialogRef;
+    this.registrationFailed.set(false);
+
+    const publicKeyCred = await this.readPublicKeyCred(args.webauthnEnrollmentResponse);
+    if (!publicKeyCred || (dialogRef && !this.dialogService.isDialogOpen(dialogRef))) {
+      this.registrationFailed.set(true);
+      return;
     }
 
-    return responseLastStep;
+    const responseLastStep = await this.finalizeEnrollment({ ...args, publicKeyCred });
+    if (!responseLastStep) {
+      this.registrationFailed.set(true);
+      return;
+    }
+    dialogRef?.close(responseLastStep);
   }
 
   readPublicKeyCred = async (enrollmentResponse: WebauthnEnrollmentResponse): Promise<PublicKeyCredential | null> => {
@@ -162,8 +190,6 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
         browserOrCredentialError instanceof Error ? browserOrCredentialError.message : String(browserOrCredentialError);
       this.notificationService.error($localize`WebAuthn credential creation failed: ${message || "Unknown error"}`);
       publicKeyCred = null;
-    } finally {
-      this.closeStepOneDialog();
     }
     return publicKeyCred;
   };
@@ -171,38 +197,39 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
   openStepOneDialog(args: {
     webauthnEnrollmentData: WebAuthnEnrollmentData;
     webauthnEnrollmentResponse: WebauthnEnrollmentResponse;
-  }): void {
-    const { webauthnEnrollmentResponse } = args;
+  }): MatDialogRef<
+    AbstractDialogComponent<TokenEnrollmentFirstStepDialogData, EnrollmentStepResult>,
+    EnrollmentStepResult
+  > {
+    const { webauthnEnrollmentData, webauthnEnrollmentResponse } = args;
+    const showCancelButton = !webauthnEnrollmentData.rollover && this.authService.actionAllowed("delete");
 
     this.reopenDialog.set(async () => {
       if (this.stepOneDialogRef && this.dialogService.isDialogOpen(this.stepOneDialogRef)) {
         return null;
       }
-      this.stepOneDialogRef = this.dialogService.openDialog({
-        component: TokenEnrollmentFirstStepDialogComponent,
-        data: { enrollmentResponse: webauthnEnrollmentResponse }
-      });
-
-      return null;
+      return this.runRegistration(args);
     });
+
     this.stepOneDialogRef = this.dialogService.openDialog({
       component: TokenEnrollmentFirstStepDialogComponent,
-      data: { enrollmentResponse: webauthnEnrollmentResponse }
+      data: {
+        enrollmentResponse: webauthnEnrollmentResponse,
+        showCancelButton,
+        showCloseButton: !showCancelButton,
+        registrationFailed: this.registrationFailed.asReadonly(),
+        onRetry: () => void this.attemptRegistration(args)
+      }
     });
-  }
-
-  closeStepOneDialog(): void {
-    if (this.stepOneDialogRef) {
-      this.stepOneDialogRef.close(true);
-      this.stepOneDialogRef = null;
-    }
+    return this.stepOneDialogRef;
   }
 
   private async finalizeEnrollment(args: {
     webauthnEnrollmentData: WebAuthnEnrollmentData;
     webauthnEnrollmentResponse: WebauthnEnrollmentResponse;
+    publicKeyCred: PublicKeyCredential;
   }): Promise<EnrollmentResponse | null> {
-    const { webauthnEnrollmentData, webauthnEnrollmentResponse } = args;
+    const { webauthnEnrollmentData, webauthnEnrollmentResponse, publicKeyCred } = args;
 
     if (!webauthnEnrollmentResponse || !webauthnEnrollmentResponse.detail) {
       this.notificationService.warning($localize`Enrollment response or its detail is missing for finalization.`);
@@ -216,11 +243,6 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
       this.notificationService.warning(
         $localize`Invalid transaction ID or serial number in enrollment detail for finalization.`
       );
-      return null;
-    }
-
-    const publicKeyCred = await this.readPublicKeyCred(webauthnEnrollmentResponse);
-    if (publicKeyCred === null) {
       return null;
     }
 

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component.ts
@@ -202,7 +202,7 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
     EnrollmentStepResult
   > {
     const { webauthnEnrollmentData, webauthnEnrollmentResponse } = args;
-    const showCancelButton = !webauthnEnrollmentData.rollover && this.authService.actionAllowed("delete");
+    const canCancel = !webauthnEnrollmentData.rollover && this.authService.actionAllowed("delete");
 
     this.reopenDialog.set(async () => {
       if (this.stepOneDialogRef && this.dialogService.isDialogOpen(this.stepOneDialogRef)) {
@@ -215,8 +215,8 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
       component: TokenEnrollmentFirstStepDialogComponent,
       data: {
         enrollmentResponse: webauthnEnrollmentResponse,
-        showCancelButton,
-        showCloseButton: !showCancelButton,
+        showCancelButton: canCancel,
+        showCloseButton: !canCancel,
         registrationFailed: this.registrationFailed.asReadonly(),
         onRetry: () => void this.attemptRegistration(args)
       }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/enroll-webauthn/enroll-webauthn.component.ts
@@ -28,11 +28,11 @@ import {
   WebauthnFinalizeData
 } from "@app/mappers/token-api-payload/webauthn-token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
 import {
   TokenEnrollmentFirstStepDialogComponent,
   TokenEnrollmentFirstStepDialogData
 } from "@components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component";
-import { EnrollmentArgs, EnrollTokenBase } from "@components/token/token-enrollment/enroll-token-base";
 import {
   ENROLLMENT_CANCELLED,
   EnrollmentStepResult
@@ -105,9 +105,18 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
       return null;
     }
 
+    const webauthnEnrollmentResponse = enrollmentResponse as WebauthnEnrollmentResponse;
+    const registerRequest = webauthnEnrollmentResponse.detail.webAuthnRegisterRequest;
+    if (!registerRequest?.transaction_id || !webauthnEnrollmentResponse.detail.serial) {
+      this.notificationService.warning(
+        $localize`Invalid transaction ID or serial number in enrollment detail for finalization.`
+      );
+      return null;
+    }
+
     return this.runRegistration({
       webauthnEnrollmentData: enrollmentData as WebAuthnEnrollmentData,
-      webauthnEnrollmentResponse: enrollmentResponse as WebauthnEnrollmentResponse
+      webauthnEnrollmentResponse
     });
   }
 
@@ -116,9 +125,10 @@ export class EnrollWebauthnComponent extends EnrollTokenBase<WebAuthnEnrollmentD
     webauthnEnrollmentResponse: WebauthnEnrollmentResponse;
   }): Promise<EnrollmentStepResult> {
     const dialogRef = this.openStepOneDialog(args);
+    const dialogClosed = lastValueFrom(dialogRef.afterClosed());
     void this.attemptRegistration(args);
 
-    const dialogResult = await lastValueFrom(dialogRef.afterClosed());
+    const dialogResult = await dialogClosed;
     if (dialogResult === ENROLLMENT_CANCELLED) {
       this.reopenDialog.set(undefined);
       return ENROLLMENT_CANCELLED;

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
@@ -20,7 +20,7 @@
 <app-dialog-wrapper
   title="Complete Token Enrollment"
   i18n-title="@@tokenEnrollCompleteTitle"
-  [showCancelButton]="true"
+  [showCloseButton]="showCloseButton()"
   [actions]="dialogActions()"
   (actionTriggered)="onDialogAction($event)"
   cancelButtonLabel="Close"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
@@ -24,8 +24,7 @@
   [actions]="dialogActions()"
   (actionTriggered)="onDialogAction($event)"
   cancelButtonLabel="Close"
-  i18n-cancelButtonLabel="@@closeButtonLabel"
-  (wrapperClose)="close()">
+  i18n-cancelButtonLabel="@@closeButtonLabel">
   <span
     class="margin-bottom-16"
     i18n>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.spec.ts
@@ -21,9 +21,12 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { ENROLLMENT_CANCELLED } from "@components/token/token-enrollment/token-enrollment.constants";
+import { AuthService } from "@services/auth/auth.service";
 import { ContentService } from "@services/content/content.service";
 import { TokenService } from "@services/token/token.service";
 import { MockContentService } from "@testing/mock-services/mock-content-service";
+import { MockAuthService } from "@testing/mock-services/mock-auth-service";
 import { MockTokenService } from "@testing/mock-services/mock-token-service";
 
 import { of } from "rxjs";
@@ -117,5 +120,70 @@ describe("TokenCompleteEnrollmentComponent", () => {
       });
     });
     component.onDialogAction("enroll");
+  });
+
+  describe("cancelling the enrollment", () => {
+    let authService: MockAuthService;
+
+    const setup = async (data: Record<string, unknown> = {}, canDelete = false) => {
+      TestBed.resetTestingModule();
+      dialogRefSpy = { close: jest.fn() };
+      await TestBed.configureTestingModule({
+        imports: [TokenCompleteEnrollmentComponent],
+        providers: [
+          { provide: TokenService, useClass: MockTokenService },
+          { provide: ContentService, useClass: MockContentService },
+          { provide: AuthService, useClass: MockAuthService },
+          { provide: MatDialogRef, useValue: dialogRefSpy },
+          { provide: MAT_DIALOG_DATA, useValue: { ...dialogData, ...data } }
+        ],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+      fixture = TestBed.createComponent(TokenCompleteEnrollmentComponent);
+      component = fixture.componentInstance;
+      mockTokenService = TestBed.inject(TokenService) as unknown as MockTokenService;
+      authService = TestBed.inject(AuthService) as unknown as MockAuthService;
+      authService.actionAllowed.mockImplementation((action: string) => canDelete && action === "delete");
+      fixture.detectChanges();
+    };
+
+    const actionValues = () => component.dialogActions().map((action) => action.value);
+
+    it("offers no cancel action without the delete right", async () => {
+      await setup({}, false);
+
+      expect(actionValues()).toEqual(["enroll"]);
+      expect(component["showCloseButton"]()).toBe(true);
+    });
+
+    it("offers the cancel action and drops the close button for two step enrollments", async () => {
+      await setup({ response: { detail: { serial: "123", "2step_output": 1 }, type: "hotp" } }, true);
+
+      expect(actionValues()).toEqual(["cancelEnrollment", "enroll"]);
+      expect(component["showCloseButton"]()).toBe(false);
+    });
+
+    it("keeps the close button for clientwait enrollments without a client part", async () => {
+      await setup({}, true);
+
+      expect(actionValues()).toEqual(["cancelEnrollment", "enroll"]);
+      expect(component["showCloseButton"]()).toBe(true);
+    });
+
+    it("never offers to cancel a rollover", async () => {
+      await setup({ rollover: true }, true);
+
+      expect(actionValues()).toEqual(["enroll"]);
+      expect(component["showCloseButton"]()).toBe(true);
+    });
+
+    it("deletes the incomplete token and reports the cancellation", async () => {
+      await setup({}, true);
+
+      component.onDialogAction("cancelEnrollment");
+
+      expect(mockTokenService.cancelEnrollment).toHaveBeenCalledWith("123");
+      expect(dialogRefSpy.close).toHaveBeenCalledWith(ENROLLMENT_CANCELLED);
+    });
   });
 });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.ts
@@ -99,7 +99,8 @@ export class TokenCompleteEnrollmentComponent extends AbstractDialogComponent<
       return;
     }
     this.tokenService.cancelEnrollment(tokenSerial).subscribe({
-      next: () => this.close(ENROLLMENT_CANCELLED)
+      next: () => this.close(ENROLLMENT_CANCELLED),
+      error: () => undefined
     });
   }
 

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.ts
@@ -24,9 +24,13 @@ import { MatFormField, MatInput, MatLabel } from "@angular/material/input";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 import { TokenEnrollmentDataComponent } from "@components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component";
+import {
+  ENROLLMENT_CANCELLED,
+  EnrollmentStepResult
+} from "@components/token/token-enrollment/token-enrollment.constants";
 import { DialogAction } from "@models/dialog";
+import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
-import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { TokenEnrollmentDialogData, TokenService, TokenServiceInterface } from "@services/token/token.service";
 
 @Component({
@@ -35,9 +39,13 @@ import { TokenEnrollmentDialogData, TokenService, TokenServiceInterface } from "
   templateUrl: "./token-complete-enrollment.component.html",
   styleUrl: "./token-complete-enrollment.component.scss"
 })
-export class TokenCompleteEnrollmentComponent extends AbstractDialogComponent<TokenEnrollmentDialogData, EnrollmentResponse> {
+export class TokenCompleteEnrollmentComponent extends AbstractDialogComponent<
+  TokenEnrollmentDialogData,
+  EnrollmentStepResult
+> {
   protected readonly tokenService: TokenServiceInterface = inject(TokenService);
   protected readonly contentService: ContentServiceInterface = inject(ContentService);
+  protected readonly authService: AuthServiceInterface = inject(AuthService);
 
   protected readonly enrollDetails = this.data.response?.detail;
   protected readonly tokenType = this.data.response?.type ?? "hotp";
@@ -56,19 +64,47 @@ export class TokenCompleteEnrollmentComponent extends AbstractDialogComponent<To
   });
   invalidInputSignal = computed(() => !this.clientPartForm().valid());
 
-  readonly dialogActions = computed<DialogAction<string>[]>(() => [
-    {
+  readonly dialogActions = computed<DialogAction<string>[]>(() => {
+    const actions: DialogAction<string>[] = [];
+    if (this.canCancelEnrollment()) {
+      actions.push({
+        label: $localize`Cancel`,
+        type: "destruct",
+        value: "cancelEnrollment"
+      });
+    }
+    actions.push({
       label: $localize`Enroll`,
       type: "confirm",
       value: "enroll",
       disabled: this.invalidInputSignal()
-    }
-  ]);
+    });
+    return actions;
+  });
+
+  protected readonly showCloseButton = computed(() => !this.twoStepEnrollment() || !this.canCancelEnrollment());
 
   onDialogAction(value: string) {
     if (value === "enroll") {
       this.enrollToken();
     }
+    if (value === "cancelEnrollment") {
+      this.cancelEnrollment();
+    }
+  }
+
+  cancelEnrollment() {
+    const tokenSerial = this.enrollDetails?.serial;
+    if (!tokenSerial) {
+      return;
+    }
+    this.tokenService.cancelEnrollment(tokenSerial).subscribe({
+      next: () => this.close(ENROLLMENT_CANCELLED)
+    });
+  }
+
+  private canCancelEnrollment(): boolean {
+    return !this.data.rollover && this.authService.actionAllowed("delete");
   }
 
   enrollToken() {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.html
@@ -17,12 +17,23 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  (actionTriggered)="onAction($event)"
   (wrapperClose)="close()"
-  [showCancelButton]="true"
+  [actions]="actions()"
+  [showCloseButton]="showCloseButton"
+  cancelButtonLabel="Close"
+  i18n-cancelButtonLabel="@@closeButtonLabel"
   i18n-title
   title="Take action on your authenticator">
   <mat-dialog-content>
-    @if (
+    @if (registrationFailed()) {
+      <p
+        class="max-width-600"
+        i18n>
+        The registration was not completed. Please try again or cancel the enrollment. Cancelling deletes the token that
+        has already been created for this enrollment.
+      </p>
+    } @else if (
       data.enrollmentResponse.detail["webAuthnRegisterRequest"] || data.enrollmentResponse.detail.passkey_registration
     ) {
       <p
@@ -51,7 +62,9 @@
           i18n-alt
           src="{{ data.enrollmentResponse.detail.pushurl.img }}"
           width="300px" />
-        <p class="max-width-600" i18n>
+        <p
+          class="max-width-600"
+          i18n>
           Your token with serial number {{ data.enrollmentResponse.detail.serial }} is not completely enrolled, yet.
           Please scan the QR code with the privacyIDEA Authenticator App or click
           <a href="{{ data.enrollmentResponse.detail.pushurl.value }}">this link</a>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.html
@@ -18,7 +18,6 @@
 -->
 <app-dialog-wrapper
   (actionTriggered)="onAction($event)"
-  (wrapperClose)="close()"
   [actions]="actions()"
   [showCloseButton]="showCloseButton"
   cancelButtonLabel="Close"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.spec.ts
@@ -18,81 +18,185 @@
  **/
 import { provideHttpClient } from "@angular/common/http";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { MatAutocompleteModule } from "@angular/material/autocomplete";
-import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
-import { MatFormFieldModule } from "@angular/material/form-field";
-import { TokenService } from "@services/token/token.service";
-import { MockTokenService, MockContentService } from "@testing/mock-services";
-import { TokenEnrollmentFirstStepDialogComponent } from "./token-enrollment-first-step-dialog.component";
+import { signal } from "@angular/core";
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogState } from "@angular/material/dialog";
+import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { ENROLLMENT_CANCELLED } from "@components/token/token-enrollment/token-enrollment.constants";
 import { ContentService } from "@services/content/content.service";
+import { DialogService } from "@services/dialog/dialog.service";
+import { TokenService } from "@services/token/token.service";
+import { MockContentService, MockTokenService } from "@testing/mock-services";
+import { MockDialogService } from "@testing/mock-services/mock-dialog-service";
+import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
+import { of, throwError } from "rxjs";
+import {
+  TokenEnrollmentFirstStepDialogComponent,
+  TokenEnrollmentFirstStepDialogData
+} from "./token-enrollment-first-step-dialog.component";
 
 describe("TokenEnrollmentFirstStepDialogComponent", () => {
   let component: TokenEnrollmentFirstStepDialogComponent;
   let fixture: ComponentFixture<TokenEnrollmentFirstStepDialogComponent>;
-  const dialogRefMock = {
-    close: jest.fn()
-  } as unknown as jest.Mocked<MatDialogRef<TokenEnrollmentFirstStepDialogComponent, string | null>>;
+  let tokenService: MockTokenService;
+  let dialogService: MockDialogService;
+  let dialogRefMock: jest.Mocked<MatDialogRef<TokenEnrollmentFirstStepDialogComponent>>;
 
-  const dialogDataStub = {
-    enrollmentResponse: {
-      detail: {
-        rollout_state: "enrolled",
-        serial: "1234567890",
-        threadid: 1,
-        passkey_registration: null,
-        u2fRegisterRequest: null,
-        pushurl: {
-          description: "Push URL",
-          img: "push.png",
-          value: "https://example.com/push",
-          value_b32: "B32VALUE"
-        },
-        googleurl: {
-          description: "Google URL",
-          img: "google.png",
-          value: "https://example.com/google",
-          value_b32: "B32VALUE"
-        },
-        otpkey: {
-          description: "OTP Key",
-          img: "otp.png",
-          value: "otpprotocol://example.com/otpkey",
-          value_b32: "B32VALUE"
-        },
-        motpurl: {
-          description: "MOTP URL",
-          img: "motp.png",
-          value: "motpprotocol://example.com/motpkey",
-          value_b32: "B32VALUE"
-        },
-        tiqrenroll: {
-          description: "Tiqr Enroll URL",
-          img: "tiqr.png",
-          value: "tiqr://example.com/enroll",
-          value_b32: "B32VALUE"
-        }
+  const enrollmentResponse = {
+    detail: {
+      rollout_state: "clientwait",
+      serial: "PIPU0001",
+      pushurl: {
+        description: "Push URL",
+        img: "push.png",
+        value: "https://example.com/push",
+        value_b32: "B32VALUE"
       }
     }
-  };
+  } as unknown as EnrollmentResponse;
 
-  beforeEach(async () => {
+  const setup = async (data: Partial<TokenEnrollmentFirstStepDialogData> = {}) => {
+    TestBed.resetTestingModule();
+    dialogRefMock = {
+      close: jest.fn(),
+      getState: jest.fn().mockReturnValue(MatDialogState.OPEN)
+    } as unknown as jest.Mocked<MatDialogRef<TokenEnrollmentFirstStepDialogComponent>>;
+
     await TestBed.configureTestingModule({
       providers: [
         provideHttpClient(),
         { provide: MatDialogRef, useValue: dialogRefMock },
-        { provide: MAT_DIALOG_DATA, useValue: dialogDataStub },
+        { provide: MAT_DIALOG_DATA, useValue: { enrollmentResponse, ...data } },
         { provide: TokenService, useClass: MockTokenService },
-        { provide: ContentService, useClass: MockContentService }
+        { provide: ContentService, useClass: MockContentService },
+        { provide: DialogService, useClass: MockDialogService }
       ],
-      imports: [MatFormFieldModule, MatAutocompleteModule, TokenEnrollmentFirstStepDialogComponent]
+      imports: [TokenEnrollmentFirstStepDialogComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TokenEnrollmentFirstStepDialogComponent);
     component = fixture.componentInstance;
+    tokenService = TestBed.inject(TokenService) as unknown as MockTokenService;
+    dialogService = TestBed.inject(DialogService) as unknown as MockDialogService;
     fixture.detectChanges();
+  };
+
+  const footerButtons = (): HTMLButtonElement[] =>
+    Array.from(fixture.nativeElement.querySelectorAll(".pi-dialog-footer button"));
+
+  const buttonLabels = (): string[] => footerButtons().map((button) => button.textContent?.trim() ?? "");
+
+  const clickButton = (label: string) => {
+    const button = footerButtons().find((candidate) => candidate.textContent?.trim() === label);
+    expect(button).toBeTruthy();
+    button!.click();
+    fixture.detectChanges();
+  };
+
+  it("should create", async () => {
+    await setup();
+    expect(component).toBeTruthy();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe("button visibility", () => {
+    it("shows only the close button when the caller offers nothing else", async () => {
+      await setup();
+      expect(buttonLabels()).toEqual(["Close"]);
+    });
+
+    it("shows the cancel button when the caller allows cancelling", async () => {
+      await setup({ showCancelButton: true });
+      expect(buttonLabels()).toEqual(["Close", "Cancel"]);
+    });
+
+    it("hides the close button when the caller replaces it with cancel", async () => {
+      await setup({ showCancelButton: true, showCloseButton: false });
+      expect(buttonLabels()).toEqual(["Cancel"]);
+    });
+
+    it("offers retry only once an attempt has failed", async () => {
+      const registrationFailed = signal(false);
+      await setup({ showCancelButton: true, showCloseButton: false, registrationFailed, onRetry: jest.fn() });
+      expect(buttonLabels()).toEqual(["Cancel"]);
+
+      registrationFailed.set(true);
+      fixture.detectChanges();
+      expect(buttonLabels()).toEqual(["Cancel", "Retry"]);
+    });
+
+    it("does not offer retry without a retry handler", async () => {
+      await setup({ showCancelButton: true, registrationFailed: signal(true) });
+      expect(buttonLabels()).not.toContain("Retry");
+    });
+  });
+
+  describe("cancelling the enrollment", () => {
+    it("deletes the incomplete token and reports the cancellation", async () => {
+      await setup({ showCancelButton: true });
+
+      clickButton("Cancel");
+
+      expect(tokenService.cancelEnrollment).toHaveBeenCalledWith("PIPU0001");
+      expect(dialogRefMock.close).toHaveBeenCalledWith(ENROLLMENT_CANCELLED);
+    });
+
+    it("keeps the dialog open when the deletion fails", async () => {
+      await setup({ showCancelButton: true });
+      tokenService.cancelEnrollment.mockReturnValue(throwError(() => new Error("denied")));
+
+      clickButton("Cancel");
+
+      expect(dialogRefMock.close).not.toHaveBeenCalled();
+    });
+
+    it("asks for confirmation first when the caller provides a message", async () => {
+      await setup({ showCancelButton: true, cancelConfirmationMessage: "Scanned codes stop working." });
+      const confirmationRef = new MockMatDialogRef();
+      confirmationRef.afterClosed.mockReturnValue(of(true));
+      dialogService.openDialog.mockReturnValue(confirmationRef);
+
+      clickButton("Cancel");
+
+      expect(dialogService.openDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ message: "Scanned codes stop working." })
+        })
+      );
+      expect(tokenService.cancelEnrollment).toHaveBeenCalledWith("PIPU0001");
+      expect(dialogRefMock.close).toHaveBeenCalledWith(ENROLLMENT_CANCELLED);
+    });
+
+    it("keeps the token when the confirmation is declined", async () => {
+      await setup({ showCancelButton: true, cancelConfirmationMessage: "Scanned codes stop working." });
+      const confirmationRef = new MockMatDialogRef();
+      confirmationRef.afterClosed.mockReturnValue(of(false));
+      dialogService.openDialog.mockReturnValue(confirmationRef);
+
+      clickButton("Cancel");
+
+      expect(tokenService.cancelEnrollment).not.toHaveBeenCalled();
+      expect(dialogRefMock.close).not.toHaveBeenCalled();
+    });
+
+    it("deletes the token even when the rollout finished while the confirmation was open", async () => {
+      await setup({ showCancelButton: true, cancelConfirmationMessage: "Scanned codes stop working." });
+      const confirmationRef = new MockMatDialogRef();
+      confirmationRef.afterClosed.mockReturnValue(of(true));
+      dialogService.openDialog.mockReturnValue(confirmationRef);
+      dialogRefMock.getState.mockReturnValue(MatDialogState.CLOSED);
+
+      clickButton("Cancel");
+
+      expect(tokenService.cancelEnrollment).toHaveBeenCalledWith("PIPU0001");
+    });
+  });
+
+  it("delegates retry to the caller", async () => {
+    const onRetry = jest.fn();
+    await setup({ registrationFailed: signal(true), onRetry });
+
+    clickButton("Retry");
+
+    expect(onRetry).toHaveBeenCalled();
+    expect(dialogRefMock.close).not.toHaveBeenCalled();
   });
 });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
@@ -118,7 +118,8 @@ export class TokenEnrollmentFirstStepDialogComponent extends AbstractDialogCompo
 
   private deleteIncompleteToken(tokenSerial: string): void {
     this.tokenService.cancelEnrollment(tokenSerial).subscribe({
-      next: () => this.close(ENROLLMENT_CANCELLED)
+      next: () => this.close(ENROLLMENT_CANCELLED),
+      error: () => undefined
     });
   }
 

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { Component, computed, inject, Signal } from "@angular/core";
-import { MatDialogContent, MatDialogState } from "@angular/material/dialog";
+import { MatDialogContent } from "@angular/material/dialog";
 import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
@@ -110,7 +110,7 @@ export class TokenEnrollmentFirstStepDialogComponent extends AbstractDialogCompo
       })
       .afterClosed()
       .subscribe((confirmed) => {
-        if (confirmed && this.dialogRef.getState() === MatDialogState.OPEN) {
+        if (confirmed) {
           this.deleteIncompleteToken(tokenSerial);
         }
       });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
@@ -17,22 +17,25 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { Component, computed, inject, Signal } from "@angular/core";
-import { MatDialogContent } from "@angular/material/dialog";
+import { MatDialogContent, MatDialogState } from "@angular/material/dialog";
 import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
+import { MessageConfirmationDialogComponent } from "@components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component";
 import {
   ENROLLMENT_CANCELLED,
   EnrollmentStepResult
 } from "@components/token/token-enrollment/token-enrollment.constants";
 import { DialogAction } from "@models/dialog";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
+import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
 import { TokenService, TokenServiceInterface } from "@services/token/token.service";
 
 export interface TokenEnrollmentFirstStepDialogData {
   enrollmentResponse: EnrollmentResponse;
   showCancelButton?: boolean;
   showCloseButton?: boolean;
+  cancelConfirmationMessage?: string;
   registrationFailed?: Signal<boolean>;
   onRetry?: () => void;
 }
@@ -51,6 +54,7 @@ export class TokenEnrollmentFirstStepDialogComponent extends AbstractDialogCompo
 > {
   protected readonly tokenService: TokenServiceInterface = inject(TokenService);
   protected readonly contentService: ContentServiceInterface = inject(ContentService);
+  protected readonly dialogService: DialogServiceInterface = inject(DialogService);
   protected readonly Object = Object;
 
   protected readonly registrationFailed = computed(() => this.data.registrationFailed?.() ?? false);
@@ -90,6 +94,29 @@ export class TokenEnrollmentFirstStepDialogComponent extends AbstractDialogCompo
     if (!tokenSerial) {
       return;
     }
+    const confirmationMessage = this.data.cancelConfirmationMessage;
+    if (!confirmationMessage) {
+      this.deleteIncompleteToken(tokenSerial);
+      return;
+    }
+    this.dialogService
+      .openDialog({
+        component: MessageConfirmationDialogComponent,
+        data: {
+          title: $localize`Cancel Enrollment`,
+          message: confirmationMessage,
+          confirmAction: { label: $localize`Delete`, value: true, type: "destruct" }
+        }
+      })
+      .afterClosed()
+      .subscribe((confirmed) => {
+        if (confirmed && this.dialogRef.getState() === MatDialogState.OPEN) {
+          this.deleteIncompleteToken(tokenSerial);
+        }
+      });
+  }
+
+  private deleteIncompleteToken(tokenSerial: string): void {
     this.tokenService.cancelEnrollment(tokenSerial).subscribe({
       next: () => this.close(ENROLLMENT_CANCELLED)
     });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
@@ -16,13 +16,28 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
-import { Component, inject } from "@angular/core";
+import { Component, computed, inject, Signal } from "@angular/core";
 import { MatDialogContent } from "@angular/material/dialog";
 import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
+import {
+  ENROLLMENT_CANCELLED,
+  EnrollmentStepResult
+} from "@components/token/token-enrollment/token-enrollment.constants";
+import { DialogAction } from "@models/dialog";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
 import { TokenService, TokenServiceInterface } from "@services/token/token.service";
+
+export interface TokenEnrollmentFirstStepDialogData {
+  enrollmentResponse: EnrollmentResponse;
+  showCancelButton?: boolean;
+  showCloseButton?: boolean;
+  registrationFailed?: Signal<boolean>;
+  onRetry?: () => void;
+}
+
+type FirstStepDialogAction = "retry" | "cancelEnrollment";
 
 @Component({
   selector: "app-token-enrollment-first-step-dialog",
@@ -31,14 +46,54 @@ import { TokenService, TokenServiceInterface } from "@services/token/token.servi
   styleUrl: "./token-enrollment-first-step-dialog.component.scss"
 })
 export class TokenEnrollmentFirstStepDialogComponent extends AbstractDialogComponent<
-  {
-    enrollmentResponse: EnrollmentResponse;
-  },
-  boolean
+  TokenEnrollmentFirstStepDialogData,
+  EnrollmentStepResult
 > {
   protected readonly tokenService: TokenServiceInterface = inject(TokenService);
   protected readonly contentService: ContentServiceInterface = inject(ContentService);
   protected readonly Object = Object;
+
+  protected readonly registrationFailed = computed(() => this.data.registrationFailed?.() ?? false);
+
+  protected readonly actions = computed<DialogAction<FirstStepDialogAction>[]>(() => {
+    const actions: DialogAction<FirstStepDialogAction>[] = [];
+    if (this.data.showCancelButton) {
+      actions.push({
+        type: "destruct",
+        label: $localize`Cancel`,
+        value: "cancelEnrollment"
+      });
+    }
+    if (this.data.onRetry && this.registrationFailed()) {
+      actions.push({
+        type: "confirm",
+        label: $localize`Retry`,
+        value: "retry",
+        primary: true
+      });
+    }
+    return actions;
+  });
+
+  protected readonly showCloseButton = this.data.showCloseButton ?? true;
+
+  onAction(action: FirstStepDialogAction): void {
+    if (action === "retry") {
+      this.data.onRetry?.();
+      return;
+    }
+    this.cancelEnrollment();
+  }
+
+  cancelEnrollment(): void {
+    const tokenSerial = this.data.enrollmentResponse.detail?.serial;
+    if (!tokenSerial) {
+      return;
+    }
+    this.tokenService.cancelEnrollment(tokenSerial).subscribe({
+      next: () => this.close(ENROLLMENT_CANCELLED)
+    });
+  }
 
   tokenSelected(tokenSerial: string) {
     this.dialogRef.close();

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
@@ -18,7 +18,6 @@
 -->
 <app-dialog-wrapper
   (wrapperClose)="close()"
-  [showCancelButton]="true"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@closeButtonLabel"
   title="{{ title() }}">

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
@@ -17,7 +17,6 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  (wrapperClose)="close()"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@closeButtonLabel"
   title="{{ title() }}">

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
@@ -17,7 +17,6 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  (wrapperClose)="close()"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@closeButtonLabel"
   i18n-title="@@tokenEnrolledTitle"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
@@ -18,7 +18,6 @@
 -->
 <app-dialog-wrapper
   (wrapperClose)="close()"
-  [showCancelButton]="true"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@closeButtonLabel"
   i18n-title="@@tokenEnrolledTitle"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.html
@@ -20,6 +20,7 @@
   (wrapperClose)="close()"
   (actionTriggered)="onAction($event)"
   [actions]="actions()"
+  [showCloseButton]="false"
   i18n-title="@@tokenEnrolledTitle"
   title="Token Successfully Enrolled">
   <mat-dialog-content>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.html
@@ -17,7 +17,6 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  (wrapperClose)="close()"
   (actionTriggered)="onAction($event)"
   [actions]="actions()"
   [showCloseButton]="false"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.spec.ts
@@ -410,7 +410,10 @@ describe("TokenEnrollmentComponent", () => {
         await component.enrollToken();
 
         expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
-          expect.objectContaining({ component: TokenCompleteEnrollmentComponent })
+          expect.objectContaining({
+            component: TokenCompleteEnrollmentComponent,
+            configOverride: { autoFocus: "input", disableClose: true }
+          })
         );
         expect(component.enrollResponse()).toBeNull();
         expect(component.enrolledDialogData()).toBeNull();
@@ -434,7 +437,10 @@ describe("TokenEnrollmentComponent", () => {
         await component.enrollToken();
 
         expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
-          expect.objectContaining({ component: TokenVerifyEnrollmentComponent })
+          expect.objectContaining({
+            component: TokenVerifyEnrollmentComponent,
+            configOverride: { autoFocus: "input", disableClose: true }
+          })
         );
         expect(component.enrollResponse()).toBeNull();
         expect(component.enrolledDialogData()).toBeNull();
@@ -557,7 +563,8 @@ describe("TokenEnrollmentComponent", () => {
         expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
           expect.objectContaining({
             component: TokenCompleteEnrollmentComponent,
-            data: expect.objectContaining({ response: enrollResponse })
+            data: expect.objectContaining({ response: enrollResponse }),
+            configOverride: { autoFocus: "input", disableClose: true }
           })
         );
         // After closed complete dialog called and opened last step dialog with correct data
@@ -637,7 +644,8 @@ describe("TokenEnrollmentComponent", () => {
         expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
           expect.objectContaining({
             component: TokenCompleteEnrollmentComponent,
-            data: expect.objectContaining({ response: enrollResponse })
+            data: expect.objectContaining({ response: enrollResponse }),
+            configOverride: { autoFocus: "input", disableClose: true }
           })
         );
         // After closed complete dialog called and opened verify with correct data
@@ -645,7 +653,8 @@ describe("TokenEnrollmentComponent", () => {
         expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
           expect.objectContaining({
             component: TokenVerifyEnrollmentComponent,
-            data: expect.objectContaining({ response: completeResponse })
+            data: expect.objectContaining({ response: completeResponse }),
+            configOverride: { autoFocus: "input", disableClose: true }
           })
         );
         // verify dialog closed and last step dialog opened with correct data
@@ -701,7 +710,8 @@ describe("TokenEnrollmentComponent", () => {
         expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
           expect.objectContaining({
             component: TokenVerifyEnrollmentComponent,
-            data: expect.objectContaining({ response: enrollResponse })
+            data: expect.objectContaining({ response: enrollResponse }),
+            configOverride: { autoFocus: "input", disableClose: true }
           })
         );
         // closed verify dialog and open last step dialog with correct data

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.spec.ts
@@ -16,6 +16,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
+import { signal } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { provideHttpClient } from "@angular/common/http";
@@ -25,10 +26,12 @@ import {
   TokenApiPayloadMapper,
   TokenEnrollmentData
 } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { ENROLLMENT_CANCELLED } from "@components/token/token-enrollment/token-enrollment.constants";
 import { TokenCompleteEnrollmentComponent } from "@components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component";
 import { TokenEnrollmentLastStepDialogComponent } from "@components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component";
 import { TokenVerifyEnrollmentComponent } from "@components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component";
 import { environment } from "@env/environment";
+import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
 import { AuthService } from "@services/auth/auth.service";
 import { ContainerService } from "@services/container/container.service";
 import { ContentService } from "@services/content/content.service";
@@ -363,6 +366,78 @@ describe("TokenEnrollmentComponent", () => {
             data: expect.anything()
           })
         );
+      });
+
+      it("resets the pending enrollment when the strategy reports a cancellation", async () => {
+        tokenService.selectedTokenType.set({ key: "push", name: "Push", info: "", text: "" });
+        const reopenDialog = signal<(() => Promise<unknown>) | undefined>(() => Promise.resolve(null));
+        installStrategy(component, {
+          buildEnrollmentArgs: jest.fn().mockReturnValue({
+            data: { type: "push" },
+            mapper: jest.fn() as unknown as TokenApiPayloadMapper<TokenEnrollmentData>
+          }),
+          onEnrollmentResponse: jest.fn().mockResolvedValue(ENROLLMENT_CANCELLED),
+          reopenDialog
+        });
+        tokenService.enrollToken.mockReturnValueOnce(
+          of({ result: { status: true }, detail: { serial: "PIPU0001", rollout_state: "clientwait" } })
+        );
+
+        const result = await component.enrollToken();
+
+        expect(result).toBe(true);
+        expect(component.enrollResponse()).toBeNull();
+        expect(component.enrolledDialogData()).toBeNull();
+        expect(reopenDialog()).toBeUndefined();
+        expect(dialogServiceMock.openDialog).not.toHaveBeenCalled();
+      });
+
+      it("resets the pending enrollment when the complete dialog cancels it", async () => {
+        tokenService.selectedTokenType.set({ key: "hotp", name: "HOTP", info: "", text: "" });
+        installStrategy(component, {
+          buildEnrollmentArgs: jest.fn().mockReturnValue({
+            data: { type: "hotp" },
+            mapper: jest.fn() as unknown as TokenApiPayloadMapper<TokenEnrollmentData>
+          })
+        });
+        tokenService.enrollToken.mockReturnValueOnce(
+          of({ result: { status: true }, detail: { serial: "OATH0001", rollout_state: "clientwait" } })
+        );
+        const dialogRef = new MockMatDialogRef();
+        dialogRef.afterClosed.mockReturnValue(of(ENROLLMENT_CANCELLED));
+        dialogServiceMock.openDialog.mockReturnValue(dialogRef);
+
+        await component.enrollToken();
+
+        expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
+          expect.objectContaining({ component: TokenCompleteEnrollmentComponent })
+        );
+        expect(component.enrollResponse()).toBeNull();
+        expect(component.enrolledDialogData()).toBeNull();
+      });
+
+      it("resets the pending enrollment when the verify dialog cancels it", async () => {
+        tokenService.selectedTokenType.set({ key: "hotp", name: "HOTP", info: "", text: "" });
+        installStrategy(component, {
+          buildEnrollmentArgs: jest.fn().mockReturnValue({
+            data: { type: "hotp" },
+            mapper: jest.fn() as unknown as TokenApiPayloadMapper<TokenEnrollmentData>
+          })
+        });
+        tokenService.enrollToken.mockReturnValueOnce(
+          of({ result: { status: true }, detail: { serial: "OATH0002", verify: { message: "Enter OTP" } } })
+        );
+        const dialogRef = new MockMatDialogRef();
+        dialogRef.afterClosed.mockReturnValue(of(ENROLLMENT_CANCELLED));
+        dialogServiceMock.openDialog.mockReturnValue(dialogRef);
+
+        await component.enrollToken();
+
+        expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
+          expect.objectContaining({ component: TokenVerifyEnrollmentComponent })
+        );
+        expect(component.enrollResponse()).toBeNull();
+        expect(component.enrolledDialogData()).toBeNull();
       });
 
       it("Strategy with showEnrollDataInLastStep false hides the enroll data in the last step dialog", async () => {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.ts
@@ -422,7 +422,8 @@ export class TokenEnrollmentComponent implements OnInit, OnDestroy {
 
     const dialogRef = this.dialogService.openDialog({
       component: TokenCompleteEnrollmentComponent,
-      data: this.enrolledDialogData()
+      data: this.enrolledDialogData(),
+      configOverride: { autoFocus: "input", disableClose: true }
     });
     dialogRef.afterClosed().subscribe((result) => {
       if (result === ENROLLMENT_CANCELLED) {
@@ -457,7 +458,8 @@ export class TokenEnrollmentComponent implements OnInit, OnDestroy {
     // Open verify dialog
     const dialogRef = this.dialogService.openDialog({
       component: TokenVerifyEnrollmentComponent,
-      data: this.enrolledDialogData()
+      data: this.enrolledDialogData(),
+      configOverride: { autoFocus: "input", disableClose: true }
     });
     dialogRef.afterClosed().subscribe((result) => {
       if (result === ENROLLMENT_CANCELLED) {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.ts
@@ -51,10 +51,7 @@ import { MatError, MatFormField, MatHint, MatLabel, MatSuffix } from "@angular/m
 import { MatInput } from "@angular/material/input";
 import { MatOption, MatSelect } from "@angular/material/select";
 import { MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltipModule } from "@angular/material/tooltip";
-import {
-  EnrollmentResponse,
-  TokenEnrollmentData
-} from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { EnrollmentResponse, TokenEnrollmentData } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { ClearableInputComponent } from "@components/shared/clearable-input/clearable-input.component";
 import { ScrollToTopDirective } from "@components/shared/directives/app-scroll-to-top.directive";
 import { EnrollTokenTypeSwitchComponent } from "@components/shared/enroll-token-type-switch/enroll-token-type-switch.component";
@@ -83,7 +80,7 @@ import { UserService, UserServiceInterface } from "@services/user/user.service";
 import { VersioningService, VersioningServiceInterface } from "@services/version/version.service";
 import { lastValueFrom, Observable } from "rxjs";
 import { TokenEnrollmentTypeSelectorComponent } from "./token-enrollment-type-selector/token-enrollment-type-selector.component";
-import { CUSTOM_TOOLTIP_OPTIONS } from "./token-enrollment.constants";
+import { CUSTOM_TOOLTIP_OPTIONS, ENROLLMENT_CANCELLED } from "./token-enrollment.constants";
 
 export const CUSTOM_DATE_FORMATS = {
   parse: { dateInput: "YYYY-MM-DD" },
@@ -294,7 +291,11 @@ export class TokenEnrollmentComponent implements OnInit, OnDestroy {
     if (reopenFunction) {
       const enrollPromise = this._toPromise(reopenFunction());
       if (!enrollPromise) return;
-      const enrollmentResponse: EnrollmentResponse | null = await enrollPromise;
+      const enrollmentResponse = await enrollPromise;
+      if (enrollmentResponse === ENROLLMENT_CANCELLED) {
+        this.resetEnrollment();
+        return;
+      }
       this.enrollResponse.set(enrollmentResponse);
       if (enrollmentResponse) {
         this._handleEnrollmentResponse(enrollmentResponse);
@@ -392,7 +393,13 @@ export class TokenEnrollmentComponent implements OnInit, OnDestroy {
     // Complete enrollment
     // Push, passkey, webauthn (TODO: maybe we can integrate this into the complete enrollment dialog component)
     if (strategy.onEnrollmentResponse && enrollmentResponse) {
-      enrollmentResponse = await strategy.onEnrollmentResponse(enrollmentResponse, enrollmentArgs.data);
+      const stepResult = await strategy.onEnrollmentResponse(enrollmentResponse, enrollmentArgs.data);
+      if (stepResult === ENROLLMENT_CANCELLED) {
+        this.resetEnrollment();
+        this.pendingChangesService.clearAllRegistrations();
+        return true;
+      }
+      enrollmentResponse = stepResult;
     }
     // two step enrollment + handles further enrollment steps (verify + success dialog)
     this.handleCompleteEnrollment(enrollmentResponse);
@@ -418,6 +425,10 @@ export class TokenEnrollmentComponent implements OnInit, OnDestroy {
       data: this.enrolledDialogData()
     });
     dialogRef.afterClosed().subscribe((result) => {
+      if (result === ENROLLMENT_CANCELLED) {
+        this.resetEnrollment();
+        return;
+      }
       if (result) {
         this.enrollResponse.set(result);
         this.enrolledDialogData.set({
@@ -449,11 +460,21 @@ export class TokenEnrollmentComponent implements OnInit, OnDestroy {
       data: this.enrolledDialogData()
     });
     dialogRef.afterClosed().subscribe((result) => {
+      if (result === ENROLLMENT_CANCELLED) {
+        this.resetEnrollment();
+        return;
+      }
       if (result) {
         this.enrollResponse.set(result);
         this._handleEnrollmentResponse(result);
       }
     });
+  }
+
+  resetEnrollment(): void {
+    this.enrollResponse.set(null);
+    this.enrolledDialogData.set(null);
+    this.enrollSwitch()?.currentStrategy()?.reopenDialog.set(undefined);
   }
 
   protected trackChange(): void {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.constants.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.constants.ts
@@ -17,6 +17,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { MatTooltipDefaultOptions } from "@angular/material/tooltip";
+import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 
 export const CUSTOM_TOOLTIP_OPTIONS: MatTooltipDefaultOptions = {
   showDelay: 500,
@@ -64,3 +65,11 @@ export const NO_REGENERATE_TOKEN_TYPES = [
  * A list of token types for which the regenerate button should show "Values" instead of "QR Code".
  */
 export const REGENERATE_AS_VALUES_TOKEN_TYPES = ["paper", "tan"];
+
+/**
+ * Result value of an enrollment dialog whose enrollment was cancelled by the user.
+ * The incomplete token has been deleted in that case.
+ */
+export const ENROLLMENT_CANCELLED = "enrollment-cancelled";
+
+export type EnrollmentStepResult = EnrollmentResponse | typeof ENROLLMENT_CANCELLED | null;

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
@@ -20,7 +20,6 @@
 <app-dialog-wrapper
   title="Verify Token Enrollment"
   i18n-title="@@tokenEnrollVerifyTitle"
-  [showCancelButton]="true"
   [actions]="dialogActions()"
   (actionTriggered)="onDialogAction($event)"
   cancelButtonLabel="Close"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
@@ -23,8 +23,7 @@
   [actions]="dialogActions()"
   (actionTriggered)="onDialogAction($event)"
   cancelButtonLabel="Close"
-  i18n-cancelButtonLabel="@@closeButtonLabel"
-  (wrapperClose)="close()">
+  i18n-cancelButtonLabel="@@closeButtonLabel">
   <app-token-enrolled-text
     [serial]="responseDetails?.serial"
     [containerSerial]="enrollData?.containerSerial"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.spec.ts
@@ -22,9 +22,12 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { provideHttpClient } from "@angular/common/http";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { ENROLLMENT_CANCELLED } from "@components/token/token-enrollment/token-enrollment.constants";
+import { AuthService } from "@services/auth/auth.service";
 import { ContentService } from "@services/content/content.service";
 import { TokenService } from "@services/token/token.service";
 import { MockContentService } from "@testing/mock-services/mock-content-service";
+import { MockAuthService } from "@testing/mock-services/mock-auth-service";
 import { MockTokenService } from "@testing/mock-services/mock-token-service";
 import { of } from "rxjs";
 import { TokenVerifyEnrollmentComponent } from "./token-verify-enrollment.component";
@@ -101,5 +104,59 @@ describe("TokenVerifyEnrollmentComponent", () => {
   it("should close dialog on switch route", () => {
     component.onSwitchRoute();
     expect(dialogRefSpy.close).toHaveBeenCalled();
+  });
+
+  describe("cancelling the enrollment", () => {
+    const setup = async (data: Record<string, unknown> = {}, canDelete = false) => {
+      TestBed.resetTestingModule();
+      dialogRefSpy = { close: jest.fn() };
+      await TestBed.configureTestingModule({
+        imports: [TokenVerifyEnrollmentComponent],
+        providers: [
+          provideHttpClient(),
+          { provide: TokenService, useClass: MockTokenService },
+          { provide: ContentService, useClass: MockContentService },
+          { provide: AuthService, useClass: MockAuthService },
+          { provide: MatDialogRef, useValue: dialogRefSpy },
+          { provide: MAT_DIALOG_DATA, useValue: { ...dialogData, ...data } }
+        ],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+      fixture = TestBed.createComponent(TokenVerifyEnrollmentComponent);
+      component = fixture.componentInstance;
+      mockTokenService = TestBed.inject(TokenService) as unknown as MockTokenService;
+      const authService = TestBed.inject(AuthService) as unknown as MockAuthService;
+      authService.actionAllowed.mockImplementation((action: string) => canDelete && action === "delete");
+      fixture.detectChanges();
+    };
+
+    const actionValues = () => component.dialogActions().map((action) => action.value);
+
+    it("offers no cancel action without the delete right", async () => {
+      await setup({}, false);
+
+      expect(actionValues()).toEqual(["verify"]);
+    });
+
+    it("offers the cancel action before the verify action", async () => {
+      await setup({}, true);
+
+      expect(actionValues()).toEqual(["cancelEnrollment", "verify"]);
+    });
+
+    it("never offers to cancel a rollover", async () => {
+      await setup({ rollover: true }, true);
+
+      expect(actionValues()).toEqual(["verify"]);
+    });
+
+    it("deletes the unverified token and reports the cancellation", async () => {
+      await setup({}, true);
+
+      component.onDialogAction("cancelEnrollment");
+
+      expect(mockTokenService.cancelEnrollment).toHaveBeenCalledWith("123");
+      expect(dialogRefSpy.close).toHaveBeenCalledWith(ENROLLMENT_CANCELLED);
+    });
   });
 });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.ts
@@ -103,7 +103,8 @@ export class TokenVerifyEnrollmentComponent extends AbstractDialogComponent<
       return;
     }
     this.tokenService.cancelEnrollment(tokenSerial).subscribe({
-      next: () => this.close(ENROLLMENT_CANCELLED)
+      next: () => this.close(ENROLLMENT_CANCELLED),
+      error: () => undefined
     });
   }
 

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.ts
@@ -26,7 +26,12 @@ import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dial
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 import { TokenEnrolledTextComponent } from "@components/token/token-enrollment/token-enrolled-text/token-enrolled-text.component";
 import { TokenEnrollmentDataComponent } from "@components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component";
+import {
+  ENROLLMENT_CANCELLED,
+  EnrollmentStepResult
+} from "@components/token/token-enrollment/token-enrollment.constants";
 import { DialogAction } from "@models/dialog";
+import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
 import { TokenEnrollmentDialogData, TokenService, TokenServiceInterface } from "@services/token/token.service";
 
@@ -45,9 +50,13 @@ import { TokenEnrollmentDialogData, TokenService, TokenServiceInterface } from "
   templateUrl: "./token-verify-enrollment.component.html",
   styleUrl: "./token-verify-enrollment.component.scss"
 })
-export class TokenVerifyEnrollmentComponent extends AbstractDialogComponent<TokenEnrollmentDialogData, EnrollmentResponse> {
+export class TokenVerifyEnrollmentComponent extends AbstractDialogComponent<
+  TokenEnrollmentDialogData,
+  EnrollmentStepResult
+> {
   protected readonly tokenService: TokenServiceInterface = inject(TokenService);
   protected readonly contentService: ContentServiceInterface = inject(ContentService);
+  protected readonly authService: AuthServiceInterface = inject(AuthService);
 
   protected readonly responseDetails = this.data.response?.detail;
   protected readonly tokenType = this.data.response?.type ?? "hotp";
@@ -61,19 +70,45 @@ export class TokenVerifyEnrollmentComponent extends AbstractDialogComponent<Toke
   });
   invalidInputSignal = computed(() => !this.verifyOTPForm().valid());
 
-  readonly dialogActions = computed<DialogAction<string>[]>(() => [
-    {
+  readonly dialogActions = computed<DialogAction<string>[]>(() => {
+    const actions: DialogAction<string>[] = [];
+    if (this.canCancelEnrollment()) {
+      actions.push({
+        label: $localize`Cancel`,
+        type: "destruct",
+        value: "cancelEnrollment"
+      });
+    }
+    actions.push({
       label: $localize`Verify`,
       type: "confirm",
       value: "verify",
       disabled: this.invalidInputSignal()
-    }
-  ]);
+    });
+    return actions;
+  });
 
   onDialogAction(value: string): void {
     if (value === "verify") {
       this.verifyOTP();
     }
+    if (value === "cancelEnrollment") {
+      this.cancelEnrollment();
+    }
+  }
+
+  cancelEnrollment(): void {
+    const tokenSerial = this.responseDetails?.serial;
+    if (!tokenSerial) {
+      return;
+    }
+    this.tokenService.cancelEnrollment(tokenSerial).subscribe({
+      next: () => this.close(ENROLLMENT_CANCELLED)
+    });
+  }
+
+  private canCancelEnrollment(): boolean {
+    return !this.data.rollover && this.authService.actionAllowed("delete");
   }
 
   verifyOTP() {

--- a/privacyidea/static_new/src/app/components/token/token-find-serial/find-serial-result-dialog/find-serial-result-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-find-serial/find-serial-result-dialog/find-serial-result-dialog.component.html
@@ -21,6 +21,7 @@
   title="Search for Token"
   i18n-title
   [actions]="[action]"
+  [showCloseButton]="false"
   (wrapperClose)="close()"
   (actionTriggered)="onAction($event)">
   @if (data.foundSerial) {

--- a/privacyidea/static_new/src/app/components/token/token-find-serial/find-serial-result-dialog/find-serial-result-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-find-serial/find-serial-result-dialog/find-serial-result-dialog.component.html
@@ -22,7 +22,6 @@
   i18n-title
   [actions]="[action]"
   [showCloseButton]="false"
-  (wrapperClose)="close()"
   (actionTriggered)="onAction($event)">
   @if (data.foundSerial) {
     <div class="alert alert-success">

--- a/privacyidea/static_new/src/app/components/token/token-find-serial/search-token-dialog/search-token-dialog.html
+++ b/privacyidea/static_new/src/app/components/token/token-find-serial/search-token-dialog/search-token-dialog.html
@@ -2,7 +2,6 @@
   title="Find Serial"
   i18n-title="@@DialogTitleFindSerial"
   [actions]="[action]"
-  (wrapperClose)="close()"
   (actionTriggered)="onAction($event)">
   <div>
     <p i18n>

--- a/privacyidea/static_new/src/app/components/token/token-find-serial/search-token-dialog/search-token-dialog.html
+++ b/privacyidea/static_new/src/app/components/token/token-find-serial/search-token-dialog/search-token-dialog.html
@@ -2,7 +2,6 @@
   title="Find Serial"
   i18n-title="@@DialogTitleFindSerial"
   [actions]="[action]"
-  [showCancelButton]="true"
   (wrapperClose)="close()"
   (actionTriggered)="onAction($event)">
   <div>

--- a/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/selected-user-attach-dialog/selected-user-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/selected-user-attach-dialog/selected-user-attach-dialog.component.html
@@ -18,7 +18,6 @@
 -->
 <app-dialog-wrapper
   (actionTriggered)="onAction($event)"
-  (wrapperClose)="onCancel()"
   [actions]="actions()"
   i18n-title
   title="Assign Selected Token to User">

--- a/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/selected-user-attach-dialog/selected-user-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/selected-user-attach-dialog/selected-user-attach-dialog.component.html
@@ -20,7 +20,6 @@
   (actionTriggered)="onAction($event)"
   (wrapperClose)="onCancel()"
   [actions]="actions()"
-  [showCancelButton]="true"
   i18n-title
   title="Assign Selected Token to User">
   @if (selectionContainsAssignedToken()) {

--- a/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/toggle-active-dialog/toggle-active-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/toggle-active-dialog/toggle-active-dialog.component.ts
@@ -35,7 +35,6 @@ export interface ToggleActiveDialogData {
     <app-dialog-wrapper
       title="(De)activate Selected Tokens"
       i18n-title
-      (wrapperClose)="close()"
       [actions]="actions"
       (actionTriggered)="onAction($event)">
       <div class="margin-right-16">

--- a/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/toggle-active-dialog/toggle-active-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/toggle-active-dialog/toggle-active-dialog.component.ts
@@ -37,7 +37,6 @@ export interface ToggleActiveDialogData {
       i18n-title
       (wrapperClose)="close()"
       [actions]="actions"
-      [showCancelButton]="true"
       (actionTriggered)="onAction($event)">
       <div class="margin-right-16">
         <p i18n>The following tokens will be toggled:</p>

--- a/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.html
@@ -19,7 +19,6 @@
 <app-dialog-wrapper
   [title]="title"
   [actions]="actions"
-  [showCancelButton]="true"
   (wrapperClose)="close()"
   (actionTriggered)="onAction($event)">
   <div class="margin-right-16">

--- a/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.html
@@ -19,7 +19,6 @@
 <app-dialog-wrapper
   [title]="title"
   [actions]="actions"
-  (wrapperClose)="close()"
   (actionTriggered)="onAction($event)">
   <div class="margin-right-16">
     <p class="server-message">{{ data.message }}</p>

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details-pin-dialog/user-details-pin-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details-pin-dialog/user-details-pin-dialog.component.html
@@ -18,7 +18,6 @@
 -->
 <app-dialog-wrapper
   (actionTriggered)="onAction($event)"
-  (wrapperClose)="close()"
   [actions]="dialogActions()"
   [showCloseButton]="false"
   i18n-title="@@tokenAssignmentTitle"

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details-pin-dialog/user-details-pin-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details-pin-dialog/user-details-pin-dialog.component.html
@@ -20,6 +20,7 @@
   (actionTriggered)="onAction($event)"
   (wrapperClose)="close()"
   [actions]="dialogActions()"
+  [showCloseButton]="false"
   i18n-title="@@tokenAssignmentTitle"
   title="Token Assignment">
   <mat-form-field

--- a/privacyidea/static_new/src/app/services/notification/notification.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/notification/notification.service.spec.ts
@@ -211,6 +211,11 @@ describe("NotificationService", () => {
     flushDebounce();
     const warningCall = snackBar.open.mock.calls[2][2];
     expect(warningCall["panelClass"]).toEqual(["warning-snackbar"]);
+
+    service.info("i");
+    flushDebounce();
+    const infoCall = snackBar.open.mock.calls[3][2];
+    expect(infoCall["panelClass"]).toEqual(["info-snackbar"]);
   });
 
   describe("handleResourceError", () => {
@@ -308,6 +313,17 @@ describe("NotificationService", () => {
       expect(message).toContain("• Boom");
       expect(message).toContain("• Almost full");
       expect(message).toContain("• Saved");
+    });
+
+    it("uses the info panel when the batch only contains info messages", () => {
+      service.info("First");
+      service.info("Second");
+      flushDebounce();
+
+      const [message, , config] = snackBar.open.mock.calls[0];
+      expect(config["panelClass"]).toEqual(["info-snackbar"]);
+      expect(message).toContain("• First");
+      expect(message).toContain("• Second");
     });
 
     it("uses singular header for a single non-coalesced batch entry per severity", () => {

--- a/privacyidea/static_new/src/app/services/notification/notification.service.ts
+++ b/privacyidea/static_new/src/app/services/notification/notification.service.ts
@@ -136,7 +136,7 @@ export class NotificationService implements NotificationServiceInterface {
     if (severity === "success") {
       return count === 1 ? $localize`1 success:` : $localize`${count} successes:`;
     }
-    return count === 1 ? $localize`1 info:` : $localize`${count} infos:`;
+    return count === 1 ? $localize`1 info:` : $localize`${count} info:`;
   }
 
   private _open(message: string, panelClass: string, duration?: number): void {

--- a/privacyidea/static_new/src/app/services/notification/notification.service.ts
+++ b/privacyidea/static_new/src/app/services/notification/notification.service.ts
@@ -21,7 +21,7 @@ import { ElementRef, inject, Injectable } from "@angular/core";
 import { MatSnackBar, MatSnackBarRef } from "@angular/material/snack-bar";
 import { Subscription, timer } from "rxjs";
 
-export type NotificationSeverity = "success" | "warning" | "error";
+export type NotificationSeverity = "success" | "warning" | "error" | "info";
 
 interface QueuedNotification {
   severity: NotificationSeverity;
@@ -39,6 +39,8 @@ export interface NotificationServiceInterface {
   error(message: string, options?: { duration?: number }): void;
 
   warning(message: string, options?: { duration?: number }): void;
+
+  info(message: string, options?: { duration?: number }): void;
 
   handleResourceError(error: Error | undefined, subject: string): void;
 }
@@ -70,6 +72,10 @@ export class NotificationService implements NotificationServiceInterface {
     this._enqueue("warning", message, options?.duration);
   }
 
+  info(message: string, options?: { duration?: number }): void {
+    this._enqueue("info", message, options?.duration);
+  }
+
   handleResourceError(error: Error | undefined, subject: string): void {
     if (error) {
       const err = error as HttpErrorResponse;
@@ -99,7 +105,7 @@ export class NotificationService implements NotificationServiceInterface {
       return;
     }
 
-    const order: NotificationSeverity[] = ["error", "warning", "success"];
+    const order: NotificationSeverity[] = ["error", "warning", "success", "info"];
     const groups = new Map<NotificationSeverity, string[]>();
     for (const sev of order) groups.set(sev, []);
     for (const m of queue) groups.get(m.severity)!.push(m.message);
@@ -127,7 +133,10 @@ export class NotificationService implements NotificationServiceInterface {
     if (severity === "warning") {
       return count === 1 ? $localize`1 warning:` : $localize`${count} warnings:`;
     }
-    return count === 1 ? $localize`1 success:` : $localize`${count} successes:`;
+    if (severity === "success") {
+      return count === 1 ? $localize`1 success:` : $localize`${count} successes:`;
+    }
+    return count === 1 ? $localize`1 info:` : $localize`${count} infos:`;
   }
 
   private _open(message: string, panelClass: string, duration?: number): void {

--- a/privacyidea/static_new/src/app/services/token/token.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/token/token.service.spec.ts
@@ -41,6 +41,7 @@ class MockNotificationService {
   success = jest.fn();
   error = jest.fn();
   warning = jest.fn();
+  info = jest.fn();
   handleResourceError = jest.fn();
 }
 
@@ -194,6 +195,53 @@ describe("TokenService", () => {
 
     expect(deleteSpy).toHaveBeenCalledWith(`${tokenService.tokenBaseUrl}${encodeURIComponent("DEL/1")}`, {
       headers: authService.getHeaders()
+    });
+  });
+
+  describe("cancelEnrollment()", () => {
+    it("deletes the incomplete token, stops the polling and reports the cancellation", (done) => {
+      const backend = MockPiResponse.fromValue(1);
+      deleteSpy.mockReturnValue(of(backend));
+      const stopPollingSpy = jest.spyOn(tokenService, "stopPolling");
+
+      tokenService.cancelEnrollment("PIPU0001").subscribe((response) => {
+        expect(deleteSpy).toHaveBeenCalledWith(`${tokenService.tokenBaseUrl}PIPU0001`, {
+          headers: authService.getHeaders()
+        });
+        expect(stopPollingSpy).toHaveBeenCalled();
+        expect(notificationService.info).toHaveBeenCalledWith("The enrollment of token PIPU0001 was cancelled.");
+        expect(response).toBe(backend);
+        done();
+      });
+    });
+
+    it("keeps the polling running and propagates the error when the deletion fails", (done) => {
+      const boom = new HttpErrorResponse({
+        error: { result: { error: { message: "denied" } } },
+        status: 403
+      });
+      deleteSpy.mockReturnValue(throwError(() => boom));
+      const stopPollingSpy = jest.spyOn(tokenService, "stopPolling");
+
+      tokenService.cancelEnrollment("PIPU0001").subscribe({
+        error: (error) => {
+          expect(error).toBe(boom);
+          expect(stopPollingSpy).not.toHaveBeenCalled();
+          expect(notificationService.error).toHaveBeenCalledWith("Failed to cancel the enrollment. denied");
+          expect(notificationService.info).not.toHaveBeenCalled();
+          done();
+        }
+      });
+    });
+
+    it("encodes the serial in the request url", () => {
+      deleteSpy.mockReturnValue(of(MockPiResponse.fromValue(1)));
+
+      tokenService.cancelEnrollment("PI/PU 1").subscribe();
+
+      expect(deleteSpy).toHaveBeenCalledWith(`${tokenService.tokenBaseUrl}${encodeURIComponent("PI/PU 1")}`, {
+        headers: authService.getHeaders()
+      });
     });
   });
 

--- a/privacyidea/static_new/src/app/services/token/token.service.ts
+++ b/privacyidea/static_new/src/app/services/token/token.service.ts
@@ -54,6 +54,7 @@ import {
   switchMap,
   takeUntil,
   takeWhile,
+  tap,
   throwError,
   timer
 } from "rxjs";
@@ -361,6 +362,8 @@ export interface TokenServiceInterface extends FilterableTableServiceInterface {
   setTokenInfos(tokenSerial: string, infos: Record<string, string>): Observable<PiResponse<boolean>[]>;
 
   deleteToken(tokenSerial: string): Observable<PiResponse<number>>;
+
+  cancelEnrollment(tokenSerial: string): Observable<PiResponse<number>>;
 
   bulkDeleteTokens(selectedTokens: string[]): Observable<PiResponse<BulkResult>>;
 
@@ -955,6 +958,19 @@ export class TokenService extends FilterableTableService implements TokenService
   deleteToken(tokenSerial: string): Observable<PiResponse<number>> {
     const headers = this.authService.getHeaders();
     return this.http.delete<PiResponse<number>>(this.tokenBaseUrl + encodeURIComponent(tokenSerial), { headers });
+  }
+
+  cancelEnrollment(tokenSerial: string): Observable<PiResponse<number>> {
+    this.stopPolling();
+    return this.deleteToken(tokenSerial).pipe(
+      tap(() => this.notificationService.info($localize`The enrollment of token ${tokenSerial} was cancelled.`)),
+      catchError((error) => {
+        console.error("Failed to cancel the enrollment.", error);
+        const message = error.error?.result?.error?.message || "";
+        this.notificationService.error($localize`Failed to cancel the enrollment. ${message}`);
+        return throwError(() => error);
+      })
+    );
   }
 
   revokeToken(tokenSerial: string): Observable<PiResponse<number>> {

--- a/privacyidea/static_new/src/app/services/token/token.service.ts
+++ b/privacyidea/static_new/src/app/services/token/token.service.ts
@@ -961,9 +961,11 @@ export class TokenService extends FilterableTableService implements TokenService
   }
 
   cancelEnrollment(tokenSerial: string): Observable<PiResponse<number>> {
-    this.stopPolling();
     return this.deleteToken(tokenSerial).pipe(
-      tap(() => this.notificationService.info($localize`The enrollment of token ${tokenSerial} was cancelled.`)),
+      tap(() => {
+        this.stopPolling();
+        this.notificationService.info($localize`The enrollment of token ${tokenSerial} was cancelled.`);
+      }),
       catchError((error) => {
         console.error("Failed to cancel the enrollment.", error);
         const message = error.error?.result?.error?.message || "";

--- a/privacyidea/static_new/src/styles/snackbar.scss
+++ b/privacyidea/static_new/src/styles/snackbar.scss
@@ -47,4 +47,13 @@
       color: white;
     }
   }
+
+  &.info-snackbar {
+    --mat-snack-bar-container-color: var(--mat-sys-surface-container-lowest);
+    --mat-snack-bar-supporting-text-color: var(--mat-sys-on-surface);
+
+    .mat-mdc-button.mat-mdc-snack-bar-action:not(:disabled).mat-unthemed {
+      color: var(--mat-sys-on-surface);
+    }
+  }
 }

--- a/privacyidea/static_new/src/testing/mock-services/mock-notification-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-notification-service.ts
@@ -23,6 +23,7 @@ export class MockNotificationService implements NotificationServiceInterface {
   success = jest.fn();
   error = jest.fn();
   warning = jest.fn();
+  info = jest.fn();
   remainingTime = 0;
   timerSub = new Subscription();
   startTime = 0;

--- a/privacyidea/static_new/src/testing/mock-services/mock-token-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-token-service.ts
@@ -159,6 +159,7 @@ export class MockTokenService implements TokenServiceInterface {
     .mockReturnValue(of(MockPiResponse.fromValue<{ count: number; serial?: string }>({ count: 1, serial: "X" })));
   readonly setTokenInfos = jest.fn().mockReturnValue(of({}));
   readonly deleteToken = jest.fn().mockReturnValue(of({}));
+  readonly cancelEnrollment = jest.fn().mockReturnValue(of({}));
   readonly bulkDeleteTokens = jest
     .fn()
     .mockReturnValue(of(MockPiResponse.fromValue<BulkResult>({ failed: [], unauthorized: [], count_success: 1 })));


### PR DESCRIPTION
"Cancel" and "Retry" buttons have been added to the token enrolment dialogues.
Only on the push token there is a cancel button next to a close button because it's the only case where cancelling can have a negative effect if the QR code has already been scanned. For the same reason i also added a confirmation dialogue when cancelling a push token rollout.