### PR TITLE
Make the migration suite pass on Oracle (#5872)

### DIFF
--- a/privacyidea/migrations/versions/5cb310101a1f_.py
+++ b/privacyidea/migrations/versions/5cb310101a1f_.py
@@ -9,11 +9,12 @@ Create Date: 2023-09-08 15:59:01.374626
 """
 from alembic import op, context
 from sqlalchemy import inspect
-from sqlalchemy.schema import Sequence, CreateSequence, DropSequence
+from sqlalchemy.schema import Sequence, DropSequence
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.expression import func
 from sqlalchemy.exc import DatabaseError
 from privacyidea.models import db
+from privacyidea.models.db import create_sequence_if_supported
 
 # revision identifiers, used by Alembic.
 revision = '5cb310101a1f'
@@ -49,8 +50,7 @@ def upgrade():
                 # Create the sequence with the correct next_id!
                 current_id = session.query(func.max(tbl.c.id)).one()[0] or 0
                 try:
-                    seq = Sequence(seq_name, start=(current_id + 1))
-                    op.execute(CreateSequence(seq, if_not_exists=True))
+                    create_sequence_if_supported(op, seq_name, start=current_id + 1)
                     print(f" +++ Created Sequence '{seq_name}' for table '{tbl.name}' "
                           f"with current id={current_id + 1}")
                 except DatabaseError as e:

--- a/privacyidea/migrations/versions/7d4e9b2c1a3f_internaluserattribute.py
+++ b/privacyidea/migrations/versions/7d4e9b2c1a3f_internaluserattribute.py
@@ -10,11 +10,10 @@ from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import text, Sequence
 from sqlalchemy.exc import OperationalError, ProgrammingError
-from sqlalchemy.schema import CreateSequence
 
-from privacyidea.models.db import build_restart_sequence_sql
+from privacyidea.models.db import (create_sequence_if_supported, drop_sequence_if_supported,
+                                   restart_sequence_past_max, sequence_id_column)
 
 # revision identifiers, used by Alembic.
 revision = '7d4e9b2c1a3f'
@@ -22,6 +21,7 @@ down_revision = '3cafe2771cdd'
 branch_labels = None
 depends_on = None
 
+SEQUENCE_NAME = "internaluserattribute_seq"
 FIDO2_USER_ID_KEY = 'fido2_user_id'
 LAST_USED_TOKEN_KEY = 'last_used_token'
 LAST_USED_TOKEN_PREFIX = 'last_used_token_'
@@ -58,34 +58,14 @@ def _new_table():
 
 
 def upgrade():
-    bind = op.get_bind()
-    is_postgres = bind.dialect.name == 'postgresql'
-
     # The model declares Sequence('internaluserattribute_seq'), so SQLAlchemy
-    # emits SELECT nextval(...) on every ORM insert. Create the sequence on
-    # any backend that supports CREATE SEQUENCE (Postgres + MariaDB 10.3+).
-    # Build it through SQLAlchemy's CreateSequence construct rather than a raw
-    # "CREATE SEQUENCE" string: CreateSequence is rewritten by the
-    # increment_by_zero @compiles hook in privacyidea.models.db, which appends
-    # INCREMENT BY 0 on MariaDB so a Galera cluster accepts the cached sequence.
-    # A raw string bypasses the hook and fails with "CACHE without INCREMENT BY
-    # 0 in Galera cluster".
-    if bind.dialect.supports_sequences:
-        op.execute(CreateSequence(Sequence("internaluserattribute_seq"), if_not_exists=True))
+    # emits SELECT nextval(...) on every ORM insert; create it where supported.
+    create_sequence_if_supported(op, SEQUENCE_NAME)
 
     try:
-        if is_postgres:
-            # Postgres needs the column default wired to the sequence so raw
-            # INSERTs (e.g. our data-migration block below) get an id.
-            id_column = sa.Column(
-                'id', sa.Integer(), nullable=False,
-                server_default=sa.text("nextval('internaluserattribute_seq')"),
-            )
-        else:
-            id_column = sa.Column('id', sa.Integer(), nullable=False, autoincrement=True)
         op.create_table(
             'internaluserattribute',
-            id_column,
+            sequence_id_column(op, SEQUENCE_NAME),
             sa.Column('user_id', sa.Unicode(length=320), nullable=True),
             sa.Column('resolver', sa.Unicode(length=120), nullable=True),
             sa.Column('realm_id', sa.Integer(), nullable=True),
@@ -109,16 +89,7 @@ def upgrade():
     # table-already-exists branch above where rows may already be present
     # and the sequence (newly created or pre-existing) would otherwise hand
     # out a value <= MAX(id), causing duplicate-PK errors on the next insert.
-    if bind.dialect.supports_sequences:
-        max_id = bind.execute(
-            text("SELECT COALESCE(MAX(id), 0) FROM internaluserattribute")
-        ).scalar() or 0
-        # No SQLAlchemy DDL construct exists for ALTER SEQUENCE ... RESTART, so a
-        # raw string would only be correct on one backend. build_restart_sequence_sql
-        # emits each dialect's accepted syntax and, crucially, appends INCREMENT BY 0
-        # on MariaDB — a Galera cluster otherwise rejects RESTART on a cached sequence
-        # with "CACHE without INCREMENT BY 0 in Galera cluster".
-        op.execute(build_restart_sequence_sql("internaluserattribute_seq", max_id + 1, bind.dialect.name))
+    restart_sequence_past_max(op, 'internaluserattribute', SEQUENCE_NAME)
 
     _run_data_migration(op.get_bind())
 
@@ -256,8 +227,7 @@ def downgrade():
 
     try:
         op.drop_table('internaluserattribute')
-        if op.get_bind().dialect.supports_sequences:
-            op.execute("DROP SEQUENCE IF EXISTS internaluserattribute_seq")
+        drop_sequence_if_supported(op, SEQUENCE_NAME)
     except (OperationalError, ProgrammingError) as ex:
         msg = str(ex.orig).lower()
         if "no such table" in msg or "unknown table" in msg or "does not exist" in msg:

--- a/privacyidea/migrations/versions/a1e0ba6ad9dc_deprecate_u2f_tokens.py
+++ b/privacyidea/migrations/versions/a1e0ba6ad9dc_deprecate_u2f_tokens.py
@@ -20,6 +20,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import Boolean, Integer, Unicode, UnicodeText, case, func, select
 from sqlalchemy.sql import column, insert, table
+from sqlalchemy.sql.elements import BinaryExpression
 
 
 # revision identifiers, used by Alembic.
@@ -50,6 +51,20 @@ _tokeninfo = table(
     column("Type", Unicode(100)),
     column("Description", Unicode(2000)),
 )
+
+
+def _marker_value_is(marker_value: str) -> BinaryExpression:
+    """
+    Return a predicate matching tokeninfo rows whose ``Value`` is
+    ``marker_value``.
+
+    ``Value`` is a ``UnicodeText`` column, which is a CLOB on Oracle, and Oracle
+    rejects ``=`` between a CLOB and a string with "ORA-00932: inconsistent
+    datatypes". LIKE is the comparison operator it does accept for LOBs, and the
+    marker values this migration writes are fixed literals without LIKE
+    wildcards ('u2f', '1', '0'), so the same rows match on every backend.
+    """
+    return _tokeninfo.c.Value.like(marker_value)
 
 
 def _stash_marker(bind, marker_key: str, marker_value_expr) -> None:
@@ -98,7 +113,11 @@ def upgrade():
     _stash_marker(
         bind,
         "original_active",
-        case((_token.c.active.is_(True), sa.literal("1")), else_=sa.literal("0")),
+        # "= true()" rather than "is_(True)": Oracle has no boolean type, and the
+        # IS operator only accepts NULL/TRUE/FALSE keywords there, so is_(True)
+        # renders as "active IS 1" and fails with ORA-00908. Equality renders as
+        # "active = 1" on Oracle and "active = true" everywhere else.
+        case((_token.c.active == sa.true(), sa.literal("1")), else_=sa.literal("0")),
     )
     _stash_marker(bind, "deprecated_in", sa.literal("3.14"))
 
@@ -119,12 +138,12 @@ def downgrade():
         token_ids_with_original_active = (
             select(_tokeninfo.c.token_id)
             .where(_tokeninfo.c.Key == "original_active")
-            .where(_tokeninfo.c.Value == stashed_value)
+            .where(_marker_value_is(stashed_value))
         )
         token_ids_with_original_type_u2f = (
             select(_tokeninfo.c.token_id)
             .where(_tokeninfo.c.Key == "original_tokentype")
-            .where(_tokeninfo.c.Value == "u2f")
+            .where(_marker_value_is("u2f"))
         )
         bind.execute(
             _token.update()
@@ -137,7 +156,7 @@ def downgrade():
     u2f_origin_ids = (
         select(_tokeninfo.c.token_id)
         .where(_tokeninfo.c.Key == "original_tokentype")
-        .where(_tokeninfo.c.Value == "u2f")
+        .where(_marker_value_is("u2f"))
     )
     bind.execute(
         _token.update()

--- a/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
+++ b/privacyidea/migrations/versions/b1a2c3d4e5f6_tokencredentialidhash_seq.py
@@ -13,10 +13,10 @@ Create Date: 2026-04-22 14:30:00.000000
 
 """
 from alembic import op
-from sqlalchemy import text, inspect, Sequence
+from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, ProgrammingError
-from sqlalchemy.schema import CreateSequence, DropSequence
-from privacyidea.models.db import build_restart_sequence_sql
+from privacyidea.models.db import (build_restart_sequence_sql, create_sequence_if_supported,
+                                   drop_sequence_if_supported, sequence_exists)
 
 revision = 'b1a2c3d4e5f6'
 down_revision = '06b105a4f941'
@@ -24,13 +24,6 @@ branch_labels = None
 depends_on = None
 
 SEQ_NAME = "tokencredentialidhash_seq"
-
-
-def _sequence_exists(bind) -> bool:
-    """Return True if SEQ_NAME already exists. Reflected names are upper-cased on
-    Oracle, so compare case-insensitively."""
-    existing = {name.lower() for name in inspect(bind).get_sequence_names()}
-    return SEQ_NAME.lower() in existing
 
 
 def upgrade():
@@ -44,48 +37,23 @@ def upgrade():
             text("SELECT COALESCE(MAX(id), 0) FROM tokencredentialidhash")
         ).scalar() or 0
         start = max_id + 1
-        # Oracle (19c+) supports neither "CREATE SEQUENCE IF NOT EXISTS" nor
-        # "ALTER SEQUENCE ... RESTART WITH" (both are 23c-only / wrong syntax), so
-        # reflect first and branch: create only when absent, otherwise advance it
-        # with build_restart_sequence_sql, which emits Oracle's RESTART START WITH.
-        if bind.dialect.name == "oracle":
-            if not _sequence_exists(bind):
-                op.execute(CreateSequence(Sequence(SEQ_NAME, start=start)))
-            else:
-                op.execute(build_restart_sequence_sql(SEQ_NAME, start, "oracle"))
-            return
-        # MariaDB/Postgres: build the sequence through SQLAlchemy's CreateSequence
-        # construct rather than a raw "CREATE SEQUENCE" string. CreateSequence is
-        # rewritten by the increment_by_zero @compiles hook in privacyidea.models.db,
-        # which appends INCREMENT BY 0 on MariaDB. A Galera cluster only accepts a
-        # cached sequence when it is defined that way (so each node gets a distinct
-        # offset); a plain string would bypass the hook and fail with "CACHE without
-        # INCREMENT BY 0 in Galera cluster". if_not_exists handles the already-present
-        # case; the explicit RESTART afterwards covers installs where the sequence
-        # exists but lags MAX(id), which would otherwise still produce duplicate-PK
-        # errors on the next insert.
-        op.execute(CreateSequence(Sequence(SEQ_NAME, start=start), if_not_exists=True))
-        # The RESTART needs the same INCREMENT BY 0 treatment as the CREATE above
-        # for Galera; there is no SQLAlchemy DDL construct for ALTER SEQUENCE that
-        # the hook could rewrite, so build_restart_sequence_sql appends it on MariaDB.
-        op.execute(build_restart_sequence_sql(SEQ_NAME, start, bind.dialect.name))
+        # Oracle (19c+) has no "CREATE SEQUENCE IF NOT EXISTS" to lean on, so
+        # create_sequence_if_supported reflects instead — which means a sequence
+        # that is already there keeps its old, possibly lagging value. Advance it
+        # explicitly in that case, and skip the RESTART when the sequence was just
+        # created with the right START WITH.
+        if sequence_exists(bind, SEQ_NAME):
+            op.execute(build_restart_sequence_sql(SEQ_NAME, start, bind.dialect.name))
+        else:
+            create_sequence_if_supported(op, SEQ_NAME, start=start)
     except (OperationalError, ProgrammingError) as ex:
         print(f"Could not create sequence '{SEQ_NAME}': {ex}")
         raise
 
 
 def downgrade():
-    bind = op.get_bind()
-    if not bind.dialect.supports_sequences:
-        return
     try:
-        # Oracle (19c+) has no "DROP SEQUENCE IF EXISTS", so reflect and drop only
-        # if present. MariaDB/Postgres accept the IF EXISTS guard directly.
-        if bind.dialect.name == "oracle":
-            if _sequence_exists(bind):
-                op.execute(DropSequence(Sequence(SEQ_NAME)))
-        else:
-            op.execute(f"DROP SEQUENCE IF EXISTS {SEQ_NAME}")
+        drop_sequence_if_supported(op, SEQ_NAME)
     except (OperationalError, ProgrammingError) as ex:
         print(f"Could not drop sequence '{SEQ_NAME}': {ex}")
         raise

--- a/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
+++ b/privacyidea/migrations/versions/d4f5a6b7c8e9_usersetting.py
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
-from privacyidea.models.db import (create_sequence_if_supported, restart_sequence_past_max,
-                                   sequence_id_column)
+from privacyidea.models.db import (create_sequence_if_supported, drop_sequence_if_supported,
+                                   restart_sequence_past_max, sequence_id_column)
 
 # revision identifiers, used by Alembic.
 revision = 'd4f5a6b7c8e9'
@@ -71,8 +71,7 @@ def upgrade():
 def downgrade():
     try:
         op.drop_table('usersetting')
-        if op.get_bind().dialect.supports_sequences:
-            op.execute("DROP SEQUENCE IF EXISTS usersetting_seq")
+        drop_sequence_if_supported(op, SEQUENCE_NAME)
     except (OperationalError, ProgrammingError) as ex:
         msg = str(ex.orig).lower()
         if "no such table" in msg or "unknown table" in msg or "does not exist" in msg:

--- a/privacyidea/models/db.py
+++ b/privacyidea/models/db.py
@@ -16,10 +16,17 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import TYPE_CHECKING
+
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy import Column, Integer, Sequence, text
+from sqlalchemy import Column, Integer, Sequence, inspect, text
+from sqlalchemy.dialects.oracle.base import OracleDialect
+from sqlalchemy.engine import Connection
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.schema import CreateSequence
+from sqlalchemy.schema import CreateSequence, DropSequence
+
+if TYPE_CHECKING:
+    from alembic.operations import Operations
 
 db = SQLAlchemy()
 
@@ -65,34 +72,97 @@ def build_restart_sequence_sql(name, restart_with, dialect_name):
         sql += " INCREMENT BY 0"
     return sql
 
-def create_sequence_if_supported(op, sequence_name):  # pragma: no cover
-    """Emit ``CREATE SEQUENCE <sequence_name> IF NOT EXISTS`` on backends that
-    support sequences (PostgreSQL, MariaDB 10.3+); a no-op elsewhere.
 
-    Built through SQLAlchemy's :class:`CreateSequence` construct so the
-    :func:`increment_by_zero` hook can append ``INCREMENT BY 0`` on MariaDB (a
-    raw ``CREATE SEQUENCE`` string would bypass it and fail in a Galera cluster).
+def build_create_sequence_ddl(sequence_name: str, dialect_name: str, start: int | None = None) -> CreateSequence:
+    """Return the :class:`~sqlalchemy.schema.CreateSequence` construct that creates
+    ``sequence_name``, with the ``IF NOT EXISTS`` guard only where it is understood.
 
-    Pairs with :func:`sequence_id_column` and :func:`restart_sequence_past_max`
-    so migrations adding a sequence-backed table do not each re-implement the
-    cross-dialect dance.
+    ``IF NOT EXISTS`` is a MariaDB/PostgreSQL spelling. Oracle accepts it from 23c
+    on only, so on the supported 19c+ baseline it fails with "ORA-00933: SQL command
+    not properly ended" — there, absence has to be established by reflection instead
+    (see :func:`sequence_exists`).
+
+    A construct rather than a raw string because it is rewritten by the
+    :func:`increment_by_zero` hook, which appends ``INCREMENT BY 0`` on MariaDB so a
+    Galera cluster accepts the cached sequence.
+    """
+    return CreateSequence(Sequence(sequence_name, start=start), if_not_exists=dialect_name != "oracle")
+
+
+def build_drop_sequence_ddl(sequence_name: str, dialect_name: str) -> DropSequence:
+    """Return the :class:`~sqlalchemy.schema.DropSequence` construct that drops
+    ``sequence_name``, with the ``IF EXISTS`` guard only where it is understood.
+
+    The Oracle counterpart of :func:`build_create_sequence_ddl`: ``DROP SEQUENCE IF
+    EXISTS`` is equally 23c-only, so on 19c+ the sequence has to be reflected first.
+    """
+    return DropSequence(Sequence(sequence_name), if_exists=dialect_name != "oracle")
+
+
+def sequence_exists(bind: Connection, sequence_name: str) -> bool:  # pragma: no cover
+    """Return True if ``sequence_name`` already exists in the database ``bind``
+    is connected to.
+
+    Oracle folds unquoted identifiers to upper case and reflects them that way,
+    so the comparison is case-insensitive.
+    """
+    existing = {name.lower() for name in inspect(bind).get_sequence_names()}
+    return sequence_name.lower() in existing
+
+
+def create_sequence_if_supported(op: "Operations", sequence_name: str,
+                                 start: int | None = None) -> None:  # pragma: no cover
+    """Create ``sequence_name`` on backends that support sequences (PostgreSQL,
+    MariaDB 10.3+, Oracle); a no-op elsewhere. Safe to re-run.
+
+    On Oracle the sequence is reflected first because it has no ``IF NOT EXISTS``
+    guard to lean on; see :func:`build_create_sequence_ddl`.
+
+    Pairs with :func:`sequence_id_column`, :func:`restart_sequence_past_max` and
+    :func:`drop_sequence_if_supported` so migrations adding a sequence-backed table
+    do not each re-implement the cross-dialect dance.
     """
     bind = op.get_bind()
-    if bind.dialect.supports_sequences:
-        op.execute(CreateSequence(Sequence(sequence_name), if_not_exists=True))
+    if not bind.dialect.supports_sequences:
+        return
+    if bind.dialect.name == "oracle" and sequence_exists(bind, sequence_name):
+        return
+    op.execute(build_create_sequence_ddl(sequence_name, bind.dialect.name, start=start))
+
+
+def drop_sequence_if_supported(op: "Operations", sequence_name: str) -> None:  # pragma: no cover
+    """Drop ``sequence_name`` on backends that support sequences; a no-op elsewhere.
+    Safe to re-run. The :func:`create_sequence_if_supported` counterpart for
+    ``downgrade()``.
+    """
+    bind = op.get_bind()
+    if not bind.dialect.supports_sequences:
+        return
+    if bind.dialect.name == "oracle" and not sequence_exists(bind, sequence_name):
+        return
+    op.execute(build_drop_sequence_ddl(sequence_name, bind.dialect.name))
 
 
 def sequence_id_column(op, sequence_name):  # pragma: no cover
     """Return the primary-key ``id`` :class:`~sqlalchemy.Column` for a table
     backed by ``sequence_name``.
 
-    On PostgreSQL the column default is wired to ``nextval(...)`` so raw INSERTs
-    (e.g. a data migration) still get an id; other backends use plain
+    On PostgreSQL and Oracle the column default is wired to the sequence so raw
+    INSERTs (e.g. a data migration) still get an id — neither derives one from
+    ``autoincrement`` alone, and on Oracle the insert would otherwise fail with
+    "ORA-01400: cannot insert NULL into". MariaDB/MySQL use plain
     ``autoincrement``. Pass the result into :func:`alembic.op.create_table`.
+
+    ``sequence_name`` must be a trusted, code-defined identifier — it is
+    interpolated verbatim.
     """
-    if op.get_bind().dialect.name == "postgresql":
+    dialect_name = op.get_bind().dialect.name
+    if dialect_name == "postgresql":
         return Column('id', Integer(), nullable=False,
                       server_default=text(f"nextval('{sequence_name}')"))
+    if dialect_name == "oracle":
+        return Column('id', Integer(), nullable=False,
+                      server_default=text(f"{sequence_name}.nextval"))
     return Column('id', Integer(), nullable=False, autoincrement=True)
 
 
@@ -118,3 +188,16 @@ def restart_sequence_past_max(op, table_name, sequence_name):  # pragma: no cove
 @compiles(db.JSON, 'oracle')
 def compile_json_oracle(type_, compiler, **kw):  # pragma: no cover
     return "CLOB"
+
+
+# The hook above only settles the column type. SQLAlchemy's Oracle dialect implements
+# no generic JSON support at all, so unlike every JSON-capable dialect it never sets
+# the _json_serializer/_json_deserializer attributes that sqlalchemy.types.JSON reads
+# when binding and fetching a value — writing to a JSON column raises
+# "AttributeError: 'OracleDialect_oracledb' object has no attribute _json_serializer".
+# Providing them as None selects the type's own json.dumps/json.loads fallback, which
+# is exactly what the CLOB column needs. Guarded so a future SQLAlchemy that does
+# support JSON on Oracle keeps its own implementation.
+if not hasattr(OracleDialect, "_json_serializer"):
+    OracleDialect._json_serializer = None
+    OracleDialect._json_deserializer = None

--- a/tests/migration_test_utils.py
+++ b/tests/migration_test_utils.py
@@ -13,6 +13,7 @@ import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy import create_engine, inspect as sa_inspect, text
+from sqlalchemy.sql.compiler import IdentifierPreparer
 
 DB_URL = os.environ.get("TEST_DATABASE_URL", "")
 
@@ -45,6 +46,49 @@ def is_mariadb(db_url: str = DB_URL) -> bool:
             return bool(conn.dialect.is_mariadb)
     finally:
         engine.dispose()
+
+
+@functools.cache
+def _identifier_preparer(db_url: str = DB_URL) -> IdentifierPreparer:
+    """Return the active dialect's identifier preparer. No connection needed."""
+    return create_engine(db_url).dialect.identifier_preparer
+
+
+@functools.cache
+def _model_identifiers() -> dict[str, str]:
+    """
+    Map every table and column name the models declare to the name object
+    SQLAlchemy created the schema with.
+
+    Plain strings lose the ``quote=True`` flag that ``Challenge.session`` carries
+    (``session`` is an Oracle keyword, so the column only exists there because it
+    was created quoted, in lower case). Looking the name up here recovers the
+    flag, which is what tells the preparer to quote it.
+    """
+    from privacyidea.models import db
+    names: dict[str, str] = {}
+    for table in db.metadata.sorted_tables:
+        names.setdefault(str(table.name), table.name)
+        for col in table.c:
+            names.setdefault(str(col.name), col.name)
+    return names
+
+
+def quote_identifier(name: str) -> str:
+    """
+    Quote *name* for use in raw SQL against the active dialect.
+
+    Delegates to the dialect's own identifier preparer, which quotes exactly when
+    the schema was created quoted — the only way raw SQL and the schema can agree:
+
+    * Mixed case (``Key``, ``Value``) is quoted on Postgres and Oracle, which fold
+      unquoted names to lower/upper case respectively.
+    * A name the model forces to be quoted (``Challenge.session``) is quoted.
+    * An all-lower-case, unforced name stays unquoted. Quoting one on Oracle would
+      look for a lower-case object that does not exist (ORA-00904 for a column,
+      ORA-00942 for a table).
+    """
+    return _identifier_preparer().quote(_model_identifiers().get(name, name))
 
 
 def get_alembic_cfg(db_url: str = DB_URL) -> AlembicConfig:
@@ -231,30 +275,21 @@ class MigrationTestBase:
 
     def _insert_rows(self, engine, table: str, rows: list[dict]) -> None:
         """
-        Insert *rows* into *table* using dialect-aware quoting.
+        Insert *rows* into *table*, quoting the column names (e.g. ``Key``,
+        ``Value``) for the active dialect via :func:`quote_identifier`.
 
-        Column names that need quoting (e.g. ``Key``, ``Value``) are quoted
-        with double-quotes on Postgres/Oracle and back-ticks on MariaDB/MySQL.
-
-        Oracle is special: it folds unquoted identifiers to upper case, so an
-        all-lower-case column (created unquoted) must be referenced unquoted to
-        match, while a mixed-case column like ``Key`` (created quoted) must be
-        quoted exactly. Quoting an all-lower-case name would look for a
-        lower-case column that does not exist (ORA-00904).
+        Bind parameters are numbered rather than named after their column: a bind
+        variable may not be a reserved word either, and ``:session`` (a real
+        column of ``challenge``) fails on Oracle with "ORA-01745: invalid
+        host/bind variable name".
         """
         if not rows:
             return
-        if is_postgres():
-            quote = lambda c: f'"{c}"'
-        elif is_oracle():
-            quote = lambda c: f'"{c}"' if any(ch.isupper() for ch in c) else c
-        else:
-            quote = lambda c: f"`{c}`"
         cols = list(rows[0].keys())
-        col_list = ", ".join(quote(c) for c in cols)
-        placeholders = ", ".join(f":{c}" for c in cols)
+        col_list = ", ".join(quote_identifier(c) for c in cols)
+        placeholders = ", ".join(f":p{i}" for i, _ in enumerate(cols))
         stmt = text(f"INSERT INTO {table} ({col_list}) VALUES ({placeholders})")
         with engine.connect() as conn:
             for row in rows:
-                conn.execute(stmt, row)
+                conn.execute(stmt, {f"p{i}": row[col] for i, col in enumerate(cols)})
             conn.commit()

--- a/tests/test_migration_3cafe2771cdd.py
+++ b/tests/test_migration_3cafe2771cdd.py
@@ -18,7 +18,7 @@ import os
 import pytest
 
 from privacyidea.lib.tokenrolloutstate import RolloutState
-from tests.migration_test_utils import MigrationTestBase
+from tests.migration_test_utils import MigrationTestBase, is_oracle
 
 # Every defined RolloutState except ENROLLED — these must round-trip unchanged.
 _NON_ENROLLED_STATES = [s for s in RolloutState.all_states() if s != RolloutState.ENROLLED]
@@ -32,6 +32,17 @@ pytestmark = [
 ]
 
 DB_URL = os.environ.get("TEST_DATABASE_URL", "")
+
+
+def _is_empty(rollout_state: str | None) -> bool:
+    """
+    Return True if *rollout_state* is the "empty" value this migration targets.
+
+    Oracle stores the empty string as NULL and hands it back as None, so there
+    both spellings are the same value; the migration covers both explicitly
+    (``rollout_state = '' OR rollout_state IS NULL``).
+    """
+    return rollout_state == "" or (is_oracle() and rollout_state is None)
 
 
 def _make_token(serial: str, rollout_state: str | None) -> dict:
@@ -68,7 +79,7 @@ class TestMigration3cafe2771cdd(MigrationTestBase):
         engine = self._engine()
         self._load_seed_and_upgrade_to_parent(engine)
         self._insert_rows(engine, "token", [_make_token("TOK001", "")])
-        assert self._fetch_rollout_state(engine, "TOK001") == ""
+        assert _is_empty(self._fetch_rollout_state(engine, "TOK001"))
         engine.dispose()
 
         self._upgrade()
@@ -136,7 +147,7 @@ class TestMigration3cafe2771cdd(MigrationTestBase):
         self._downgrade()
 
         engine = self._engine()
-        assert self._fetch_rollout_state(engine, "TOK005") == "", (
+        assert _is_empty(self._fetch_rollout_state(engine, "TOK005")), (
             "downgrade() must revert 'enrolled' back to '' in token.rollout_state"
         )
         engine.dispose()
@@ -155,7 +166,7 @@ class TestMigration3cafe2771cdd(MigrationTestBase):
         self._downgrade()
 
         engine = self._engine()
-        assert self._fetch_rollout_state(engine, "TOK006") == "", (
+        assert _is_empty(self._fetch_rollout_state(engine, "TOK006")), (
             "Round-trip must restore rows that started as '' back to ''"
         )
         for state in _NON_ENROLLED_STATES:
@@ -214,7 +225,7 @@ class TestMigration3cafe2771cdd(MigrationTestBase):
         self._downgrade()
 
         engine = self._engine()
-        assert self._fetch_rollout_state(engine, "TOK_LOSSY") == "", (
+        assert _is_empty(self._fetch_rollout_state(engine, "TOK_LOSSY")), (
             "downgrade() rewrites every 'enrolled' row to '' — including rows "
             "that were already 'enrolled' before the upgrade. If this assertion "
             "starts failing, the migration's downgrade strategy has changed."

--- a/tests/test_migration_7301d5130c3a.py
+++ b/tests/test_migration_7301d5130c3a.py
@@ -17,7 +17,7 @@ import os
 
 import pytest
 
-from tests.migration_test_utils import MigrationTestBase, is_oracle, is_postgres
+from tests.migration_test_utils import MigrationTestBase, quote_identifier
 
 pytestmark = [
     pytest.mark.migration,
@@ -54,8 +54,8 @@ class TestMigration7301d5130c3a(MigrationTestBase):
     def _fetch_option(self, engine, eventhandler_id: int, key: str) -> str | None:
         # Mixed-case columns are quoted with double-quotes on Postgres/Oracle
         # and back-ticks on MariaDB/MySQL.
-        key_col = "`Key`" if (not is_postgres() and not is_oracle()) else '"Key"'
-        val_col = "`Value`" if (not is_postgres() and not is_oracle()) else '"Value"'
+        key_col = quote_identifier("Key")
+        val_col = quote_identifier("Value")
         return self._fetch_scalar(
             engine,
             f"SELECT {val_col} FROM eventhandleroption "

--- a/tests/test_migration_7d4e9b2c1a3f.py
+++ b/tests/test_migration_7d4e9b2c1a3f.py
@@ -24,7 +24,7 @@ import os
 
 import pytest
 
-from tests.migration_test_utils import MigrationTestBase, is_postgres
+from tests.migration_test_utils import MigrationTestBase, quote_identifier
 
 pytestmark = [
     pytest.mark.migration,
@@ -33,10 +33,6 @@ pytestmark = [
         reason="TEST_DATABASE_URL environment variable is not set",
     ),
 ]
-
-
-def _q(col: str) -> str:
-    return f'"{col}"' if is_postgres() else f"`{col}`"
 
 
 PI_INTERNAL = "pi_internal"  # value the pre-migration code wrote into customuserattribute.Type
@@ -66,8 +62,8 @@ class TestMigration7d4e9b2c1a3f(MigrationTestBase):
     def _fetch_custom_value(self, engine, user_id: str, key: str) -> str | None:
         return self._fetch_scalar(
             engine,
-            f"SELECT {_q('Value')} FROM customuserattribute "
-            f"WHERE user_id = :uid AND {_q('Key')} = :key",
+            f"SELECT {quote_identifier('Value')} FROM customuserattribute "
+            f"WHERE user_id = :uid AND {quote_identifier('Key')} = :key",
             {"uid": user_id, "key": key},
         )
 
@@ -75,7 +71,7 @@ class TestMigration7d4e9b2c1a3f(MigrationTestBase):
         return self._fetch_scalar(
             engine,
             f"SELECT COUNT(*) FROM customuserattribute "
-            f"WHERE user_id = :uid AND {_q('Key')} = :key",
+            f"WHERE user_id = :uid AND {quote_identifier('Key')} = :key",
             {"uid": user_id, "key": key},
         )
 
@@ -83,8 +79,8 @@ class TestMigration7d4e9b2c1a3f(MigrationTestBase):
         """Return the parsed JSON value of an internaluserattribute row."""
         raw = self._fetch_scalar(
             engine,
-            f"SELECT {_q('Value')} FROM internaluserattribute "
-            f"WHERE user_id = :uid AND {_q('Key')} = :key",
+            f"SELECT {quote_identifier('Value')} FROM internaluserattribute "
+            f"WHERE user_id = :uid AND {quote_identifier('Key')} = :key",
             {"uid": user_id, "key": key},
         )
         if raw is None:
@@ -102,7 +98,7 @@ class TestMigration7d4e9b2c1a3f(MigrationTestBase):
         return self._fetch_scalar(
             engine,
             f"SELECT COUNT(*) FROM internaluserattribute "
-            f"WHERE user_id = :uid AND {_q('Key')} = :key",
+            f"WHERE user_id = :uid AND {quote_identifier('Key')} = :key",
             {"uid": user_id, "key": key},
         )
 

--- a/tests/test_migration_a1e0ba6ad9dc.py
+++ b/tests/test_migration_a1e0ba6ad9dc.py
@@ -23,7 +23,7 @@ import os
 
 import pytest
 
-from tests.migration_test_utils import MigrationTestBase, is_postgres
+from tests.migration_test_utils import MigrationTestBase, quote_identifier
 
 pytestmark = [
     pytest.mark.migration,
@@ -64,8 +64,8 @@ class TestMigrationA1e0ba6ad9dc(MigrationTestBase):
         )
 
     def _fetch_tokeninfo_value(self, engine, token_id: int, key: str) -> str | None:
-        key_col = '"Key"' if is_postgres() else "`Key`"
-        val_col = '"Value"' if is_postgres() else "`Value`"
+        key_col = quote_identifier("Key")
+        val_col = quote_identifier("Value")
         return self._fetch_scalar(
             engine,
             f"SELECT {val_col} FROM tokeninfo WHERE token_id = :tid AND {key_col} = :key",

--- a/tests/test_migration_b8c9d0e1f2a3.py
+++ b/tests/test_migration_b8c9d0e1f2a3.py
@@ -21,7 +21,7 @@ import os
 
 import pytest
 
-from tests.migration_test_utils import MigrationTestBase, is_postgres
+from tests.migration_test_utils import MigrationTestBase, quote_identifier
 
 pytestmark = [
     pytest.mark.migration,
@@ -102,7 +102,7 @@ class TestMigrationB8c9d0e1f2a3(MigrationTestBase):
         }])
 
     def _fetch_token_column(self, engine, token_id: int, column: str):
-        col = f'"{column}"' if is_postgres() else f"`{column}`"
+        col = quote_identifier(column)
         return self._fetch_scalar(engine, f"SELECT {col} FROM token WHERE id = :tid",
                                   {"tid": token_id})
 

--- a/tests/test_migration_c3d4e5f6a7b8.py
+++ b/tests/test_migration_c3d4e5f6a7b8.py
@@ -15,7 +15,7 @@ import os
 
 import pytest
 
-from tests.migration_test_utils import MigrationTestBase, is_postgres
+from tests.migration_test_utils import MigrationTestBase
 
 pytestmark = [
     pytest.mark.migration,
@@ -24,10 +24,6 @@ pytestmark = [
         reason="TEST_DATABASE_URL environment variable is not set",
     ),
 ]
-
-
-def _q(col: str) -> str:
-    return f'"{col}"' if is_postgres() else f"`{col}`"
 
 
 class TestMigrationC3d4e5f6a7b8(MigrationTestBase):

--- a/tests/test_migration_d9e0f1a2b3c4.py
+++ b/tests/test_migration_d9e0f1a2b3c4.py
@@ -16,7 +16,7 @@ import os
 import pytest
 from sqlalchemy import text
 
-from tests.migration_test_utils import MigrationTestBase, is_postgres
+from tests.migration_test_utils import MigrationTestBase, quote_identifier
 
 pytestmark = [
     pytest.mark.migration,
@@ -55,7 +55,7 @@ class TestMigrationD9e0f1a2b3c4(MigrationTestBase):
         ])
 
     def _column(self) -> str:
-        return '"abort_on_error"' if is_postgres() else "abort_on_error"
+        return quote_identifier("abort_on_error")
 
     def _abort_on_error(self, engine, handler_id: int):
         return self._fetch_scalar(engine, f"SELECT {self._column()} FROM eventhandler WHERE id = :id",

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -31,11 +31,10 @@ migration does. Concretely, it verifies that:
     restores the original schema and does not destroy data in surviving
     tables (row-count survival, not just one realm row).
 
-Tests run against the dialect provided in TEST_DATABASE_URL — the project
-supports MariaDB and PostgreSQL — and use a pre-written seed file per
-dialect (tests/testdata/migrations/) as a complete, on-disk snapshot of the
-database state at START_REVISION. No runtime fixups; the seed is
-authoritative.
+Tests run against the dialect provided in TEST_DATABASE_URL — MariaDB, MySQL,
+PostgreSQL and Oracle — and use a pre-written seed file per dialect
+(tests/testdata/migrations/) as a complete, on-disk snapshot of the database
+state at START_REVISION. No runtime fixups; the seed is authoritative.
 
 Migrations older than START_REVISION are intentionally not covered: the pin
 exists because nothing in the supported window upgrades from older state,
@@ -45,6 +44,11 @@ real install hits anymore. Bump the pin when keeping it gets in the way.
 Data-transformation tests for specific migrations do NOT belong here. They
 live in tests/test_migration_<revision>.py and use MigrationTestBase. See
 tests/README.md for the full guide.
+
+Checks that need no database connection do not belong here either — this
+module is marked ``migration`` and therefore skipped in the regular unit-test
+run. The static guards on portable sequence DDL live in
+tests/test_sequence_ddl.py, which runs on every PR.
 """
 
 import os
@@ -65,6 +69,7 @@ from tests.migration_test_utils import (
     is_oracle,
     is_postgres,
     load_seed,
+    quote_identifier,
 )
 
 # Skip these tests if no database URL is provided
@@ -1020,13 +1025,6 @@ def test_each_migration_survives_round_trip(flask_app):
         # Leave the DB at rev.revision — the next iteration will upgrade from here.
 
 
-def _quote_ident(name: str) -> str:
-    """Dialect-aware identifier quoting for raw SQL."""
-    if is_postgres():
-        return f'"{name}"'
-    return f"`{name}`"
-
-
 def _row_counts(engine, tables: set[str]) -> dict[str, int]:
     """Return {table: row_count} for every table in *tables* that exists."""
     counts: dict[str, int] = {}
@@ -1037,103 +1035,9 @@ def _row_counts(engine, tables: set[str]) -> dict[str, int]:
             if table not in existing:
                 continue
             counts[table] = conn.execute(
-                text(f"SELECT COUNT(*) FROM {_quote_ident(table)}")
+                text(f"SELECT COUNT(*) FROM {quote_identifier(table)}")
             ).scalar()
     return counts
-
-
-def test_migrations_do_not_emit_raw_create_sequence_sql():
-    """
-    Migrations must create sequences via SQLAlchemy's CreateSequence construct,
-    never a raw "CREATE SEQUENCE ..." SQL string.
-
-    CreateSequence is rewritten by the increment_by_zero @compiles hook in
-    privacyidea.models.db, which appends INCREMENT BY 0 on MariaDB. A Galera
-    cluster only accepts a cached sequence defined that way; a raw string
-    bypasses the hook and fails with "CACHE without INCREMENT BY 0 in Galera
-    cluster". We cannot reproduce that rejection in CI — it needs a live wsrep
-    provider, and standalone MariaDB accepts the cached sequence — so this
-    static check is the guard against the gap.
-
-    Only CREATE is restricted: ALTER SEQUENCE / DROP SEQUENCE carry no such
-    Galera constraint and may stay as raw strings.
-
-    The check only inspects strings passed to op.execute(...) — docstrings,
-    comments and print() messages that merely mention "create sequence" are
-    ignored. Both plain strings and f-strings are covered (an f-string's
-    literal segments are ast.Constant nodes).
-    """
-    import ast
-
-    def _literal_sql(node) -> str:
-        """Concatenate the literal string content of a string, f-string, or text('...') argument."""
-        if isinstance(node, ast.Constant) and isinstance(node.value, str):
-            return node.value
-        if isinstance(node, ast.JoinedStr):
-            return "".join(
-                part.value for part in node.values
-                if isinstance(part, ast.Constant) and isinstance(part.value, str)
-            )
-        # Unwrap text("...") / sa.text("...") wrappers.
-        if isinstance(node, ast.Call) and node.args:
-            func = node.func
-            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
-            if name == "text":
-                return _literal_sql(node.args[0])
-        return ""
-
-    def _is_op_execute(node) -> bool:
-        return (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "execute"
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "op"
-        )
-
-    versions_dir = pathlib.Path(__file__).parent.parent / "privacyidea" / "migrations" / "versions"
-    offenders: list[str] = []
-    for path in sorted(versions_dir.glob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for node in ast.walk(tree):
-            if _is_op_execute(node) and node.args:
-                if "CREATE SEQUENCE" in _literal_sql(node.args[0]).upper():
-                    offenders.append(f"{path.name}:{node.lineno}")
-
-    assert not offenders, (
-        "The following migrations build a sequence from a raw 'CREATE SEQUENCE' "
-        "string instead of SQLAlchemy's CreateSequence construct:\n"
-        + "\n".join(f"  {o}" for o in offenders)
-        + "\n\nUse op.execute(CreateSequence(Sequence(name, start=...), if_not_exists=...)) "
-        "so the increment_by_zero hook can make it Galera-safe."
-    )
-
-
-def test_create_sequence_is_galera_safe_on_mariadb():
-    """
-    The increment_by_zero hook (privacyidea.models.db) must render CREATE
-    SEQUENCE with INCREMENT BY 0 on MariaDB, and must NOT do so on PostgreSQL
-    (which rejects a zero increment). This guards the hook itself against being
-    removed or scoped to the wrong dialect — the thing every sequence migration
-    and db.create_all() rely on to work on a Galera cluster.
-    """
-    from sqlalchemy import Sequence
-    from sqlalchemy.schema import CreateSequence
-    from sqlalchemy.dialects import mysql, postgresql
-    import privacyidea.models.db  # noqa: F401 - importing registers the @compiles hook
-
-    seq = Sequence("dummy_galera_check_seq", start=1)
-
-    mariadb_sql = str(CreateSequence(seq).compile(dialect=mysql.dialect(is_mariadb=True))).upper()
-    assert "INCREMENT BY 0" in mariadb_sql, (
-        f"CREATE SEQUENCE on MariaDB must include INCREMENT BY 0 to work on Galera, got: {mariadb_sql!r}"
-    )
-
-    postgres_sql = str(CreateSequence(seq).compile(dialect=postgresql.dialect())).upper()
-    assert "INCREMENT BY 0" not in postgres_sql, (
-        f"CREATE SEQUENCE on PostgreSQL must NOT include INCREMENT BY 0 (zero increment is invalid), "
-        f"got: {postgres_sql!r}"
-    )
 
 
 def test_downgrade_does_not_destroy_data_in_surviving_tables(flask_app):

--- a/tests/test_sequence_ddl.py
+++ b/tests/test_sequence_ddl.py
@@ -75,8 +75,8 @@ def test_migrations_do_not_emit_raw_create_sequence_sql():
     static check is the guard against the gap.
 
     ALTER SEQUENCE ... RESTART hits the same constraint and is guarded by
-    test_migrations_do_not_emit_raw_alter_sequence_sql. DROP SEQUENCE carries no
-    Galera constraint and may stay a raw string.
+    test_migrations_do_not_emit_raw_alter_sequence_sql, DROP SEQUENCE IF EXISTS by
+    test_migrations_do_not_emit_raw_drop_sequence_if_exists_sql.
     """
     offenders = [loc for loc, sql in _iter_op_execute_sql_literals() if "CREATE SEQUENCE" in sql]
     assert not offenders, (
@@ -114,6 +114,72 @@ def test_migrations_do_not_emit_raw_alter_sequence_sql():
         + "\n\nUse op.execute(build_restart_sequence_sql(name, restart_with, bind.dialect.name)) "
         "(privacyidea.models.db) for the correct per-dialect syntax."
     )
+
+
+def test_migrations_do_not_emit_raw_drop_sequence_if_exists_sql():
+    """
+    Migrations must not drop a sequence with a raw "DROP SEQUENCE IF EXISTS ..."
+    string. The IF EXISTS guard is a MariaDB/PostgreSQL spelling; Oracle accepts it
+    from 23c on only, so on the supported 19c+ baseline the statement fails with
+    "ORA-00933: SQL command not properly ended" and takes the whole downgrade with
+    it.
+
+    Use privacyidea.models.db.drop_sequence_if_supported(op, name), which reflects
+    the sequence on Oracle and uses the guard everywhere else. A raw DROP SEQUENCE
+    without IF EXISTS is valid on every backend and stays allowed.
+    """
+    offenders = [
+        loc for loc, sql in _iter_op_execute_sql_literals()
+        if "DROP SEQUENCE" in sql and "IF EXISTS" in sql
+    ]
+    assert not offenders, (
+        "The following migrations drop a sequence with a raw 'DROP SEQUENCE IF EXISTS' "
+        "string, which Oracle 19c+ rejects:\n"
+        + "\n".join(f"  {o}" for o in offenders)
+        + "\n\nUse drop_sequence_if_supported(op, name) (privacyidea.models.db) instead."
+    )
+
+
+def test_sequence_ddl_guards_are_omitted_on_oracle():
+    """
+    build_create_sequence_ddl / build_drop_sequence_ddl (privacyidea.models.db) must
+    emit the IF NOT EXISTS / IF EXISTS guard on MariaDB and PostgreSQL but never on
+    Oracle, where both spellings are 23c-only and fail on the supported 19c+
+    baseline with "ORA-00933: SQL command not properly ended".
+
+    This is the guard on the decision itself; that a sequence which already exists
+    is then skipped on Oracle by reflecting it is exercised by the migration tests
+    running against a real Oracle database.
+    """
+    from sqlalchemy.dialects import mysql, oracle, postgresql
+    from privacyidea.models.db import build_create_sequence_ddl, build_drop_sequence_ddl
+
+    dialects = {
+        "oracle": oracle.dialect(),
+        "postgresql": postgresql.dialect(),
+        "mariadb": mysql.dialect(is_mariadb=True),
+    }
+    for name, dialect in dialects.items():
+        create_sql = str(build_create_sequence_ddl("dummy_guard_seq", name).compile(dialect=dialect)).upper()
+        drop_sql = str(build_drop_sequence_ddl("dummy_guard_seq", name).compile(dialect=dialect)).upper()
+        if name == "oracle":
+            assert "IF NOT EXISTS" not in create_sql, (
+                f"CREATE SEQUENCE on Oracle must not carry the 23c-only IF NOT EXISTS guard, "
+                f"got: {create_sql!r}"
+            )
+            assert "IF EXISTS" not in drop_sql, (
+                f"DROP SEQUENCE on Oracle must not carry the 23c-only IF EXISTS guard, "
+                f"got: {drop_sql!r}"
+            )
+        else:
+            assert "IF NOT EXISTS" in create_sql, (
+                f"CREATE SEQUENCE on {name} must be guarded with IF NOT EXISTS so the "
+                f"migration can be re-run, got: {create_sql!r}"
+            )
+            assert "IF EXISTS" in drop_sql, (
+                f"DROP SEQUENCE on {name} must be guarded with IF EXISTS so the downgrade "
+                f"can be re-run, got: {drop_sql!r}"
+            )
 
 
 def test_create_sequence_is_galera_safe_on_mariadb():


### PR DESCRIPTION
Fixes #5872.

The nightly Oracle migration run reported 44 of 65 tests failing. Fixing the first cause uncovered four more that were hidden behind it, so there were nine in total. Reproduced locally against `compose-dev.yml`'s `oracle-test` (Oracle XE 21c, python-oracledb thin) before and after each fix.

### Results

| Engine | Before | After |
| --- | --- | --- |
| Oracle XE 21c | 44 failed, 21 passed | **63 passed** |
| PostgreSQL 17 | 65 passed | 63 passed |
| MariaDB 11 | 65 passed | 63 passed |
| MySQL 8.4 | 64 passed, 1 skipped | 62 passed, 1 skipped |

65 → 63 is the two duplicated tests removed below, not lost coverage.

### Migrations and models

- **`CREATE`/`DROP SEQUENCE IF [NOT] EXISTS`** is a MariaDB/PostgreSQL spelling; Oracle accepts it only from 23c, so on the supported 19c+ baseline it fails with `ORA-00933` and takes the whole upgrade down. New `build_create_sequence_ddl` / `build_drop_sequence_ddl` emit the guard on every dialect except Oracle, where `create_sequence_if_supported` and the new `drop_sequence_if_supported` establish presence through the new `sequence_exists()` instead. `7d4e9b2c1a3f` (which hand-rolled all three pieces) and `b1a2c3d4e5f6` (which had its own copy of the reflection helper) now use the shared helpers; `5cb310101a1f` and `d4f5a6b7c8e9` were fixed the same way — both were latent breakage for any real Oracle upgrade, not part of the reported failures.
- **`sequence_id_column`** wired the `nextval` column default on PostgreSQL only, so a raw `INSERT` into a newly created table hit `ORA-01400: cannot insert NULL into`. Oracle now gets `DEFAULT <seq>.nextval` (valid 12c+).
- **`a1e0ba6ad9dc`**: `.is_(True)` on a Boolean renders as `active IS 1` on Oracle, whose `IS` accepts only the `NULL`/`TRUE`/`FALSE` keywords (`ORA-00908`); `== sa.true()` renders correctly everywhere. Its `downgrade()` also compared `tokeninfo.Value` — a CLOB on Oracle — with `=`, which Oracle rejects with `ORA-00932`. `LIKE` is the one comparison operator Oracle accepts on a LOB; I checked the alternatives against a live database first, and both `to_char` and `CAST` fail with `ORA-22835` as soon as any row exceeds 4000 characters, while `dbms_lob.substr` is Oracle-only. The marker values are wildcard-free literals, so `LIKE` matches the same rows on every backend.
- **JSON columns could not be written on Oracle at all** — worth a look beyond the tests. SQLAlchemy's Oracle dialect implements no generic JSON support and therefore never sets the `_json_serializer`/`_json_deserializer` attributes that `sqlalchemy.types.JSON` reads, so every insert raised `AttributeError: 'OracleDialect_oracledb' object has no attribute '_json_serializer'`; the existing `@compiles(db.JSON, 'oracle')` hook only ever settled the column type. Providing the two attributes selects the type's own `json.dumps`/`json.loads` fallback, which is exactly what the CLOB column needs, and is guarded by `hasattr` so a future SQLAlchemy with real Oracle JSON support keeps its own implementation. Round-trip verified including non-ASCII, `{}` and `[]`. This affected `clients.config`, `usersetting.settings` and `internaluserattribute.Value`.

### Test harness

- Five per-migration modules each carried their own quoting helper with MariaDB back-ticks hardcoded (`ORA-00911`). They now share one `quote_identifier()` that delegates to the dialect's own identifier preparer. It resolves the name through the model metadata first, because `challenge.session` is declared `quote=True` — `session` is an Oracle keyword that Oracle rejects even in `CREATE TABLE`, so the column exists there lower-case quoted, and no name-based rule can know that. A bind variable may not be a reserved word either (`:session` → `ORA-01745`), so `_insert_rows` numbers its parameters.
- Oracle stores the empty string as `NULL`, so the `3cafe2771cdd` assertions accept both spellings there. The migration itself already handled both (`= '' OR IS NULL`).

### Guards

Two new dialect-agnostic checks in `tests/test_sequence_ddl.py`, which runs on every PR rather than only in the migration job: a static scan rejecting raw `DROP SEQUENCE IF EXISTS` in migrations, and a compile-level check that the existence guards appear on MariaDB and PostgreSQL but never on Oracle.

Two stale duplicates of such checks were left behind in `test_migrations.py` when they moved to `test_sequence_ddl.py` (one byte-identical, one an older inlined copy of the same AST scan — I compared both ASTs before deleting). They are removed, and the module docstring now records that connection-less checks belong in `test_sequence_ddl.py` so they do not drift back.

No CI change here: the Oracle leg stays on our own infra as decided, and the nightly already covers it.
