### PR TITLE
Improve documentation for user modification in requests

### DIFF
--- a/doc/configuration/realms.rst
+++ b/doc/configuration/realms.rst
@@ -24,7 +24,7 @@ Users and Realms in a request
 .............................
 
 When a request is processed, the given parameters are evaluated and a user object is created within the request.
-If the user object can not be created, a User Eror E904 is returned.
+If the user object can not be created, a User Error E904 is returned.
 
 However, privacyIDEA can modify the given user related parameters and modify the user object.
 
@@ -33,8 +33,8 @@ To do so, you have three different possibilities.
 
 You can use the policy :ref:`policy_set_realm` in the scope authentication if you want to set the realm to a specific
 value.
-You can use the policy :ref:`policy_mange` in the scope authentication if you want to set the realm, the username
-or even the password. In this case you can use regualr expressions to modify these values.
+You can use the policy :ref:`policy_mangle` in the scope authentication if you want to set the realm, the username
+or even the password. In this case you can use regular expressions to modify these values.
 
 The third possibility to modify user parameters in the request is using the pre event handler
 :ref:`requestmanglerhandler`.

--- a/doc/configuration/realms.rst
+++ b/doc/configuration/realms.rst
@@ -18,6 +18,30 @@ Therefor the users need to authenticate with their username and the realm like t
 
    user@realm
 
+.. _user_parameters_in_request:
+
+Users and Realms in a request
+.............................
+
+When a request is processed, the given parameters are evaluated and a user object is created within the request.
+If the user object can not be created, a User Eror E904 is returned.
+
+However, privacyIDEA can modify the given user related parameters and modify the user object.
+
+Parameters can be modified *before* they are evaluated to a user object.
+To do so, you have three different possibilities.
+
+You can use the policy :ref:`policy_set_realm` in the scope authentication if you want to set the realm to a specific
+value.
+You can use the policy :ref:`policy_mange` in the scope authentication if you want to set the realm, the username
+or even the password. In this case you can use regualr expressions to modify these values.
+
+The third possibility to modify user parameters in the request is using the pre event handler
+:ref:`requestmanglerhandler`.
+
+There is also a possibility to change the user object in the request, *after* the user object has been initially
+created from the given parameters. To do so you can use the policy :ref:`policy_setrealm` from the scope authorization.
+
 .. _relate_realm:
 
 Relate User to a Realm

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -283,13 +283,18 @@ type: ``string``
 
 This policy sets or overwrites the realm parameter at the beginning of authentication requests to :http:post:`/auth`
 and :http:post:`/validate/check`. It is applied before the first user resolving to avoid unnecessary user store
-requests.
+requests. This means, when this policy is evaluated there is no user object in the request, yet!
 
-This can be used if the user can not pass their realm when authenticating at a certain
-client, but the realm needs to be available during authentication, since the user is not located in the default realm or
-the user should not be unnecessarily annoyed with a realm selection.
+Please note, due to this, it is not possible to use user-related conditions for this policy!
 
-.. note:: This policy takes precedence over the :ref:`policy_mangle` and :ref:`policy_setrealm` policies.
+Also, the given parameters can actually point to a non-existing user object.
+
+This policy can be used if the user can not pass his realm when authenticating at a certain
+client, but this username would not be found in the default realm.
+
+.. note:: This policy is evaluated before the :ref:`policy_mangle` and :ref:`policy_setrealm` policies.
+
+For in depth information about user and realm mapping read :ref:`realms`.
 
 .. versionadded:: 3.12
 
@@ -304,7 +309,7 @@ type: ``string``
 
 The ``mangle`` policy can mangle the authentication request data before they
 are processed. Meaning the parameters ``user``, ``pass`` and ``realm`` can be
-modified prior to authentication.
+modified prior to authentication and before the user object is created during processing of the request.
 
 .. note:: This policy is only applied to :http:post:`/validate/check`.
 

--- a/doc/policies/authorization.rst
+++ b/doc/policies/authorization.rst
@@ -133,14 +133,21 @@ the realm in this action.
 
 This policy is only applied to :http:post:`/validate/check`.
 
-This can be used if the user can not pass their realm when authenticating at a certain client, but the realm needs to
-be available during authentication since the user is not located in the default realm.
+Note, that this policy is evaluated, after the parameters of the request have been processed. This means,
+that the parameters like `user` and `realm` would already have to result in a valid user object. And thereafter this
+policy is applied.
+However, this means, that is is also possible to use the original user object in the policy conditions.
 
-.. note:: It is recommended to use the policy :ref:`policy_set_realm` from the authentication scope instead of this
-    policy. It takes precedence over this policy, is also applied to :http:post:`/auth`, and is applied before the
-    first user resolving, which avoids unnecessary requests to the user store.
+This policy can be used to move users from one original realm to a different realm, e.g. for authorization
+reasons. For this policy, the user has to be available in both realms!
+
+.. note:: Please check if you might actually want to use the policy :ref:`policy_set_realm` from the authentication
+    scope instead. That is applied before user resolving and thus it is not necessary to have the user in both
+    realms.
 
 .. note:: The :ref:`policy_mangle` policy is still executed after this policy and can change the realm again.
+
+For in depth information about user and realm mapping read :ref:`realms`.
 
 .. _policy_no_detail_on_success:
 


### PR DESCRIPTION
Clarify the documentation for set_realm, mangle, setrealm and Requestmangler.
Which work before user resolving, which work after. When to use which one.