### PR TITLE
Fixed Regenerate QR-Code

### DIFF
--- a/privacyidea/static_new/src/app/components/container/container-create/container-create.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-create.component.spec.ts
@@ -24,6 +24,8 @@ import { signal } from "@angular/core";
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
 import { PiResponse } from "@app/app.component";
+import { TokenEnrollmentPayload } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { getTokenApiPayloadMapper } from "@app/mappers/token-api-payload/token-api-payload-mapper-registry";
 import { ROUTE_PATHS } from "@app/route_paths";
 import { ContainerRegistrationCompletedDialogComponent } from "@components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.component";
 import { ContainerRegistrationCompletedDialogWizardComponent } from "@components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.wizard.component";
@@ -41,7 +43,7 @@ import { DialogService } from "@services/dialog/dialog.service";
 import { NotificationService } from "@services/notification/notification.service";
 import { PendingChangesService } from "@services/pending-changes/pending-changes.service";
 import { RealmService } from "@services/realm/realm.service";
-import { TokenService } from "@services/token/token.service";
+import { EnrollTokenArguments, TokenService, TokenTypeKey } from "@services/token/token.service";
 import { UserService } from "@services/user/user.service";
 import { VersioningService } from "@services/version/version.service";
 import {
@@ -59,11 +61,17 @@ import {
 import { MockAuthService } from "@testing/mock-services/mock-auth-service";
 import { MockPendingChangesService } from "@testing/mock-services/mock-pending-changes-service";
 import { ContainerCreateComponent } from "./container-create.component";
+import { ContainerTokensEnrolledDialogData } from "./container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component";
 import { ContainerCreateSelfServiceComponent } from "./container-create.self-service.component";
 import { ContainerCreateWizardComponent } from "./container-create.wizard.component";
 import { ContainerCreatedDialogWizardComponent } from "./container-created-dialog/container-created-dialog.wizard.component";
 
 interface ComponentPrivates {
+  buildEnrollmentParameters: (
+    tokenType: TokenTypeKey,
+    serial: string,
+    templateTokens: TokenEnrollmentPayload[]
+  ) => EnrollTokenArguments;
   registerContainer: (serial: string, regenerate?: boolean) => void;
   openRegistrationDialog: (response: PiResponse<ContainerRegisterData>, serial: string) => void;
   registrationConfigComponent: {
@@ -236,6 +244,87 @@ describe("ContainerCreateComponent", () => {
         user: "",
         realm: userService.selectedUserRealm()
       })
+    );
+  });
+
+  describe("buildEnrollmentParameters", () => {
+    const buildFor = (tokenType: TokenTypeKey, serial: string, templateTokens: TokenEnrollmentPayload[]) =>
+      (component as unknown as ComponentPrivates).buildEnrollmentParameters(tokenType, serial, templateTokens);
+
+    it("takes the token options from the template and targets the enrolled serial", () => {
+      const templateTokens = [{ type: "hotp", hashlib: "sha256", otplen: 8 }] as TokenEnrollmentPayload[];
+
+      const parameters = buildFor("hotp", "OATH0001", templateTokens);
+
+      expect(parameters.data).toEqual(
+        expect.objectContaining({
+          type: "hotp",
+          serial: "OATH0001",
+          hashAlgorithm: "sha256",
+          otpLength: 8
+        })
+      );
+      expect(parameters.mapper).toBe(getTokenApiPayloadMapper("hotp"));
+    });
+
+    it("always asks the server for a new secret so the regenerated QR code really changes", () => {
+      const templateTokens = [{ type: "hotp" }] as TokenEnrollmentPayload[];
+
+      const parameters = buildFor("hotp", "OATH0001", templateTokens);
+
+      expect(parameters.data["generateOnServer"]).toBe(true);
+      expect(parameters.mapper.toApiPayload(parameters.data)).toEqual(
+        expect.objectContaining({ serial: "OATH0001", genkey: 1 })
+      );
+    });
+
+    it("consumes one template entry per token so tokens of the same type keep their own options", () => {
+      const templateTokens = [
+        { type: "hotp", otplen: 6 },
+        { type: "hotp", otplen: 8 }
+      ] as TokenEnrollmentPayload[];
+
+      const first = buildFor("hotp", "OATH0001", templateTokens);
+      const second = buildFor("hotp", "OATH0002", templateTokens);
+
+      expect(first.data["otpLength"]).toBe(6);
+      expect(second.data["otpLength"]).toBe(8);
+      expect(templateTokens).toEqual([]);
+    });
+
+    it("falls back to the bare token type when the template holds no matching entry", () => {
+      const parameters = buildFor("paper", "PPR0001", []);
+
+      expect(parameters.data).toEqual(expect.objectContaining({ type: "paper", serial: "PPR0001" }));
+      expect(parameters.mapper).toBe(getTokenApiPayloadMapper("paper"));
+    });
+  });
+
+  it("hands the enrollment parameters of every enrolled token to the tokens-enrolled dialog", () => {
+    containerServiceMock.selectedContainerType.set({ containerType: "generic", description: "", token_types: [] });
+    component.selectedTemplate.set({
+      container_type: "generic",
+      default: false,
+      name: "two-factor",
+      template_options: { tokens: [{ type: "hotp", hashlib: "sha256" }] as TokenEnrollmentPayload[] }
+    });
+    (containerServiceMock.createContainer as jest.Mock).mockReturnValueOnce(
+      of({
+        result: {
+          value: {
+            container_serial: "C-001",
+            tokens: { OATH0001: { type: "hotp", serial: "OATH0001", googleurl: { img: "img", value: "url" } } }
+          }
+        }
+      } as unknown as PiResponse<ContainerCreateResult>)
+    );
+
+    component.createContainer();
+
+    const dialogData = dialogServiceMock.openDialog.mock.calls.at(-1)?.[0].data as ContainerTokensEnrolledDialogData;
+    expect(dialogData.enrolledTokens).toHaveLength(1);
+    expect(dialogData.enrolledTokens[0].enrollmentParameters.data).toEqual(
+      expect.objectContaining({ type: "hotp", serial: "OATH0001", hashAlgorithm: "sha256", generateOnServer: true })
     );
   });
 

--- a/privacyidea/static_new/src/app/components/container/container-create/container-create.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-create.component.ts
@@ -38,6 +38,8 @@ import { MatFormField, MatSelect } from "@angular/material/select";
 import { MatTooltip } from "@angular/material/tooltip";
 import { Router } from "@angular/router";
 import { PiResponse } from "@app/app.component";
+import { BaseApiPayloadMapper, TokenEnrollmentPayload } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { getTokenApiPayloadMapper } from "@app/mappers/token-api-payload/token-api-payload-mapper-registry";
 import { ROUTE_PATHS } from "@app/route_paths";
 import {
   ContainerCreatedDialogComponent,
@@ -69,7 +71,7 @@ import {
 import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
 import { NotificationService, NotificationServiceInterface } from "@services/notification/notification.service";
 import { PendingChangesService } from "@services/pending-changes/pending-changes.service";
-import { TokenService, TokenServiceInterface } from "@services/token/token.service";
+import { EnrollTokenArguments, TokenService, TokenServiceInterface, TokenTypeKey } from "@services/token/token.service";
 import { UserService, UserServiceInterface } from "@services/user/user.service";
 import { firstValueFrom } from "rxjs";
 
@@ -261,8 +263,13 @@ export class ContainerCreateComponent implements OnInit, OnDestroy {
           this.registerContainer(containerSerial);
         } else {
           const tokensRecord = response.result?.value?.tokens;
+          const templateTokens = [...(template?.template_options.tokens ?? [])];
           const enrolledTokens = tokensRecord
-            ? Object.entries(tokensRecord).map(([serial, detail]) => ({ ...detail, serial }))
+            ? Object.entries(tokensRecord).map(([serial, detail]) => ({
+                ...detail,
+                serial,
+                enrollmentParameters: this.buildEnrollmentParameters(detail.type, serial, templateTokens)
+              }))
             : [];
           if (enrolledTokens.length > 0) {
             this.openTokensEnrolledDialog({ enrolledTokens, containerSerial });
@@ -272,6 +279,21 @@ export class ContainerCreateComponent implements OnInit, OnDestroy {
         }
       }
     });
+  }
+
+  protected buildEnrollmentParameters(
+    tokenType: TokenTypeKey,
+    serial: string,
+    templateTokens: TokenEnrollmentPayload[]
+  ): EnrollTokenArguments {
+    const mapper = getTokenApiPayloadMapper(tokenType) ?? new BaseApiPayloadMapper();
+    const templateIndex = templateTokens.findIndex((token) => token.type === tokenType);
+    const payload =
+      templateIndex >= 0 ? templateTokens.splice(templateIndex, 1)[0] : ({ type: tokenType } as TokenEnrollmentPayload);
+    return {
+      data: { ...mapper.fromApiPayload(payload), serial: serial, generateOnServer: true },
+      mapper: mapper
+    };
   }
 
   protected onCreationSuccess(serial: string) {

--- a/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.html
@@ -38,7 +38,9 @@
       Token <strong>{{ currentToken().serial }}</strong> successfully enrolled.
     </p>
     <app-token-enrollment-data
+      (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
       [enrolledInputData]="currentToken()"
+      [enrollmentParameters]="currentToken().enrollmentParameters"
       [tokenType]="currentToken().type" />
   </div>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.spec.ts
@@ -131,6 +131,24 @@ describe("ContainerTokensEnrolledDialogComponent", () => {
       expect(enrollmentData.enrolledData().googleurl?.img).toBe("regenerated-img");
     });
 
+    it("applies a response to the token it belongs to even when another one is on screen", () => {
+      component.next();
+      fixture.detectChanges();
+      expect(component.currentToken().serial).toBe("TOK-2");
+
+      emitRegenerated(regenerated({ serial: "TOK-1", googleurl: { img: "late-img", value: "late-url" } }));
+
+      expect(component.enrolledTokens()[0].googleurl?.img).toBe("late-img");
+      expect(component.enrolledTokens()[1].googleurl?.img).toBe("img");
+      expect(component.currentToken().serial).toBe("TOK-2");
+    });
+
+    it("ignores a response that carries no serial", () => {
+      emitRegenerated(regenerated({ googleurl: { img: "unattributable", value: "url" } }));
+
+      expect(component.enrolledTokens().map((token) => token.googleurl?.img)).toEqual(["img", "img", "img"]);
+    });
+
     it("shows the regenerated data and leaves the other tokens untouched", () => {
       emitRegenerated(
         regenerated({ serial: "TOK-1", googleurl: { img: "regenerated-img", value: "regenerated-url" } })

--- a/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.spec.ts
@@ -17,25 +17,33 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 
-import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { ContentService } from "@services/content/content.service";
 import { MockContentService } from "@testing/mock-services/mock-content-service";
 import {
   ContainerTokensEnrolledDialogComponent,
-  ContainerTokensEnrolledDialogData
+  ContainerTokensEnrolledDialogData,
+  EnrolledTokenInfo
 } from "./container-tokens-enrolled-dialog.component";
-import { TokenService } from "@services/token/token.service";
+import { BaseApiPayloadMapper, EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { By } from "@angular/platform-browser";
+import { TokenEnrollmentDataComponent } from "@components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component";
+import { TokenService, TokenTypeKey } from "@services/token/token.service";
+import { of } from "rxjs";
 import { MockTokenService } from "@testing/mock-services";
 
 const dialogClose = jest.fn();
 const dialogRefMock = { close: dialogClose };
 
-const makeToken = (serial: string, type: string) => ({
+const makeToken = (serial: string, type: TokenTypeKey): EnrolledTokenInfo => ({
   serial,
   type,
-  googleurl: { img: "img", value: "url", description: "" }
+  googleurl: { img: "img", value: "url", description: "" },
+  enrollmentParameters: {
+    data: { type, serial, generateOnServer: true },
+    mapper: new BaseApiPayloadMapper()
+  }
 });
 
 const threeTokens: ContainerTokensEnrolledDialogData = {
@@ -57,8 +65,7 @@ describe("ContainerTokensEnrolledDialogComponent", () => {
         { provide: MAT_DIALOG_DATA, useValue: threeTokens },
         { provide: ContentService, useClass: MockContentService },
         { provide: TokenService, useClass: MockTokenService }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ContainerTokensEnrolledDialogComponent);
@@ -69,6 +76,115 @@ describe("ContainerTokensEnrolledDialogComponent", () => {
 
   it("creates", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("regenerating one of the tokens", () => {
+    const regenerated = (detail: Record<string, unknown>): EnrollmentResponse =>
+      ({
+        type: "hotp",
+        result: { status: true },
+        detail: { type: "hotp", ...detail }
+      }) as unknown as EnrollmentResponse;
+
+    const emitRegenerated = (response: EnrollmentResponse) => {
+      fixture.debugElement
+        .query(By.css("app-token-enrollment-data"))
+        .triggerEventHandler("enrollmentResponseChange", response);
+      fixture.detectChanges();
+    };
+
+    it("passes the enrollment parameters of the current token to the enrollment data", () => {
+      const enrollmentData = fixture.debugElement.query(By.directive(TokenEnrollmentDataComponent))
+        .componentInstance as TokenEnrollmentDataComponent;
+
+      expect(enrollmentData.enrollmentParameters()).toBe(threeTokens.enrolledTokens[0].enrollmentParameters);
+      expect(enrollmentData.enrolledInputData()).toBe(threeTokens.enrolledTokens[0]);
+    });
+
+    it("regenerating via the button keeps the new QR code while paging through the tokens", () => {
+      const tokenService = TestBed.inject(TokenService) as unknown as MockTokenService;
+      tokenService.enrollToken = jest
+        .fn()
+        .mockReturnValue(
+          of(regenerated({ serial: "TOK-1", googleurl: { img: "regenerated-img", value: "regenerated-url" } }))
+        );
+      const regenerateButton = Array.from(fixture.nativeElement.querySelectorAll("button")).find((button) =>
+        (button as HTMLButtonElement).textContent?.includes("Regenerate QR Code")
+      ) as HTMLButtonElement;
+      expect(regenerateButton).toBeTruthy();
+
+      regenerateButton.click();
+      fixture.detectChanges();
+
+      expect(tokenService.enrollToken).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ serial: "TOK-1", generateOnServer: true }) })
+      );
+      expect(component.currentToken().googleurl?.img).toBe("regenerated-img");
+
+      component.next();
+      component.previous();
+      fixture.detectChanges();
+
+      expect(component.currentToken().googleurl?.img).toBe("regenerated-img");
+      const enrollmentData = fixture.debugElement.query(By.directive(TokenEnrollmentDataComponent))
+        .componentInstance as TokenEnrollmentDataComponent;
+      expect(enrollmentData.enrolledData().googleurl?.img).toBe("regenerated-img");
+    });
+
+    it("shows the regenerated data and leaves the other tokens untouched", () => {
+      emitRegenerated(
+        regenerated({ serial: "TOK-1", googleurl: { img: "regenerated-img", value: "regenerated-url" } })
+      );
+
+      expect(component.currentToken().googleurl?.img).toBe("regenerated-img");
+      expect(component.enrolledTokens()[1].googleurl?.img).toBe("img");
+      expect(component.total()).toBe(3);
+    });
+
+    it("keeps the regenerated data when paging away and back", () => {
+      emitRegenerated(
+        regenerated({ serial: "TOK-1", googleurl: { img: "regenerated-img", value: "regenerated-url" } })
+      );
+
+      component.next();
+      component.previous();
+
+      expect(component.currentToken().googleurl?.img).toBe("regenerated-img");
+    });
+
+    it("keeps regenerated OTP values of a value based token when paging away and back", () => {
+      emitRegenerated(regenerated({ serial: "TOK-1", otps: { "0": "111111", "1": "222222" } }));
+
+      component.next();
+      component.previous();
+
+      expect(component.currentToken()["otps"]).toEqual({ "0": "111111", "1": "222222" });
+    });
+
+    it("keeps serial, type and enrollment parameters of the regenerated token", () => {
+      emitRegenerated(
+        regenerated({ serial: "TOK-1", googleurl: { img: "regenerated-img", value: "regenerated-url" } })
+      );
+
+      expect(component.currentToken().serial).toBe("TOK-1");
+      expect(component.currentToken().type).toBe("hotp");
+      expect(component.currentToken().enrollmentParameters).toBe(threeTokens.enrolledTokens[0].enrollmentParameters);
+    });
+
+    it("regenerating the second token does not affect the first one", () => {
+      component.next();
+      fixture.detectChanges();
+
+      emitRegenerated(
+        regenerated({ serial: "TOK-2", googleurl: { img: "regenerated-img", value: "regenerated-url" } })
+      );
+
+      expect(component.currentToken().serial).toBe("TOK-2");
+      expect(component.currentToken().googleurl?.img).toBe("regenerated-img");
+
+      component.previous();
+      expect(component.currentToken().googleurl?.img).toBe("img");
+    });
   });
 
   it("starts on first token with correct total and progress", () => {

--- a/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.ts
@@ -20,14 +20,19 @@
 import { TitleCasePipe } from "@angular/common";
 import { Component, computed, inject, signal } from "@angular/core";
 import { MatProgressBar } from "@angular/material/progress-bar";
-import { EnrollmentResponseDetail } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { EnrollmentResponse, EnrollmentResponseDetail } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 import { TokenEnrollmentDataComponent } from "@components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component";
 import { DialogAction } from "@models/dialog";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
+import { EnrollTokenArguments } from "@services/token/token.service";
 
-export type EnrolledTokenInfo = EnrollmentResponseDetail & { type: string; serial: string };
+export type EnrolledTokenInfo = EnrollmentResponseDetail & {
+  type: string;
+  serial: string;
+  enrollmentParameters: EnrollTokenArguments;
+};
 
 export interface ContainerTokensEnrolledDialogData {
   enrolledTokens: EnrolledTokenInfo[];
@@ -44,9 +49,10 @@ export class ContainerTokensEnrolledDialogComponent extends AbstractDialogCompon
   private readonly contentService: ContentServiceInterface = inject(ContentService);
 
   readonly currentIndex = signal(0);
+  readonly enrolledTokens = signal<EnrolledTokenInfo[]>(this.data.enrolledTokens);
 
-  readonly currentToken = computed(() => this.data.enrolledTokens[this.currentIndex()]);
-  readonly total = computed(() => this.data.enrolledTokens.length);
+  readonly currentToken = computed(() => this.enrolledTokens()[this.currentIndex()]);
+  readonly total = computed(() => this.enrolledTokens().length);
   readonly progress = computed(() => ((this.currentIndex() + 1) / this.total()) * 100);
   readonly isFirst = computed(() => this.currentIndex() === 0);
   readonly isLast = computed(() => this.currentIndex() === this.total() - 1);
@@ -63,6 +69,13 @@ export class ContainerTokensEnrolledDialogComponent extends AbstractDialogCompon
       ? { type: "confirm", label: $localize`Go to Container`, value: "finish", primary: true, icon: "check" }
       : { type: "auxiliary", label: $localize`Next`, value: "next", primary: true, icon: "arrow_forward" }
   ]);
+
+  onEnrollmentResponseChange(response: EnrollmentResponse) {
+    const index = this.currentIndex();
+    this.enrolledTokens.update((tokens) =>
+      tokens.map((token, tokenIndex) => (tokenIndex === index ? { ...token, ...response.detail } : token))
+    );
+  }
 
   onDialogAction(value: string) {
     if (value === "previous") this.previous();

--- a/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.ts
@@ -71,9 +71,15 @@ export class ContainerTokensEnrolledDialogComponent extends AbstractDialogCompon
   ]);
 
   onEnrollmentResponseChange(response: EnrollmentResponse) {
-    const index = this.currentIndex();
+    // Match on the serial rather than the current index: regenerating is asynchronous and the
+    // user can page to another token before the response arrives, which would otherwise write
+    // the regenerated secret and QR code into the token that happens to be shown by then.
+    const serial = response.detail?.serial;
+    if (!serial) {
+      return;
+    }
     this.enrolledTokens.update((tokens) =>
-      tokens.map((token, tokenIndex) => (tokenIndex === index ? { ...token, ...response.detail } : token))
+      tokens.map((token) => (token.serial === serial ? { ...token, ...response.detail } : token))
     );
   }
 

--- a/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.html
@@ -30,7 +30,7 @@
       >.
     </p>
 
-    <mat-form-field>
+    <mat-form-field class="input-width-l">
       <mat-label i18n>New Template Name</mat-label>
       <input
         matInput

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.spec.ts
@@ -115,6 +115,42 @@ describe("TokenRolloverComponent", () => {
     expect(reloadSpy).toHaveBeenCalled();
   });
 
+  it("should keep the regenerated response for a reopened last step dialog", async () => {
+    const mockEnrollResp = {
+      result: { status: true },
+      detail: { rollout_state: "done", serial: "ABC123", googleurl: { img: "initial-img", value: "initial-url" } }
+    } as unknown as EnrollmentResponse;
+
+    component.token.set({ type: "hotp", serial: "ABC123" });
+    installStrategy(component, {
+      buildEnrollmentArgs: jest.fn().mockReturnValue({
+        data: {},
+        mapper: { map: (x: unknown) => x }
+      })
+    });
+    tokenService.enrollToken.mockReturnValue(of(mockEnrollResp));
+
+    await component.rolloverToken();
+
+    const regenerated = {
+      result: { status: true },
+      detail: { rollout_state: "done", serial: "ABC123", googleurl: { img: "regenerated-img", value: "regen-url" } }
+    } as unknown as EnrollmentResponse;
+    component.enrolledDialogData()?.onEnrollmentResponseChange?.(regenerated);
+
+    expect(component.enrollResponse()).toBe(regenerated);
+    expect(component.enrolledDialogData()?.response).toBe(regenerated);
+
+    dialogService.openDialog.mockClear();
+    (component as unknown as { openLastStepDialog: (response: EnrollmentResponse | null) => void }).openLastStepDialog(
+      component.enrolledDialogData()?.response ?? null
+    );
+
+    expect(dialogService.openDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ response: regenerated }) })
+    );
+  });
+
   it("should show snackbar if no token is set", async () => {
     component.token.set(null);
     await component.rolloverToken();

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.ts
@@ -129,7 +129,8 @@ export class TokenRolloverComponent extends AbstractDialogComponent<
       response: enrollmentResponse,
       enrollParameters: enrollmentArgs,
       tokenType: this.tokenService.selectedTokenType().key,
-      rollover: true
+      rollover: true,
+      onEnrollmentResponseChange: (response) => this.updateEnrollmentResponse(response)
     });
 
     // Complete rollover
@@ -141,6 +142,11 @@ export class TokenRolloverComponent extends AbstractDialogComponent<
     // two step enrollment + handles further enrollment steps (verify + success dialog)
     this.dialogRef.close();
     this.handleCompleteEnrollment(enrollmentResponse);
+  }
+
+  updateEnrollmentResponse(response: EnrollmentResponse): void {
+    this.enrollResponse.set(response);
+    this.enrolledDialogData.update((data) => (data ? { ...data, response: response } : data));
   }
 
   handleCompleteEnrollment(enrollmentResponse: EnrollmentResponse | null): void {

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/verify-enrollment/verify-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/verify-enrollment/verify-enrollment.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <div class="flex-column">
-  <mat-form-field class="input-width-s">
+  <mat-form-field class="input-width-l">
     <mat-label i18n>OTP</mat-label>
     <input
       [formField]="otpForm"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
@@ -32,11 +32,13 @@
     Your token with serial {{ enrollDetails?.serial }} is not completely enrolled, yet.
   </span>
 
-  <app-token-enrollment-data
-    (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
-    [enrolledInputData]="enrollDetails"
-    [tokenType]="tokenType"
-    [enrollmentParameters]="enrollParameters"></app-token-enrollment-data>
+  @if (data.response) {
+    <app-token-enrollment-data
+      (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
+      [enrolledInputData]="data.response.detail"
+      [tokenType]="tokenType"
+      [enrollmentParameters]="enrollParameters"></app-token-enrollment-data>
+  }
 
   @if (twoStepEnrollment()) {
     <div class="margin-top-16">

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
@@ -33,6 +33,7 @@
   </span>
 
   <app-token-enrollment-data
+    (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
     [enrolledInputData]="enrollDetails"
     [tokenType]="tokenType"
     [enrollmentParameters]="enrollParameters"></app-token-enrollment-data>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
@@ -42,7 +42,7 @@
   @if (twoStepEnrollment()) {
     <div class="margin-top-16">
       <div i18n>Please scan the QR code with the privacyIDEA Authenticator app and enter the generated code below.</div>
-      <mat-form-field class="width-100">
+      <mat-form-field class="input-width-l">
         <mat-label i18n>Client Part</mat-label>
         <input
           [formField]="clientPartForm"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.spec.ts
@@ -20,6 +20,7 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { By } from "@angular/platform-browser";
 import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { ContentService } from "@services/content/content.service";
 import { TokenService } from "@services/token/token.service";
@@ -37,7 +38,8 @@ describe("TokenCompleteEnrollmentComponent", () => {
 
   const dialogData = {
     response: { detail: { serial: "123" }, type: "hotp" },
-    enrollParameters: { data: { type: "hotp", twoStepInit: true } }
+    enrollParameters: { data: { type: "hotp", twoStepInit: true } },
+    onEnrollmentResponseChange: jest.fn()
   };
 
   beforeEach(async () => {
@@ -60,6 +62,18 @@ describe("TokenCompleteEnrollmentComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should report a regenerated QR code to the opener of the dialog", () => {
+    const regenerated = {
+      type: "hotp",
+      detail: { type: "hotp", serial: "123", googleurl: { img: "regenerated-img", value: "regenerated-url" } },
+      result: { status: true }
+    } as EnrollmentResponse;
+    const enrollmentData = fixture.debugElement.query(By.css("app-token-enrollment-data"));
+    enrollmentData.triggerEventHandler("enrollmentResponseChange", regenerated);
+
+    expect(dialogData.onEnrollmentResponseChange).toHaveBeenCalledWith(regenerated);
   });
 
   it("should disable enroll action if input is invalid", () => {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.ts
@@ -28,6 +28,7 @@ import {
   ENROLLMENT_CANCELLED,
   EnrollmentStepResult
 } from "@components/token/token-enrollment/token-enrollment.constants";
+import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { DialogAction } from "@models/dialog";
 import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.ts
@@ -71,6 +71,10 @@ export class TokenCompleteEnrollmentComponent extends AbstractDialogComponent<To
     }
   }
 
+  onEnrollmentResponseChange(response: EnrollmentResponse): void {
+    this.data.onEnrollmentResponseChange?.(response);
+  }
+
   enrollToken() {
     this.enrollParameters.data.serial = this.enrollDetails?.serial;
     if (this.clientPart()) {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.html
@@ -40,25 +40,25 @@
         {{ regenerateButtonText() }}
       </button>
     }
-    @if (enrolledData()?.["password"]) {
+    @if (enrolledData()["password"]) {
       <p i18n>
-        Your Password: <strong>{{ enrolledData()?.["password"] }}</strong
+        Your Password: <strong>{{ enrolledData()["password"] }}</strong
         >.
       </p>
     }
-    @if (enrolledData()?.otpkey?.value && !enrolledData()?.["otps"] && showQRCode()) {
+    @if (enrolledData().otpkey?.value && !enrolledData()["otps"] && showQRCode()) {
       <app-otp-key
-        [otpKeyHex]="enrolledData()?.otpkey?.value ?? ''"
-        [otpKeyBase32]="enrolledData()?.otpkey?.value_b32 ?? ''" />
+        [otpKeyHex]="enrolledData().otpkey?.value ?? ''"
+        [otpKeyBase32]="enrolledData().otpkey?.value_b32 ?? ''" />
     }
     @if (tokenType() === "tiqr") {
-      <app-tiqr-enroll-url [url]="enrolledData()?.['tiqrenroll']?.value ?? ''" />
+      <app-tiqr-enroll-url [url]="enrolledData()['tiqrenroll']?.value ?? ''" />
     }
     @if (tokenType() === "registration") {
-      <app-registration-code [registrationCode]="enrolledData()?.['registrationcode'] ?? ''" />
+      <app-registration-code [registrationCode]="enrolledData()['registrationcode'] ?? ''" />
     }
-    @if (enrolledData()?.["otps"]) {
-      <app-otp-values [otpValues]="enrolledData()?.['otps'] ?? []" />
+    @if (enrolledData()["otps"]) {
+      <app-otp-values [otpValues]="enrolledData()['otps'] ?? []" />
     }
   </div>
 </div>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.html
@@ -34,31 +34,32 @@
     @if (url() && showRegenerateButton()) {
       <button
         (click)="regenerateQRCode()"
+        [disabled]="regenerating()"
         class="action-button-primary button-width-l"
         mat-stroked-button>
         <mat-icon>autorenew</mat-icon>
         {{ regenerateButtonText() }}
       </button>
     }
-    @if (enrolledData()["password"]) {
+    @if (enrolledData()?.["password"]) {
       <p i18n>
-        Your Password: <strong>{{ enrolledData()["password"] }}</strong
+        Your Password: <strong>{{ enrolledData()?.["password"] }}</strong
         >.
       </p>
     }
-    @if (enrolledData().otpkey?.value && !enrolledData()["otps"] && showQRCode()) {
+    @if (enrolledData()?.otpkey?.value && !enrolledData()?.["otps"] && showQRCode()) {
       <app-otp-key
-        [otpKeyHex]="enrolledData().otpkey?.value ?? ''"
-        [otpKeyBase32]="enrolledData().otpkey?.value_b32 ?? ''" />
+        [otpKeyHex]="enrolledData()?.otpkey?.value ?? ''"
+        [otpKeyBase32]="enrolledData()?.otpkey?.value_b32 ?? ''" />
     }
     @if (tokenType() === "tiqr") {
-      <app-tiqr-enroll-url [url]="enrolledData()['tiqrenroll']?.value ?? ''" />
+      <app-tiqr-enroll-url [url]="enrolledData()?.['tiqrenroll']?.value ?? ''" />
     }
     @if (tokenType() === "registration") {
-      <app-registration-code [registrationCode]="enrolledData()['registrationcode'] ?? ''" />
+      <app-registration-code [registrationCode]="enrolledData()?.['registrationcode'] ?? ''" />
     }
-    @if (enrolledData()["otps"]) {
-      <app-otp-values [otpValues]="enrolledData()['otps'] ?? []" />
+    @if (enrolledData()?.["otps"]) {
+      <app-otp-values [otpValues]="enrolledData()?.['otps'] ?? []" />
     }
   </div>
 </div>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.spec.ts
@@ -98,6 +98,28 @@ describe("TokenEnrollmentDataComponent", () => {
     expect(component.showRegenerateButton()).toBe(false);
   });
 
+  it("should hide the regenerate button while the token awaits enrollment verification", () => {
+    fixture.componentRef.setInput("tokenType", "hotp");
+    fixture.componentRef.setInput("enrolledInputData", {
+      serial: "OATH0001",
+      rollout_state: "verify",
+      googleurl: { img: "img", value: "url" }
+    });
+    fixture.detectChanges();
+    expect(component.showRegenerateButton()).toBe(false);
+  });
+
+  it("should show the regenerate button once the token has left the verify state", () => {
+    fixture.componentRef.setInput("tokenType", "hotp");
+    fixture.componentRef.setInput("enrolledInputData", {
+      serial: "OATH0001",
+      rollout_state: "enrolled",
+      googleurl: { img: "img", value: "url" }
+    });
+    fixture.detectChanges();
+    expect(component.showRegenerateButton()).toBe(true);
+  });
+
   it("should adopt regenerate button text to token type", () => {
     fixture.componentRef.setInput("tokenType", "spass");
     fixture.detectChanges();
@@ -152,6 +174,55 @@ describe("TokenEnrollmentDataComponent", () => {
 
     expect(mockTokenService.enrollToken).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ type: "hotp", serial: "OATH0001" }) })
+    );
+  });
+
+  it("should request a rollover so the existing token is re-initialized", () => {
+    mockTokenService.enrollToken = jest.fn().mockReturnValue(
+      of({
+        type: "hotp",
+        result: { status: true },
+        detail: { type: "hotp", serial: "OATH0001", googleurl: { img: "new_img", value: "new_url" } }
+      })
+    );
+    fixture.componentRef.setInput("enrollmentParameters", {
+      data: { type: "hotp", serial: "OATH0001" },
+      mapper: { map: jest.fn() }
+    });
+    fixture.componentRef.setInput("enrolledInputData", { serial: "OATH0001" });
+    fixture.detectChanges();
+
+    component.regenerateQRCode();
+
+    expect(mockTokenService.enrollToken).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ rollover: true }) })
+    );
+  });
+
+  it("should keep 2stepinit alongside the rollover so the two-step handshake is preserved", () => {
+    mockTokenService.enrollToken = jest.fn().mockReturnValue(
+      of({
+        type: "hotp",
+        result: { status: true },
+        detail: { type: "hotp", serial: "OATH0001", rollout_state: "clientwait" }
+      })
+    );
+    fixture.componentRef.setInput("enrollmentParameters", {
+      data: { type: "hotp", serial: "OATH0001", "2stepinit": true },
+      mapper: { map: jest.fn() }
+    });
+    fixture.componentRef.setInput("enrolledInputData", {
+      serial: "OATH0001",
+      rollout_state: "clientwait"
+    });
+    fixture.detectChanges();
+
+    component.regenerateQRCode();
+
+    expect(mockTokenService.enrollToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ rollover: true, "2stepinit": true, serial: "OATH0001" })
+      })
     );
   });
 

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.spec.ts
@@ -22,11 +22,9 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 
 import { ContentService } from "@services/content/content.service";
-import { NotificationService } from "@services/notification/notification.service";
 import { TokenService } from "@services/token/token.service";
 import { MockTokenService } from "@testing/mock-services";
 import { MockContentService } from "@testing/mock-services/mock-content-service";
-import { MockNotificationService } from "@testing/mock-services/mock-notification-service";
 import { of } from "rxjs";
 import { TokenEnrollmentDataComponent } from "./token-enrollment-data.component";
 
@@ -34,23 +32,23 @@ describe("TokenEnrollmentDataComponent", () => {
   let component: TokenEnrollmentDataComponent;
   let fixture: ComponentFixture<TokenEnrollmentDataComponent>;
   let mockTokenService: MockTokenService;
-  let mockNotificationService: MockNotificationService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TokenEnrollmentDataComponent],
       providers: [
         { provide: TokenService, useClass: MockTokenService },
-        { provide: ContentService, useClass: MockContentService },
-        { provide: NotificationService, useClass: MockNotificationService }
+        { provide: ContentService, useClass: MockContentService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
     fixture = TestBed.createComponent(TokenEnrollmentDataComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput("enrolledInputData", { type: "hotp", serial: "" });
+    fixture.componentRef.setInput("enrollmentParameters", { data: { type: "hotp" }, mapper: { map: jest.fn() } });
+    fixture.componentRef.setInput("tokenType", "hotp");
     fixture.detectChanges();
     mockTokenService = TestBed.inject(TokenService) as unknown as MockTokenService;
-    mockNotificationService = TestBed.inject(NotificationService) as unknown as MockNotificationService;
   });
 
   it("should create", () => {
@@ -181,11 +179,45 @@ describe("TokenEnrollmentDataComponent", () => {
     expect(emitted).toEqual([regenerated]);
   });
 
-  it("should open notification if no enrollmentParameters are available on regenerateQRCode", () => {
-    component.regenerateQRCode();
-    expect(mockNotificationService.warning).toHaveBeenCalledWith(
-      "Enrollment parameters are missing. Cannot regenerate token."
+  it.each(["paper", "tan"])("should regenerate the OTP values of a %s token", (tokenType) => {
+    const regenerated = {
+      type: tokenType,
+      result: { status: true },
+      detail: {
+        type: tokenType,
+        serial: "PPR0001",
+        otpkey: { img: "", value: "new-hex", value_b32: "" },
+        otps: { "0": "111111", "1": "222222" }
+      }
+    } as unknown as EnrollmentResponse;
+    mockTokenService.enrollToken = jest.fn().mockReturnValue(of(regenerated));
+    const emitted: EnrollmentResponse[] = [];
+    component.enrollmentResponseChange.subscribe((response) => emitted.push(response));
+    fixture.componentRef.setInput("tokenType", tokenType);
+    fixture.componentRef.setInput("enrollmentParameters", {
+      data: { type: tokenType, serial: null },
+      mapper: { map: jest.fn() }
+    });
+    fixture.componentRef.setInput("enrolledInputData", {
+      serial: "PPR0001",
+      otpkey: { img: "", value: "old-hex", value_b32: "" },
+      otps: { "0": "999999" }
+    });
+    fixture.detectChanges();
+
+    const regenerateButton = Array.from(fixture.nativeElement.querySelectorAll("button")).find((button) =>
+      (button as HTMLButtonElement).textContent?.includes("Regenerate Values")
+    ) as HTMLButtonElement;
+    expect(component.showQRCode()).toBe(false);
+    expect(regenerateButton).toBeTruthy();
+
+    regenerateButton.click();
+
+    expect(mockTokenService.enrollToken).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ type: tokenType, serial: "PPR0001" }) })
     );
+    expect(component.enrolledData()?.["otps"]).toEqual({ "0": "111111", "1": "222222" });
+    expect(emitted).toEqual([regenerated]);
   });
 
   it("uses pushurl for QR code and URL when googleurl is absent (push token)", () => {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.spec.ts
@@ -19,6 +19,7 @@
 
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 
 import { ContentService } from "@services/content/content.service";
 import { NotificationService } from "@services/notification/notification.service";
@@ -129,6 +130,55 @@ describe("TokenEnrollmentDataComponent", () => {
     expect(component.enrolledData()).toEqual({ serial: "SERIAL123", googleurl: { img: "new_img", value: "456" } });
     expect(component["qrCode"]()).toEqual("new_img");
     expect(component["url"]()).toEqual("456");
+  });
+
+  it("should regenerate the enrolled token even if the enrollment parameters carry no serial", () => {
+    mockTokenService.enrollToken = jest.fn().mockReturnValue(
+      of({
+        type: "hotp",
+        result: { status: true },
+        detail: { type: "hotp", serial: "OATH0001", googleurl: { img: "new_img", value: "new_url" } }
+      })
+    );
+    fixture.componentRef.setInput("enrollmentParameters", {
+      data: { type: "hotp", serial: null },
+      mapper: { map: jest.fn() }
+    });
+    fixture.componentRef.setInput("enrolledInputData", {
+      serial: "OATH0001",
+      googleurl: { img: "old_img", value: "old_url" }
+    });
+    fixture.detectChanges();
+
+    component.regenerateQRCode();
+
+    expect(mockTokenService.enrollToken).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ type: "hotp", serial: "OATH0001" }) })
+    );
+  });
+
+  it("should emit the regenerated enrollment response on regenerateQRCode", () => {
+    const regenerated = {
+      type: "hotp",
+      result: { status: true },
+      detail: { type: "hotp", serial: "OATH0001", googleurl: { img: "new_img", value: "new_url" } }
+    } as EnrollmentResponse;
+    mockTokenService.enrollToken = jest.fn().mockReturnValue(of(regenerated));
+    const emitted: EnrollmentResponse[] = [];
+    component.enrollmentResponseChange.subscribe((response) => emitted.push(response));
+    fixture.componentRef.setInput("enrollmentParameters", {
+      data: { type: "hotp", serial: "OATH0001" },
+      mapper: { map: jest.fn() }
+    });
+    fixture.componentRef.setInput("enrolledInputData", {
+      serial: "OATH0001",
+      googleurl: { img: "old_img", value: "old_url" }
+    });
+    fixture.detectChanges();
+
+    component.regenerateQRCode();
+
+    expect(emitted).toEqual([regenerated]);
   });
 
   it("should open notification if no enrollmentParameters are available on regenerateQRCode", () => {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.spec.ts
@@ -25,7 +25,7 @@ import { ContentService } from "@services/content/content.service";
 import { TokenService } from "@services/token/token.service";
 import { MockTokenService } from "@testing/mock-services";
 import { MockContentService } from "@testing/mock-services/mock-content-service";
-import { of } from "rxjs";
+import { Subject, of } from "rxjs";
 import { TokenEnrollmentDataComponent } from "./token-enrollment-data.component";
 
 describe("TokenEnrollmentDataComponent", () => {
@@ -177,6 +177,68 @@ describe("TokenEnrollmentDataComponent", () => {
     );
   });
 
+  it("should not start a second regeneration while one is still in flight", () => {
+    const pending = new Subject<EnrollmentResponse>();
+    mockTokenService.enrollToken = jest.fn().mockReturnValue(pending);
+    fixture.componentRef.setInput("enrollmentParameters", {
+      data: { type: "hotp", serial: "OATH0001" },
+      mapper: { map: jest.fn() }
+    });
+    fixture.componentRef.setInput("enrolledInputData", { serial: "OATH0001" });
+    fixture.detectChanges();
+
+    component.regenerateQRCode();
+    component.regenerateQRCode();
+
+    expect(mockTokenService.enrollToken).toHaveBeenCalledTimes(1);
+    expect(component.regenerating()).toBe(true);
+
+    pending.next({
+      type: "hotp",
+      result: { status: true },
+      detail: { type: "hotp", serial: "OATH0001" }
+    } as unknown as EnrollmentResponse);
+
+    expect(component.regenerating()).toBe(false);
+  });
+
+  it("should not overwrite the displayed token when a response for another one arrives late", () => {
+    const pending = new Subject<EnrollmentResponse>();
+    mockTokenService.enrollToken = jest.fn().mockReturnValue(pending);
+    fixture.componentRef.setInput("enrollmentParameters", {
+      data: { type: "hotp", serial: "OATH0001" },
+      mapper: { map: jest.fn() }
+    });
+    fixture.componentRef.setInput("enrolledInputData", {
+      serial: "OATH0001",
+      googleurl: { img: "first-img", value: "first-url" }
+    });
+    fixture.detectChanges();
+
+    component.regenerateQRCode();
+
+    // the surrounding dialog pages to another token before the response arrives
+    fixture.componentRef.setInput("enrolledInputData", {
+      serial: "OATH0002",
+      googleurl: { img: "second-img", value: "second-url" }
+    });
+    fixture.detectChanges();
+
+    const emitted: EnrollmentResponse[] = [];
+    component.enrollmentResponseChange.subscribe((response) => emitted.push(response));
+
+    const late = {
+      type: "hotp",
+      result: { status: true },
+      detail: { type: "hotp", serial: "OATH0001", googleurl: { img: "late-img", value: "late-url" } }
+    } as unknown as EnrollmentResponse;
+    pending.next(late);
+    fixture.detectChanges();
+
+    expect(component.enrolledData().googleurl?.img).toBe("second-img");
+    expect(emitted).toEqual([late]);
+  });
+
   it("should request a rollover so the existing token is re-initialized", () => {
     mockTokenService.enrollToken = jest.fn().mockReturnValue(
       of({
@@ -197,6 +259,29 @@ describe("TokenEnrollmentDataComponent", () => {
     expect(mockTokenService.enrollToken).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ rollover: true }) })
     );
+  });
+
+  it("should not resend the PIN when regenerating", () => {
+    mockTokenService.enrollToken = jest.fn().mockReturnValue(
+      of({
+        type: "hotp",
+        result: { status: true },
+        detail: { type: "hotp", serial: "OATH0001" }
+      })
+    );
+    fixture.componentRef.setInput("enrollmentParameters", {
+      data: { type: "hotp", serial: "OATH0001", pin: "1234" },
+      mapper: { map: jest.fn() }
+    });
+    fixture.componentRef.setInput("enrolledInputData", { serial: "OATH0001" });
+    fixture.detectChanges();
+
+    component.regenerateQRCode();
+
+    const sent = (mockTokenService.enrollToken as jest.Mock).mock.calls[0][0].data;
+    expect(sent.pin).toBeUndefined();
+    expect(sent.rollover).toBe(true);
+    expect(sent.serial).toBe("OATH0001");
   });
 
   it("should keep 2stepinit alongside the rollover so the two-step handshake is preserved", () => {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.ts
@@ -17,11 +17,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 
-import { Component, computed, inject, input, linkedSignal } from "@angular/core";
+import { Component, computed, inject, input, linkedSignal, output } from "@angular/core";
 import { MatButton } from "@angular/material/button";
 import { MatIcon } from "@angular/material/icon";
 import {
   BaseApiPayloadMapper,
+  EnrollmentResponse,
   EnrollmentResponseDetail,
   TokenEnrollmentData
 } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
@@ -62,6 +63,7 @@ export class TokenEnrollmentDataComponent {
   enrolledInputData = input<EnrollmentResponseDetail>();
   enrollmentParameters = input<EnrollTokenArguments>();
   tokenType = input<string>(this.tokenService.selectedTokenType()?.key);
+  enrollmentResponseChange = output<EnrollmentResponse>();
 
   enrolledData = linkedSignal(() => this.enrolledInputData());
   protected readonly serial = computed(() => this.enrolledData()?.serial ?? "");
@@ -111,7 +113,8 @@ export class TokenEnrollmentDataComponent {
       return;
     }
     const newEnrollmentData: TokenEnrollmentData = {
-      ...(this.enrollmentParameters()?.data ?? ({} as TokenEnrollmentData))
+      ...(this.enrollmentParameters()?.data ?? ({} as TokenEnrollmentData)),
+      serial: this.serial() || this.enrollmentParameters()?.data?.serial
     };
     const mapper = this.enrollmentParameters()?.mapper ?? new BaseApiPayloadMapper();
 
@@ -119,6 +122,7 @@ export class TokenEnrollmentDataComponent {
       next: (response) => {
         if (response?.detail) {
           this.enrolledData.set(response.detail);
+          this.enrollmentResponseChange.emit(response);
         }
       }
     });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.ts
@@ -21,7 +21,6 @@ import { Component, computed, inject, input, linkedSignal, output } from "@angul
 import { MatButton } from "@angular/material/button";
 import { MatIcon } from "@angular/material/icon";
 import {
-  BaseApiPayloadMapper,
   EnrollmentResponse,
   EnrollmentResponseDetail,
   TokenEnrollmentData
@@ -37,7 +36,6 @@ import {
   REGENERATE_AS_VALUES_TOKEN_TYPES
 } from "@components/token/token-enrollment/token-enrollment.constants";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
-import { NotificationService, NotificationServiceInterface } from "@services/notification/notification.service";
 import { EnrollTokenArguments, TokenService, TokenServiceInterface } from "@services/token/token.service";
 
 @Component({
@@ -58,11 +56,10 @@ import { EnrollTokenArguments, TokenService, TokenServiceInterface } from "@serv
 export class TokenEnrollmentDataComponent {
   protected readonly tokenService: TokenServiceInterface = inject(TokenService);
   protected readonly contentService: ContentServiceInterface = inject(ContentService);
-  protected readonly notificationService: NotificationServiceInterface = inject(NotificationService);
   protected readonly Object = Object;
-  enrolledInputData = input<EnrollmentResponseDetail>();
-  enrollmentParameters = input<EnrollTokenArguments>();
-  tokenType = input<string>(this.tokenService.selectedTokenType()?.key);
+  enrolledInputData = input.required<EnrollmentResponseDetail>();
+  enrollmentParameters = input.required<EnrollTokenArguments>();
+  tokenType = input.required<string>();
   enrollmentResponseChange = output<EnrollmentResponse>();
 
   enrolledData = linkedSignal(() => this.enrolledInputData());
@@ -108,17 +105,13 @@ export class TokenEnrollmentDataComponent {
   );
 
   regenerateQRCode() {
-    if (!this.enrollmentParameters()) {
-      this.notificationService.warning($localize`Enrollment parameters are missing. Cannot regenerate token.`);
-      return;
-    }
+    const enrollmentParameters = this.enrollmentParameters();
     const newEnrollmentData: TokenEnrollmentData = {
-      ...(this.enrollmentParameters()?.data ?? ({} as TokenEnrollmentData)),
-      serial: this.serial() || this.enrollmentParameters()?.data?.serial
+      ...enrollmentParameters.data,
+      serial: this.serial() || enrollmentParameters.data.serial
     };
-    const mapper = this.enrollmentParameters()?.mapper ?? new BaseApiPayloadMapper();
 
-    this.tokenService.enrollToken({ data: newEnrollmentData, mapper: mapper }).subscribe({
+    this.tokenService.enrollToken({ data: newEnrollmentData, mapper: enrollmentParameters.mapper }).subscribe({
       next: (response) => {
         if (response?.detail) {
           this.enrolledData.set(response.detail);

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.ts
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 
-import { Component, computed, inject, input, linkedSignal, output } from "@angular/core";
+import { Component, computed, inject, input, linkedSignal, output, signal } from "@angular/core";
 import { MatButton } from "@angular/material/button";
 import { MatIcon } from "@angular/material/icon";
 import {
@@ -110,11 +110,20 @@ export class TokenEnrollmentDataComponent {
       : $localize`Regenerate QR Code`
   );
 
+  regenerating = signal(false);
+
   regenerateQRCode() {
+    if (this.regenerating()) {
+      return;
+    }
     const enrollmentParameters = this.enrollmentParameters();
+    // The component instance is reused when the surrounding dialog pages between tokens, so
+    // remember which token this request belongs to and drop the response if it is no longer
+    // the one on screen.
+    const requestedSerial = this.serial() || enrollmentParameters.data.serial;
     const newEnrollmentData: TokenEnrollmentData = {
       ...enrollmentParameters.data,
-      serial: this.serial() || enrollmentParameters.data.serial,
+      serial: requestedSerial,
       // The token already exists, so this call re-initializes it rather than enrolling a new
       // one. Without "rollover" the backend treats the request as the next step of the original
       // enrollment and rejects it - for a two-step enrollment the token is still in "clientwait"
@@ -122,14 +131,26 @@ export class TokenEnrollmentDataComponent {
       // secret is generated and, for two-step, a new server component is issued.
       rollover: true
     };
+    // Regenerating replaces the secret and nothing else. The PIN is deliberately not sent
+    // again: the server keeps the existing one when the parameter is absent, and re-submitting
+    // it would re-apply it without the PIN policy checks, which the server skips for rollover
+    // requests.
+    delete newEnrollmentData.pin;
 
+    this.regenerating.set(true);
     this.tokenService.enrollToken({ data: newEnrollmentData, mapper: enrollmentParameters.mapper }).subscribe({
       next: (response) => {
+        this.regenerating.set(false);
         if (response?.detail) {
-          this.enrolledData.set(response.detail);
+          // The opener keys the update on the serial, so it is always told about the response.
+          // Only the displayed data is left alone when the dialog has moved on to another token.
+          if (this.serial() === requestedSerial) {
+            this.enrolledData.set(response.detail);
+          }
           this.enrollmentResponseChange.emit(response);
         }
-      }
+      },
+      error: () => this.regenerating.set(false)
     });
   }
 }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component.ts
@@ -97,7 +97,13 @@ export class TokenEnrollmentDataComponent {
         this.enrolledData()?.["otps"]
       )
   );
-  showRegenerateButton = computed(() => !NO_REGENERATE_TOKEN_TYPES.includes(this.tokenType()));
+  // A token waiting for enrollment verification cannot be regenerated: the backend rejects any
+  // further /token/init for it until a valid "verify" value is supplied, so offering the button
+  // would only ever produce an error.
+  protected readonly isVerifyPending = computed(() => this.enrolledData()?.rollout_state === "verify");
+  showRegenerateButton = computed(
+    () => !NO_REGENERATE_TOKEN_TYPES.includes(this.tokenType()) && !this.isVerifyPending()
+  );
   regenerateButtonText = computed(() =>
     REGENERATE_AS_VALUES_TOKEN_TYPES.includes(this.tokenType())
       ? $localize`Regenerate Values`
@@ -108,7 +114,13 @@ export class TokenEnrollmentDataComponent {
     const enrollmentParameters = this.enrollmentParameters();
     const newEnrollmentData: TokenEnrollmentData = {
       ...enrollmentParameters.data,
-      serial: this.serial() || enrollmentParameters.data.serial
+      serial: this.serial() || enrollmentParameters.data.serial,
+      // The token already exists, so this call re-initializes it rather than enrolling a new
+      // one. Without "rollover" the backend treats the request as the next step of the original
+      // enrollment and rejects it - for a two-step enrollment the token is still in "clientwait"
+      // and resending "2stepinit" fails. "rollover" resets the rollout state first, so a fresh
+      // secret is generated and, for two-step, a new server component is issued.
+      rollover: true
     };
 
     this.tokenService.enrollToken({ data: newEnrollmentData, mapper: enrollmentParameters.mapper }).subscribe({

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
@@ -31,10 +31,10 @@
     [userRealm]="data.enrollParameters.data.realm"
     [username]="data.enrollParameters.data.user"></app-token-enrolled-text>
 
-  @if (data.showEnrollData !== false) {
+  @if (data.showEnrollData !== false && data.response) {
     <app-token-enrollment-data
       (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
-      [enrolledInputData]="data.response?.detail"
+      [enrolledInputData]="data.response.detail"
       [enrollmentParameters]="data.enrollParameters"
       [tokenType]="data.tokenType"></app-token-enrollment-data>
   }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
@@ -33,6 +33,7 @@
 
   @if (data.showEnrollData !== false) {
     <app-token-enrollment-data
+      (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
       [enrolledInputData]="data.response?.detail"
       [enrollmentParameters]="data.enrollParameters"
       [tokenType]="data.tokenType"></app-token-enrollment-data>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.spec.ts
@@ -18,15 +18,18 @@
  **/
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { By } from "@angular/platform-browser";
 import { ContentService } from "@services/content/content.service";
 import {
   BaseApiPayloadMapper,
+  EnrollmentResponse,
   TokenEnrollmentData
 } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { TokenEnrollmentDialogData, TokenService } from "@services/token/token.service";
 import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
 import { MockContentService, MockTokenService } from "@testing/mock-services";
 import { TokenEnrollmentLastStepDialogComponent } from "./token-enrollment-last-step-dialog.component";
+import { TokenEnrollmentLastStepDialogSelfServiceComponent } from "./token-enrollment-last-step-dialog.self-service.component";
 
 describe("TokenEnrollmentLastStepDialogComponent", () => {
   let component: TokenEnrollmentLastStepDialogComponent;
@@ -51,8 +54,23 @@ describe("TokenEnrollmentLastStepDialogComponent", () => {
     enrollParameters: {
       data: {} as unknown as TokenEnrollmentData,
       mapper: {} as unknown as BaseApiPayloadMapper
-    }
+    },
+    onEnrollmentResponseChange: jest.fn()
   });
+
+  const regeneratedResponse: EnrollmentResponse = {
+    type: "totp",
+    detail: {
+      type: "totp",
+      serial: "1234567890",
+      googleurl: {
+        description: "Google Authenticator URL",
+        img: "regenerated-img",
+        value: "otpauth://totp/Example:user?secret=REGENERATED&issuer=Example"
+      }
+    },
+    result: { status: true }
+  };
 
   const setup = async (dialogData: TokenEnrollmentDialogData): Promise<void> => {
     TestBed.resetTestingModule();
@@ -120,10 +138,46 @@ describe("TokenEnrollmentLastStepDialogComponent", () => {
     ).toBe(true);
   });
 
+  it("should report a regenerated QR code to the opener of the dialog", () => {
+    const enrollmentData = fixture.debugElement.query(By.css("app-token-enrollment-data"));
+    enrollmentData.triggerEventHandler("enrollmentResponseChange", regeneratedResponse);
+
+    expect(component.data.onEnrollmentResponseChange).toHaveBeenCalledWith(regeneratedResponse);
+  });
+
   it("should render title for rollover", async () => {
     await setup({ ...createDialogData(), rollover: true });
 
     expect(component["rollover"]).toBe(true);
     expect(component.title()).toBe("Token Successfully Rolled Over");
+  });
+
+  describe("self service", () => {
+    let selfServiceFixture: ComponentFixture<TokenEnrollmentLastStepDialogSelfServiceComponent>;
+    let dialogData: TokenEnrollmentDialogData;
+
+    beforeEach(async () => {
+      dialogData = createDialogData();
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [TokenEnrollmentLastStepDialogSelfServiceComponent],
+        providers: [
+          { provide: MatDialogRef, useClass: MockMatDialogRef },
+          { provide: MAT_DIALOG_DATA, useValue: dialogData },
+          { provide: ContentService, useClass: MockContentService },
+          { provide: TokenService, useClass: MockTokenService }
+        ]
+      }).compileComponents();
+
+      selfServiceFixture = TestBed.createComponent(TokenEnrollmentLastStepDialogSelfServiceComponent);
+      selfServiceFixture.detectChanges();
+    });
+
+    it("should report a regenerated QR code to the opener of the dialog", () => {
+      const enrollmentData = selfServiceFixture.debugElement.query(By.css("app-token-enrollment-data"));
+      enrollmentData.triggerEventHandler("enrollmentResponseChange", regeneratedResponse);
+
+      expect(dialogData.onEnrollmentResponseChange).toHaveBeenCalledWith(regeneratedResponse);
+    });
   });
 });

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.ts
@@ -25,6 +25,7 @@ import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper
 import { TokenEnrolledTextComponent } from "@components/token/token-enrollment/token-enrolled-text/token-enrolled-text.component";
 import { TokenEnrollmentDataComponent } from "@components/token/token-enrollment/token-enrollment-data/token-enrollment-data.component";
 import { NO_QR_CODE_TOKEN_TYPES } from "@components/token/token-enrollment/token-enrollment.constants";
+import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
 import { TokenEnrollmentDialogData, TokenService, TokenServiceInterface } from "@services/token/token.service";
 
@@ -74,6 +75,10 @@ export class TokenEnrollmentLastStepDialogComponent extends AbstractDialogCompon
 
   showQRCode(): boolean {
     return !NO_QR_CODE_TOKEN_TYPES.includes(this.data.tokenType);
+  }
+
+  onEnrollmentResponseChange(response: EnrollmentResponse): void {
+    this.data.onEnrollmentResponseChange?.(response);
   }
 
 

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
@@ -31,6 +31,7 @@
 
   @if (data.showEnrollData !== false) {
     <app-token-enrollment-data
+      (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
       [enrolledInputData]="data.response?.detail"
       [enrollmentParameters]="data.enrollParameters"
       [tokenType]="data.tokenType"></app-token-enrollment-data>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
@@ -29,10 +29,10 @@
     [rollover]="data.rollover ?? false"
     [serial]="serial"></app-token-enrolled-text>
 
-  @if (data.showEnrollData !== false) {
+  @if (data.showEnrollData !== false && data.response) {
     <app-token-enrollment-data
       (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
-      [enrolledInputData]="data.response?.detail"
+      [enrolledInputData]="data.response.detail"
       [enrollmentParameters]="data.enrollParameters"
       [tokenType]="data.tokenType"></app-token-enrollment-data>
   }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.spec.ts
@@ -689,6 +689,42 @@ describe("TokenEnrollmentComponent", () => {
       expect(dialogServiceMock.openDialog).not.toHaveBeenCalled();
     });
 
+    it("reopenEnrollmentDialog: reopens with the regenerated response instead of the initial one", async () => {
+      tokenService.selectedTokenType.set({ key: "totp", name: "TOTP", info: "", text: "" });
+      installStrategy(component, {
+        buildEnrollmentArgs: jest.fn().mockReturnValue({
+          data: { type: "totp" },
+          mapper: jest.fn() as unknown as TokenApiPayloadMapper<TokenEnrollmentData>
+        }),
+        reopenDialog: () => undefined
+      });
+      const enrollResponse = {
+        result: { status: true },
+        detail: { serial: "TOTP0001", googleurl: { img: "initial-img", value: "initial-url" } }
+      } as unknown as EnrollmentResponse;
+      tokenService.enrollToken.mockReturnValueOnce(of(enrollResponse));
+      await component.enrollToken();
+
+      const regenerated = {
+        result: { status: true },
+        detail: { serial: "TOTP0001", googleurl: { img: "regenerated-img", value: "regenerated-url" } }
+      } as unknown as EnrollmentResponse;
+      component.enrolledDialogData()?.onEnrollmentResponseChange?.(regenerated);
+
+      expect(component.enrollResponse()).toBe(regenerated);
+      expect(component.enrolledDialogData()?.response).toBe(regenerated);
+
+      dialogServiceMock.openDialog.mockClear();
+      component.reopenEnrollmentDialog();
+
+      expect(dialogServiceMock.openDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          component: TokenEnrollmentLastStepDialogComponent,
+          data: expect.objectContaining({ response: regenerated })
+        })
+      );
+    });
+
     it("reopenEnrollmentDialog: falls back to last-step data", () => {
       tokenService.selectedTokenType.set({ key: "hotp", name: "HOTP", info: "", text: "" });
       component.enrolledDialogData.set({

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.component.ts
@@ -386,7 +386,8 @@ export class TokenEnrollmentComponent implements OnInit, OnDestroy {
       userRealm: enrollmentArgs.data.realm,
       onlyAddToRealm: enrollmentArgs.data.onlyAddToRealm ?? false,
       rollover: false,
-      showEnrollData: strategy.showEnrollDataInLastStep
+      showEnrollData: strategy.showEnrollDataInLastStep,
+      onEnrollmentResponseChange: (response) => this.updateEnrollmentResponse(response)
     });
 
     // Complete enrollment
@@ -398,6 +399,11 @@ export class TokenEnrollmentComponent implements OnInit, OnDestroy {
     this.handleCompleteEnrollment(enrollmentResponse);
     this.pendingChangesService.clearAllRegistrations();
     return true;
+  }
+
+  updateEnrollmentResponse(response: EnrollmentResponse): void {
+    this.enrollResponse.set(response);
+    this.enrolledDialogData.update((data) => (data ? { ...data, response: response } : data));
   }
 
   handleCompleteEnrollment(enrollmentResponse: EnrollmentResponse | null): void {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
@@ -49,14 +49,17 @@
 
   <div class="margin-top-16">
     <h3 i18n>Verify Enrollment</h3>
+    <!-- The message comes from the token class and varies in length (the indexed-secret one
+         embeds a list of positions), so it is rendered at full dialog width instead of as a
+         mat-hint, which would be capped to the width of the input and wrap. -->
+    @if (verifyMessage) {
+      <div class="margin-bottom-16">{{ verifyMessage }}</div>
+    }
+    <mat-form-field class="input-width-l">
+      <mat-label i18n>OTP</mat-label>
+      <input
+        [formField]="verifyOTPForm"
+        matInput />
+    </mat-form-field>
   </div>
-  <mat-form-field class="width-100">
-    <mat-label i18n>OTP</mat-label>
-    <input
-      [formField]="verifyOTPForm"
-      matInput />
-    <mat-hint>
-      {{ verifyMessage }}
-    </mat-hint>
-  </mat-form-field>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
@@ -43,6 +43,7 @@
 
   @if (data.showEnrollData !== false) {
     <app-token-enrollment-data
+      (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
       [enrolledInputData]="responseDetails"
       [tokenType]="tokenType"
       [enrollmentParameters]="enrollParameters"></app-token-enrollment-data>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
@@ -41,10 +41,10 @@
     >However, to activate your token you still need to verify the enrollment.</span
   >
 
-  @if (data.showEnrollData !== false) {
+  @if (data.showEnrollData !== false && data.response) {
     <app-token-enrollment-data
       (enrollmentResponseChange)="onEnrollmentResponseChange($event)"
-      [enrolledInputData]="responseDetails"
+      [enrolledInputData]="data.response.detail"
       [tokenType]="tokenType"
       [enrollmentParameters]="enrollParameters"></app-token-enrollment-data>
   }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.spec.ts
@@ -22,6 +22,8 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { provideHttpClient } from "@angular/common/http";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
+import { By } from "@angular/platform-browser";
 import { ContentService } from "@services/content/content.service";
 import { TokenService } from "@services/token/token.service";
 import { MockContentService } from "@testing/mock-services/mock-content-service";
@@ -37,7 +39,8 @@ describe("TokenVerifyEnrollmentComponent", () => {
 
   const dialogData = {
     response: { detail: { serial: "123", verify: { message: "Enter OTP" } }, type: "hotp" },
-    enrollParameters: { data: {} }
+    enrollParameters: { data: {} },
+    onEnrollmentResponseChange: jest.fn()
   };
 
   beforeEach(async () => {
@@ -61,6 +64,18 @@ describe("TokenVerifyEnrollmentComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should report a regenerated QR code to the opener of the dialog", () => {
+    const regenerated = {
+      type: "hotp",
+      detail: { type: "hotp", serial: "123", googleurl: { img: "regenerated-img", value: "regenerated-url" } },
+      result: { status: true }
+    } as EnrollmentResponse;
+    const enrollmentData = fixture.debugElement.query(By.css("app-token-enrollment-data"));
+    enrollmentData.triggerEventHandler("enrollmentResponseChange", regenerated);
+
+    expect(dialogData.onEnrollmentResponseChange).toHaveBeenCalledWith(regenerated);
   });
 
   it("should disable verify action if input is invalid", () => {

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.spec.ts
@@ -81,6 +81,16 @@ describe("TokenVerifyEnrollmentComponent", () => {
     expect(dialogData.onEnrollmentResponseChange).toHaveBeenCalledWith(regenerated);
   });
 
+  it("should render the verification message outside the input so it is not capped to its width", () => {
+    const message = fixture.debugElement
+      .queryAll(By.css("div"))
+      .find((element) => element.nativeElement.textContent.trim() === "Enter OTP");
+
+    expect(message).toBeTruthy();
+    expect(fixture.debugElement.query(By.css("mat-hint"))).toBeNull();
+    expect(message!.nativeElement.closest("mat-form-field")).toBeNull();
+  });
+
   it("should disable verify action if input is invalid", () => {
     component.verifyOTP_value.set("");
     fixture.detectChanges();

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.ts
@@ -91,6 +91,10 @@ export class TokenVerifyEnrollmentComponent extends AbstractDialogComponent<Toke
     });
   }
 
+  onEnrollmentResponseChange(response: EnrollmentResponse): void {
+    this.data.onEnrollmentResponseChange?.(response);
+  }
+
   onSwitchRoute() {
     this.dialogRef.close();
   }

--- a/privacyidea/static_new/src/app/mappers/token-api-payload/_token-api-payload.mapper.ts
+++ b/privacyidea/static_new/src/app/mappers/token-api-payload/_token-api-payload.mapper.ts
@@ -67,7 +67,7 @@ export interface U2fRegisterRequest {
 }
 
 export interface EnrollmentResponseDetail {
-  type: string;
+  type: TokenTypeKey;
   serial: string;
   rollout_state?: string;
   threadid?: number;

--- a/privacyidea/static_new/src/app/services/token/token.service.ts
+++ b/privacyidea/static_new/src/app/services/token/token.service.ts
@@ -298,6 +298,7 @@ export interface TokenEnrollmentDialogData {
   onlyAddToRealm?: boolean;
   rollover?: boolean;
   showEnrollData?: boolean;
+  onEnrollmentResponseChange?: (response: EnrollmentResponse) => void;
 }
 
 export interface LostTokenData {


### PR DESCRIPTION
On the tokens enrolment page, the correct QR code, TAN list, etc. is now displayed when the dialog is reopened after regeneration.
On the container creation page, the 'Regenerate' button now works as intended when using a template.