### PR TITLE
4914/ca auth log reason detail dialog

### DIFF
--- a/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.html
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.html
@@ -346,13 +346,9 @@
                   </span>
                 }
                 @case ("reason") {
-                  <!-- Every reason the request produced, highest signal first: one line each, so a request whose
-                    tokens failed differently shows all of its findings rather than only the top-ranked one. -->
-                  <div class="reason-list">
-                    @for (reason of element.reasons ?? []; track reason) {
-                      <span class="reason-entry">{{ reason }}</span>
-                    }
-                  </div>
+                  <app-reason-cell
+                    [reasons]="element.reasons"
+                    [info]="element.other_info" />
                 }
                 @case ("serial") {
                   @for (serial of splitSerials(element.serial); track serial) {

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.scss
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.scss
@@ -253,15 +253,3 @@ td.cell-info {
   background: var(--mat-sys-surface-container-highest);
   color: var(--mat-sys-on-surface-variant);
 }
-
-// The reasons of one entry: stacked, since a request that failed for several reasons lists them all and they read as
-// separate findings rather than one wrapped value.
-.reason-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.reason-entry {
-  white-space: nowrap;
-}

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.spec.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.spec.ts
@@ -291,7 +291,7 @@ describe("AuthenticationLog", () => {
     expect(badges[0].classList).toContain("role-badge-admin-internal");
   });
 
-  it("lists every reason of an entry, not just the first", () => {
+  it("lists every reason of an entry, not just the first, and offers its detail where one was recorded", () => {
     // A request whose tokens failed differently carries one reason per finding, ordered by precedence.
     service.authenticationLogResource.set(
       MockPiResponse.fromValue({
@@ -300,7 +300,8 @@ describe("AuthenticationLog", () => {
             id: 1,
             event_type: "NO_USABLE_TOKEN",
             timestamp: "2026-06-22T10:00:00+00:00",
-            reasons: ["TOKEN_DISABLED", "WRONG_OTP"]
+            reasons: ["TOKEN_DISABLED", "WRONG_OTP"],
+            other_info: { reason_detail: { reasons: { PIOO0001: "TOKEN_DISABLED", PIOO0002: "WRONG_OTP" } } }
           },
           { id: 2, event_type: "LOGIN_SUCCESS", timestamp: "2026-06-22T10:01:00+00:00", reasons: [] }
         ],
@@ -311,10 +312,12 @@ describe("AuthenticationLog", () => {
       })
     );
     fixture.detectChanges();
-    const rendered = Array.from(
-      fixture.nativeElement.querySelectorAll<HTMLElement>(".reason-entry")
-    ).map((element) => element.textContent!.trim());
+    const rendered = Array.from(fixture.nativeElement.querySelectorAll<HTMLElement>(".reason-entry")).map((element) =>
+      element.textContent!.trim()
+    );
     expect(rendered).toEqual(["TOKEN_DISABLED", "WRONG_OTP"]);
+    // Only the row whose reasons were detailed gets the button that opens them.
+    expect(fixture.nativeElement.querySelectorAll(".reason-detail-button").length).toBe(1);
   });
 
   it("hasInfoValues only reports true when an entry on the page actually carries something to show", () => {
@@ -327,6 +330,8 @@ describe("AuthenticationLog", () => {
     component.dataSource.set(new MatTableDataSource(rows));
     expect(component.hasInfoValues()).toBe(false);
 
+    // The reason detail is the one key the Info cell skips (the Reasons column offers it as a dialog), so a row
+    // carrying only that has nothing for this column to claim its 300px for.
     component.dataSource.set(
       new MatTableDataSource([
         ...rows,
@@ -334,6 +339,19 @@ describe("AuthenticationLog", () => {
           id: 3,
           event_type: "PIN_FAIL",
           timestamp: "2026-08-03T09:00:02Z",
+          other_info: { reason_detail: { reasons: { PIOO0001: "WRONG_OTP" } } }
+        }
+      ])
+    );
+    expect(component.hasInfoValues()).toBe(false);
+
+    component.dataSource.set(
+      new MatTableDataSource([
+        ...rows,
+        {
+          id: 4,
+          event_type: "PIN_FAIL",
+          timestamp: "2026-08-03T09:00:03Z",
           other_info: { truncated: { serial: "TOK…" } }
         }
       ])

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.ts
@@ -55,7 +55,8 @@ import {
 } from "@angular/material/table";
 import { RouterLink } from "@angular/router";
 import { ConditionalAccessCell } from "./cells/conditional-access-cell/conditional-access-cell";
-import { InfoCell } from "./cells/info-cell/info-cell";
+import { hasInfoContent, InfoCell } from "./cells/info-cell/info-cell";
+import { ReasonCell } from "./cells/reason-cell/reason-cell";
 import { ClearableInputComponent } from "@components/shared/clearable-input/clearable-input.component";
 import { SourceIpCell } from "./cells/source-ip-cell/source-ip-cell";
 import { CopyableComponent } from "@components/shared/copyable/copyable.component";
@@ -295,6 +296,7 @@ const TRUNCATED_COLUMN_CLASSES: Record<string, string> = {
     ClearableInputComponent,
     ConditionalAccessCell,
     InfoCell,
+    ReasonCell,
     MultiSelectFilterComponent,
     MultiSelectMenuComponent,
     MatDivider,
@@ -549,9 +551,9 @@ export class AuthenticationLog {
   });
   // An info-like column only earns its width when something is actually in it: it is widened for the current page when
   // at least one entry has content for it, and otherwise stays as narrow as the table wants.
-  readonly hasInfoValues = computed(() =>
-    this.dataSource().data.some((entry) => entry.other_info && Object.keys(entry.other_info).length > 0)
-  );
+  // The Info cell decides what it renders (it skips what another column shows), so it also answers whether a page has
+  // any Info content to claim the column's width for.
+  readonly hasInfoValues = computed(() => this.dataSource().data.some((entry) => hasInfoContent(entry.other_info)));
   readonly hasOutcomeValues = computed(() =>
     this.dataSource().data.some((entry) => (entry.conditional_access_outcomes?.length ?? 0) > 0)
   );

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/cells/info-cell/info-cell.spec.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/cells/info-cell/info-cell.spec.ts
@@ -18,7 +18,7 @@
  **/
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
-import { InfoCell } from "./info-cell";
+import { hasInfoContent, InfoCell } from "./info-cell";
 
 describe("InfoCell", () => {
   let component: InfoCell;
@@ -108,6 +108,27 @@ describe("InfoCell", () => {
     expect(entriesFor("")).toEqual([]);
     expect(entriesFor(["a", "b"])).toEqual([]);
     expect(entriesFor(undefined)).toEqual([]);
+  });
+
+  it("skips the reason detail, which the Reasons column shows as a dialog", () => {
+    // The one key another column owns: here it could only be a one-line JSON dump of a nested map.
+    expect(
+      entriesFor({
+        serial: "TOTP001",
+        reason_detail: { reasons: { TOTP001: "WRONG_OTP" }, policies: ["deny_vpn"] }
+      })
+    ).toEqual([{ key: "Serial", value: "TOTP001" }]);
+    expect(entriesFor({ reason_detail: { reasons: { TOTP001: "WRONG_OTP" } } })).toEqual([]);
+  });
+
+  it("reports content only for an other_info this cell would actually render something for", () => {
+    // What the table sizes the Info column on, so a row whose only key is the skipped one must not claim its width.
+    expect(hasInfoContent(null)).toBe(false);
+    expect(hasInfoContent(undefined)).toBe(false);
+    expect(hasInfoContent({})).toBe(false);
+    expect(hasInfoContent({ reason_detail: { reasons: { TOTP001: "WRONG_OTP" } } })).toBe(false);
+    expect(hasInfoContent({ serial: "TOTP001" })).toBe(true);
+    expect(hasInfoContent({ reason_detail: {}, serial: "TOTP001" })).toBe(true);
   });
 
   it("shows a list in the DOM as bullets under its key", () => {

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/cells/info-cell/info-cell.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/cells/info-cell/info-cell.ts
@@ -20,6 +20,13 @@ import { Component, computed, input } from "@angular/core";
 
 import { AuthenticationLogEntry } from "@services/authentication-log/authentication-log.service";
 
+import { REASON_DETAIL_INFO_KEY } from "../../reason-detail";
+
+// other_info keys another column shows, and this one therefore skips. The reason detail is a nested map explaining the
+// row's reasons: folded into this column it could only be a one-line JSON dump, so the Reasons column offers it as a
+// dialog instead (see ReasonCell) and nothing is lost by leaving it out here.
+const KEYS_SHOWN_ELSEWHERE: readonly string[] = [REASON_DETAIL_INFO_KEY];
+
 // Fragments that are an acronym rather than a word, so a humanized key reads "Source IP" and not "Source ip".
 const INFO_KEY_ACRONYMS: Record<string, string> = {
   // transaction_id, attempt_id
@@ -44,11 +51,23 @@ export interface InfoEntry {
 }
 
 /**
+ * Whether the Info cell would render anything for this entry: an `other_info` with at least one key the cell actually
+ * shows. Asked by the table before it sizes the Info column, so a row whose only key is one the cell skips (see
+ * KEYS_SHOWN_ELSEWHERE) does not make the column claim its width for an empty cell.
+ */
+export function hasInfoContent(info: AuthenticationLogEntry["other_info"]): boolean {
+  return !!info && Object.keys(info).some((key) => !KEYS_SHOWN_ELSEWHERE.includes(key));
+}
+
+/**
  * The authentication log's Info cell: `other_info` as "Key: value" rows.
  *
  * Scalars are shown as they are, and one level of nesting - a dict (the `truncated` overflow, the only thing the
  * backend puts here) or a list - becomes a bulleted sub-list under its key. Anything deeper is folded into compact
  * JSON, which is honest for a payload nothing writes today and better than silently dropping it.
+ *
+ * What another column already shows is skipped (see KEYS_SHOWN_ELSEWHERE), so the same value is not read twice - once
+ * here as JSON and once there in a form that fits it.
  *
  * Deliberately generic, and deliberately *not* shared with the Conditional access cell: this one walks arbitrary JSON,
  * while an outcome has one known shape. They share their looks (../info-list), not their rendering.
@@ -68,7 +87,8 @@ export class InfoCell {
     // The guard is not redundant with the input's type: the table's skeleton rows are built by column key and set every
     // column to "", so the declared type is a promise the loading state breaks.
     if (!this.isPlainObject(info)) return [];
-    return Object.entries(info).map(([key, raw]) => {
+    const shown = Object.entries(info).filter(([key]) => !KEYS_SHOWN_ELSEWHERE.includes(key));
+    return shown.map(([key, raw]) => {
       const label = this.humanizeKey(key);
       if (this.isPlainObject(raw)) {
         return { key: label, children: this.rows(raw) };

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/cells/reason-cell/reason-cell.html
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/cells/reason-cell/reason-cell.html
@@ -1,0 +1,44 @@
+<!--
+ (c) NetKnights GmbH 2026,  https://netknights.it
+
+ This code is free software; you can redistribute it and/or
+ modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ as published by the Free Software Foundation; either
+ version 3 of the License, or any later version.
+
+ This code is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+
+ You should have received a copy of the GNU Affero General Public
+ License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<div class="reason-cell">
+  <div class="reason-list">
+    @for (reason of reasons() ?? []; track reason) {
+      <span class="reason-entry">{{ reason }}</span>
+    }
+    @if (showsPlaceholder()) {
+      <span
+        class="reason-placeholder"
+        i18n>see details</span>
+    }
+  </div>
+  <!-- Only for an entry that actually recorded a detail: a button that opened an empty dialog would be a promise the
+    row cannot keep. -->
+  @if (detail(); as reasonDetail) {
+    <button
+      class="reason-detail-button"
+      mat-icon-button
+      type="button"
+      [attr.aria-label]="detailLabel"
+      [matTooltip]="detailLabel"
+      (click)="openDetail(reasonDetail)">
+      <mat-icon class="reason-detail-icon">help_outline</mat-icon>
+    </button>
+  }
+</div>

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/cells/reason-cell/reason-cell.scss
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/cells/reason-cell/reason-cell.scss
@@ -1,0 +1,43 @@
+// The reasons and the button that explains them: the button sits beside the list rather than under it, and shares its
+// centre line, so the glyph reads as belonging to the reasons rather than hanging below them. A cell of several
+// reasons therefore offers the button at the middle of the stack, which is the whole cell's centre too.
+.reason-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+// The reasons of one entry: stacked, since a request that failed for several reasons lists them all and they read as
+// separate findings rather than one wrapped value.
+.reason-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.reason-entry {
+  white-space: nowrap;
+}
+
+// Stands in for the reason an entry has none of, so the cell is not an empty column beside a lone button. Muted, in
+// the column's own size and face: it is a pointer rather than a value, and reads as one by being the quiet thing in
+// the row - it needs no styling of its own on top of that.
+.reason-placeholder {
+  color: var(--mat-sys-on-surface-variant);
+  white-space: nowrap;
+}
+
+// Sized down to the line it sits beside, through Material's own size tokens: the button's box is what carries the
+// glyph, and at its default 40px it would stretch the cell past the row's other columns. The 48px touch target inside
+// the button's own view is pinned to match in styles/buttons.scss, which is the only part of this a component
+// stylesheet cannot reach.
+.reason-detail-button {
+  --mat-icon-button-state-layer-size: 24px;
+  --mat-icon-button-icon-size: 20px;
+}
+
+.reason-detail-icon {
+  width: 20px;
+  height: 20px;
+  font-size: 20px;
+}

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/cells/reason-cell/reason-cell.spec.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/cells/reason-cell/reason-cell.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { DialogService } from "@services/dialog/dialog.service";
+import { MockDialogService } from "@testing/mock-services/mock-dialog-service";
+
+import { ReasonDetailDialog } from "../../reason-detail-dialog/reason-detail-dialog";
+import { ReasonCell } from "./reason-cell";
+
+describe("ReasonCell", () => {
+  let component: ReasonCell;
+  let fixture: ComponentFixture<ReasonCell>;
+  let dialogService: MockDialogService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReasonCell],
+      providers: [{ provide: DialogService, useClass: MockDialogService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReasonCell);
+    component = fixture.componentInstance;
+    dialogService = TestBed.inject(DialogService) as unknown as MockDialogService;
+  });
+
+  function renderedReasons(): string[] {
+    return Array.from(fixture.nativeElement.querySelectorAll(".reason-entry")).map((entry) =>
+      (entry as HTMLElement).textContent!.trim()
+    );
+  }
+
+  function detailButton(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector(".reason-detail-button");
+  }
+
+  function placeholder(): HTMLElement | null {
+    return fixture.nativeElement.querySelector(".reason-placeholder");
+  }
+
+  it("lists every reason of the entry, not just the first", () => {
+    fixture.componentRef.setInput("reasons", ["TOKEN_DISABLED", "WRONG_OTP"]);
+    fixture.detectChanges();
+
+    expect(renderedReasons()).toEqual(["TOKEN_DISABLED", "WRONG_OTP"]);
+  });
+
+  it("renders nothing for an entry that produced no reason", () => {
+    fixture.componentRef.setInput("reasons", null);
+    fixture.detectChanges();
+
+    expect(renderedReasons()).toEqual([]);
+    expect(detailButton()).toBeNull();
+    // Neither a reason nor a detail: a placeholder on every success row would be noise.
+    expect(component.showsPlaceholder()).toBe(false);
+    expect(placeholder()).toBeNull();
+  });
+
+  it("points at the dialog when the entry has a detail but no reason of its own", () => {
+    // What a wrong PIN looks like: the deciding token records no reason (PIN_FAIL already names the cause), while the
+    // tokens the request never checked keep their findings in the detail.
+    fixture.componentRef.setInput("reasons", []);
+    fixture.componentRef.setInput("info", {
+      reason_detail: { reasons: { OATH0001: "TOKEN_FAILCOUNT_EXCEEDED" } }
+    });
+    fixture.detectChanges();
+
+    expect(renderedReasons()).toEqual([]);
+    expect(component.showsPlaceholder()).toBe(true);
+    expect(placeholder()?.textContent?.trim()).toBe("see details");
+    expect(detailButton()).not.toBeNull();
+  });
+
+  it("stands aside once the entry carries a reason of its own", () => {
+    fixture.componentRef.setInput("reasons", ["WRONG_OTP"]);
+    fixture.componentRef.setInput("info", { reason_detail: { reasons: { OATH0001: "WRONG_OTP" } } });
+    fixture.detectChanges();
+
+    expect(component.showsPlaceholder()).toBe(false);
+    expect(placeholder()).toBeNull();
+  });
+
+  it("offers no detail button while the entry carries no reason detail", () => {
+    // A button that opened an empty dialog would be a promise the row cannot keep.
+    fixture.componentRef.setInput("reasons", ["WRONG_OTP"]);
+    fixture.componentRef.setInput("info", { client_label: "vpn" });
+    fixture.detectChanges();
+
+    expect(component.detail()).toBeNull();
+    expect(detailButton()).toBeNull();
+  });
+
+  it("opens the dialog with the entry's own detail", () => {
+    fixture.componentRef.setInput("reasons", ["WRONG_OTP"]);
+    fixture.componentRef.setInput("info", {
+      reason_detail: { reasons: { OATH0001: "WRONG_OTP" }, policies: ["deny_vpn"] }
+    });
+    fixture.detectChanges();
+
+    detailButton()!.click();
+
+    expect(dialogService.openDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: ReasonDetailDialog,
+        data: { tokens: [{ serial: "OATH0001", reason: "WRONG_OTP" }], policies: ["deny_vpn"] }
+      })
+    );
+  });
+
+  it("names what the button opens, since it carries no visible text", () => {
+    fixture.componentRef.setInput("info", { reason_detail: { policies: ["deny_vpn"] } });
+    fixture.detectChanges();
+
+    const button = detailButton()!;
+    expect(button.getAttribute("aria-label")).toBe(component.detailLabel);
+  });
+});

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/cells/reason-cell/reason-cell.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/cells/reason-cell/reason-cell.ts
@@ -1,0 +1,69 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { Component, computed, inject, input } from "@angular/core";
+import { MatButtonModule } from "@angular/material/button";
+import { MatIcon } from "@angular/material/icon";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { AuthenticationLogEntry } from "@services/authentication-log/authentication-log.service";
+import { DialogService, DialogServiceInterface } from "@services/dialog/dialog.service";
+
+import { ReasonDetailDialog } from "../../reason-detail-dialog/reason-detail-dialog";
+import { parseReasonDetail, ReasonDetail } from "../../reason-detail";
+
+/**
+ * The authentication log's Reasons cell: why the request came out the way it did.
+ *
+ * Every reason the request produced is listed, one line each, so a request whose tokens failed differently shows all
+ * of its findings rather than only the top-ranked one. What is *behind* those reasons - which token was found to be
+ * what, which policies decided - is a nested map, and it is offered as a dialog (see ReasonDetailDialog) rather than
+ * rendered in the row: the log has twelve columns, and neither this one nor the Info column, where it used to be
+ * folded into one line of JSON, has room to show it as the table it is.
+ */
+@Component({
+  selector: "app-reason-cell",
+  standalone: true,
+  imports: [MatButtonModule, MatIcon, MatTooltipModule],
+  templateUrl: "./reason-cell.html",
+  styleUrl: "./reason-cell.scss"
+})
+export class ReasonCell {
+  // Every reason of the entry, in the backend's own order (see AuthenticationLogReason); empty for a success.
+  readonly reasons = input<AuthenticationLogEntry["reasons"]>(null);
+  // The entry's other_info, which is where the detail behind those reasons is recorded. The whole record rather than
+  // the detail alone, so the table hands the cell a column and this cell owns what it reads out of it.
+  readonly info = input<AuthenticationLogEntry["other_info"]>(null);
+
+  private readonly dialogService: DialogServiceInterface = inject(DialogService);
+
+  // Null for an entry whose reasons nobody detailed, which is what leaves the cell without its button.
+  readonly detail = computed<ReasonDetail | null>(() => parseReasonDetail(this.info()));
+
+  // A request can end with a detail but no reason of its own: the token that decided the outcome records none when the
+  // event type already names the cause - a wrong PIN is logged as PIN_FAIL, and the findings of the tokens the request
+  // never got to check are deliberately not promoted to the row (see _note_event in lib/token/auth.py). The cell would
+  // then be an empty column beside a lone button, so it says where the answer is instead. Only in that case: a success
+  // has neither, and a placeholder on every one of those rows would be noise.
+  readonly showsPlaceholder = computed<boolean>(() => !this.reasons()?.length && !!this.detail());
+
+  readonly detailLabel = $localize`Show which token was found to be what`;
+
+  openDetail(detail: ReasonDetail): void {
+    this.dialogService.openDialog({ component: ReasonDetailDialog, data: detail });
+  }
+}

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.html
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.html
@@ -1,0 +1,78 @@
+<!--
+ (c) NetKnights GmbH 2026,  https://netknights.it
+
+ This code is free software; you can redistribute it and/or
+ modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ as published by the Free Software Foundation; either
+ version 3 of the License, or any later version.
+
+ This code is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+
+ You should have received a copy of the GNU Affero General Public
+ License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<app-dialog-wrapper
+  [cancelButtonPrimary]="true"
+  cancelButtonLabel="Close"
+  i18n-cancelButtonLabel="@@common.close"
+  icon="help_outline"
+  i18n-title
+  title="Reason Details">
+  <!-- Each half is shown only when the request recorded it: the token layer records the per-serial findings, a policy
+    layer the rules that decided, and most requests produce one of the two. -->
+  @if (data.tokens.length) {
+    <section class="reason-detail-section">
+      <h4
+        class="reason-detail-heading"
+        i18n>Tokens</h4>
+      <p
+        class="reason-detail-hint"
+        i18n>
+        What each of the user's tokens was found to be during this request.
+      </p>
+      <table class="reason-detail-table">
+        <thead>
+          <tr>
+            <th
+              scope="col"
+              i18n>Serial</th>
+            <th
+              scope="col"
+              i18n>Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (token of data.tokens; track token.serial) {
+            <tr>
+              <td class="reason-detail-serial">{{ token.serial }}</td>
+              <td>{{ token.reason }}</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </section>
+  }
+  @if (data.policies.length) {
+    <section class="reason-detail-section">
+      <h4
+        class="reason-detail-heading"
+        i18n>Deciding policies</h4>
+      <p
+        class="reason-detail-hint"
+        i18n>
+        The policies whose decision produced this outcome.
+      </p>
+      <ul class="reason-detail-policies">
+        @for (policy of data.policies; track policy) {
+          <li>{{ policy }}</li>
+        }
+      </ul>
+    </section>
+  }
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.html
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.html
@@ -26,6 +26,23 @@
   title="Reason Details">
   <!-- Each half is shown only when the request recorded it: the token layer records the per-serial findings, a policy
     layer the rules that decided, and most requests produce one of the two. -->
+  @if (data.policies.length) {
+    <section class="reason-detail-section">
+      <h4
+        class="reason-detail-heading"
+        i18n>Deciding policies</h4>
+      <p
+        class="reason-detail-hint"
+        i18n>
+        The policies whose decision produced this outcome.
+      </p>
+      <ul class="reason-detail-policies">
+        @for (policy of data.policies; track policy) {
+          <li>{{ policy }}</li>
+        }
+      </ul>
+    </section>
+  }
   @if (data.tokens.length) {
     <section class="reason-detail-section">
       <h4
@@ -56,23 +73,6 @@
           }
         </tbody>
       </table>
-    </section>
-  }
-  @if (data.policies.length) {
-    <section class="reason-detail-section">
-      <h4
-        class="reason-detail-heading"
-        i18n>Deciding policies</h4>
-      <p
-        class="reason-detail-hint"
-        i18n>
-        The policies whose decision produced this outcome.
-      </p>
-      <ul class="reason-detail-policies">
-        @for (policy of data.policies; track policy) {
-          <li>{{ policy }}</li>
-        }
-      </ul>
     </section>
   }
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.scss
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.scss
@@ -1,0 +1,60 @@
+// Capped so a handful of short serial/reason pairs does not stretch the dialog across a wide viewport, and given a
+// floor so the table's two columns keep their headers on one line.
+:host {
+  display: block;
+  min-width: 320px;
+  max-width: 560px;
+}
+
+.reason-detail-section + .reason-detail-section {
+  margin-top: 24px;
+}
+
+.reason-detail-heading {
+  margin: 0;
+}
+
+.reason-detail-hint {
+  margin: 4px 0 12px;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+// The per-serial findings. Left-aligned and full width, so serial and reason line up in columns rather than being
+// read as one run of text - which is the whole point of showing them here instead of in the log's Info column.
+//
+// The app stripes the even *column* of every table (see styles/table.scss); this one is read along its rows - a serial
+// and the finding beside it - so it opts out and stripes the rows instead, the way the detail cards' key/value tables
+// do (details-key-value-table).
+.reason-detail-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 6px 8px;
+    text-align: left;
+    vertical-align: top;
+    background: transparent;
+  }
+
+  th {
+    color: var(--mat-sys-on-surface-variant);
+    font-weight: 500;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+  }
+
+  tbody tr:nth-child(odd) td {
+    background: var(--mat-sys-surface-variant);
+  }
+}
+
+// A serial is an identifier, never a sentence: it keeps its own line rather than wrapping mid-serial when the reason
+// beside it is the long half.
+.reason-detail-serial {
+  white-space: nowrap;
+}
+
+.reason-detail-policies {
+  margin: 0;
+  padding-left: 20px;
+}

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.spec.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
+
+import { ReasonDetail } from "../reason-detail";
+import { ReasonDetailDialog } from "./reason-detail-dialog";
+
+describe("ReasonDetailDialog", () => {
+  let fixture: ComponentFixture<ReasonDetailDialog>;
+
+  async function render(data: ReasonDetail): Promise<void> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ReasonDetailDialog],
+      providers: [
+        { provide: MatDialogRef, useClass: MockMatDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: data }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReasonDetailDialog);
+    fixture.detectChanges();
+  }
+
+  function rows(): string[][] {
+    return Array.from(fixture.nativeElement.querySelectorAll(".reason-detail-table tbody tr")).map((row) =>
+      Array.from((row as HTMLElement).querySelectorAll("td")).map((cell) => cell.textContent!.trim())
+    );
+  }
+
+  it("shows each finding as its serial and its reason rather than as one line of JSON", async () => {
+    await render({
+      tokens: [
+        { serial: "OATH0001", reason: "WRONG_OTP" },
+        { serial: "TOTP002", reason: "TOKEN_DISABLED" }
+      ],
+      policies: []
+    });
+
+    expect(rows()).toEqual([
+      ["OATH0001", "WRONG_OTP"],
+      ["TOTP002", "TOKEN_DISABLED"]
+    ]);
+    // Nothing about policies for a request that named none.
+    expect(fixture.nativeElement.querySelector(".reason-detail-policies")).toBeNull();
+  });
+
+  it("lists the deciding policies, and leaves out the token table when no token was found wanting", async () => {
+    await render({ tokens: [], policies: ["deny_vpn", "auth_max_fail"] });
+
+    expect(fixture.nativeElement.querySelector(".reason-detail-table")).toBeNull();
+    const policies: HTMLLIElement[] = Array.from(fixture.nativeElement.querySelectorAll(".reason-detail-policies li"));
+    expect(policies.map((policy) => policy.textContent!.trim())).toEqual(["deny_vpn", "auth_max_fail"]);
+  });
+
+  it("shows both halves when the request recorded both", async () => {
+    await render({ tokens: [{ serial: "OATH0001", reason: "WRONG_OTP" }], policies: ["deny_vpn"] });
+
+    expect(rows()).toEqual([["OATH0001", "WRONG_OTP"]]);
+    expect(fixture.nativeElement.querySelectorAll(".reason-detail-policies li").length).toBe(1);
+  });
+});

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail-dialog/reason-detail-dialog.ts
@@ -1,0 +1,43 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { Component } from "@angular/core";
+import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
+
+import { ReasonDetail } from "../reason-detail";
+
+/**
+ * What is behind one authentication-log entry's reasons: which of the user's tokens was found to be what, and which
+ * policies decided the request.
+ *
+ * Opened from the Reasons column (see ReasonCell) rather than shown in the Info column, which is where the same data
+ * used to be read as a one-line JSON dump. A dialog is what buys it a shape: the per-serial findings are a table of
+ * serial and reason, which is how an admin reads them - "which token failed, and why" - and a table is exactly what
+ * the twelve-column log has no room for.
+ *
+ * Read-only, so it closes rather than returning anything.
+ */
+@Component({
+  selector: "app-reason-detail-dialog",
+  standalone: true,
+  imports: [DialogWrapperComponent],
+  templateUrl: "./reason-detail-dialog.html",
+  styleUrl: "./reason-detail-dialog.scss"
+})
+export class ReasonDetailDialog extends AbstractDialogComponent<ReasonDetail> {}

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail.spec.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { parseReasonDetail } from "./reason-detail";
+
+describe("parseReasonDetail", () => {
+  it("reads the per-serial findings and the deciding policies of one entry", () => {
+    expect(
+      parseReasonDetail({
+        reason_detail: {
+          reasons: { OATH0001: "WRONG_OTP", TOTP002: "TOKEN_DISABLED" },
+          policies: ["deny_vpn"]
+        },
+        client_label: "vpn"
+      })
+    ).toEqual({
+      tokens: [
+        { serial: "OATH0001", reason: "WRONG_OTP" },
+        { serial: "TOTP002", reason: "TOKEN_DISABLED" }
+      ],
+      policies: ["deny_vpn"]
+    });
+  });
+
+  it("keeps the half the request recorded, since each layer records only its own", () => {
+    expect(parseReasonDetail({ reason_detail: { reasons: { OATH0001: "WRONG_OTP" } } })).toEqual({
+      tokens: [{ serial: "OATH0001", reason: "WRONG_OTP" }],
+      policies: []
+    });
+    expect(parseReasonDetail({ reason_detail: { policies: ["auth_max_fail"] } })).toEqual({
+      tokens: [],
+      policies: ["auth_max_fail"]
+    });
+  });
+
+  it("reports nothing to show for an entry whose reasons nobody detailed", () => {
+    // Which is what leaves the Reasons column without its dialog button.
+    expect(parseReasonDetail(null)).toBeNull();
+    expect(parseReasonDetail({})).toBeNull();
+    expect(parseReasonDetail({ client_label: "vpn" })).toBeNull();
+    expect(parseReasonDetail({ reason_detail: {} })).toBeNull();
+    expect(parseReasonDetail({ reason_detail: { reasons: {}, policies: [] } })).toBeNull();
+  });
+
+  it("yields no detail for a value of an unexpected shape rather than a broken cell", () => {
+    // other_info is a free-form JSON column, and the table's skeleton rows set every column to "".
+    expect(parseReasonDetail("")).toBeNull();
+    expect(parseReasonDetail(["reason_detail"])).toBeNull();
+    expect(parseReasonDetail({ reason_detail: "WRONG_OTP" })).toBeNull();
+    expect(parseReasonDetail({ reason_detail: { reasons: "WRONG_OTP" } })).toBeNull();
+    expect(parseReasonDetail({ reason_detail: { reasons: { OATH0001: "WRONG_OTP" }, policies: "deny_vpn" } })).toEqual({
+      tokens: [{ serial: "OATH0001", reason: "WRONG_OTP" }],
+      policies: []
+    });
+  });
+
+  it("renders a recorded value that is not a plain string rather than dropping it", () => {
+    // A mislabelled reason is worth seeing: hiding it would hide that it was recorded that way.
+    expect(
+      parseReasonDetail({ reason_detail: { reasons: { OATH0001: { code: 3 }, TOTP002: 7, WAN003: null } } })
+    ).toEqual({
+      tokens: [
+        { serial: "OATH0001", reason: '{"code":3}' },
+        { serial: "TOTP002", reason: "7" },
+        { serial: "WAN003", reason: "" }
+      ],
+      policies: []
+    });
+  });
+});

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/reason-detail.ts
@@ -1,0 +1,72 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+
+// The key the backend records the reason detail under inside an entry's other_info (REASON_DETAIL_INFO_KEY in
+// privacyidea/lib/conditional_access/authentication_event_types.py).
+//
+// The detail explains the row's *reasons*, so it belongs to the Reasons column and not to the Info cell, which skips
+// it (see InfoCell): a nested map in a narrow JSON column can only be folded into a one-line dump, while the Reasons
+// column can offer it as the serial/reason pairs it actually is (see ReasonCell and ReasonDetailDialog).
+export const REASON_DETAIL_INFO_KEY = "reason_detail";
+
+// One token's finding: what this request found the token with that serial to be. The serials are the keys of the
+// backend's per-serial map (see build_reason_detail).
+export interface TokenReason {
+  serial: string;
+  reason: string;
+}
+
+// The reason detail of one entry. Either half can be empty: each layer records only its own - the token layer the
+// per-serial findings, a policy layer the rules that decided - and they are merged into one dict on the way into the
+// row (see build_reason_detail and ConditionalAccessContext.reclassify).
+export interface ReasonDetail {
+  tokens: TokenReason[];
+  policies: string[];
+}
+
+/**
+ * The reason detail of an entry's *other_info*, or `null` when it carries nothing to show - which is what an entry
+ * whose reasons nobody detailed looks like, and the answer that leaves the Reasons column without its dialog button.
+ *
+ * `other_info` is a free-form JSON column, so every level is checked rather than trusted (and the table's skeleton
+ * rows set *every* column to `""`, so even "a record" is not a promise the loading state keeps). Anything of an
+ * unexpected shape yields no detail rather than a broken cell.
+ */
+export function parseReasonDetail(info: unknown): ReasonDetail | null {
+  if (!isRecord(info)) return null;
+  const detail = info[REASON_DETAIL_INFO_KEY];
+  if (!isRecord(detail)) return null;
+  const reasons = detail["reasons"];
+  const tokens = isRecord(reasons)
+    ? Object.entries(reasons).map(([serial, reason]) => ({ serial, reason: asText(reason) }))
+    : [];
+  const policies = Array.isArray(detail["policies"]) ? detail["policies"].map((policy) => asText(policy)) : [];
+  return tokens.length || policies.length ? { tokens, policies } : null;
+}
+
+// Renders whatever the column holds: the backend writes a string per serial and a list of names, and a value that is
+// neither is still shown - a mislabelled reason is worth seeing, and dropping it would hide that it was recorded.
+function asText(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return typeof value === "object" ? JSON.stringify(value) : String(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/privacyidea/static_new/src/styles/buttons.scss
+++ b/privacyidea/static_new/src/styles/buttons.scss
@@ -460,11 +460,13 @@ $button-low-contrast-variant: linear-gradient(
 }
 
 // Compact icon buttons that sit inline with table text (column sorting, the
-// conditional-access priority arrows). The touch target is pinned to the visible
-// 24px box: Material's default 48px target would overhang the neighbouring cell
-// content and pull the ripple/hover layer out of line with the icon.
+// conditional-access priority arrows, the authentication log's reason detail).
+// The touch target is pinned to the visible 24px box: Material's default 48px
+// target would overhang the neighbouring cell content and pull the ripple/hover
+// layer out of line with the icon.
 .sort-button,
-.reorder-button {
+.reorder-button,
+.reason-detail-button {
   top: 0;
   right: 2px;
   height: 24px;


### PR DESCRIPTION
The per-serial reason detail is a nested map - which token was found to be what, and which policies decided - and the Info column could only fold it into one line of compact JSON, which is unreadable at that width and the widest thing in the table. It moves to the Reasons column, where it belongs: an icon button next to the reasons opens a dialog listing the findings as the serial/reason table they are, with the deciding policies under them.

The Reasons column becomes a cell component of its own (cells/reason-cell), joining the other columns that render a list rather than a scalar; the reason lines and their styles move over unchanged. The button appears only for an entry that actually recorded a detail, so it never opens an empty dialog.

The Info cell skips the reason_detail key and exports hasInfoContent, which the table now asks before sizing the column: a row whose only key is the skipped one would otherwise make the Info column claim its 300px for a cell that renders nothing - and that is the common case, since most failed requests record nothing else there.

An entry can carry a detail and no reason of its own: the token that decided the outcome records none when the event type already names the cause (a wrong PIN is logged as PIN_FAIL), and the findings of the tokens the request never got to check are deliberately not promoted to the row. Such a cell would be an empty column beside a lone button, so it shows a muted "see details" instead.