### PR TITLE
Cache only complete, verified credentials in the auth cache

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -74,6 +74,34 @@
   noticed, because that per-process cache sits in front of the shared one. See the "Redis cache" section of the
   documentation.
 
+* **The `auth_cache` policy no longer covers challenge-response, push, `passOnNoToken` and `passOnNoUser`.** The cache
+  exists so that a client which authenticates again at short intervals — a VPN gateway reconnecting every hour, for
+  example — may present the same credential instead of obtaining a new OTP. It now only holds a complete credential that
+  was really verified, which means the credential of a single `/validate/check` request. Three kinds of successful
+  authentication are no longer stored in the cache, and no longer answered from it:
+
+    * **Requests carrying a `transaction_id`** (or its alias `state`), i.e. the response to a challenge. Such a request
+      contains only part of the credential — the PIN was sent in the request that triggered the challenge — and a push
+      token is confirmed on the phone and sends no credential at all, previously caching an *empty* credential that
+      then authenticated on its own. **If you use `auth_cache` together with a challenge-response token type (including
+      email, SMS and push, or HOTP/TOTP with the `challenge_response` policy), those users now authenticate against
+      their token on every login.** Expect the corresponding load — LDAP binds, SMS and email dispatch — to return to
+      one per authentication. The combination cannot be made to work: the PIN and the response arrive in two separate
+      requests, so a complete credential to cache never exists.
+    * **Requests with an empty or absent `pass`.** Besides the push case above, this also removes a `TypeError` (an HTTP
+      500 on an otherwise successful authentication) when a client omitted the `pass` parameter entirely.
+    * **Authentications decided by `passOnNoToken` or `passOnNoUser`.** These succeed because the user has no token or
+      does not exist, not because the credential was checked, so an entry kept authenticating after the policy was
+      withdrawn or the user was given a token.
+
+  Existing rows in the `authcache` table are not touched by the update and keep working until they expire or are
+  cleaned up. If you want the previous entries gone immediately, run
+  `pi-manage config authcache cleanup --minutes 0` (with `PI_REDIS_CACHE_AUTH` the entries expire on their own).
+
+  `passthru` against a RADIUS server is unchanged and still caches what the remote server accepted, which means the
+  remote system's replay protection does not apply for the duration of the policy. Keep the interval short if you
+  combine the two.
+
 * **`clientapplication.lastseen` is written again.** Since 3.13 the column was only ever set when a client's row was
   first created: the update path assigned an attribute that is not the column, so the client list in the WebUI and the
   metering of plugin traffic showed when each client was *first* seen rather than last. This is fixed. Expect the

--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -88,15 +88,23 @@
       their token on every login.** Expect the corresponding load — LDAP binds, SMS and email dispatch — to return to
       one per authentication. The combination cannot be made to work: the PIN and the response arrive in two separate
       requests, so a complete credential to cache never exists.
-    * **Requests with an empty or absent `pass`.** Besides the push case above, this also removes a `TypeError` (an HTTP
-      500 on an otherwise successful authentication) when a client omitted the `pass` parameter entirely.
+    * **Requests with an empty or absent `pass`.** This also removes a `TypeError` (an HTTP 500 on an authentication
+      that had already succeeded) when a client confirmed a push token and then omitted the `pass` parameter instead of
+      sending an empty one.
     * **Authentications decided by `passOnNoToken` or `passOnNoUser`.** These succeed because the user has no token or
       does not exist, not because the credential was checked, so an entry kept authenticating after the policy was
       withdrawn or the user was given a token.
 
-  Existing rows in the `authcache` table are not touched by the update and keep working until they expire or are
-  cleaned up. If you want the previous entries gone immediately, run
-  `pi-manage config authcache cleanup --minutes 0` (with `PI_REDIS_CACHE_AUTH` the entries expire on their own).
+  **Clear the cache after the update if you used any of these combinations.** Entries written by the previous version
+  are not touched by the update, and an entry holding the response to a challenge keeps authenticating on its own until
+  it expires — the new rules decide what is written and what is looked up, they do not remove what is already there.
+  Empty credentials are refused outright, so the push case is closed either way, but the remaining entries are only
+  gone once you run:
+
+      pi-manage config authcache cleanup --minutes 0
+
+  With `PI_REDIS_CACHE_AUTH` the entries carry the policy's interval as their TTL and expire on their own, at the
+  latest after the first interval of the policy that wrote them.
 
   `passthru` against a RADIUS server is unchanged and still caches what the remote server accepted, which means the
   remote system's replay protection does not apply for the duration of the policy. Keep the interval short if you

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -706,7 +706,7 @@ Two consequences worth knowing:
 
 Like the other workloads it degrades safely: if Redis cannot be reached the
 database takes over, and a lost entry costs one real authentication against the
-user store, nothing else.
+token or the user store, nothing else.
 
 .. _redis_health_cache:
 

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -132,6 +132,8 @@ for this user will always be true.
 .. warning:: Only use this if you know exactly what
    you are doing.
 
+.. _passonnouser:
+
 passOnNoUser
 ~~~~~~~~~~~~
 
@@ -575,8 +577,33 @@ auth_cache
 type: ``string``
 
 The Authentication Cache caches the credentials of a successful authentication
-and allows using the same credentials (inluding the OTP value) for the specified
-amount of time and optionally for a specified number of authentications.
+and allows using the same credentials (including the OTP value) for the specified
+amount of time and optionally for a specified number of authentications. It is
+meant for clients that authenticate again at short intervals - a VPN gateway that
+reconnects every hour, for example - which would otherwise need a new OTP each
+time.
+
+Only a complete credential that was verified against a token or a user store is
+cached, which means the credential of a single ``/validate/check`` request. The
+following successful authentications are therefore neither stored in the cache nor
+answered from it:
+
+* **Requests that answer a challenge**, i.e. requests carrying a ``transaction_id``.
+  Such a request contains only the response to the challenge and not the whole
+  credential: the PIN was sent in the request that triggered the challenge, and a
+  push token is confirmed on the phone and sends no credential at all. Users of a
+  challenge-response token therefore authenticate against the token on every login.
+* **Requests without a credential**, i.e. with an empty or absent ``pass``.
+* Authentications that succeeded **without checking the presented credential**,
+  namely through :ref:`passonnotoken` and :ref:`passonnouser`. Those decisions
+  follow from the absence of a token or of a user, so they last only as long as
+  that condition and the policy do.
+
+.. warning:: With ``passthru`` pointing to a RADIUS server, the cached credential is
+   whatever that server accepted, and for the duration of the policy privacyIDEA
+   answers from its own cache instead of asking again. The replay protection and the
+   counters of the remote system do not apply during that time. Keep the interval
+   short, or do not combine the two.
 
 The time to cache the credentials can be specified like "4h", "5m", "2d", "3s"
 (hours, minutes, days, seconds). The number of allowed authentications can be

--- a/doc/policies/authentication.rst
+++ b/doc/policies/authentication.rst
@@ -583,13 +583,14 @@ meant for clients that authenticate again at short intervals - a VPN gateway tha
 reconnects every hour, for example - which would otherwise need a new OTP each
 time.
 
-Only a complete credential that was verified against a token or a user store is
-cached, which means the credential of a single ``/validate/check`` request. The
-following successful authentications are therefore neither stored in the cache nor
-answered from it:
+Only a complete credential that was verified - against a token, a user store, or the
+RADIUS server of a ``passthru`` policy - is cached, which means the credential of a
+single ``/validate/check`` request. The following successful authentications are
+therefore neither stored in the cache nor answered from it:
 
-* **Requests that answer a challenge**, i.e. requests carrying a ``transaction_id``.
-  Such a request contains only the response to the challenge and not the whole
+* **Requests that answer a challenge**, i.e. requests carrying a ``transaction_id`` or
+  its legacy alias ``state``. Such a request contains only the response to the
+  challenge and not the whole
   credential: the PIN was sent in the request that triggered the challenge, and a
   push token is confirmed on the phone and sends no credential at all. Users of a
   challenge-response token therefore authenticate against the token on every login.

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -186,11 +186,15 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
 
     * A request that answers a challenge. Such a request carries only the response to the
       challenge, not the whole credential - the PIN was sent in the preceding request and
-      a push token confirms out of band and sends nothing at all. Those requests are
-      neither served from the cache nor stored in it.
-    * A success without any credential, i.e. an empty or absent ``pass``.
+      a push token confirms out of band and sends nothing at all.
+    * A request without any credential, i.e. an empty or absent ``pass``.
     * A success that did not verify the presented credential at all, which the deciding
       decorator marks with ``AUTH_CACHE_EXCLUDE`` in its reply.
+
+    The first two are decided from the request alone, so such a request is neither served
+    from the cache nor stored in it. Answering one from the cache would accept an entry
+    written by an earlier version, and looking one up without a credential also reaches
+    ``argon2.verify`` with ``None``, which raises.
 
     :param wrapped_function: usually "check_user_pass"
     :param user_object: User who tries to authenticate
@@ -203,7 +207,7 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
     auth_cache_policy = None
     answers_challenge = bool(options.get("transaction_id") or options.get("state"))
 
-    if g and not answers_challenge:
+    if g and passw and not answers_challenge:
         auth_cache_policy = (Match.user(g, scope=SCOPE.AUTH, action=PolicyAction.AUTH_CACHE, user_object=user_object)
                              .action_values(unique=True, write_to_audit_log=False))
         if auth_cache_policy:
@@ -239,7 +243,8 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
     # The marker is meant for this decorator only and the reply dictionary is handed to the
     # client, so it is removed in any case, whether the policy applies or not.
     credential_unverified = reply_dict.pop(AUTH_CACHE_EXCLUDE, False)
-    if auth_cache_policy and res and passw and not credential_unverified:
+    # A request excluded above never matched a policy, so it cannot reach this either.
+    if auth_cache_policy and res and not credential_unverified:
         # If authentication is successful, we store the password in auth_cache.
         # The first interval of the policy is how long the entry can be used at
         # the most, so a cache that can expire entries by itself is told to drop

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -65,6 +65,11 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Marks a successful authentication that did not verify the credential the client presented,
+# so that :func:`auth_cache` does not store that credential. Set in the reply dictionary of the
+# deciding decorator and removed again by :func:`auth_cache`, which is the outermost one.
+AUTH_CACHE_EXCLUDE = "auth_cache_exclude"
+
 
 class libpolicy:
     """
@@ -173,6 +178,20 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
     Decorate lib.token:check_user_pass. Verify, if the authentication can
     be found in the auth_cache.
 
+    The cache lets a client present the same credential again for the duration of the
+    policy, so that a client which reconnects regularly - a VPN gateway, for example -
+    does not have to obtain a new OTP every time. It therefore only ever holds a complete
+    credential that was actually verified against a token or a user store. Three kinds of
+    successful authentication are excluded, because their credential is neither of those:
+
+    * A request that answers a challenge. Such a request carries only the response to the
+      challenge, not the whole credential - the PIN was sent in the preceding request and
+      a push token confirms out of band and sends nothing at all. Those requests are
+      neither served from the cache nor stored in it.
+    * A success without any credential, i.e. an empty or absent ``pass``.
+    * A success that did not verify the presented credential at all, which the deciding
+      decorator marks with ``AUTH_CACHE_EXCLUDE`` in its reply.
+
     :param wrapped_function: usually "check_user_pass"
     :param user_object: User who tries to authenticate
     :param passw: The PIN and OTP
@@ -182,8 +201,9 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
     options = options or {}
     g = options.get("g")
     auth_cache_policy = None
+    answers_challenge = bool(options.get("transaction_id") or options.get("state"))
 
-    if g:
+    if g and not answers_challenge:
         auth_cache_policy = (Match.user(g, scope=SCOPE.AUTH, action=PolicyAction.AUTH_CACHE, user_object=user_object)
                              .action_values(unique=True, write_to_audit_log=False))
         if auth_cache_policy:
@@ -216,7 +236,10 @@ def auth_cache(wrapped_function, user_object, passw, options=None):
 
     # If nothing else returned, call the wrapped function
     res, reply_dict = wrapped_function(user_object, passw, options)
-    if auth_cache_policy and res:
+    # The marker is meant for this decorator only and the reply dictionary is handed to the
+    # client, so it is removed in any case, whether the policy applies or not.
+    credential_unverified = reply_dict.pop(AUTH_CACHE_EXCLUDE, False)
+    if auth_cache_policy and res and passw and not credential_unverified:
         # If authentication is successful, we store the password in auth_cache.
         # The first interval of the policy is how long the entry can be used at
         # the most, so a cache that can expire entries by itself is told to drop
@@ -257,7 +280,10 @@ def auth_user_has_no_token(wrapped_function, user_object, passw,
             token_count = _get_token_count_excluding_rollout_states(user_object, ignore_rollout_state)
             if token_count == 0:
                 g.audit_object.add_policy({p.get("name") for p in pass_no_token})
-                return True, {"message": f"user has no token, accepted due to '{pass_no_token[0].get('name')}'"}
+                # The credential was never verified: the success comes from the absence of a
+                # token and ends as soon as the user is given one or the policy is withdrawn.
+                return True, {"message": f"user has no token, accepted due to '{pass_no_token[0].get('name')}'",
+                              AUTH_CACHE_EXCLUDE: True}
 
     # If nothing else returned, we return the wrapped function
     return wrapped_function(user_object, passw, options)
@@ -285,7 +311,10 @@ def auth_user_does_not_exist(wrapped_function, user_object, passw, options=None)
         if not user_object.exist():
             if pass_no_user:
                 g.audit_object.add_policy({p.get("name") for p in pass_no_user})
-                return True, {"message": f"user does not exist, accepted due to '{pass_no_user[0].get('name')}'"}
+                # The credential was never verified: the success comes from the absence of the
+                # user and ends as soon as the policy is withdrawn.
+                return True, {"message": f"user does not exist, accepted due to '{pass_no_user[0].get('name')}'",
+                              AUTH_CACHE_EXCLUDE: True}
 
             hide_message = Match.user(g, scope=SCOPE.AUTH, action=PolicyAction.HIDE_SPECIFIC_ERROR_MESSAGE,
                                       user_object=user_object).any()

--- a/tests/test_api_validate_authcache.py
+++ b/tests/test_api_validate_authcache.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from passlib.hash import argon2
 
+from privacyidea.lib.authcache import add_to_cache
 from privacyidea.lib.challenge import get_challenges
 from privacyidea.lib.error import ResourceNotFoundError
 from privacyidea.lib.policies.actions import PolicyAction
@@ -167,6 +168,29 @@ class AuthCacheCredentialTestCase(MyApiTestCase):
 
         remove_token("AC_CR2")
 
+    def test_02a_a_challenge_answered_with_state_is_not_cached(self):
+        """``state`` is the alias of ``transaction_id`` for legacy clients and marks the
+        request as the answer to a challenge just the same."""
+        self._drop_tokens("cornelius")
+        init_token({"serial": "AC_CR3", "otpkey": self.otpkey, "pin": "pin"},
+                   user=User("cornelius", self.realm1))
+        set_policy("chalresp", scope=SCOPE.AUTH, action=f"{PolicyAction.CHALLENGERESPONSE}=hotp")
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        first = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "pin"})
+        self.assertFalse(first["result"]["value"], first)
+        state = first["detail"]["transaction_id"]
+
+        second = self._validate({"user": "cornelius", "realm": self.realm1,
+                                 "pass": "755224", "state": state})
+        self.assertTrue(second["result"]["value"], second)
+        self.assertFalse(self._cache_holds("cornelius", "755224"))
+
+        replay = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "755224"})
+        self.assertFalse(replay["result"]["value"], replay)
+
+        remove_token("AC_CR3")
+
     def test_03_push_confirmation_is_not_cached(self):
         """A push token is confirmed out of band and its final request carries no
         credential at all, so there is nothing to cache."""
@@ -193,6 +217,28 @@ class AuthCacheCredentialTestCase(MyApiTestCase):
         self.assertFalse(replay["result"]["value"], replay)
 
         remove_token(serial)
+
+    def test_03a_an_entry_for_an_empty_credential_is_never_served(self):
+        """An entry holding the empty string - written by a version that cached the
+        confirmation of a push token - does not authenticate anybody."""
+        self._drop_tokens("cornelius")
+        init_token({"serial": "AC_EMPTY", "otpkey": self.otpkey, "pin": "pin"},
+                   user=User("cornelius", self.realm1))
+        add_to_cache("cornelius", self.realm1, self.resolvername1, "")
+        self.assertTrue(self._cache_holds("cornelius", ""))
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        result = self._validate({"user": "cornelius", "realm": self.realm1, "pass": ""})
+        self.assertFalse(result["result"]["value"], result)
+
+        # Control: a complete credential is still served, so the entry above is refused
+        # for being empty and not because the cache was bypassed altogether.
+        add_to_cache("cornelius", self.realm1, self.resolvername1, "pin755224")
+        control = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "pin755224"})
+        self.assertTrue(control["result"]["value"], control)
+        self.assertEqual("Authenticated by AuthCache.", control["detail"]["message"])
+
+        remove_token("AC_EMPTY")
 
     def test_04_push_confirmation_without_a_pass_parameter(self):
         """A client may omit ``pass`` instead of sending an empty one. The request

--- a/tests/test_api_validate_authcache.py
+++ b/tests/test_api_validate_authcache.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: 2026 NetKnights GmbH <https://netknights.it>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Which authentications the ``auth_cache`` policy stores and serves.
+
+The cache lets a client present the same credential again for the duration of the
+policy, so a client that reconnects regularly does not need a fresh OTP every time.
+It therefore only holds a complete credential that was verified against a token or a
+user store: a request answering a challenge, a request without a credential, and a
+success that was decided by the absence of a token or of a user are all kept out.
+
+Each test ends with a control step, so every result is attributable to the cache and
+to nothing else.
+"""
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from passlib.hash import argon2
+
+from privacyidea.lib.challenge import get_challenges
+from privacyidea.lib.error import ResourceNotFoundError
+from privacyidea.lib.policies.actions import PolicyAction
+from privacyidea.lib.policy import SCOPE, delete_policy, set_policy
+from privacyidea.lib.token import get_tokens, init_token, remove_token
+from privacyidea.lib.tokens.pushtoken import (POLL_ONLY, PRIVATE_KEY_SERVER, PUBLIC_KEY_SERVER,
+                                             PUBLIC_KEY_SMARTPHONE, PushAction, PushTokenClass,
+                                             strip_pem_headers)
+from privacyidea.lib.user import User
+from privacyidea.lib.utils import b32encode_and_unicode, to_unicode
+from privacyidea.models import AuthCache
+from .base import MyApiTestCase
+
+
+class AuthCacheCredentialTestCase(MyApiTestCase):
+
+    server_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+    smartphone_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+
+    def setUp(self) -> None:
+        super().setUp()
+        # The assertions read the authcache table, so keep the Redis backend out of it.
+        # The decision which authentication is cached sits in the policy decorator above
+        # both stores and is the same for either.
+        self.pin_to_database("auth")
+        self.setUp_user_realms()
+
+    def tearDown(self) -> None:
+        for policy in ("authcache", "chalresp", "nopass_token", "nopass_user", "passthru", "otppin"):
+            try:
+                delete_policy(policy)
+            except ResourceNotFoundError:
+                pass
+        super().tearDown()
+
+    def _validate(self, data: dict) -> dict:
+        with self.app.test_request_context("/validate/check", method="POST", data=data):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            return res.json
+
+    def _cache_holds(self, username: str, credential: str) -> bool:
+        """Whether any entry of that user verifies the given credential. A hash only
+        answers "does this string verify", so the credential has to be presented."""
+        return any(argon2.verify(credential, row.authentication)
+                   for row in AuthCache.query.filter(AuthCache.username == username).all())
+
+    def _drop_tokens(self, username: str) -> None:
+        for token in get_tokens(user=User(username, self.realm1)):
+            remove_token(token.get_serial())
+
+    def _create_push_token(self, user: str, pin: str) -> PushTokenClass:
+        """A rolled-out, poll-only push token, so no Firebase call is involved."""
+        server_key_pem = to_unicode(self.server_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption()))
+        server_public_pem = to_unicode(self.server_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo))
+        smartphone_public_pem = to_unicode(self.smartphone_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo))
+
+        token = init_token({"type": "push", "genkey": 1})
+        token.add_tokeninfo(PushAction.FIREBASE_CONFIG, POLL_ONLY)
+        token.add_tokeninfo(PUBLIC_KEY_SMARTPHONE,
+                            strip_pem_headers(smartphone_public_pem).replace("+", "-").replace("/", "_"))
+        token.add_tokeninfo(PUBLIC_KEY_SERVER, server_public_pem)
+        token.add_tokeninfo(PRIVATE_KEY_SERVER, server_key_pem, "password")
+        token.delete_tokeninfo("enrollment_credential")
+        token.token.rollout_state = "enrolled"
+        token.token.active = True
+        token.set_pin(pin)
+        token.add_user(User(user, self.realm1))
+        return token
+
+    def _confirm_push(self, serial: str, transaction_id: str) -> None:
+        """What the smartphone posts to /ttype/push to accept the request."""
+        challenge = get_challenges(serial=serial, transaction_id=transaction_id)[0].challenge
+        signature = b32encode_and_unicode(
+            self.smartphone_key.sign(f"{challenge}|{serial}".encode(),
+                                     padding.PKCS1v15(), hashes.SHA256()))
+        with self.app.test_request_context("/ttype/push", method="POST",
+                                           data={"serial": serial, "nonce": challenge,
+                                                 "signature": signature}):
+            res = self.app.full_dispatch_request()
+            self.assertEqual(200, res.status_code, res)
+            self.assertTrue(res.json["result"]["value"], res.json)
+
+    def test_01_challenge_response_is_not_cached(self):
+        """The response to a challenge is only one part of the credential - the PIN was
+        sent in the request before it - so it neither enters the cache nor is served
+        from it."""
+        self._drop_tokens("cornelius")
+        init_token({"serial": "AC_CR", "otpkey": self.otpkey, "pin": "pin"},
+                   user=User("cornelius", self.realm1))
+        set_policy("chalresp", scope=SCOPE.AUTH, action=f"{PolicyAction.CHALLENGERESPONSE}=hotp")
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        # The PIN triggers a challenge, so this request is not a success.
+        first = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "pin"})
+        self.assertFalse(first["result"]["value"], first)
+        transaction_id = first["detail"]["transaction_id"]
+        self.assertFalse(self._cache_holds("cornelius", "pin"))
+
+        # The OTP answers that challenge and authenticates, but is not stored.
+        second = self._validate({"user": "cornelius", "realm": self.realm1,
+                                 "pass": "755224", "transaction_id": transaction_id})
+        self.assertTrue(second["result"]["value"], second)
+        self.assertFalse(self._cache_holds("cornelius", "755224"))
+
+        # So the OTP does not authenticate on its own afterwards: the token has moved
+        # past it and the cache does not hold it either.
+        replay = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "755224"})
+        self.assertFalse(replay["result"]["value"], replay)
+
+        remove_token("AC_CR")
+
+    def test_02_challenge_response_is_not_served_from_the_cache(self):
+        """A request that answers a challenge is answered by the token. A credential the
+        cache happens to hold does not authenticate such a request."""
+        self._drop_tokens("cornelius")
+        init_token({"serial": "AC_CR2", "otpkey": self.otpkey, "pin": "pin"},
+                   user=User("cornelius", self.realm1))
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        # A single-request authentication fills the cache with PIN+OTP.
+        first = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "pin287082"})
+        self.assertTrue(first["result"]["value"], first)
+        self.assertTrue(self._cache_holds("cornelius", "pin287082"))
+
+        # The same credential presented against an open challenge is not accepted, even
+        # though the cache holds it.
+        set_policy("chalresp", scope=SCOPE.AUTH, action=f"{PolicyAction.CHALLENGERESPONSE}=hotp")
+        triggered = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "pin"})
+        transaction_id = triggered["detail"]["transaction_id"]
+        answer = self._validate({"user": "cornelius", "realm": self.realm1,
+                                 "pass": "pin287082", "transaction_id": transaction_id})
+        self.assertFalse(answer["result"]["value"], answer)
+
+        # Control: without a transaction_id the same credential is still served from the
+        # cache, so the refusal above is the transaction_id and nothing else.
+        delete_policy("chalresp")
+        control = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "pin287082"})
+        self.assertTrue(control["result"]["value"], control)
+        self.assertEqual("Authenticated by AuthCache.", control["detail"]["message"])
+
+        remove_token("AC_CR2")
+
+    def test_03_push_confirmation_is_not_cached(self):
+        """A push token is confirmed out of band and its final request carries no
+        credential at all, so there is nothing to cache."""
+        self._drop_tokens("cornelius")
+        token = self._create_push_token("cornelius", "pushpin")
+        serial = token.get_serial()
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        first = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "pushpin"})
+        self.assertFalse(first["result"]["value"], first)
+        transaction_id = first["detail"]["transaction_id"]
+
+        # The user accepts the request on the phone.
+        self._confirm_push(serial, transaction_id)
+
+        # The client picks up the result. This request succeeds and carries an empty pass.
+        second = self._validate({"user": "cornelius", "realm": self.realm1,
+                                 "pass": "", "transaction_id": transaction_id})
+        self.assertTrue(second["result"]["value"], second)
+        self.assertFalse(self._cache_holds("cornelius", ""))
+
+        # An empty pass therefore does not authenticate afterwards.
+        replay = self._validate({"user": "cornelius", "realm": self.realm1, "pass": ""})
+        self.assertFalse(replay["result"]["value"], replay)
+
+        remove_token(serial)
+
+    def test_04_push_confirmation_without_a_pass_parameter(self):
+        """A client may omit ``pass`` instead of sending an empty one. The request
+        authenticates and is answered normally."""
+        self._drop_tokens("cornelius")
+        token = self._create_push_token("cornelius", "pushpin")
+        serial = token.get_serial()
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        first = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "pushpin"})
+        transaction_id = first["detail"]["transaction_id"]
+        self._confirm_push(serial, transaction_id)
+
+        second = self._validate({"user": "cornelius", "realm": self.realm1,
+                                 "transaction_id": transaction_id})
+        self.assertTrue(second["result"]["value"], second)
+
+        remove_token(serial)
+
+    def test_05_pass_on_no_token_is_not_cached(self):
+        """The success comes from the absence of a token, not from the credential, so
+        the credential is not stored and stops working with the policy."""
+        self._drop_tokens("selfservice")
+        set_policy("nopass_token", scope=SCOPE.AUTH, action=f"{PolicyAction.PASSONNOTOKEN}=True")
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        first = self._validate({"user": "selfservice", "realm": self.realm1, "pass": "whatever"})
+        self.assertTrue(first["result"]["value"], first)
+        self.assertFalse(self._cache_holds("selfservice", "whatever"))
+        # The marker that keeps this success out of the cache stays on the server.
+        self.assertNotIn("auth_cache_exclude", first["detail"])
+
+        delete_policy("nopass_token")
+        after = self._validate({"user": "selfservice", "realm": self.realm1, "pass": "whatever"})
+        self.assertFalse(after["result"]["value"], after)
+
+    def test_06_pass_on_no_user_is_not_cached(self):
+        """Same for a user that does not exist: the entry does not outlive the policy."""
+        set_policy("nopass_user", scope=SCOPE.AUTH, action=f"{PolicyAction.PASSONNOUSER}=True")
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        first = self._validate({"user": "ghostuser", "realm": self.realm1, "pass": "whatever"})
+        self.assertTrue(first["result"]["value"], first)
+        self.assertFalse(self._cache_holds("ghostuser", "whatever"))
+        self.assertNotIn("auth_cache_exclude", first["detail"])
+
+        # Without the policy the user is unknown again, which is an error and not a
+        # failed authentication.
+        delete_policy("nopass_user")
+        with self.app.test_request_context("/validate/check", method="POST",
+                                           data={"user": "ghostuser", "realm": self.realm1,
+                                                 "pass": "whatever"}):
+            res = self.app.full_dispatch_request()
+            self.assertGreaterEqual(res.status_code, 400, res.json)
+
+    def test_07_passthru_userstore_is_cached(self):
+        """A user store password is a complete, verified credential, so it is cached and
+        the next authentication does not reach the user store."""
+        self._drop_tokens("cornelius")
+        set_policy("passthru", scope=SCOPE.AUTH, action=f"{PolicyAction.PASSTHRU}=userstore")
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        first = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "test"})
+        self.assertTrue(first["result"]["value"], first)
+        self.assertIn("userstore", first["detail"]["message"])
+        self.assertTrue(self._cache_holds("cornelius", "test"))
+
+        second = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "test"})
+        self.assertTrue(second["result"]["value"], second)
+        self.assertEqual("Authenticated by AuthCache.", second["detail"]["message"])
+
+        delete_policy("passthru")
+
+    def test_08_otppin_userstore_caches_password_and_otp(self):
+        """The credential of a single request is complete even when it contains an OTP,
+        so the whole string is cached and stays usable for the window."""
+        self._drop_tokens("cornelius")
+        init_token({"serial": "AC_PIN", "otpkey": self.otpkey}, user=User("cornelius", self.realm1))
+        set_policy("otppin", scope=SCOPE.AUTH, action=f"{PolicyAction.OTPPIN}=userstore")
+        set_policy("authcache", scope=SCOPE.AUTH, action=f"{PolicyAction.AUTH_CACHE}=4m")
+
+        first = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "test755224"})
+        self.assertTrue(first["result"]["value"], first)
+        self.assertTrue(self._cache_holds("cornelius", "test755224"))
+
+        # The token's counter has moved on, so only the cache can still accept this.
+        second = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "test755224"})
+        self.assertTrue(second["result"]["value"], second)
+        self.assertEqual("Authenticated by AuthCache.", second["detail"]["message"])
+
+        delete_policy("authcache")
+        control = self._validate({"user": "cornelius", "realm": self.realm1, "pass": "test755224"})
+        self.assertFalse(control["result"]["value"], control)
+
+        delete_policy("otppin")
+        remove_token("AC_PIN")


### PR DESCRIPTION
## What this is about

The `auth_cache` policy exists so that a client which authenticates again at short
intervals - a VPN gateway reconnecting every hour, for example - may present the same
credential instead of obtaining a new OTP. The token would rightly refuse the replayed
value, so the cache answers instead.

It stored the credential of *every* successful `check_user_pass`, keyed on
`(user, realm, resolver, credential string)`. That records **that** a string
authenticated, never **why**. `auth_cache` is also the outermost `@libpolicy` on
`check_user_pass`, so a hit short-circuits every other decorator and the whole token
list. Wherever the decision rested on something other than the string itself, the entry
outlived its reason.

## What went wrong

* **Push.** The final request of a push login carries `transaction_id` and `"pass": ""`.
  That success cached the **empty string**, and for the rest of the window a bare request
  with an empty `pass` authenticated the user - no phone, no confirmation, no credential.
* **Challenge-response.** The request carrying the PIN returns `False` because a challenge
  is issued, so it is never cached; the request carrying the response succeeds, so the
  **response alone** is cached. It then authenticated on its own with no `transaction_id`,
  with the PIN dropped and the token's counter already past that value.
* **`passOnNoToken` / `passOnNoUser`.** The success came from the absence of a token or of
  a user, not from a credential check. Both decorators sit inside `auth_cache`, so the
  string was cached anyway and kept working after the policy was withdrawn and after the
  user was given a token demanding a PIN and an OTP.
* **A missing `pass` parameter** yielded `None`, the authentication still succeeded, and
  `_hash_password(None)` then raised a `TypeError` inside passlib - an HTTP 500 on a
  request that had already authenticated the user.

## The change

Only a complete credential that was actually verified is cached, which means the
credential of a single `/validate/check` request. Three kinds of success are excluded:

* **Requests that answer a challenge**, recognised by `transaction_id` or its alias
  `state` (the idiom already used in `lib/token/auth.py`). Such requests are neither
  stored nor served, so a response cannot authenticate on its own and a cached credential
  cannot answer an open challenge. This covers push without naming it: its final request
  always carries a `transaction_id`.
* **Requests with an empty or absent `pass`**, which also removes the 500.
* **Successes that did not verify the credential.** `auth_user_has_no_token` and
  `auth_user_does_not_exist` mark their reply with `AUTH_CACHE_EXCLUDE`. `auth_cache` is
  the outermost decorator and pops the marker unconditionally, so it never reaches the
  client. The marker travels in `reply_dict`, which is built server-side, rather than in
  `options`, which carries client-supplied request data.

`passthru` against a RADIUS server keeps caching what the remote server accepted - it is
the same reuse window with a different verifier, and the classic VPN deployment. The
documentation now states that the remote system's replay protection does not apply for
the duration of the policy.

### Why not restrict by token type

A type allowlist cannot separate the two cases: `challenge_response=hotp` and a plain
single-request HOTP login are the same token type. Excluding push, email, SMS and TAN
would leave HOTP/TOTP under `challenge_response` still caching a PIN-less response. What
distinguishes them is not the type but whether the request answered a challenge.
Mechanically, the branch that matters does not even carry a type: on the
challenge-answering success path `reply_dict` has `serial` but no `type`.

## Behaviour change

Documented in `READ_BEFORE_UPDATE.md`. **Anyone combining `auth_cache` with a
challenge-response token type (email, SMS, push, or HOTP/TOTP under
`challenge_response`) loses the reuse window** and goes back to one real authentication
per login, with the LDAP binds, SMS and email dispatch that come with it. The
combination cannot be made to work: the PIN and the response arrive in two separate
requests, so a complete credential to cache never exists.

Existing rows in the `authcache` table are untouched by the upgrade and keep working
until they expire or are cleaned up with `pi-manage config authcache cleanup --minutes 0`.

## Tests

`tests/test_api_validate_authcache.py` (new, 8 tests) drives `/validate/check` the way a
client would, including a real push enrollment, a signed `/ttype/push` confirmation and
the empty-`pass` request. Each test ends with a control step - remove the policy, replay
the identical request, assert the outcome flips - so every result is attributable to the
cache and nothing else. Two cover the intended configurations (`passthru=userstore`,
`otppin=userstore`), which are unchanged, and two assert that `auth_cache_exclude` does
not appear in the response `detail`.

Reproductions of all four defects were written against the previous behaviour first and
verified to pass; after the change all of them fail while the intended-case ones keep
passing. The existing `test_33_auth_cache` (single-request HOTP replay, the main use
case) passes untouched.

Run locally: `test_api_validate.py` (55), `test_lib_policydecorator.py` +
`test_lib_authcache.py` (28), `test_api_auth.py` + `test_api_offline_no_token.py` +
`test_lib_logging_redaction.py` (101), `test_lib_tokens_push.py` +
`test_lib_cache_redis_auth.py` (27 passed, 21 skipped without Redis) - all green.

## Notes

The behaviour is identical in the database-backed cache and in the Redis backend: the
decision sits in the policy decorator above both stores.
