### PR TITLE
conditional access: limit retrigger by next higher stage / threshold

### DIFF
--- a/doc/conditional_access/policies.rst
+++ b/doc/conditional_access/policies.rst
@@ -136,8 +136,14 @@ lock permanently at 20. Thresholds must be unique within a policy.
 By default an action fires **once**, exactly when the count reaches the
 threshold: an email configured at 8 is sent on the 8th failure and not again on
 the 9th. Enable **re-trigger above threshold** for an action that should fire on
-every further request as well. ``DENY`` defaults to re-trigger, as it is a one-time action denying only the current
-request.
+every further request as well. Re-triggering stops where the next stage begins:
+an action re-triggering at threshold 8 fires from the 8th failure up to the one
+before the next stage's threshold, and once the policy has escalated it does not
+resume - not even on the requests the more severe stage itself sits out. Each
+stage therefore owns one range of counts, and escalation is a hand-over rather
+than an overlay. ``DENY`` defaults to re-trigger, as it is a one-time action
+denying only the current request; it follows the same rule, so a more severe
+stage that does not itself deny ends the refusal.
 
 Stages are evaluated from the highest threshold down, so the order follows the
 thresholds themselves and there is nothing else to configure.
@@ -146,7 +152,8 @@ A threshold counts failures and therefore starts at 1. ``DENY`` is the exception
 it states a standing verdict instead of reacting to a count, so a stage carrying
 nothing but ``DENY`` may use threshold ``0``, which then means *always*. That is
 how a lockdown is written - refuse everything the policy covers, whatever the
-subject has done.
+subject has done. Where the policy has further stages, that ``0`` stage hands
+over like any other, so *always* reaches up to the next threshold.
 
 .. warning:: A ``DENY`` at threshold 0 refuses **every** request the policy
    covers, whatever the subject has done. Scope it with conditions, and leave

--- a/doc/conditional_access/policies.rst
+++ b/doc/conditional_access/policies.rst
@@ -136,14 +136,21 @@ lock permanently at 20. Thresholds must be unique within a policy.
 By default an action fires **once**, exactly when the count reaches the
 threshold: an email configured at 8 is sent on the 8th failure and not again on
 the 9th. Enable **re-trigger above threshold** for an action that should fire on
-every further request as well. Re-triggering stops where the next stage begins:
-an action re-triggering at threshold 8 fires from the 8th failure up to the one
-before the next stage's threshold, and once the policy has escalated it does not
-resume - not even on the requests the more severe stage itself sits out. Each
-stage therefore owns one range of counts, and escalation is a hand-over rather
-than an overlay. ``DENY`` defaults to re-trigger, as it is a one-time action
-denying only the current request; it follows the same rule, so a more severe
-stage that does not itself deny ends the refusal.
+every further request instead, for as long as the count stays in the range its
+stage owns - at or above its own threshold, below the next stage's. Each stage
+therefore owns one range of counts, and only the stage owning the *current*
+count acts, so escalation is a hand-over rather than an overlay.
+
+This is a live read of the count, not a state the policy remembers: should the
+count later drop back into a milder stage's range - the time window ageing old
+failures out, or a successful login where ``reset_on_success`` applies - that
+stage's re-triggering action fires again. ``DENY`` defaults to re-trigger, as it
+is a one-time action denying only the current request, and follows the same
+rule. In practice, though, a re-triggering ``DENY`` rarely hands over to a
+higher stage on its own: once enforced, every further request is refused before
+any credentials are checked and logged as ``ACCESS_DENIED``, a type no policy
+can count, so the very count that would carry it past the next threshold stops
+climbing while the refusal holds.
 
 Stages are evaluated from the highest threshold down, so the order follows the
 thresholds themselves and there is nothing else to configure.

--- a/privacyidea/lib/conditional_access/engine.py
+++ b/privacyidea/lib/conditional_access/engine.py
@@ -74,7 +74,8 @@ log = logging.getLogger(__name__)
 # pre-auth decision and every source_ip mode deliberately do not.
 #
 # What trips: stages, each with a failure threshold. Only the highest matching stage of a policy fires, and each of
-# its actions decides for itself - once at the exact threshold by default, or on every request at or above it.
+# its actions decides for itself - once at the exact threshold by default, or on every request within the range its
+# stage owns (at or above its threshold, below the next stage's).
 #
 # Policies run by ascending priority and the first one to decide wins. A `dry_run` policy still produces outcomes
 # but changes nothing, which is how an admin measures a policy before enforcing it.
@@ -1100,9 +1101,9 @@ def evaluate_access_decision(context: CAContext, now: datetime | None = None) ->
     :attr:`ConditionalAccessAction.LOCK_USER`). With the policy's
     ``reset_on_success`` the count is floored at the user's last completed
     login, so a ``DENY`` also lifts on a successful authentication and not only
-    with the passage of time. Because ``DENY`` defaults to re-triggering
-    (``count >= threshold``), a stage with ``failure_threshold`` 0 always matches,
-    which is the lockdown idiom - scope it with conditions.
+    with the passage of time. Because ``DENY`` defaults to re-triggering, a stage
+    with ``failure_threshold`` 0 matches every count below the next stage's
+    threshold, which is the lockdown idiom - scope it with conditions.
 
     Policies are evaluated by ascending ``priority`` (a lower number means higher
     precedence, matching privacyIDEA's policy engine) and the first one that denies
@@ -1156,12 +1157,14 @@ def _policy_access_decision(policy: ConditionalAccessPolicy, context: CAContext,
     subject, no ``DENY`` action's threshold condition is met, or the policy is in dry run - a dry-run policy is never
     enforced, but it still yields its outcome, which is how an admin measures what enforcing it would do.
 
-    Each ``DENY`` action decides for itself via :func:`_action_threshold_met`: it
-    defaults to re-triggering (``count >= threshold``, so the refusal stands while
-    the failures are high), which is what makes it a self-healing reject. An admin
-    can switch it to fire-once, in which case it only refuses the request at the
-    exact threshold count. The stage with the highest threshold whose ``DENY``
-    action is met supplies the decision.
+    Each ``DENY`` action decides for itself via :func:`_action_fires`: it
+    defaults to re-triggering, so the refusal stands while the count stays within
+    the range its stage owns, which is what makes it a self-healing reject. An
+    admin can switch it to fire-once, in which case it only refuses the request at
+    the exact threshold count. The stage with the highest threshold whose ``DENY``
+    action is met supplies the decision - and because a re-triggering ``DENY``
+    stops at the next threshold, a more severe stage that does not itself deny
+    lifts the refusal rather than inheriting it.
     """
     # Applicability is checked first: a policy whose conditions exclude this request contributes no decision and
     # costs no counting query.
@@ -1184,8 +1187,9 @@ def _policy_access_decision(policy: ConditionalAccessPolicy, context: CAContext,
             return AccessDecisionResult()
         count = _policy_count(policy, context.user, now, since_last_success=policy.reset_on_success)
         subject_label = repr(context.user)
-    deciding_stage = next((stage for stage in policy.stages if _stage_denies(stage, count)), None)
-    if deciding_stage is None:
+
+    deciding_stage = _stage_in_range(policy, count)
+    if deciding_stage is None or not _stage_denies(deciding_stage, count):
         return AccessDecisionResult()
     decision = AccessDecision.DENY
     types = _types_label(policy.counter_types_to_track)
@@ -1206,9 +1210,9 @@ def _policy_access_decision(policy: ConditionalAccessPolicy, context: CAContext,
 
 def _stage_denies(stage: ConditionalAccessPolicyStage, count: int) -> bool:
     """
-    Whether *stage* refuses the request at *count*: it carries a ``DENY`` action
-    whose per-action threshold condition is met. An unparsable action type is
-    skipped rather than treated as a refusal.
+    Whether *stage* refuses the request at *count*: it carries a ``DENY`` action whose per-action condition is met
+    (see :func:`_action_fires`), given that *stage* is the one :func:`_stage_in_range` returned for it. An
+    unparsable action type is skipped rather than treated as a refusal.
     """
     for action in stage.actions:
         try:
@@ -1217,7 +1221,7 @@ def _stage_denies(stage: ConditionalAccessPolicyStage, count: int) -> bool:
             continue
         if action_type != ConditionalAccessAction.DENY:
             continue
-        if _action_threshold_met(action, stage.failure_threshold, count):
+        if _action_fires(action, stage.failure_threshold, count):
             return True
     return False
 
@@ -1258,13 +1262,14 @@ def evaluate_conditional_access_policies(context: CAContext, event_type: AuthEve
     Each action decides for itself whether it fires. By default an action fires
     once, when the failure count reaches its stage's threshold exactly: an action
     at threshold 8 runs on the 8th failure and not again on the 9th. An action with
-    ``retrigger_above_threshold`` fires whenever the count is at or above the
-    threshold, so a single stage can email once at threshold 8 while keeping the
-    user locked for every further failure (see :func:`_action_threshold_met`). The
-    count climbs by one per tracked failure and, for a policy with
-    ``reset_on_success``, resets after a successful login (see
-    :func:`count_user_events`), so a fresh burst re-triggers the fire-once
-    actions too.
+    ``retrigger_above_threshold`` fires on every request while the count stays
+    within the range its stage owns - at or above threshold 8, but below the next
+    stage's threshold - so a single stage can email once at 8 while keeping the
+    user locked for every further failure until the policy escalates past it (see
+    :func:`_action_fires` and :func:`_stage_in_range`). The count climbs by one per
+    tracked failure and, for a policy with ``reset_on_success``, resets after a
+    successful login (see :func:`count_user_events`), so a fresh burst
+    re-triggers the fire-once actions too.
 
     The persistent side effects (lock state) are consulted by the *next* inbound
     request via the pre-check, which reads the error message back off the row they wrote. A stage that only
@@ -1333,42 +1338,55 @@ def evaluate_conditional_access_policies(context: CAContext, event_type: AuthEve
                                        enforced_targets=enforced)
 
 
-def _action_threshold_met(action: ConditionalAccessStageAction, threshold: int, count: int) -> bool:
+def _stage_in_range(policy: ConditionalAccessPolicy, count: int) -> ConditionalAccessPolicyStage | None:
     """
-    Whether *action* fires at the given failure *count*, for its stage's
-    *threshold*.
+    The stage that owns *count*: the highest ``failure_threshold`` at or below it, or ``None`` when *count* is
+    below every stage's threshold.
 
-    Default (``retrigger_above_threshold`` unset): the action fires only when the
-    count equals the threshold exactly, so it triggers once as the count climbs
-    past it. With ``retrigger_above_threshold`` the action fires whenever the count
-    is at or above the threshold (the classic re-triggering lock). The flag is
-    per action, so one stage can e.g. email once at its threshold while keeping the
-    user locked as long as the count stays at or above it.
+    ``policy.stages`` is ordered by descending ``failure_threshold`` and the ``(policy_id, failure_threshold)``
+    unique constraint makes that a total order - the stages partition every count into disjoint ranges - so the
+    stage that owns *count* is simply the first one in that order whose threshold does not exceed it.
     """
-    if action.retrigger_above_threshold:
-        return count >= threshold
-    return count == threshold
+    return next((stage for stage in policy.stages if stage.failure_threshold <= count), None)
 
 
-def _stage_pending_actions(stage: ConditionalAccessPolicyStage, count: int) -> list[ConditionalAccessStageAction]:
-    """The actions of *stage* whose per-action condition is met at *count*."""
-    return [action for action in stage.actions
-            if _action_threshold_met(action, stage.failure_threshold, count)]
+def _action_fires(action: ConditionalAccessStageAction, threshold: int, count: int) -> bool:
+    """
+    Whether *action* fires at *count*, given that its stage is the one :func:`_stage_in_range` returned for it -
+    this does not itself check that *count* falls in the stage's range.
+
+    Default (``retrigger_above_threshold`` unset): the action fires only when the count equals the threshold
+    exactly, so it triggers once as the count climbs into the stage's range. With ``retrigger_above_threshold`` the
+    action fires on every request for as long as the count stays in that range, so one stage can e.g. email once at
+    its threshold while keeping the user locked for every further failure up to the next one. Escalation therefore
+    hands over for good: once a more severe stage owns the count, :func:`_stage_in_range` no longer returns this
+    stage at all, so its actions stop firing - not even on the requests the more severe stage itself sits out.
+    """
+    return action.retrigger_above_threshold or count == threshold
+
+
+def _pending_actions(stage: ConditionalAccessPolicyStage, count: int) -> list[ConditionalAccessStageAction]:
+    """
+    The actions of *stage* that fire at *count* (see :func:`_action_fires`), given that *stage* is the one
+    :func:`_stage_in_range` returned for it.
+    """
+    return [action for action in stage.actions if _action_fires(action, stage.failure_threshold, count)]
 
 
 def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_type: str,
                      now: datetime) -> "ConditionalAccessEvaluation":
     """
     Evaluate a single policy: count the user's events over the policy window,
-    find the triggered stage, then execute the stage's *pending* actions (or, in
-    dry-run, only log what they would have done).
+    find the stage that owns the count (see :func:`_stage_in_range`), then execute
+    that stage's *pending* actions (or, in dry-run, only log what they would have
+    done).
 
-    Each action decides for itself whether it fires (see
-    :func:`_action_threshold_met`): by default an action triggers once, when the
-    count equals the stage's ``failure_threshold``; an action with
-    ``retrigger_above_threshold`` fires whenever the count is at or above the
-    threshold. So one stage can, for example, email once at threshold 8 while
-    keeping the user locked for every further failure at 8 or more.
+    Each action decides for itself whether it fires (see :func:`_action_fires`):
+    by default an action triggers only when the count equals its stage's
+    ``failure_threshold`` exactly; an action with ``retrigger_above_threshold``
+    fires on every request for as long as the count stays in that stage's range.
+    So one stage can, for example, email once at threshold 8 while keeping the
+    user locked for every further failure up to the threshold that supersedes it.
 
     :return: a :class:`ConditionalAccessEvaluation` with the user-facing messages produced by the executed actions
         and the outcomes describing what was done (both empty if no stage triggered; in dry run there are outcomes
@@ -1416,18 +1434,17 @@ def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_
         count = _policy_count(policy, user, now, since_last_success=policy.reset_on_success)
         subject_label = repr(user)
 
-    # Picks the triggered stage: the highest-threshold stage with at least one action whose per-action condition is
-    # met (see _action_threshold_met).
-    # By default an action fires once, exactly at the threshold (a threshold-8 email sends on the 8th failure, not
-    # again at 9); retrigger_above_threshold keeps it firing while the count stays at or above the threshold.
-    # Stages are ordered by descending threshold, so the most severe stage with a pending action wins and only that
-    # stage's actions run (one stage per policy per request); contrast the pre-auth DENY decision in
-    # _policy_access_decision.
-    triggered_stage = next((stage for stage in policy.stages
-                            if _stage_pending_actions(stage, count)), None)
-    if triggered_stage is None:
+    # The stage that owns this count (see _stage_in_range) is the only one whose actions can fire - a stage below
+    # it cannot reach its own threshold again (the count has moved past it), and a stage above it has not been
+    # reached yet. One stage per policy per request, therefore, with no severity search needed; contrast the
+    # pre-auth DENY decision in _policy_access_decision, which asks the same owner a narrower question.
+    # By default, an action fires once, exactly at the threshold (a threshold-8 email sends on the 8th failure, not
+    # again at 9); retrigger_above_threshold keeps it firing for as long as this stage owns the count, so
+    # escalation is a hand-over and the milder stage never resumes.
+    triggered_stage = _stage_in_range(policy, count)
+    pending_actions = _pending_actions(triggered_stage, count) if triggered_stage else []
+    if not pending_actions:
         return ConditionalAccessEvaluation()
-    pending_actions = _stage_pending_actions(triggered_stage, count)
 
     if policy.dry_run:
         log.info(f"[dry-run] policy {policy.name!r} would trigger stage {triggered_stage.id} "

--- a/privacyidea/lib/conditional_access/engine.py
+++ b/privacyidea/lib/conditional_access/engine.py
@@ -1162,9 +1162,18 @@ def _policy_access_decision(policy: ConditionalAccessPolicy, context: CAContext,
     the range its stage owns, which is what makes it a self-healing reject. An
     admin can switch it to fire-once, in which case it only refuses the request at
     the exact threshold count. The stage with the highest threshold whose ``DENY``
-    action is met supplies the decision - and because a re-triggering ``DENY``
-    stops at the next threshold, a more severe stage that does not itself deny
-    lifts the refusal rather than inheriting it.
+    action is met supplies the decision.
+
+    A re-triggering ``DENY`` is bounded like any other action: it stops once a
+    more severe stage's threshold is reached. That escalation is rarely something
+    live traffic reaches on its own, though: once the ``DENY`` is enforced, every
+    further request is refused here, pre-auth, and logged as ``ACCESS_DENIED`` -
+    one of the :data:`~privacyidea.lib.conditional_access.authentication_event_types.CA_ENFORCEMENT_EVENT_TYPES`
+    no policy can count. So the very count that would carry this stage's ``DENY``
+    past the next threshold stops advancing while the refusal holds, and only
+    resumes moving (in either direction) once something outside this policy's own
+    refusal changes it - the window sliding the triggering events out, or a
+    successful login where ``reset_on_success`` applies.
     """
     # Applicability is checked first: a policy whose conditions exclude this request contributes no decision and
     # costs no counting query.
@@ -1358,9 +1367,13 @@ def _action_fires(action: ConditionalAccessStageAction, threshold: int, count: i
     Default (``retrigger_above_threshold`` unset): the action fires only when the count equals the threshold
     exactly, so it triggers once as the count climbs into the stage's range. With ``retrigger_above_threshold`` the
     action fires on every request for as long as the count stays in that range, so one stage can e.g. email once at
-    its threshold while keeping the user locked for every further failure up to the next one. Escalation therefore
-    hands over for good: once a more severe stage owns the count, :func:`_stage_in_range` no longer returns this
-    stage at all, so its actions stop firing - not even on the requests the more severe stage itself sits out.
+    its threshold while keeping the user locked for every further failure up to the next one.
+
+    This is a live classification of the *current* count, not a state the policy remembers: once a more severe
+    stage owns the count, :func:`_stage_in_range` stops returning this stage and its actions stop firing - but
+    nothing here stops the count from moving back down again (the time window sliding old events out, or a
+    ``reset_on_success`` floor), at which point this stage owns the count once more and a re-triggering action
+    fires again. There is no one-way hand-over; escalation and de-escalation follow the count symmetrically.
     """
     return action.retrigger_above_threshold or count == threshold
 
@@ -1439,8 +1452,10 @@ def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_
     # reached yet. One stage per policy per request, therefore, with no severity search needed; contrast the
     # pre-auth DENY decision in _policy_access_decision, which asks the same owner a narrower question.
     # By default, an action fires once, exactly at the threshold (a threshold-8 email sends on the 8th failure, not
-    # again at 9); retrigger_above_threshold keeps it firing for as long as this stage owns the count, so
-    # escalation is a hand-over and the milder stage never resumes.
+    # again at 9); retrigger_above_threshold keeps it firing for as long as this stage owns the count. Ownership is
+    # recomputed fresh from the current count on every request, not remembered, so a milder stage's re-triggering
+    # action stops once a more severe stage takes over and fires again if the count later drops back into its own
+    # range (the window sliding old events out, or a reset_on_success floor) - there is no permanent hand-over.
     triggered_stage = _stage_in_range(policy, count)
     pending_actions = _pending_actions(triggered_stage, count) if triggered_stage else []
     if not pending_actions:

--- a/privacyidea/lib/conditional_access/policy.py
+++ b/privacyidea/lib/conditional_access/policy.py
@@ -139,8 +139,8 @@ MAX_NAME_LENGTH = 255
 # on the lock/block state rows that copy it. Shared, so any path taking one as input validates alike.
 MAX_ERROR_MESSAGE_LENGTH = 500
 
-# DENY is a standing pre-auth decision, so it defaults to re-triggering while the count stays at or above the
-# threshold; the post-response lock/email/block actions default to firing once. A set because both the threshold-0 rule
+# DENY is a standing pre-auth decision, so it defaults to re-triggering over the range its stage owns; the
+# post-response lock/email/block actions default to firing once. A set because both the threshold-0 rule
 # and the retrigger default ask "is this a standing verdict?".
 DECISION_ACTIONS = frozenset({ConditionalAccessAction.DENY})
 
@@ -962,9 +962,9 @@ def _build_stages(stage_defs: list[StageDefinition]) -> list[ConditionalAccessPo
 
     An action whose ``retrigger_above_threshold`` is ``None`` (not chosen by the
     admin) gets the action-aware default: the :data:`DECISION_ACTIONS` are
-    standing pre-auth decisions that apply while the count stays at or above the
-    threshold, so they re-trigger; the post-response effects (lock/email/block)
-    fire once, at the exact threshold.
+    standing pre-auth decisions that apply over the range their stage owns, so
+    they re-trigger; the post-response effects (lock/email/block) fire once, at
+    the exact threshold.
     """
     return [
         ConditionalAccessPolicyStage(

--- a/privacyidea/models/conditional_access_policy.py
+++ b/privacyidea/models/conditional_access_policy.py
@@ -249,13 +249,14 @@ class ConditionalAccessStageAction(MethodsMixin, db.Model):
     ``retrigger_above_threshold`` controls how this action fires as the failure
     count crosses its stage's threshold. False: fire once, when the count equals
     the threshold exactly. True: keep firing while the count stays at or above the
-    threshold (the classic re-triggering lock; de-dup still throttles repeats
-    within one incident). Because it is per action, one stage can e.g. email once
+    threshold and below the next stage's, so escalation ends it for good (the
+    classic re-triggering lock; de-dup still throttles repeats within one
+    incident). Because it is per action, one stage can e.g. email once
     at its threshold while re-triggering the user lock. The CRUD layer picks an
     action-aware default when the client omits it (the DENY decision defaults to
     True, the lock/email/block effects to False); see
     :func:`~privacyidea.lib.conditional_access.policy._validate_stages`
-    and :func:`~privacyidea.lib.conditional_access.engine._action_threshold_met`.
+    and :func:`~privacyidea.lib.conditional_access.engine._action_fires`.
     """
     __tablename__ = 'conditional_access_stage_actions'
     id: Mapped[int] = mapped_column(Integer, Identity(always=False), primary_key=True)

--- a/tests/test_lib_conditional_access_engine.py
+++ b/tests/test_lib_conditional_access_engine.py
@@ -1224,6 +1224,30 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
 
         self.assertListEqual([mild_stage.failure_threshold], self._triggered_thresholds())
 
+    def test_retrigger_stops_at_the_next_threshold_and_does_not_resume(self):
+        # A re-triggering action owns the range up to the next stage's threshold and hands over there for good.
+        _, stages = self._make_policy(
+            name="tiers", counter_type=AuthEventType.MFA_FAIL,
+            stages=(StageDefinition(5, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 1800,
+                                                                 retrigger_above_threshold=False)]),
+                    StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 600,
+                                                                 retrigger_above_threshold=True)])))
+        severe_stage = stages[0]
+        mild_stage = stages[1]
+
+        self._seed_events(AuthEventType.MFA_FAIL, 3)  # count 3 -> the mild stage's own threshold
+        self.assertListEqual([mild_stage.failure_threshold], self._triggered_thresholds())
+
+        self._seed_events(AuthEventType.MFA_FAIL, 1)  # count 4 -> still inside the mild stage's range
+        self.assertListEqual([mild_stage.failure_threshold], self._triggered_thresholds())
+
+        self._seed_events(AuthEventType.MFA_FAIL, 1)  # count 5 -> the severe (fire-once) stage's exact threshold
+        self.assertListEqual([severe_stage.failure_threshold], self._triggered_thresholds())
+
+        self._seed_events(AuthEventType.MFA_FAIL, 1)  # count 6 -> past both: the severe stage already fired once,
+        # and the mild stage's range ended at 5, so it does not resume
+        self.assertListEqual([], self._triggered_thresholds())
+
     def test_permanent_lock_action(self):
         self._make_policy(name="perm", counter_type=AuthEventType.MFA_FAIL,
                           stages=(StageDefinition(
@@ -1631,6 +1655,21 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self._seed_events(AuthEventType.PASSWORD_FAIL, 3)
         self.assertEqual(AccessDecision.DENY, evaluate_access_decision(CAContext(self.user)).decision)
         self._seed_events(AuthEventType.PASSWORD_FAIL, 1)  # count 4 > 3
+        self.assertEqual(AccessDecision.CONTINUE, evaluate_access_decision(CAContext(self.user)).decision)
+
+    def test_access_decision_retriggering_deny_stops_at_the_next_threshold(self):
+        # The range rule applies to the standing DENY verdict too: it holds while the count stays below the next
+        # stage's threshold, and the more severe stage supplies the decision from there on. That stage only emails,
+        # so once the count reaches 10 nothing denies any more.
+        self._make_policy(
+            name="deny", counter_type=AuthEventType.PASSWORD_FAIL,
+            stages=(StageDefinition(10, [StageActionDefinition(ConditionalAccessAction.EMAIL_ADMIN,
+                                                                  {"smtp_identifier": "nosuch"})]),
+                    StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.DENY,
+                                                                 retrigger_above_threshold=True)])))
+        self._seed_events(AuthEventType.PASSWORD_FAIL, 9)
+        self.assertEqual(AccessDecision.DENY, evaluate_access_decision(CAContext(self.user)).decision)
+        self._seed_events(AuthEventType.PASSWORD_FAIL, 1)  # count 10 -> the milder stage no longer decides
         self.assertEqual(AccessDecision.CONTINUE, evaluate_access_decision(CAContext(self.user)).decision)
 
     def test_access_decision_denies_on_combined_count(self):

--- a/tests/test_lib_conditional_access_engine.py
+++ b/tests/test_lib_conditional_access_engine.py
@@ -1224,8 +1224,10 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
 
         self.assertListEqual([mild_stage.failure_threshold], self._triggered_thresholds())
 
-    def test_retrigger_stops_at_the_next_threshold_and_does_not_resume(self):
-        # A re-triggering action owns the range up to the next stage's threshold and hands over there for good.
+    def test_retrigger_stops_once_a_more_severe_stage_owns_the_count(self):
+        # A re-triggering action owns the range up to the next stage's threshold, and stops once the count moves
+        # into a more severe stage's range - as long as the count keeps climbing. See
+        # test_retrigger_resumes_once_the_count_decays_back_into_its_range for what happens when it does not.
         _, stages = self._make_policy(
             name="tiers", counter_type=AuthEventType.MFA_FAIL,
             stages=(StageDefinition(5, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 1800,
@@ -1245,8 +1247,36 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self.assertListEqual([severe_stage.failure_threshold], self._triggered_thresholds())
 
         self._seed_events(AuthEventType.MFA_FAIL, 1)  # count 6 -> past both: the severe stage already fired once,
-        # and the mild stage's range ended at 5, so it does not resume
+        # and the count has moved out of the mild stage's range
         self.assertListEqual([], self._triggered_thresholds())
+
+    def test_retrigger_resumes_once_the_count_decays_back_into_its_range(self):
+        # Stage ownership is a live read of the current count, not a state the policy remembers: once the events
+        # that pushed the count into a more severe stage's range age out of the time window, the count can drop
+        # back into a milder stage's range, and that stage's re-triggering action fires again - there is no
+        # permanent hand-over.
+        now = utc_now()
+        _, stages = self._make_policy(
+            name="tiers", counter_type=AuthEventType.MFA_FAIL, window=100,
+            stages=(StageDefinition(5, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 50,
+                                                                 retrigger_above_threshold=False)]),
+                    StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 600,
+                                                                 retrigger_above_threshold=True)])))
+        severe_stage = stages[0]
+        mild_stage = stages[1]
+
+        # count 5 at 'now' -> the severe stage fires (fire-once, at its exact threshold).
+        self._seed_events(AuthEventType.MFA_FAIL, 5, timestamp=now)
+        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=now)
+        self.assertListEqual([severe_stage.failure_threshold], [o.threshold for o in evaluation.outcomes])
+
+        # 250s later: the five events are now outside the 100s window (count decays to 0), and the severe stage's
+        # 50s lock has long since expired. Three fresh failures bring the count back to 3 -> the mild stage's own
+        # (re-triggering) threshold, and it fires again even though the severe stage already fired once.
+        later = now + timedelta(seconds=250)
+        self._seed_events(AuthEventType.MFA_FAIL, 3, timestamp=later)
+        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=later)
+        self.assertListEqual([mild_stage.failure_threshold], [o.threshold for o in evaluation.outcomes])
 
     def test_permanent_lock_action(self):
         self._make_policy(name="perm", counter_type=AuthEventType.MFA_FAIL,

--- a/tests/test_lib_conditional_access_engine.py
+++ b/tests/test_lib_conditional_access_engine.py
@@ -1702,6 +1702,29 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self._seed_events(AuthEventType.PASSWORD_FAIL, 1)  # count 10 -> the milder stage no longer decides
         self.assertEqual(AccessDecision.CONTINUE, evaluate_access_decision(CAContext(self.user)).decision)
 
+    def test_access_decision_retriggering_deny_resumes_once_the_count_decays_back_into_its_range(self):
+        # The hand-over above is not one-way: once the events that pushed the count past the milder stage's range
+        # age out of the window, a re-triggering DENY at that stage resumes deciding - the same live-count reading
+        # that applies to LOCK_USER (see test_retrigger_resumes_once_the_count_decays_back_into_its_range) applies
+        # to the pre-auth decision too. The milder stage here only emails, so nothing here refuses the request and
+        # stops it from being counted (see the DENY-specific de-escalation note in doc/conditional_access/policies).
+        now = utc_now()
+        self._make_policy(
+            name="deny", counter_type=AuthEventType.PASSWORD_FAIL, window=100,
+            stages=(StageDefinition(10, [StageActionDefinition(ConditionalAccessAction.EMAIL_ADMIN,
+                                                                  {"smtp_identifier": "nosuch"})]),
+                    StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.DENY,
+                                                                 retrigger_above_threshold=True)])))
+        self._seed_events(AuthEventType.PASSWORD_FAIL, 10, timestamp=now)
+        self.assertEqual(AccessDecision.CONTINUE, evaluate_access_decision(CAContext(self.user), now=now).decision)
+
+        # 250s later: the ten events are now outside the 100s window (count decays to 0). Three fresh failures bring
+        # the count back to 3 - the milder stage's own (re-triggering) threshold - and DENY fires again even though
+        # the more severe stage already owned the count once.
+        later = now + timedelta(seconds=250)
+        self._seed_events(AuthEventType.PASSWORD_FAIL, 3, timestamp=later)
+        self.assertEqual(AccessDecision.DENY, evaluate_access_decision(CAContext(self.user), now=later).decision)
+
     def test_access_decision_denies_on_combined_count(self):
         # The pre-auth decision also counts all tracked types together: 2 + 2 = 4 crosses the threshold of 3,
         # so the request is denied.


### PR DESCRIPTION
A stage action with retrigger_above_threshold fired on every request at or above its own threshold, with no upper bound — so a milder stage kept re-triggering (e.g. LOCK_USER) even after the count passed a
  more severe stage's threshold, on any request where that severe stage itself didn't fire (a fire-once action past its own exact count, for instance). Escalation should hand over for good, not run both     
  stages' effects indefinitely.                                                                                                                                                                                
                                                                                                                                                                                                               
  Each stage now owns the half-open range [its threshold, next stage's threshold). A re-triggering action fires only while the count is inside its own stage's range; once the count reaches the next          
  threshold, the milder stage stops and never resumes — even on requests the more severe stage sits out. This applies uniformly, including the pre-auth DENY verdict (no exemption): a DENY at a low threshold 
  now also stops once a more severe stage takes over, so if that stage doesn't itself deny, the refusal lifts rather than persisting forever.  