### PR TITLE
CA - Add cli commands for ca policy

### DIFF
--- a/doc/conditional_access/authentication_log.rst
+++ b/doc/conditional_access/authentication_log.rst
@@ -242,8 +242,9 @@ request path:
 
 Every authentication reaches the server as a request, so an entry written by an
 authentication always names its endpoint; the column is empty only for an entry
-staged outside a view. The same value is what an *Endpoint* condition of a lockout
-policy is matched against, see :ref:`lockout_policies`, so a policy can be
+staged outside a view. The same value is what an *Endpoint* condition of a
+conditional access policy is matched against, see
+:ref:`conditional_access_policies`, so a policy can be
 limited to the endpoints it should watch: counting the failed authentications
 of an application without counting WebUI logins, for instance.
 
@@ -362,10 +363,11 @@ pruned automatically. Set up a cron job to enforce your retention period, using
 
    pi-manage authlog cleanup --age 365
 
-This deletes all entries older than one year, together with the
-conditional-access outcomes recorded on them. Add ``--chunksize`` to delete in
-batches on a large table, and ``--dryrun`` to see how many entries would be
-removed without deleting anything.
+``--age`` is required and counts in days, so this deletes all entries older
+than one year, together with the classified reasons and the conditional-access
+outcomes recorded on them. Add ``--chunksize`` to delete in batches on a large
+table, and ``--dryrun`` to see how many entries would be removed without
+deleting anything.
 
 .. note:: Deleting entries also removes them from the counts a conditional
    access policy makes. Keep the retention period comfortably longer than the

--- a/doc/conditional_access/locks_and_blocks.rst
+++ b/doc/conditional_access/locks_and_blocks.rst
@@ -41,6 +41,11 @@ add ``--resolver`` only if the login exists in more than one resolver. The two
    address to *ConditionalAccessNeverBlock*, see
    :ref:`conditional_access_never_block`.
 
+Lifting a lock only undoes what a policy has already done - it will do it again
+on the next request. Switching the policy itself off, which is what a ``DENY``
+needs (it stores nothing that could be lifted), is described in
+:ref:`conditional_access_policies_cli`.
+
 .. _conditional_access_never_block:
 
 Never blocking an address

--- a/doc/conditional_access/policies.rst
+++ b/doc/conditional_access/policies.rst
@@ -270,16 +270,22 @@ you need when a policy has locked you out of the WebUI itself - an unscoped
 ``DENY``, say::
 
    pi-manage conditionalaccess list-policies
-   pi-manage conditionalaccess disable-policy <name|id>
-   pi-manage conditionalaccess enable-policy <name|id>
-   pi-manage conditionalaccess enable-dry-run <name|id>
-   pi-manage conditionalaccess disable-dry-run <name|id>
-   pi-manage conditionalaccess delete-policy <name|id> [--yes]
+   pi-manage conditionalaccess disable-policy <name>
+   pi-manage conditionalaccess enable-policy <name>
+   pi-manage conditionalaccess enable-dry-run <name>
+   pi-manage conditionalaccess disable-dry-run <name>
+   pi-manage conditionalaccess delete-policy <name> [--yes]
 
 ``list-policies`` prints one line per policy - name, id, enabled and dry-run
 state, priority and target - lowest priority number first, which is the order
-the policies are evaluated in. Every other command takes either the name or the
-id, whichever is quicker to type.
+the policies are evaluated in.
+
+Every other command addresses one policy, either by the name given as its
+argument or by ``--id`` - which is the handier one for a name that contains
+spaces::
+
+   pi-manage conditionalaccess disable-policy --id 7
+
 
 ``disable-policy`` is the way back in: the policy is no longer evaluated, so it
 cannot refuse the next request. ``enable-dry-run`` is the gentler variant - the

--- a/doc/conditional_access/policies.rst
+++ b/doc/conditional_access/policies.rst
@@ -153,7 +153,9 @@ subject has done.
    yourself a way back in - *user role is not one of [admin-internal]* keeps the
    internal administrators able to log in. A ``DENY`` stores no state, so none of
    the ``pi-manage conditionalaccess`` reset commands can lift it; undoing an
-   unscoped one means disabling the policy in the database.
+   unscoped one means disabling the policy itself, with
+   ``pi-manage conditionalaccess disable-policy <name>`` if it has locked you out
+   of the WebUI, see :ref:`conditional_access_policies_cli`.
 
 .. _conditional_access_policies_actions:
 
@@ -254,4 +256,35 @@ many users share an address - shared egress such as NAT or CGNAT can put
 hundreds of users behind one address.
 
 Filter the authentication log on *dry run* outcomes to see what a policy would
-have done, then disable dry run once the threshold fits.
+have done, then disable dry run once the threshold fits. Dry run can also be
+switched on and off from the command line, which defuses a policy that has
+locked everybody out without losing what it records.
+
+.. _conditional_access_policies_cli:
+
+Managing policies on the command line
+-------------------------------------
+
+The policies can also be managed with :ref:`pi-manage <pimanage>`, which is what
+you need when a policy has locked you out of the WebUI itself - an unscoped
+``DENY``, say::
+
+   pi-manage conditionalaccess list-policies
+   pi-manage conditionalaccess disable-policy <name|id>
+   pi-manage conditionalaccess enable-policy <name|id>
+   pi-manage conditionalaccess enable-dry-run <name|id>
+   pi-manage conditionalaccess disable-dry-run <name|id>
+   pi-manage conditionalaccess delete-policy <name|id> [--yes]
+
+``list-policies`` prints one line per policy - name, id, enabled and dry-run
+state, priority and target - lowest priority number first, which is the order
+the policies are evaluated in. Every other command takes either the name or the
+id, whichever is quicker to type.
+
+``disable-policy`` is the way back in: the policy is no longer evaluated, so it
+cannot refuse the next request. ``enable-dry-run`` is the gentler variant - the
+policy stays enabled and keeps recording what it *would* do, but nothing is
+enforced. Both leave the locks and blocks the policy has already written in
+force, so clear those as well, see :ref:`conditional_access_policies_lifting`.
+``delete-policy`` removes the policy with its stages and actions for good and
+asks for confirmation first, so pass ``--yes`` when calling it from a script.

--- a/doc/installation/system/pi-manage.rst
+++ b/doc/installation/system/pi-manage.rst
@@ -148,6 +148,28 @@ Policies
 
 You can use ``pi-manage config policy`` to enable, disable, create and delete policies.
 
+.. _pimanage_authlog:
+
+Clean up the authentication log
+-------------------------------
+
+.. index:: retention time
+
+The :ref:`authentication_log` records every authentication request and is not
+pruned automatically, so its retention period is enforced by a cron job running::
+
+   pi-manage authlog cleanup --age 365
+
+``--age`` is required and is given in days: the command deletes every entry
+older than that, together with the classified reasons and the conditional-access
+outcomes recorded on those entries. As with the challenge cleanup, ``--chunksize``
+deletes in batches to avoid long locks on a large table, and ``--dryrun`` only
+reports how many entries would be removed.
+
+Keep the retention period comfortably longer than the longest time window used
+by a conditional access policy - deleted entries no longer count towards its
+thresholds, see :ref:`authentication_log_cleanup`.
+
 Conditional Access
 ------------------
 

--- a/doc/installation/system/pi-manage.rst
+++ b/doc/installation/system/pi-manage.rst
@@ -148,6 +148,23 @@ Policies
 
 You can use ``pi-manage config policy`` to enable, disable, create and delete policies.
 
+Conditional Access
+------------------
+
+``pi-manage conditionalaccess`` manages the :ref:`conditional access
+<conditional_access>` policies and the locks and IP blocks they produce. It is
+the escape hatch when a policy has locked you out of the WebUI itself: you can
+list the policies, disable one, put it into dry run or delete it, and lift the
+locks and blocks that are in force::
+
+   pi-manage conditionalaccess list-policies
+   pi-manage conditionalaccess disable-policy <name|id>
+   pi-manage conditionalaccess list-locked-users
+   pi-manage conditionalaccess clear-blocks
+
+See :ref:`conditional_access_policies_lifting` and
+:ref:`conditional_access_policies_cli` for the complete list.
+
 
 Exporting and Importing the Configuration
 -----------------------------------------

--- a/doc/installation/system/pi-manage.rst
+++ b/doc/installation/system/pi-manage.rst
@@ -180,7 +180,7 @@ list the policies, disable one, put it into dry run or delete it, and lift the
 locks and blocks that are in force::
 
    pi-manage conditionalaccess list-policies
-   pi-manage conditionalaccess disable-policy <name|id>
+   pi-manage conditionalaccess disable-policy <name>
    pi-manage conditionalaccess list-locked-users
    pi-manage conditionalaccess clear-blocks
 

--- a/privacyidea/cli/pimanage/conditional_access.py
+++ b/privacyidea/cli/pimanage/conditional_access.py
@@ -27,6 +27,9 @@ policy has already done - a policy that keeps refusing requests (a ``DENY`` at
 threshold 0, say) has to be disabled, put into dry run or deleted, which is what
 the ``*-policy`` and ``*-dry-run`` commands are for.
 """
+from collections.abc import Callable
+from typing import Any, TypeVar
+
 import click
 from flask.cli import AppGroup
 from sqlalchemy import select
@@ -51,6 +54,12 @@ conditional_access_cli = AppGroup("conditionalaccess",
                                        "blocks they produced")
 
 
+# The undecorated callback a command decorator is stacked on. click declares its own argument/option
+# decorators as Callable[[FC], FC] with FC private to click.decorators, so this mirrors that shape rather
+# than importing the internal name.
+_CommandCallback = TypeVar("_CommandCallback", bound=Callable[..., Any])
+
+
 def _format_expiry(expires_at):
     return expires_at.isoformat() if expires_at else "permanent"
 
@@ -59,19 +68,40 @@ def _yes_no(value) -> str:
     return "yes" if value else "no"
 
 
-def _resolve_policy(identifier: str) -> ConditionalAccessPolicy:
+def _policy_selector(command: _CommandCallback) -> _CommandCallback:
     """
-    Look a policy up by name, falling back to its id.
+    Add the policy selector every policy command shares: the ``NAME`` argument, or ``--id``.
 
-    The name is what an administrator reads off ``list-policies`` and is unique, so it
-    wins; the numeric id is tried only when no policy carries that name, which keeps a
-    policy whose name happens to be a number reachable by both.
+    The two spellings are kept strictly apart. A policy name may itself be a number, so a single
+    argument resolved by precedence would let ``delete-policy 7`` address a policy *named* "7"
+    while the caller meant the policy *with id* 7 - silently deleting the wrong one. Here the
+    argument is always a name and ``--id`` is always an id, so there is nothing to guess.
     """
-    policy = db.session.scalar(select(ConditionalAccessPolicy).where(ConditionalAccessPolicy.name == identifier))
-    if not policy and identifier.isdigit():
-        policy = db.session.get(ConditionalAccessPolicy, int(identifier))
+    command = click.option("--id", "policy_id", type=int,
+                           help="Address the policy by its numeric id instead of its name.")(command)
+    return click.argument("name", required=False)(command)
+
+
+def _select_policy(name: str | None, policy_id: int | None) -> ConditionalAccessPolicy:
+    """
+    Fetch the policy the selector addresses.
+
+    :raises click.UsageError: if both spellings, or neither, were given
+    :raises click.ClickException: if no such policy exists
+    """
+    if (name is None) == (policy_id is None):
+        raise click.UsageError("Give either the policy NAME or --id, not both.")
+    if policy_id is not None:
+        policy = db.session.get(ConditionalAccessPolicy, policy_id)
+        if not policy:
+            raise click.ClickException(f"No conditional-access policy with the id {policy_id}. "
+                                       f"Run 'pi-manage conditionalaccess list-policies' to see them.")
+        return policy
+    policy = db.session.scalar(select(ConditionalAccessPolicy).where(ConditionalAccessPolicy.name == name))
     if not policy:
-        raise click.ClickException(f"No conditional-access policy with the name or id '{identifier}'. "
+        # A name is never retried as an id, see _policy_selector; point at the explicit spelling instead.
+        hint = f" If you meant the id, use '--id {name}'." if name.isdigit() else ""
+        raise click.ClickException(f"No conditional-access policy with the name '{name}'.{hint} "
                                    f"Run 'pi-manage conditionalaccess list-policies' to see them.")
     return policy
 
@@ -98,31 +128,31 @@ def list_policies():
                    f"{_yes_no(policy['dry_run']):8} {policy['priority']:<9} {policy['target']}")
 
 
-@conditional_access_cli.command("enable-policy", help="Enable a single policy, given by its name or id.")
-@click.argument("policy")
-def enable_policy(policy):
-    row = _resolve_policy(policy)
-    label = _policy_label(row)
-    if row.enabled:
+@conditional_access_cli.command("enable-policy", help="Enable a single policy, given by its name or --id.")
+@_policy_selector
+def enable_policy(name: str | None, policy_id: int | None) -> None:
+    policy = _select_policy(name, policy_id)
+    label = _policy_label(policy)
+    if policy.enabled:
         click.echo(f"Conditional-access policy {label} is already enabled.")
         return
-    enable_conditional_access_policy(row.id, enable=True)
+    enable_conditional_access_policy(policy.id, enable=True)
     click.echo(f"Enabled conditional-access policy {label}.")
 
 
 @conditional_access_cli.command("disable-policy",
-                                help="Disable a single policy, given by its name or id. The policy stops being "
+                                help="Disable a single policy, given by its name or --id. The policy stops being "
                                      "evaluated; locks and blocks it already wrote stay in force.")
-@click.argument("policy")
-def disable_policy(policy):
+@_policy_selector
+def disable_policy(name: str | None, policy_id: int | None) -> None:
     # The way back in from an over-strict policy: it is no longer evaluated, so it cannot refuse
     # the next request. What it already wrote is separate state - clear that with clear-locks/clear-blocks.
-    row = _resolve_policy(policy)
-    label = _policy_label(row)
-    if not row.enabled:
+    policy = _select_policy(name, policy_id)
+    label = _policy_label(policy)
+    if not policy.enabled:
         click.echo(f"Conditional-access policy {label} is already disabled.")
         return
-    enable_conditional_access_policy(row.id, enable=False)
+    enable_conditional_access_policy(policy.id, enable=False)
     click.echo(f"Disabled conditional-access policy {label}. Locks and blocks it already wrote stay in "
                f"force; clear them with clear-locks / clear-blocks.")
 
@@ -130,42 +160,42 @@ def disable_policy(policy):
 @conditional_access_cli.command("enable-dry-run",
                                 help="Put a policy into dry run: it is still evaluated and logged, but nothing "
                                      "is enforced.")
-@click.argument("policy")
-def enable_dry_run(policy):
-    row = _resolve_policy(policy)
-    label = _policy_label(row)
-    if row.dry_run:
+@_policy_selector
+def enable_dry_run(name: str | None, policy_id: int | None) -> None:
+    policy = _select_policy(name, policy_id)
+    label = _policy_label(policy)
+    if policy.dry_run:
         click.echo(f"Conditional-access policy {label} is already in dry run.")
         return
-    update_conditional_access_policy(row.id, dry_run=True)
+    update_conditional_access_policy(policy.id, dry_run=True)
     click.echo(f"Conditional-access policy {label} is now in dry run: nothing it decides is enforced.")
 
 
 @conditional_access_cli.command("disable-dry-run",
                                 help="Take a policy out of dry run, so its actions are enforced again.")
-@click.argument("policy")
-def disable_dry_run(policy):
-    row = _resolve_policy(policy)
-    label = _policy_label(row)
-    if not row.dry_run:
+@_policy_selector
+def disable_dry_run(name: str | None, policy_id: int | None) -> None:
+    policy = _select_policy(name, policy_id)
+    label = _policy_label(policy)
+    if not policy.dry_run:
         click.echo(f"Conditional-access policy {label} is not in dry run.")
         return
-    update_conditional_access_policy(row.id, dry_run=False)
+    update_conditional_access_policy(policy.id, dry_run=False)
     click.echo(f"Conditional-access policy {label} is no longer in dry run: its actions are enforced again.")
 
 
 @conditional_access_cli.command("delete-policy",
-                                help="Delete a single policy, given by its name or id, with all its stages and "
+                                help="Delete a single policy, given by its name or --id, with all its stages and "
                                      "actions.")
-@click.argument("policy")
+@_policy_selector
 @click.option("--yes", is_flag=True, help="Do not ask for confirmation.")
-def delete_policy(policy, yes):
-    row = _resolve_policy(policy)
-    label = _policy_label(row)
+def delete_policy(name: str | None, policy_id: int | None, yes: bool) -> None:
+    policy = _select_policy(name, policy_id)
+    label = _policy_label(policy)
     # The configuration is gone for good, so confirm by default; --yes is there for scripts.
     if not yes:
         click.confirm(f"Delete conditional-access policy {label}?", abort=True)
-    delete_conditional_access_policy(row.id)
+    delete_conditional_access_policy(policy.id)
     click.echo(f"Deleted conditional-access policy {label}.")
 
 

--- a/privacyidea/cli/pimanage/conditional_access.py
+++ b/privacyidea/cli/pimanage/conditional_access.py
@@ -17,15 +17,24 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
 ``pi-manage conditionalaccess`` — inspect and clear the conditional-access
-lock state (locked users and blocked IPs).
+lock state (locked users and blocked IPs), and switch off the policies that
+produce it.
 
 This is the operational escape hatch for the conditional-access engine: it works without
 the WebUI, so an administrator who has been locked out (or who blocked a shared
-proxy IP) can recover from the command line.
+proxy IP) can recover from the command line. Lifting a lock only undoes what a
+policy has already done - a policy that keeps refusing requests (a ``DENY`` at
+threshold 0, say) has to be disabled, put into dry run or deleted, which is what
+the ``*-policy`` and ``*-dry-run`` commands are for.
 """
 import click
 from flask.cli import AppGroup
+from sqlalchemy import select
 
+from privacyidea.lib.conditional_access.policy import (delete_conditional_access_policy,
+                                                       enable_conditional_access_policy,
+                                                       list_conditional_access_policies,
+                                                       update_conditional_access_policy)
 from privacyidea.lib.conditional_access.state import (block_ip, list_blocklist,
                                                               list_locked_users, lock_user,
                                                               purge_expired_blocklist,
@@ -34,14 +43,130 @@ from privacyidea.lib.conditional_access.state import (block_ip, list_blocklist,
                                                               unlock_user_by_id, unlock_user_by_username)
 from privacyidea.lib.user import User
 from privacyidea.models import db
-from privacyidea.models.conditional_access_policy import BlockList, UserLockState
+from privacyidea.models.conditional_access_policy import (BlockList, ConditionalAccessPolicy,
+                                                          UserLockState)
 
 conditional_access_cli = AppGroup("conditionalaccess",
-                                  help="Inspect and clear conditional-access locks and IP blocks")
+                                  help="Manage conditional-access policies and clear the locks and IP "
+                                       "blocks they produced")
 
 
 def _format_expiry(expires_at):
     return expires_at.isoformat() if expires_at else "permanent"
+
+
+def _yes_no(value) -> str:
+    return "yes" if value else "no"
+
+
+def _resolve_policy(identifier: str) -> ConditionalAccessPolicy:
+    """
+    Look a policy up by name, falling back to its id.
+
+    The name is what an administrator reads off ``list-policies`` and is unique, so it
+    wins; the numeric id is tried only when no policy carries that name, which keeps a
+    policy whose name happens to be a number reachable by both.
+    """
+    policy = db.session.scalar(select(ConditionalAccessPolicy).where(ConditionalAccessPolicy.name == identifier))
+    if not policy and identifier.isdigit():
+        policy = db.session.get(ConditionalAccessPolicy, int(identifier))
+    if not policy:
+        raise click.ClickException(f"No conditional-access policy with the name or id '{identifier}'. "
+                                   f"Run 'pi-manage conditionalaccess list-policies' to see them.")
+    return policy
+
+
+def _policy_label(policy: ConditionalAccessPolicy) -> str:
+    return f"'{policy.name}' (id {policy.id})"
+
+
+@conditional_access_cli.command("list-policies", help="List the conditional-access policies in evaluation order.")
+def list_policies():
+    # The same table shape as "pi-manage config policy list", listing what identifies a policy and what
+    # the commands below change. The stages, conditions and everything else belong to the policy detail
+    # view in the WebUI or the API, not to a one-line-per-policy overview.
+    policies = list_conditional_access_policies()
+    if not policies:
+        click.echo("No conditional-access policies.")
+        return
+    click.echo(f"{'Name':30} {'ID':5} {'Enabled':8} {'Dry run':8} {'Priority':9} Target")
+    click.echo(71 * "=")
+    for policy in policies:
+        # The id is listed next to the name because every command below takes either, and the id is the
+        # shorter thing to type when the name is long or carries spaces.
+        click.echo(f"{policy['name']:30} {policy['id']:<5} {_yes_no(policy['enabled']):8} "
+                   f"{_yes_no(policy['dry_run']):8} {policy['priority']:<9} {policy['target']}")
+
+
+@conditional_access_cli.command("enable-policy", help="Enable a single policy, given by its name or id.")
+@click.argument("policy")
+def enable_policy(policy):
+    row = _resolve_policy(policy)
+    label = _policy_label(row)
+    if row.enabled:
+        click.echo(f"Conditional-access policy {label} is already enabled.")
+        return
+    enable_conditional_access_policy(row.id, enable=True)
+    click.echo(f"Enabled conditional-access policy {label}.")
+
+
+@conditional_access_cli.command("disable-policy",
+                                help="Disable a single policy, given by its name or id. The policy stops being "
+                                     "evaluated; locks and blocks it already wrote stay in force.")
+@click.argument("policy")
+def disable_policy(policy):
+    # The way back in from an over-strict policy: it is no longer evaluated, so it cannot refuse
+    # the next request. What it already wrote is separate state - clear that with clear-locks/clear-blocks.
+    row = _resolve_policy(policy)
+    label = _policy_label(row)
+    if not row.enabled:
+        click.echo(f"Conditional-access policy {label} is already disabled.")
+        return
+    enable_conditional_access_policy(row.id, enable=False)
+    click.echo(f"Disabled conditional-access policy {label}. Locks and blocks it already wrote stay in "
+               f"force; clear them with clear-locks / clear-blocks.")
+
+
+@conditional_access_cli.command("enable-dry-run",
+                                help="Put a policy into dry run: it is still evaluated and logged, but nothing "
+                                     "is enforced.")
+@click.argument("policy")
+def enable_dry_run(policy):
+    row = _resolve_policy(policy)
+    label = _policy_label(row)
+    if row.dry_run:
+        click.echo(f"Conditional-access policy {label} is already in dry run.")
+        return
+    update_conditional_access_policy(row.id, dry_run=True)
+    click.echo(f"Conditional-access policy {label} is now in dry run: nothing it decides is enforced.")
+
+
+@conditional_access_cli.command("disable-dry-run",
+                                help="Take a policy out of dry run, so its actions are enforced again.")
+@click.argument("policy")
+def disable_dry_run(policy):
+    row = _resolve_policy(policy)
+    label = _policy_label(row)
+    if not row.dry_run:
+        click.echo(f"Conditional-access policy {label} is not in dry run.")
+        return
+    update_conditional_access_policy(row.id, dry_run=False)
+    click.echo(f"Conditional-access policy {label} is no longer in dry run: its actions are enforced again.")
+
+
+@conditional_access_cli.command("delete-policy",
+                                help="Delete a single policy, given by its name or id, with all its stages and "
+                                     "actions.")
+@click.argument("policy")
+@click.option("--yes", is_flag=True, help="Do not ask for confirmation.")
+def delete_policy(policy, yes):
+    row = _resolve_policy(policy)
+    label = _policy_label(row)
+    # The configuration is gone for good, so confirm by default; --yes is there for scripts.
+    if not yes:
+        click.confirm(f"Delete conditional-access policy {label}?", abort=True)
+    delete_conditional_access_policy(row.id)
+    click.echo(f"Deleted conditional-access policy {label}.")
 
 
 @conditional_access_cli.command("list-blocked-ips", help="List the currently blocked IPs.")

--- a/tests/cli/test_cli_pimanage.py
+++ b/tests/cli/test_cli_pimanage.py
@@ -30,11 +30,14 @@ from sqlalchemy.orm.session import close_all_sessions
 from privacyidea.app import create_app
 from privacyidea.cli.pimanage import cli as pi_manage
 from privacyidea.lib.conditional_access.authentication_event_types import AuthEventType
+from privacyidea.lib.conditional_access.engine import ConditionalAccessAction, ConditionalAccessTarget
+from privacyidea.lib.conditional_access.policy import create_conditional_access_policy
 from privacyidea.lib.lifecycle import call_finalizers
 from privacyidea.lib.resolver import (save_resolver, delete_resolver,
                                       get_resolver_list)
 from privacyidea.models import db, Challenge, AuthenticationLog, ConditionalAccessOutcome
-from privacyidea.models.conditional_access_policy import BlockList, UserLockState
+from privacyidea.models.conditional_access_policy import (BlockList, ConditionalAccessPolicy,
+                                                          ConditionalAccessPolicyStage, UserLockState)
 from privacyidea.models.utils import utc_now
 from .base import CliTestCase
 from ..base import PWFILE
@@ -1179,3 +1182,144 @@ class PIManageConditionalAccessTestCase(CliTestCase):
         res = runner.invoke(pi_manage, ["conditionalaccess", "purge-expired-locks"])
         self.assertIn("Removed 1 stale user lock(s).", res.output, res)
         self.assertEqual(1, UserLockState.query.count())
+
+
+class PIManageConditionalAccessPolicyTestCase(CliTestCase):
+    """
+    Tests for the ``pi-manage conditionalaccess`` policy commands — the escape hatch for
+    switching off a policy that is refusing everybody, without the WebUI.
+    """
+
+    def tearDown(self):
+        # Deleted through the ORM, so the stage/action/counter-type children go with the policy: a bulk
+        # delete would leave them behind (SQLite does not enforce the FK cascade) and the next test's
+        # policy would collide with them.
+        for policy in ConditionalAccessPolicy.query.all():
+            db.session.delete(policy)
+        db.session.commit()
+        super().tearDown()
+
+    @staticmethod
+    def _create_policy(name="lockdown", priority=1, enabled=True, dry_run=False,
+                       threshold=0, action=ConditionalAccessAction.DENY) -> int:
+        return create_conditional_access_policy(
+            name=name, time_window_seconds=3600,
+            counter_types_to_track=[str(AuthEventType.PASSWORD_FAIL)],
+            stages=[{"failure_threshold": threshold,
+                     "actions": [{"action_type": str(action), "action_value": None}]}],
+            target=ConditionalAccessTarget.USER, priority=priority,
+            enabled=enabled, dry_run=dry_run)
+
+    def test_01_help_lists_policy_subcommands(self):
+        runner = self.app.test_cli_runner()
+        res = runner.invoke(pi_manage, ["conditionalaccess"])
+        for command in ("list-policies", "enable-policy", "disable-policy",
+                        "enable-dry-run", "disable-dry-run", "delete-policy"):
+            self.assertIn(command, res.output, res)
+
+    def test_02_list_policies(self):
+        runner = self.app.test_cli_runner()
+        res = runner.invoke(pi_manage, ["conditionalaccess", "list-policies"])
+        self.assertIn("No conditional-access policies.", res.output, res)
+
+        policy_id = self._create_policy(priority=7)
+        res = runner.invoke(pi_manage, ["conditionalaccess", "list-policies"])
+        self.assertEqual(0, res.exit_code, res.output)
+        self.assertIn("Name", res.output, res)
+        rows = [line for line in res.output.splitlines() if line.startswith("lockdown")]
+        self.assertEqual(1, len(rows), res.output)
+        self.assertListEqual(["lockdown", str(policy_id), "yes", "no", "7", "user"], rows[0].split())
+
+    def test_03_list_policies_in_evaluation_order(self):
+        runner = self.app.test_cli_runner()
+        self._create_policy(name="second", priority=20)
+        self._create_policy(name="first", priority=10)
+        res = runner.invoke(pi_manage, ["conditionalaccess", "list-policies"])
+        self.assertLess(res.output.index("first"), res.output.index("second"), res.output)
+
+    def test_04_disable_and_enable_policy_by_name(self):
+        runner = self.app.test_cli_runner()
+        policy_id = self._create_policy()
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", "lockdown"])
+        self.assertEqual(0, res.exit_code, res.output)
+        self.assertIn(f"Disabled conditional-access policy 'lockdown' (id {policy_id}).", res.output, res)
+        self.assertFalse(db.session.get(ConditionalAccessPolicy, policy_id).enabled)
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", "lockdown"])
+        self.assertIn("is already disabled", res.output, res)
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "enable-policy", "lockdown"])
+        self.assertIn(f"Enabled conditional-access policy 'lockdown' (id {policy_id}).", res.output, res)
+        self.assertTrue(db.session.get(ConditionalAccessPolicy, policy_id).enabled)
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "enable-policy", "lockdown"])
+        self.assertIn("is already enabled", res.output, res)
+
+    def test_05_disable_policy_by_id(self):
+        runner = self.app.test_cli_runner()
+        policy_id = self._create_policy()
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", str(policy_id)])
+        self.assertEqual(0, res.exit_code, res.output)
+        self.assertFalse(db.session.get(ConditionalAccessPolicy, policy_id).enabled)
+
+    def test_06_numeric_name_wins_over_the_id(self):
+        # A policy may legitimately be named "1"; the name must not be shadowed by another policy's id.
+        runner = self.app.test_cli_runner()
+        by_id = self._create_policy(name="by-id", priority=1)
+        by_name = self._create_policy(name=str(by_id), priority=2)
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", str(by_id)])
+        self.assertEqual(0, res.exit_code, res.output)
+        self.assertFalse(db.session.get(ConditionalAccessPolicy, by_name).enabled)
+        self.assertTrue(db.session.get(ConditionalAccessPolicy, by_id).enabled)
+
+    def test_07_unknown_policy_fails(self):
+        runner = self.app.test_cli_runner()
+        for identifier in ("ghost", "4711"):
+            res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", identifier])
+            self.assertEqual(1, res.exit_code, res.output)
+            self.assertIn(f"No conditional-access policy with the name or id '{identifier}'", res.output, res)
+
+    def test_08_toggle_dry_run(self):
+        runner = self.app.test_cli_runner()
+        policy_id = self._create_policy()
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "enable-dry-run", "lockdown"])
+        self.assertEqual(0, res.exit_code, res.output)
+        self.assertIn("is now in dry run", res.output, res)
+        self.assertTrue(db.session.get(ConditionalAccessPolicy, policy_id).dry_run)
+        # Dry run leaves the policy enabled: it is still evaluated and logged, just not enforced.
+        self.assertTrue(db.session.get(ConditionalAccessPolicy, policy_id).enabled)
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "enable-dry-run", "lockdown"])
+        self.assertIn("is already in dry run", res.output, res)
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-dry-run", "lockdown"])
+        self.assertIn("is no longer in dry run", res.output, res)
+        self.assertFalse(db.session.get(ConditionalAccessPolicy, policy_id).dry_run)
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-dry-run", "lockdown"])
+        self.assertIn("is not in dry run", res.output, res)
+
+    def test_09_delete_policy(self):
+        runner = self.app.test_cli_runner()
+        policy_id = self._create_policy()
+
+        # Without --yes the confirmation aborts, and the policy survives.
+        res = runner.invoke(pi_manage, ["conditionalaccess", "delete-policy", "lockdown"], input="n\n")
+        self.assertEqual(1, res.exit_code, res.output)
+        self.assertIsNotNone(db.session.get(ConditionalAccessPolicy, policy_id))
+
+        res = runner.invoke(pi_manage, ["conditionalaccess", "delete-policy", "lockdown", "--yes"])
+        self.assertEqual(0, res.exit_code, res.output)
+        self.assertIn(f"Deleted conditional-access policy 'lockdown' (id {policy_id}).", res.output, res)
+        self.assertIsNone(db.session.get(ConditionalAccessPolicy, policy_id))
+
+    def test_10_delete_policy_removes_stages_and_actions(self):
+        runner = self.app.test_cli_runner()
+        policy_id = self._create_policy()
+        stage_ids = [stage.id for stage in db.session.get(ConditionalAccessPolicy, policy_id).stages]
+        res = runner.invoke(pi_manage, ["conditionalaccess", "delete-policy", str(policy_id), "--yes"])
+        self.assertEqual(0, res.exit_code, res.output)
+        self.assertEqual(0, ConditionalAccessPolicyStage.query.filter(
+            ConditionalAccessPolicyStage.id.in_(stage_ids)).count())

--- a/tests/cli/test_cli_pimanage.py
+++ b/tests/cli/test_cli_pimanage.py
@@ -1259,28 +1259,55 @@ class PIManageConditionalAccessPolicyTestCase(CliTestCase):
     def test_05_disable_policy_by_id(self):
         runner = self.app.test_cli_runner()
         policy_id = self._create_policy()
-        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", str(policy_id)])
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", "--id", str(policy_id)])
         self.assertEqual(0, res.exit_code, res.output)
         self.assertFalse(db.session.get(ConditionalAccessPolicy, policy_id).enabled)
 
-    def test_06_numeric_name_wins_over_the_id(self):
-        # A policy may legitimately be named "1"; the name must not be shadowed by another policy's id.
+    def test_06_numeric_name_is_never_taken_for_an_id(self):
+        # A policy may legitimately be named "1" while another policy has the id 1. The argument is always a
+        # name and --id is always an id, so neither spelling can address the other's policy.
         runner = self.app.test_cli_runner()
         by_id = self._create_policy(name="by-id", priority=1)
         by_name = self._create_policy(name=str(by_id), priority=2)
+
         res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", str(by_id)])
         self.assertEqual(0, res.exit_code, res.output)
         self.assertFalse(db.session.get(ConditionalAccessPolicy, by_name).enabled)
         self.assertTrue(db.session.get(ConditionalAccessPolicy, by_id).enabled)
 
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", "--id", str(by_id)])
+        self.assertEqual(0, res.exit_code, res.output)
+        self.assertFalse(db.session.get(ConditionalAccessPolicy, by_id).enabled)
+
     def test_07_unknown_policy_fails(self):
         runner = self.app.test_cli_runner()
-        for identifier in ("ghost", "4711"):
-            res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", identifier])
-            self.assertEqual(1, res.exit_code, res.output)
-            self.assertIn(f"No conditional-access policy with the name or id '{identifier}'", res.output, res)
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", "ghost"])
+        self.assertEqual(1, res.exit_code, res.output)
+        self.assertIn("No conditional-access policy with the name 'ghost'.", res.output, res)
 
-    def test_08_toggle_dry_run(self):
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", "--id", "4711"])
+        self.assertEqual(1, res.exit_code, res.output)
+        self.assertIn("No conditional-access policy with the id 4711.", res.output, res)
+
+    def test_08_missing_name_points_at_the_id_option(self):
+        # A numeric argument is a name, not an id; the error says how to ask for the id instead.
+        runner = self.app.test_cli_runner()
+        res = runner.invoke(pi_manage, ["conditionalaccess", "disable-policy", "4711"])
+        self.assertEqual(1, res.exit_code, res.output)
+        self.assertIn("No conditional-access policy with the name '4711'.", res.output, res)
+        self.assertIn("If you meant the id, use '--id 4711'.", res.output, res)
+
+    def test_09_selector_must_be_unambiguous(self):
+        runner = self.app.test_cli_runner()
+        policy_id = self._create_policy()
+        for args in (["conditionalaccess", "disable-policy"],
+                     ["conditionalaccess", "disable-policy", "lockdown", "--id", str(policy_id)]):
+            res = runner.invoke(pi_manage, args)
+            self.assertEqual(2, res.exit_code, res.output)
+            self.assertIn("Give either the policy NAME or --id, not both.", res.output, res)
+        self.assertTrue(db.session.get(ConditionalAccessPolicy, policy_id).enabled)
+
+    def test_10_toggle_dry_run(self):
         runner = self.app.test_cli_runner()
         policy_id = self._create_policy()
 
@@ -1301,7 +1328,7 @@ class PIManageConditionalAccessPolicyTestCase(CliTestCase):
         res = runner.invoke(pi_manage, ["conditionalaccess", "disable-dry-run", "lockdown"])
         self.assertIn("is not in dry run", res.output, res)
 
-    def test_09_delete_policy(self):
+    def test_11_delete_policy(self):
         runner = self.app.test_cli_runner()
         policy_id = self._create_policy()
 
@@ -1315,11 +1342,11 @@ class PIManageConditionalAccessPolicyTestCase(CliTestCase):
         self.assertIn(f"Deleted conditional-access policy 'lockdown' (id {policy_id}).", res.output, res)
         self.assertIsNone(db.session.get(ConditionalAccessPolicy, policy_id))
 
-    def test_10_delete_policy_removes_stages_and_actions(self):
+    def test_12_delete_policy_removes_stages_and_actions(self):
         runner = self.app.test_cli_runner()
         policy_id = self._create_policy()
         stage_ids = [stage.id for stage in db.session.get(ConditionalAccessPolicy, policy_id).stages]
-        res = runner.invoke(pi_manage, ["conditionalaccess", "delete-policy", str(policy_id), "--yes"])
+        res = runner.invoke(pi_manage, ["conditionalaccess", "delete-policy", "--id", str(policy_id), "--yes"])
         self.assertEqual(0, res.exit_code, res.output)
         self.assertEqual(0, ConditionalAccessPolicyStage.query.filter(
             ConditionalAccessPolicyStage.id.in_(stage_ids)).count())


### PR DESCRIPTION
###  A threshold-0 DENY policy has no supported recovery path

Validation deliberately permits `failure_threshold: 0` for `DENY` and documents
it as "the lockdown idiom". The same docstring names the consequence: "a `DENY`
writes no state, so no `pi-manage conditionalaccess` reset command can lift it".

Confirmed against the CLI: `pi-manage conditionalaccess` has nine commands and
every one is about *state* — blocks and locks. There is **no policy command at
all**: no list, no enable, no disable, no delete. So one POST creating an
unscoped threshold-0 DENY locks out every user and every administrator, and the
only supported recovery is direct SQL.

Contrast the rest of the design: locks and blocks all have CLI recovery, and the
IP allowlist lives in `pi.cfg` precisely so a mistaken policy cannot be
self-inflicted. `DENY` has neither. Mitigating: no shipped template uses
threshold 0 (the DENY templates sit at 10, 20 and 30), so it must be
hand-crafted. A `disable-policy` / `list-policies` pair closes it with no design
questions.

