### PR TITLE
Back up and restore PostgreSQL databases

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -179,14 +179,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mariadb-client
 
+      # pi-manage backup shells out to pg_dump/psql, which refuse to work with a
+      # server newer than themselves. The client Ubuntu ships is older than the
+      # PostgreSQL service container above, so the client is installed from the
+      # PostgreSQL project's own repository -- keep the major version below in
+      # sync with the image of the postgresql service.
+      - name: Install PostgreSQL client for backup round-trip
+        if: startsWith(matrix.db.label, 'PostgreSQL')
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+
       # Fail loudly if a dump client is missing, so the round-trip below runs for real
       # instead of self-skipping.
       - name: Verify a dump client is present
         if: startsWith(matrix.db.label, 'MariaDB') || startsWith(matrix.db.label, 'MySQL')
         run: mysqldump --version
 
+      - name: Verify the PostgreSQL dump client is present
+        if: startsWith(matrix.db.label, 'PostgreSQL')
+        run: pg_dump --version
+
       - name: Run backup/restore round-trip test
-        if: startsWith(matrix.db.label, 'MariaDB') || startsWith(matrix.db.label, 'MySQL')
+        if: startsWith(matrix.db.label, 'MariaDB') || startsWith(matrix.db.label, 'MySQL') || startsWith(matrix.db.label, 'PostgreSQL')
         env:
           TEST_DATABASE_URL: ${{ matrix.db.db_url }}
           PYTHONWARNINGS: "once::DeprecationWarning"

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -27,6 +27,14 @@ on:
       - 'requirements.txt'
       - '.github/workflows/migration-tests.yml'
       - '.github/python-versions.env'
+  schedule:
+    # 03:00 UTC, after the 02:00 unit-test runs, so the two do not compete for
+    # runners. The path filter above only catches a pull request that touches
+    # the migrations or the backup command itself; a change anywhere else that
+    # breaks them - the app setup they go through, a dependency bump, a new
+    # model - would go unnoticed until the next such pull request. The nightly
+    # run is what turns these tests into a standing signal.
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 permissions:
@@ -303,3 +311,27 @@ jobs:
           PYTHONWARNINGS: "once::DeprecationWarning"
         run: |
           python -b -m pytest -v --tb=short -m backup tests/cli/test_backup_roundtrip.py
+
+  notify-failure:
+    needs: [ migration-tests, galera-migration-tests ]
+    # Surface nightly breakage as a GitHub issue. Scheduled runs only — pull
+    # request failures already show up as checks. Runs when any job failed.
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read # for actions/checkout to reach the local composite action
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/notify-nightly-failure
+        with:
+          title: Nightly migration and backup tests failed on master
+          body: |
+            The nightly migration / backup round-trip run failed on master.
+
+            Commit: ${{ github.sha }}
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit-tests-redis.yml
+++ b/.github/workflows/unit-tests-redis.yml
@@ -10,9 +10,10 @@
 # is independent of the Python version, so a per-version matrix would only add
 # redundant runs. The DB-only matrix lives in the MariaDB/Postgres workflows.
 # Migration tests are excluded - they have their own dedicated workflow. Backup
-# round-trip tests are excluded too: they dump the database via mysqldump and
-# exercise nothing on the Redis path, so they add no signal here (the DB-only
-# MariaDB job already covers them).
+# round-trip tests are excluded too: they dump the database with the client
+# commands of the respective engine and exercise nothing on the Redis path, so
+# they add no signal here (the migration workflow covers them, and it is the
+# only one that installs those clients).
 
 name: Unit Tests Redis
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -189,10 +189,17 @@ jobs:
         # the intra-file ordering the unittest-style suite currently relies on.
         # Collect coverage only on the lowest Python version to avoid redundant
         # reports and reduce overhead on all other matrix jobs.
+        # Migration tests are excluded - they have their own workflow. So are
+        # the backup round-trip tests: they shell out to the dump and restore
+        # commands of the database, which only the migration workflow installs
+        # in the version matching its service container. Whatever client the
+        # runner image happens to carry would either refuse to work (pg_dump
+        # rejects a server newer than itself) or be the wrong one for the
+        # server (the preinstalled MySQL dumper against a MariaDB service).
         if [ "$COVERAGE" = "true" ] && [ "$PYTHON_VERSION" = "$MIN_PYTHON_VERSION" ]; then
-          python -b -m pytest -v -n "$WORKERS" --dist=loadfile --cov=privacyidea --cov-report=xml -m "not migration" tests/
+          python -b -m pytest -v -n "$WORKERS" --dist=loadfile --cov=privacyidea --cov-report=xml -m "not migration and not backup" tests/
         else
-          python -b -m pytest -v -n "$WORKERS" --dist=loadfile -m "not migration" tests/
+          python -b -m pytest -v -n "$WORKERS" --dist=loadfile -m "not migration and not backup" tests/
         fi
 
     - name: Codecov upload

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -17,6 +17,26 @@ services:
       timeout: 5s
       retries: 10
 
+  mariadb-lts-test:
+    # DB URI: mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3307/privacyidea_test
+    # 10.11 is the maintained 10.x LTS (and the version Ubuntu 24.04 ships), so
+    # it is the 10.x most installations run.
+    image: mariadb:10.11
+    container_name: pi-mariadb-lts-test
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: privacyidea_test
+      MARIADB_USER: privacyidea
+      MARIADB_PASSWORD: privacyidea
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   mysql-test:
     # DB URI: mysql+pymysql://privacyidea:privacyidea@127.0.0.1:3308/privacyidea_test
     image: mysql:8.4

--- a/doc/installation/system/pi-manage.rst
+++ b/doc/installation/system/pi-manage.rst
@@ -69,6 +69,64 @@ the backup or not.
 As the backup contains the etc directory and the database you only need this
 tar archive backup to perform a complete restore.
 
+Supported databases
+~~~~~~~~~~~~~~~~~~~
+
+SQLite, MySQL/MariaDB and PostgreSQL are supported. The database is dumped and
+restored with the command line tools of the respective database, which have to
+be installed on the privacyIDEA machine:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Database
+     - Commands used
+     - Debian/Ubuntu package
+   * - SQLite
+     - none, the database file is copied
+     - --
+   * - MySQL/MariaDB
+     - ``mysqldump``, ``mysql``
+     - *mariadb-client* or *mysql-client*
+   * - PostgreSQL
+     - ``pg_dump``, ``psql``
+     - *postgresql-client*
+
+For PostgreSQL the client has to be at least as new as the server it connects
+to. Dumping a PostgreSQL 17 server with the ``pg_dump`` of an older major
+version fails, so install the *postgresql-client-<version>* package that
+matches your server.
+
+Restoring
+~~~~~~~~~
+
+The restore overwrites the contents of the database the restored *pi.cfg*
+points to::
+
+   pi-manage backup restore /var/lib/privacyidea/backup/privacyidea-backup-<date>.tgz
+
+It does not create the database: the database and the database user have to
+exist already, as they do on a machine that has been set up before. Only the
+contents are replaced.
+
+.. note:: The archive also contains the *pi.cfg* of the machine the backup was
+   taken on, including its ``SQLALCHEMY_DATABASE_URI``. If you restore onto a
+   machine whose database is reached under a different URI, use
+   ``--keep-db-uri`` to keep the URI of the running installation instead of
+   the one from the backup.
+
+.. warning:: On MySQL/MariaDB the dump contains the name of the database it was
+   taken from and creates that database if it is missing, so the restore always
+   writes into a database of that name - also with ``--keep-db-uri``, which
+   only changes the server, the credentials and the port that are connected to.
+   Restore a MySQL/MariaDB backup only into an installation that uses the same
+   database name, otherwise the data ends up in a newly created copy of the
+   original database while the configured one stays untouched.
+
+A backup can only be restored into the database it was taken from: a dump
+written by one database cannot be read by another one. Restoring an archive
+onto an installation using a different database aborts with an error.
+
 
 Rotate Audit Log
 ----------------

--- a/privacyidea/cli/pimanage/backup.py
+++ b/privacyidea/cli/pimanage/backup.py
@@ -21,21 +21,65 @@ import configparser
 import os
 import pathlib
 import re
-import shlex
 import shutil
 import subprocess
 import sys
 import tarfile
 from datetime import datetime
-from urllib.parse import urlparse
+from typing import IO, NoReturn
 
 import click
 from dateutil.tz import tzlocal
 from flask import current_app
 from flask.cli import AppGroup
 from flask.config import Config
+from sqlalchemy.engine.url import URL, make_url
+from sqlalchemy.exc import ArgumentError
 
-MYSQL_DIALECTS = ["mysql", "pymysql", "mysql+pymysql", "mariadb+pymysql"]
+SQLITE = "sqlite"
+MYSQL = "mysql"
+POSTGRESQL = "postgresql"
+
+# Backup implementation per SQLAlchemy backend name (the part of the URI before
+# the "+"), so every driver of a supported engine is recognised.
+BACKEND_FAMILIES = {
+    "sqlite": SQLITE,
+    "mysql": MYSQL,
+    "mariadb": MYSQL,
+    "postgresql": POSTGRESQL,
+    "postgres": POSTGRESQL,
+}
+
+FAMILY_NAMES = {SQLITE: "SQLite", MYSQL: "MySQL/MariaDB", POSTGRESQL: "PostgreSQL"}
+
+# The client packages providing the dump/restore commands, used in error messages.
+CLIENT_PACKAGES = {MYSQL: "mariadb-client (or mysql-client)", POSTGRESQL: "postgresql-client"}
+
+# Suffix of the database dump inside the backup archive. The suffix records which
+# engine wrote the dump, so a restore can refuse to feed it to a different one.
+# ".sql" and ".sqlite" are the names earlier versions wrote and stay unchanged.
+DUMP_SUFFIXES = {SQLITE: ".sqlite", MYSQL: ".sql", POSTGRESQL: ".pgsql"}
+DUMP_FAMILIES = {suffix: family for family, suffix in DUMP_SUFFIXES.items()}
+DUMP_FILE_PATTERN = re.compile(r"dbdump-\d{8}-\d{4}(?P<suffix>\.sqlite|\.pgsql|\.sql)$")
+
+# libpq environment variables for the connection parameters that can appear in
+# the query part of a PostgreSQL URI. Parameters outside this mapping are
+# reported as ignored instead of being dropped silently.
+POSTGRESQL_ENV_PARAMS = {
+    "host": "PGHOST",
+    "port": "PGPORT",
+    "sslmode": "PGSSLMODE",
+    "sslrootcert": "PGSSLROOTCERT",
+    "sslcert": "PGSSLCERT",
+    "sslkey": "PGSSLKEY",
+    "sslcrl": "PGSSLCRL",
+    "gssencmode": "PGGSSENCMODE",
+    "channel_binding": "PGCHANNELBINDING",
+    "application_name": "PGAPPNAME",
+    "connect_timeout": "PGCONNECT_TIMEOUT",
+    "options": "PGOPTIONS",
+    "target_session_attrs": "PGTARGETSESSIONATTRS",
+}
 
 backup_cli = AppGroup("backup", help="Create/Restore database backup of privacyIDEA installation")
 
@@ -67,6 +111,10 @@ def backup_create(backup_dir, config_dir, radius_dir, enckey):
 
     You can also include a given FreeRADIUS configuration into the backup.
     Just specify a directory using 'radius_dir'.
+
+    SQLite, MySQL/MariaDB and PostgreSQL databases are supported. Dumping a
+    MySQL/MariaDB or a PostgreSQL database requires the client commands of the
+    respective engine (mysqldump, or pg_dump) to be installed.
     """
     # TODO: Add requirement for the config file and remove app initialization.
     #  Currently, when calling this function, the Flask app gets initialized
@@ -90,46 +138,18 @@ def backup_create(backup_dir, config_dir, radius_dir, enckey):
         enc_file_stat = enc_file.stat()
         shutil.chown(directory, user=enc_file_stat.st_uid, group=enc_file_stat.st_gid)
 
-    sqlfile = directory.joinpath(f"dbdump-{cur_date}.sql")
+    url = _database_url(current_app.config.get("SQLALCHEMY_DATABASE_URI"))
+    family = _backend_family(url)
+
     backup_file = directory.joinpath(f"{base_name}-{cur_date}.tgz")
+    sqlfile = directory.joinpath(f"dbdump-{cur_date}{DUMP_SUFFIXES[family]}")
 
-    parsed_sqluri = urlparse(current_app.config.get("SQLALCHEMY_DATABASE_URI"))
-    sqltype = parsed_sqluri.scheme
-
-    if sqltype == "sqlite":
-        productive_file = parsed_sqluri.path
-        click.echo(f"Backup SQLite file {productive_file}")
-        sqlfile = directory.joinpath(f"dbdump-{cur_date}.sqlite")
-        shutil.copyfile(productive_file, sqlfile)
-    elif sqltype in MYSQL_DIALECTS:
-        database = parsed_sqluri.path[1:]
-        defaults_file = conf_dir.joinpath("mysql.cnf")
-        _write_mysql_defaults(defaults_file, parsed_sqluri)
-        # call mysqldump to get a copy of the database.
-        # --single-transaction dumps a consistent InnoDB snapshot without taking
-        # table locks. The default (LOCK TABLES) path fails on a MariaDB Galera
-        # cluster, which rejects locking the SEQUENCE objects privacyIDEA creates
-        # ("This version of MariaDB doesn't yet support 'LOCK TABLE on SEQUENCES
-        # in Galera cluster'"). --skip-lock-tables is already implied by
-        # --single-transaction and is passed only as an explicit safeguard.
-        cmd = ['mysqldump', f'--defaults-file={defaults_file!s}',
-               '--single-transaction', '--skip-lock-tables', '-h',
-               shlex.quote(parsed_sqluri.hostname)]
-        if parsed_sqluri.port:
-            cmd.extend(['-P', str(parsed_sqluri.port)])
-        cmd.extend(['-B', shlex.quote(database), '-r', sqlfile])
-        result = subprocess.run(cmd)  # nosec B603 - fixed argv, no shell
-        if result.returncode != 0:
-            # Never package a partial or empty dump as a successful backup.
-            if sqlfile.exists():
-                sqlfile.unlink()
-            click.secho(
-                f"Database dump failed (mysqldump exit code {result.returncode}); "
-                "no backup file was written.", fg="red")
-            sys.exit(2)
+    if family == SQLITE:
+        _dump_sqlite(url, sqlfile)
+    elif family == MYSQL:
+        _dump_mysql(url, conf_dir, sqlfile)
     else:
-        click.echo(f"unsupported SQL syntax: {sqltype}")
-        sys.exit(2)
+        _dump_postgresql(url, sqlfile)
 
     with tarfile.open(backup_file, "x:gz") as tf:
         tf.add(sqlfile)
@@ -161,7 +181,12 @@ def backup_create(backup_dir, config_dir, radius_dir, enckey):
               help="Keep the current SQLALCHEMY_DATABASE_URI from the live config "
                    "instead of overwriting it with the one stored in the backup.")
 def backup_restore(backup_file, keep_db_uri):
-    """Restore a previously made backup from the BACKUP_FILE"""
+    """Restore a previously made backup from the BACKUP_FILE
+
+    The contents of the target database are overwritten. The database itself is
+    not created: the database and the role connecting to it have to exist
+    already, as they do on a regular privacyIDEA installation.
+    """
     # TODO: Also allow to specify a target directory, otherwise it will always
     #  extract to the base /
     # TODO: extracting the SQLite file does not work if there are other SQLite
@@ -169,16 +194,19 @@ def backup_restore(backup_file, keep_db_uri):
 
     config_file = None
     sqlfile = None
+    dump_family = None
     enckey_contained = False
 
     try:
         with tarfile.open(backup_file, "r:gz") as tf:
             for member in tf:
                 member_name = member.name
+                dump_match = DUMP_FILE_PATTERN.search(member_name)
                 if re.search(r"/pi.cfg$", member_name):
                     config_file = f"/{member_name}"
-                elif re.search(r"dbdump-\d{8}-\d{4}\.sql", member_name):
+                elif dump_match:
                     sqlfile = f"/{member_name}"
+                    dump_family = DUMP_FAMILIES[dump_match.group("suffix")]
                 elif re.search(r"/enc[kK]ey", member_name):
                     enckey_contained = True
     except (tarfile.TarError, OSError) as e:
@@ -260,36 +288,267 @@ def backup_restore(backup_file, keep_db_uri):
         click.secho(f"No SQLALCHEMY_DATABASE_URI found in {config_file}",
                     fg="red")
         sys.exit(2)
-    parsed_sqluri = urlparse(sqluri)
-    sqltype = parsed_sqluri.scheme
-    if sqltype == "sqlite":
-        productive_file = parsed_sqluri.path
-        click.echo(f"Restore SQLite {productive_file}")
-        shutil.copyfile(sqlfile, productive_file)
-        os.unlink(sqlfile)
-    elif sqltype in MYSQL_DIALECTS:
-        database = parsed_sqluri.path[1:]
-        defaults_file = pathlib.Path(config_file).parent.joinpath("mysql.cnf")
-        _write_mysql_defaults(defaults_file, parsed_sqluri)
-        # Rewriting database
-        click.echo("Restoring database.")
-        cmd = ["mysql", f"--defaults-file={defaults_file}",
-               "-h", parsed_sqluri.hostname]
-        if parsed_sqluri.port:
-            cmd.extend(['-P', str(parsed_sqluri.port)])
-        cmd.extend(['-B', shlex.quote(database)])
-        with open(sqlfile) as sql_file:
-            p = subprocess.run(cmd, input=sql_file.read(), text=True)  # nosec B603 - fixed argv, no shell
-        if p.returncode != 0:
-            click.secho(
-                f"Database restore failed (mysql exit code {p.returncode}). "
+
+    url = _database_url(sqluri)
+    family = _backend_family(url)
+    if family != dump_family:
+        # A dump replayed against another engine fails with syntax errors at
+        # best and writes a partial schema at worst.
+        click.secho(f"The backup contains a {FAMILY_NAMES[dump_family]} dump, but the database URI "
+                    f"points to {FAMILY_NAMES[family]}. Restoring across database engines is not "
+                    f"supported. The configuration was restored and the dump was kept at {sqlfile}; "
+                    "the database was not touched.", fg="red")
+        sys.exit(2)
+
+    if family == SQLITE:
+        _restore_sqlite(url, sqlfile)
+    elif family == MYSQL:
+        _restore_mysql(url, config_file.parent, sqlfile)
+    else:
+        _restore_postgresql(url, sqlfile)
+
+
+def _database_url(sqluri: str | None) -> URL:
+    """Parse a database URI into a SQLAlchemy URL, or exit if it is unusable.
+
+    SQLAlchemy is used instead of ``urlparse`` because it knows the driver
+    syntax and percent-decodes username, password and database name.
+    """
+    if not sqluri:
+        click.secho("No database URI configured (SQLALCHEMY_DATABASE_URI).", fg="red")
+        sys.exit(2)
+    try:
+        url = make_url(sqluri)
+    except ArgumentError as e:
+        click.secho(f"Cannot parse the database URI: {e}", fg="red")
+        sys.exit(2)
+    if not url.database:
+        click.secho(f"The database URI contains no database: {url.render_as_string(hide_password=True)}",
+                    fg="red")
+        sys.exit(2)
+    if url.database == ":memory:":
+        click.secho("An in-memory database cannot be backed up or restored.", fg="red")
+        sys.exit(2)
+    return url
+
+
+def _backend_family(url: URL) -> str:
+    """Return the backup implementation to use for a database URL, or exit.
+
+    The backend name is the part of the URI scheme before the "+", so all
+    drivers of an engine (mysql+pymysql, postgresql+psycopg, ...) map to the
+    same family.
+    """
+    family = BACKEND_FAMILIES.get(url.get_backend_name())
+    if not family:
+        click.secho(f"Unsupported database: {url.get_backend_name()}. Backup and restore support "
+                    f"{', '.join(FAMILY_NAMES[f] for f in (SQLITE, MYSQL, POSTGRESQL))}.", fg="red")
+        sys.exit(2)
+    return family
+
+
+def _run_client(cmd: list[str], family: str, env: dict[str, str] | None = None,
+                stdin: IO[bytes] | None = None) -> subprocess.CompletedProcess:
+    """Run a database client command, turning a missing binary into a clear error.
+
+    Without this, an installation lacking the client package fails with a
+    FileNotFoundError traceback instead of telling the admin what to install.
+
+    ``stdin`` is an open binary file the client reads the dump from. Handing
+    over the file itself keeps the dump out of the memory of this process and
+    away from any text decoding, so the size of the database and the encoding
+    the dump was written in do not matter.
+    """
+    try:
+        return subprocess.run(cmd, env=env, stdin=stdin)  # nosec B603 - fixed argv, no shell
+    except FileNotFoundError:
+        click.secho(f"Could not find the '{cmd[0]}' command, which is needed to dump and restore a "
+                    f"{FAMILY_NAMES[family]} database. Install the {CLIENT_PACKAGES[family]} package.",
+                    fg="red")
+        sys.exit(2)
+
+
+def _dump_failed(binary: str, returncode: int, sqlfile: pathlib.Path, hint: str | None = None) -> NoReturn:
+    """Report a failed database dump and exit.
+
+    A partial dump is removed, so it can never be packaged and reported as a
+    successful backup.
+    """
+    if sqlfile.exists():
+        sqlfile.unlink()
+    message = (f"Database dump failed ({binary} exit code {returncode}); "
+               "no backup file was written.")
+    if hint:
+        message = f"{message} {hint}"
+    click.secho(message, fg="red")
+    sys.exit(2)
+
+
+def _restore_failed(binary: str, returncode: int, sqlfile: pathlib.Path) -> NoReturn:
+    """Report a failed database restore and exit, keeping the dump file."""
+    click.secho(f"Database restore failed ({binary} exit code {returncode}). "
                 f"The dump file was kept at {sqlfile} for inspection/retry.",
                 fg="red")
-            sys.exit(2)
-        os.unlink(sqlfile)
-    else:
-        print(f"unsupported SQL syntax: {sqltype}")
-        sys.exit(2)
+    sys.exit(2)
+
+
+def _dump_sqlite(url: URL, sqlfile: pathlib.Path) -> None:
+    click.echo(f"Backup SQLite file {url.database}")
+    shutil.copyfile(url.database, sqlfile)
+
+
+def _restore_sqlite(url: URL, sqlfile: pathlib.Path) -> None:
+    click.echo(f"Restore SQLite {url.database}")
+    shutil.copyfile(sqlfile, url.database)
+    os.unlink(sqlfile)
+
+
+def _mysql_connection_args(url: URL) -> list[str]:
+    """Host and port options shared by mysqldump and mysql.
+
+    Both are omitted for a URI without a host, which connects via the local
+    socket.
+    """
+    args = []
+    if url.host:
+        args.extend(["-h", url.host])
+    if url.port:
+        args.extend(["-P", str(url.port)])
+    return args
+
+
+def _dump_mysql(url: URL, conf_dir: pathlib.Path, sqlfile: pathlib.Path) -> None:
+    defaults_file = conf_dir.joinpath("mysql.cnf")
+    _write_mysql_defaults(defaults_file, url)
+    # call mysqldump to get a copy of the database.
+    # --single-transaction dumps a consistent InnoDB snapshot without taking
+    # table locks. The default (LOCK TABLES) path fails on a MariaDB Galera
+    # cluster, which rejects locking the SEQUENCE objects privacyIDEA creates
+    # ("This version of MariaDB doesn't yet support 'LOCK TABLE on SEQUENCES
+    # in Galera cluster'"). --skip-lock-tables is already implied by
+    # --single-transaction and is passed only as an explicit safeguard.
+    cmd = ["mysqldump", f"--defaults-file={defaults_file!s}",
+           "--single-transaction", "--skip-lock-tables"]
+    cmd.extend(_mysql_connection_args(url))
+    # -B emits CREATE DATABASE IF NOT EXISTS and DROP TABLE IF EXISTS, which is
+    # what makes the dump replayable into a database that still holds the old
+    # schema. It also writes the name of the dumped database into the dump
+    # itself (CREATE DATABASE followed by USE), so a restore always writes into
+    # a database of that name, whatever the target URI says.
+    cmd.extend(["-B", url.database, "-r", str(sqlfile)])
+    result = _run_client(cmd, MYSQL)
+    if result.returncode != 0:
+        _dump_failed("mysqldump", result.returncode, sqlfile)
+
+
+def _restore_mysql(url: URL, conf_dir: pathlib.Path, sqlfile: pathlib.Path) -> None:
+    defaults_file = conf_dir.joinpath("mysql.cnf")
+    _write_mysql_defaults(defaults_file, url)
+    # Rewriting database
+    click.echo("Restoring database.")
+    cmd = ["mysql", f"--defaults-file={defaults_file!s}"]
+    cmd.extend(_mysql_connection_args(url))
+    # -B here is the client's --batch, not mysqldump's --databases. The database
+    # it selects is only a default: the dump's own USE statement takes over.
+    cmd.extend(["-B", url.database])
+    with open(sqlfile, "rb") as sql_file:
+        p = _run_client(cmd, MYSQL, stdin=sql_file)
+    if p.returncode != 0:
+        _restore_failed("mysql", p.returncode, sqlfile)
+    os.unlink(sqlfile)
+
+
+def _postgresql_connection_args(url: URL) -> list[str]:
+    """Connection options shared by pg_dump and psql.
+
+    Host and port are omitted for a URI without them, which connects via the
+    local socket. They are omitted as well when the query part of the URI
+    carries them: SQLAlchemy lets those override the host and port of the URI,
+    so that is where privacyIDEA itself connects, and the backup has to follow.
+    They reach the client through PGHOST/PGPORT instead, which a command line
+    option would take precedence over.
+
+    --no-password makes libpq fail instead of asking for a password, so a
+    missing or wrong password cannot leave a scheduled backup waiting on a
+    prompt forever.
+    """
+    args = []
+    if url.host and not url.query.get("host"):
+        args.extend(["--host", url.host])
+    if url.port and not url.query.get("port"):
+        args.extend(["--port", str(url.port)])
+    if url.username:
+        args.extend(["--username", url.username])
+    args.append("--no-password")
+    return args
+
+
+def _postgresql_env(url: URL) -> dict[str, str]:
+    """Environment for pg_dump and psql.
+
+    The password is passed in the environment rather than on the command line,
+    where it would be visible in the process list, and rather than in a file in
+    the config directory, which would end up inside the backup archive.
+    """
+    env = dict(os.environ)
+    if url.password:
+        env["PGPASSWORD"] = str(url.password)
+    ignored = []
+    for parameter, value in url.query.items():
+        if isinstance(value, tuple):
+            # A parameter given more than once; libpq uses the last occurrence.
+            value = value[-1] if value else None
+        if value is None:
+            continue
+        env_name = POSTGRESQL_ENV_PARAMS.get(parameter)
+        if env_name:
+            env[env_name] = str(value)
+        else:
+            ignored.append(parameter)
+    if ignored:
+        click.secho("The following connection parameters of the database URI are not applied when "
+                    f"dumping or restoring the database: {', '.join(sorted(ignored))}", fg="yellow")
+    return env
+
+
+def _dump_postgresql(url: URL, sqlfile: pathlib.Path) -> None:
+    # --clean --if-exists drops every object before recreating it, which is what
+    # makes the dump replayable into a database that still holds the old schema.
+    # A plain dump without it only applies to an empty database.
+    # --no-owner/--no-privileges/--no-comments keep the restore working when the
+    # role running it differs from the one the backup was taken with: owners,
+    # privileges and comments are not part of what privacyIDEA manages, but
+    # restoring them requires ownership. A comment on the public schema in
+    # particular is dumped whenever it differs from the server default, and
+    # applying it as a role that does not own the schema fails - which would
+    # abort the whole restore.
+    cmd = ["pg_dump", "--format=plain", "--clean", "--if-exists",
+           "--no-owner", "--no-privileges", "--no-comments"]
+    cmd.extend(_postgresql_connection_args(url))
+    cmd.extend(["--dbname", url.database, "--file", str(sqlfile)])
+    result = _run_client(cmd, POSTGRESQL, env=_postgresql_env(url))
+    if result.returncode != 0:
+        _dump_failed("pg_dump", result.returncode, sqlfile,
+                     hint="pg_dump has to be at least as new as the PostgreSQL server it dumps.")
+
+
+def _restore_postgresql(url: URL, sqlfile: pathlib.Path) -> None:
+    click.echo("Restoring database.")
+    # ON_ERROR_STOP together with --single-transaction makes the restore
+    # all-or-nothing, instead of leaving a half-restored schema behind on the
+    # first failing statement. --no-psqlrc keeps a psqlrc file in the home
+    # directory of the calling user from changing settings mid-restore.
+    # The query results psql would print are the return values of the set_config
+    # and setval calls in the dump, one table per sequence; they are discarded,
+    # while errors and warnings still reach the terminal on stderr.
+    cmd = ["psql", "--quiet", "--no-psqlrc", "--set", "ON_ERROR_STOP=on", "--single-transaction",
+           f"--output={os.devnull}"]
+    cmd.extend(_postgresql_connection_args(url))
+    cmd.extend(["--dbname", url.database, "--file", str(sqlfile)])
+    result = _run_client(cmd, POSTGRESQL, env=_postgresql_env(url))
+    if result.returncode != 0:
+        _restore_failed("psql", result.returncode, sqlfile)
+    os.unlink(sqlfile)
 
 
 def _safe_members(tf, dest):
@@ -326,12 +585,23 @@ def _safe_members(tf, dest):
         yield member
 
 
-def _write_mysql_defaults(defaults_file, parsed_sqluri):
+def _quote_mysql_option(value: str) -> str:
+    """Quote a value for a MySQL option file.
+
+    An unquoted value ends at a '#', which would silently truncate a password
+    containing one, and the option file parser expands backslash escapes inside
+    the value, so a literal backslash has to be doubled.
+    """
+    escaped = str(value).replace("\\", "\\\\")
+    return f'"{escaped}"'
+
+
+def _write_mysql_defaults(defaults_file: pathlib.Path, url: URL) -> None:
     # create a mysql config file to avoid adding username and password to the command
     sql_defaults = configparser.ConfigParser(interpolation=None)
     sql_defaults['client'] = {
-        "user": str(parsed_sqluri.username or ""),
-        "password": str(parsed_sqluri.password or "")
+        "user": _quote_mysql_option(url.username or ""),
+        "password": _quote_mysql_option(url.password or "")
     }
     sql_defaults['mysqldump'] = {"no-tablespaces": "True"}
     with defaults_file.open(mode="w") as f:

--- a/privacyidea/cli/pimanage/backup.py
+++ b/privacyidea/cli/pimanage/backup.py
@@ -63,12 +63,14 @@ DUMP_SUFFIXES = {SQLITE: ".sqlite", MYSQL: ".sql", POSTGRESQL: ".pgsql"}
 DUMP_FAMILIES = {suffix: family for family, suffix in DUMP_SUFFIXES.items()}
 DUMP_FILE_PATTERN = re.compile(r"dbdump-\d{8}-\d{4}(?P<suffix>\.sqlite|\.pgsql|\.sql)$")
 
-# libpq environment variables for the connection parameters that can appear in
-# the query part of a PostgreSQL URI. Parameters outside this mapping are
-# reported as ignored instead of being dropped silently.
+# The connection parameters that pg_dump and psql take as a command line
+# option; everything else has to reach them through the environment.
+POSTGRESQL_COMMAND_LINE_PARAMS = frozenset(["host", "port", "user", "password", "dbname"])
+
+# libpq environment variables for the connection parameters that have no
+# command line option. Parameters outside this mapping are reported as ignored
+# instead of being dropped silently.
 POSTGRESQL_ENV_PARAMS = {
-    "host": "PGHOST",
-    "port": "PGPORT",
     "sslmode": "PGSSLMODE",
     "sslrootcert": "PGSSLROOTCERT",
     "sslcert": "PGSSLCERT",
@@ -464,47 +466,58 @@ def _restore_mysql(url: URL, sqlfile: pathlib.Path) -> None:
     os.unlink(sqlfile)
 
 
-def _postgresql_connection_args(url: URL) -> list[str]:
+def _postgresql_driver_parameters(url: URL) -> dict:
+    """The connection parameters psycopg2 would use for this URI.
+
+    Asking the dialect instead of reading the fields of the URI keeps the client
+    on the database privacyIDEA itself talks to, whatever shape the URI has: the
+    query part can override the host and the port of the URI, and a host given
+    more than once turns into the comma separated multi-host list of libpq,
+    together with the matching list of ports. Both are assembled here by the
+    same code that builds the connection of the application.
+
+    The keys are libpq connection keywords; host, port, user, password and
+    dbname become command line options, the rest are passed in the environment.
+    """
+    return url.get_dialect()().create_connect_args(url)[1]
+
+
+def _postgresql_connection_args(parameters: dict) -> list[str]:
     """Connection options shared by pg_dump and psql.
 
-    Host and port are omitted for a URI without them, which connects via the
-    local socket. They are omitted as well when the query part of the URI
-    carries them: SQLAlchemy lets those override the host and port of the URI,
-    so that is where privacyIDEA itself connects, and the backup has to follow.
-    They reach the client through PGHOST/PGPORT instead, which a command line
-    option would take precedence over.
+    Host and port are omitted for a URI that has neither, which connects over
+    the local socket.
 
     --no-password makes libpq fail instead of asking for a password, so a
     missing or wrong password cannot leave a scheduled backup waiting on a
     prompt forever.
     """
     args = []
-    if url.host and not url.query.get("host"):
-        args.extend(["--host", url.host])
-    if url.port and not url.query.get("port"):
-        args.extend(["--port", str(url.port)])
-    if url.username:
-        args.extend(["--username", url.username])
+    if parameters.get("host"):
+        args.extend(["--host", str(parameters["host"])])
+    if parameters.get("port"):
+        args.extend(["--port", str(parameters["port"])])
+    if parameters.get("user"):
+        args.extend(["--username", str(parameters["user"])])
     args.append("--no-password")
     return args
 
 
-def _postgresql_env(url: URL) -> dict[str, str]:
+def _postgresql_env(parameters: dict) -> dict[str, str]:
     """Environment for pg_dump and psql.
 
     The password is passed in the environment rather than on the command line,
     where it would be visible in the process list, and rather than in a file in
-    the config directory, which would end up inside the backup archive.
+    the config directory, which would end up inside the backup archive. The
+    remaining connection parameters have no command line option and reach the
+    client as the libpq variable of the same meaning.
     """
     env = dict(os.environ)
-    if url.password:
-        env["PGPASSWORD"] = str(url.password)
+    if parameters.get("password"):
+        env["PGPASSWORD"] = str(parameters["password"])
     ignored = []
-    for parameter, value in url.query.items():
-        if isinstance(value, tuple):
-            # A parameter given more than once; libpq uses the last occurrence.
-            value = value[-1] if value else None
-        if value is None:
+    for parameter, value in parameters.items():
+        if parameter in POSTGRESQL_COMMAND_LINE_PARAMS or value is None:
             continue
         env_name = POSTGRESQL_ENV_PARAMS.get(parameter)
         if env_name:
@@ -528,11 +541,12 @@ def _dump_postgresql(url: URL, sqlfile: pathlib.Path) -> None:
     # particular is dumped whenever it differs from the server default, and
     # applying it as a role that does not own the schema fails - which would
     # abort the whole restore.
+    parameters = _postgresql_driver_parameters(url)
     cmd = ["pg_dump", "--format=plain", "--clean", "--if-exists",
            "--no-owner", "--no-privileges", "--no-comments"]
-    cmd.extend(_postgresql_connection_args(url))
-    cmd.extend(["--dbname", url.database, "--file", str(sqlfile)])
-    result = _run_client(cmd, POSTGRESQL, env=_postgresql_env(url))
+    cmd.extend(_postgresql_connection_args(parameters))
+    cmd.extend(["--dbname", str(parameters["dbname"]), "--file", str(sqlfile)])
+    result = _run_client(cmd, POSTGRESQL, env=_postgresql_env(parameters))
     if result.returncode != 0:
         _dump_failed("pg_dump", result.returncode, sqlfile,
                      hint="pg_dump has to be at least as new as the PostgreSQL server it dumps.")
@@ -547,11 +561,12 @@ def _restore_postgresql(url: URL, sqlfile: pathlib.Path) -> None:
     # The query results psql would print are the return values of the set_config
     # and setval calls in the dump, one table per sequence; they are discarded,
     # while errors and warnings still reach the terminal on stderr.
+    parameters = _postgresql_driver_parameters(url)
     cmd = ["psql", "--quiet", "--no-psqlrc", "--set", "ON_ERROR_STOP=on", "--single-transaction",
            f"--output={os.devnull}"]
-    cmd.extend(_postgresql_connection_args(url))
-    cmd.extend(["--dbname", url.database, "--file", str(sqlfile)])
-    result = _run_client(cmd, POSTGRESQL, env=_postgresql_env(url))
+    cmd.extend(_postgresql_connection_args(parameters))
+    cmd.extend(["--dbname", str(parameters["dbname"]), "--file", str(sqlfile)])
+    result = _run_client(cmd, POSTGRESQL, env=_postgresql_env(parameters))
     if result.returncode != 0:
         _restore_failed("psql", result.returncode, sqlfile)
     os.unlink(sqlfile)
@@ -596,9 +611,11 @@ def _quote_mysql_option(value: str) -> str:
 
     An unquoted value ends at a '#', which would silently truncate a password
     containing one, and the option file parser expands backslash escapes inside
-    the value, so a literal backslash has to be doubled.
+    the value, so a literal backslash has to be doubled. A '"' has to be escaped
+    as well: it would end the quoted part of the value, and a '#' behind it
+    would start a comment again.
     """
-    escaped = str(value).replace("\\", "\\\\")
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
 
 

--- a/privacyidea/cli/pimanage/backup.py
+++ b/privacyidea/cli/pimanage/backup.py
@@ -25,6 +25,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 from datetime import datetime
 from typing import IO, NoReturn
 
@@ -147,7 +148,8 @@ def backup_create(backup_dir, config_dir, radius_dir, enckey):
     if family == SQLITE:
         _dump_sqlite(url, sqlfile)
     elif family == MYSQL:
-        _dump_mysql(url, conf_dir, sqlfile)
+        _report_obsolete_mysql_defaults(conf_dir)
+        _dump_mysql(url, sqlfile)
     else:
         _dump_postgresql(url, sqlfile)
 
@@ -303,7 +305,8 @@ def backup_restore(backup_file, keep_db_uri):
     if family == SQLITE:
         _restore_sqlite(url, sqlfile)
     elif family == MYSQL:
-        _restore_mysql(url, config_file.parent, sqlfile)
+        _report_obsolete_mysql_defaults(config_file.parent)
+        _restore_mysql(url, sqlfile)
     else:
         _restore_postgresql(url, sqlfile)
 
@@ -417,9 +420,7 @@ def _mysql_connection_args(url: URL) -> list[str]:
     return args
 
 
-def _dump_mysql(url: URL, conf_dir: pathlib.Path, sqlfile: pathlib.Path) -> None:
-    defaults_file = conf_dir.joinpath("mysql.cnf")
-    _write_mysql_defaults(defaults_file, url)
+def _dump_mysql(url: URL, sqlfile: pathlib.Path) -> None:
     # call mysqldump to get a copy of the database.
     # --single-transaction dumps a consistent InnoDB snapshot without taking
     # table locks. The default (LOCK TABLES) path fails on a MariaDB Galera
@@ -427,32 +428,37 @@ def _dump_mysql(url: URL, conf_dir: pathlib.Path, sqlfile: pathlib.Path) -> None
     # ("This version of MariaDB doesn't yet support 'LOCK TABLE on SEQUENCES
     # in Galera cluster'"). --skip-lock-tables is already implied by
     # --single-transaction and is passed only as an explicit safeguard.
-    cmd = ["mysqldump", f"--defaults-file={defaults_file!s}",
-           "--single-transaction", "--skip-lock-tables"]
-    cmd.extend(_mysql_connection_args(url))
-    # -B emits CREATE DATABASE IF NOT EXISTS and DROP TABLE IF EXISTS, which is
-    # what makes the dump replayable into a database that still holds the old
-    # schema. It also writes the name of the dumped database into the dump
-    # itself (CREATE DATABASE followed by USE), so a restore always writes into
-    # a database of that name, whatever the target URI says.
-    cmd.extend(["-B", url.database, "-r", str(sqlfile)])
-    result = _run_client(cmd, MYSQL)
+    with tempfile.TemporaryDirectory() as defaults_dir:
+        defaults_file = pathlib.Path(defaults_dir).joinpath("mysql.cnf")
+        _write_mysql_defaults(defaults_file, url)
+        cmd = ["mysqldump", f"--defaults-file={defaults_file!s}",
+               "--single-transaction", "--skip-lock-tables"]
+        cmd.extend(_mysql_connection_args(url))
+        # -B emits CREATE DATABASE IF NOT EXISTS and DROP TABLE IF EXISTS, which
+        # is what makes the dump replayable into a database that still holds the
+        # old schema. It also writes the name of the dumped database into the
+        # dump itself (CREATE DATABASE followed by USE), so a restore always
+        # writes into a database of that name, whatever the target URI says.
+        cmd.extend(["-B", url.database, "-r", str(sqlfile)])
+        result = _run_client(cmd, MYSQL)
     if result.returncode != 0:
         _dump_failed("mysqldump", result.returncode, sqlfile)
 
 
-def _restore_mysql(url: URL, conf_dir: pathlib.Path, sqlfile: pathlib.Path) -> None:
-    defaults_file = conf_dir.joinpath("mysql.cnf")
-    _write_mysql_defaults(defaults_file, url)
+def _restore_mysql(url: URL, sqlfile: pathlib.Path) -> None:
     # Rewriting database
     click.echo("Restoring database.")
-    cmd = ["mysql", f"--defaults-file={defaults_file!s}"]
-    cmd.extend(_mysql_connection_args(url))
-    # -B here is the client's --batch, not mysqldump's --databases. The database
-    # it selects is only a default: the dump's own USE statement takes over.
-    cmd.extend(["-B", url.database])
-    with open(sqlfile, "rb") as sql_file:
-        p = _run_client(cmd, MYSQL, stdin=sql_file)
+    with tempfile.TemporaryDirectory() as defaults_dir:
+        defaults_file = pathlib.Path(defaults_dir).joinpath("mysql.cnf")
+        _write_mysql_defaults(defaults_file, url)
+        cmd = ["mysql", f"--defaults-file={defaults_file!s}"]
+        cmd.extend(_mysql_connection_args(url))
+        # -B here is the client's --batch, not mysqldump's --databases. The
+        # database it selects is only a default: the dump's own USE statement
+        # takes over.
+        cmd.extend(["-B", url.database])
+        with open(sqlfile, "rb") as sql_file:
+            p = _run_client(cmd, MYSQL, stdin=sql_file)
     if p.returncode != 0:
         _restore_failed("mysql", p.returncode, sqlfile)
     os.unlink(sqlfile)
@@ -594,6 +600,19 @@ def _quote_mysql_option(value: str) -> str:
     """
     escaped = str(value).replace("\\", "\\\\")
     return f'"{escaped}"'
+
+
+def _report_obsolete_mysql_defaults(conf_dir: pathlib.Path) -> None:
+    """Point out the mysql.cnf earlier versions left in the config directory.
+
+    It holds the database password in cleartext and is not used any more, but
+    removing someone else's file in the config directory is not this command's
+    call to make.
+    """
+    obsolete = conf_dir.joinpath("mysql.cnf")
+    if obsolete.exists():
+        click.secho(f"{obsolete} was written by an earlier version, is not used any more and "
+                    "contains the database password in cleartext. You can delete it.", fg="yellow")
 
 
 def _write_mysql_defaults(defaults_file: pathlib.Path, url: URL) -> None:

--- a/tests/cli/test_backup_roundtrip.py
+++ b/tests/cli/test_backup_roundtrip.py
@@ -2,20 +2,20 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-End-to-end backup/restore round-trip against a live MySQL/MariaDB.
+End-to-end backup/restore round-trip against a live MySQL/MariaDB or PostgreSQL.
 
 This drives the real ``pi-manage backup create`` / ``backup restore`` commands:
-it seeds a sentinel row and a (Galera-safe) sequence, creates a backup, simulates
-a disaster by dropping them, restores from the backup, and asserts they came
-back. It guards the backup tooling against drift that unit tests cannot catch —
-e.g. the mysqldump default-locking failure on a MariaDB Galera cluster (which
-needs a real wsrep node to reproduce), or a silently incomplete dump being
+it seeds a sentinel row and a sequence, creates a backup, simulates a disaster
+by dropping them, restores from the backup, and asserts they came back. It
+guards the backup tooling against drift that unit tests cannot catch — e.g. the
+mysqldump default-locking failure on a MariaDB Galera cluster (which needs a
+real wsrep node to reproduce), a PostgreSQL dump that cannot be replayed into a
+database that still holds the old schema, or a silently incomplete dump being
 packaged and reported as success.
 
-The test is gated on a MySQL/MariaDB ``TEST_DATABASE_URL`` *and* on the
-``mysqldump`` client binary being available, so it is skipped where those are
-absent (plain local runs, SQLite/PostgreSQL). PostgreSQL is intentionally not
-covered yet — ``pi-manage backup`` has no ``pg_dump`` path.
+The test is gated on a MySQL/MariaDB or PostgreSQL ``TEST_DATABASE_URL`` *and*
+on the dump client for that engine being available, so it is skipped where
+those are absent (plain local runs, SQLite).
 """
 import os
 import pathlib
@@ -30,15 +30,21 @@ DB_URL = os.environ.get("TEST_DATABASE_URL", "")
 # tests/cli/test_backup_roundtrip.py -> repo root
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
+# The command pi-manage shells out to per engine, which has to be installed for
+# the round trip to run for real instead of self-skipping.
+DUMP_CLIENTS = {"mysql": "mysqldump", "mariadb": "mysqldump", "postgresql": "pg_dump"}
+DUMP_CLIENT = next((binary for prefix, binary in DUMP_CLIENTS.items()
+                    if DB_URL.startswith(prefix)), None)
+
 pytestmark = [
     pytest.mark.backup,
     pytest.mark.skipif(
-        not DB_URL.startswith(("mysql", "mariadb")),
-        reason="backup round-trip needs a MySQL/MariaDB TEST_DATABASE_URL",
+        DUMP_CLIENT is None,
+        reason="backup round-trip needs a MySQL/MariaDB or PostgreSQL TEST_DATABASE_URL",
     ),
     pytest.mark.skipif(
-        shutil.which("mysqldump") is None,
-        reason="mysqldump client binary not available",
+        DUMP_CLIENT is not None and shutil.which(DUMP_CLIENT) is None,
+        reason=f"{DUMP_CLIENT} client binary not available",
     ),
 ]
 
@@ -54,22 +60,33 @@ def _run_pimanage(args, config_file):
 
 def test_backup_restore_roundtrip(tmp_path):
     engine = create_engine(DB_URL)
-    # Real MySQL has no CREATE SEQUENCE at all, unlike MariaDB 10.3+ -- so the
-    # Galera-specific sequence checks below only apply where the dialect
+    # Real MySQL has no CREATE SEQUENCE at all, unlike MariaDB 10.3+ and
+    # PostgreSQL -- so the sequence checks below only apply where the dialect
     # actually supports them. The table/row round trip still runs everywhere.
     with engine.connect() as conn:
         has_sequences = conn.dialect.supports_sequences
+        postgresql = conn.dialect.name == "postgresql"
 
-    # 1. Seed a sentinel table plus, on MariaDB, a sequence. INCREMENT BY 0 is
-    #    required to create a cached sequence on a Galera cluster (and behaves
-    #    like the default increment on a standalone server), so the seed loads
-    #    on both -- and the sequence is exactly what made mysqldump's default
-    #    LOCK TABLES fail on Galera.
+    if postgresql:
+        create_sequence = "CREATE SEQUENCE backup_rt_seq START WITH 7"
+        count_sequence = ("SELECT COUNT(*) FROM information_schema.sequences "
+                          "WHERE sequence_name = 'backup_rt_seq'")
+    else:
+        # INCREMENT BY 0 is required to create a cached sequence on a Galera
+        # cluster (and behaves like the default increment on a standalone
+        # server), so the seed loads on both -- and the sequence is exactly what
+        # made mysqldump's default LOCK TABLES fail on Galera.
+        create_sequence = "CREATE SEQUENCE backup_rt_seq START WITH 7 INCREMENT BY 0"
+        count_sequence = ("SELECT COUNT(*) FROM information_schema.tables "
+                          "WHERE table_schema = DATABASE() AND table_type = 'SEQUENCE' "
+                          "AND table_name = 'backup_rt_seq'")
+
+    # 1. Seed a sentinel table plus, where the engine has them, a sequence.
     with engine.begin() as conn:
         conn.execute(text("DROP TABLE IF EXISTS backup_roundtrip"))
         if has_sequences:
             conn.execute(text("DROP SEQUENCE IF EXISTS backup_rt_seq"))
-            conn.execute(text("CREATE SEQUENCE backup_rt_seq START WITH 7 INCREMENT BY 0"))
+            conn.execute(text(create_sequence))
         conn.execute(text("CREATE TABLE backup_roundtrip (id INTEGER PRIMARY KEY, val VARCHAR(50))"))
         conn.execute(text("INSERT INTO backup_roundtrip (id, val) VALUES (1, 'sentinel')"))
 
@@ -108,18 +125,25 @@ def test_backup_restore_roundtrip(tmp_path):
             ["backup", "restore", "--keep-db-uri", str(archives[0])], pi_cfg)
         assert result.returncode == 0, result.stdout + result.stderr
 
-        # 6. Verify the row (and, on MariaDB, the sequence) are back.
+        # 6. Verify the row and the sequence are back.
         with engine.connect() as conn:
             val = conn.execute(
                 text("SELECT val FROM backup_roundtrip WHERE id = 1")).scalar()
             if has_sequences:
-                seq_count = conn.execute(text(
-                    "SELECT COUNT(*) FROM information_schema.tables "
-                    "WHERE table_schema = DATABASE() AND table_type = 'SEQUENCE' "
-                    "AND table_name = 'backup_rt_seq'")).scalar()
+                seq_count = conn.execute(text(count_sequence)).scalar()
         assert val == "sentinel", f"sentinel row was not restored (got {val!r})"
         if has_sequences:
             assert seq_count == 1, "sequence backup_rt_seq was not restored"
+
+        # 7. Restore a second time, now that the objects exist again. A dump
+        #    that only applies to an empty database would fail here.
+        result = _run_pimanage(
+            ["backup", "restore", "--keep-db-uri", str(archives[0])], pi_cfg)
+        assert result.returncode == 0, result.stdout + result.stderr
+        with engine.connect() as conn:
+            val = conn.execute(
+                text("SELECT val FROM backup_roundtrip WHERE id = 1")).scalar()
+        assert val == "sentinel", f"sentinel row was not restored (got {val!r})"
     finally:
         with engine.begin() as conn:
             conn.execute(text("DROP TABLE IF EXISTS backup_roundtrip"))

--- a/tests/cli/test_cli_pimanage.py
+++ b/tests/cli/test_cli_pimanage.py
@@ -22,6 +22,8 @@ import json
 import os
 import pathlib
 import tempfile
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 import sqlalchemy as sa
@@ -75,8 +77,9 @@ class PIManageBackupTestCase(CliTestCase):
         self.assertIn("--keep-db-uri", result.output, result)
 
     @staticmethod
-    def _make_fake_tarfile(live_pi_cfg, backup_uri,
-                           include_cfg=True, include_sql=True, include_enckey=False):
+    def _make_fake_tarfile(live_pi_cfg: pathlib.Path, backup_uri: str, include_cfg: bool = True,
+                           include_sql: bool = True, include_enckey: bool = False,
+                           dump_suffix: str = ".sqlite") -> Callable:
         """
         Return a context manager that replaces ``tarfile.open`` with a fake
         that simulates:
@@ -92,10 +95,14 @@ class PIManageBackupTestCase(CliTestCase):
 
         The ``backup_restore`` command opens the archive twice (once to list,
         once to extract), so the fake supports both uses.
+
+        ``dump_suffix`` selects the database engine the archive claims to come
+        from, which has to match the engine of ``backup_uri``: ".sqlite" for
+        SQLite, ".sql" for MySQL/MariaDB, ".pgsql" for PostgreSQL.
         """
         import unittest.mock as mock
 
-        sql_file_path = live_pi_cfg.parent / "dbdump-20240101-1200.sql"
+        sql_file_path = live_pi_cfg.parent / f"dbdump-20240101-1200{dump_suffix}"
         cfg_rel = str(live_pi_cfg).lstrip("/")
         sql_rel = str(sql_file_path).lstrip("/")
         enckey_rel = str(live_pi_cfg.parent / "enckey").lstrip("/")
@@ -263,7 +270,7 @@ class PIManageBackupTestCase(CliTestCase):
             self.assertIn("Missing config file pi.cfg", result.output, result.output)
             # The fake's extractall would have created the SQL file; ensure we
             # bailed out before extraction.
-            self.assertFalse((tmp / "dbdump-20240101-1200.sql").exists())
+            self.assertFalse((tmp / "dbdump-20240101-1200.sqlite").exists())
 
     def test_05_missing_sql_file_exits(self):
         """
@@ -288,7 +295,7 @@ class PIManageBackupTestCase(CliTestCase):
 
             self.assertEqual(result.exit_code, 2, result.output)
             self.assertIn("Missing database dump", result.output, result.output)
-            self.assertFalse((tmp / "dbdump-20240101-1200.sql").exists())
+            self.assertFalse((tmp / "dbdump-20240101-1200.sqlite").exists())
 
     def test_06_unreadable_archive_exits(self):
         """
@@ -311,41 +318,63 @@ class PIManageBackupTestCase(CliTestCase):
     def test_07_write_mysql_defaults_handles_missing_password(self):
         """
         A SQLALCHEMY_DATABASE_URI without a password yields
-        parsed.password is None. _write_mysql_defaults must still produce a
+        url.password is None. _write_mysql_defaults must still produce a
         valid mysql defaults file (Python 3.12+ ConfigParser requires string
         values).
         """
         import configparser
-        from urllib.parse import urlparse
+        from sqlalchemy.engine.url import make_url
         from privacyidea.cli.pimanage.backup import _write_mysql_defaults
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             defaults_file = pathlib.Path(tmp_dir) / "mysql.cnf"
-            # URI without password — parsed.password is None
-            parsed = urlparse("mysql+pymysql://privacyidea@127.0.0.1/privacyidea_test")
-            self.assertIsNone(parsed.password)
+            # URI without password — url.password is None
+            url = make_url("mysql+pymysql://privacyidea@127.0.0.1/privacyidea_test")
+            self.assertIsNone(url.password)
 
-            _write_mysql_defaults(defaults_file, parsed)
+            _write_mysql_defaults(defaults_file, url)
 
             cp = configparser.ConfigParser(interpolation=None)
             cp.read(defaults_file)
-            self.assertEqual(cp["client"]["user"], "privacyidea")
-            self.assertEqual(cp["client"]["password"], "")
+            self.assertEqual('"privacyidea"', cp["client"]["user"])
+            self.assertEqual('""', cp["client"]["password"])
 
-        # Passwords containing '%' must be written verbatim — the default
-        # ConfigParser BasicInterpolation would otherwise reject them.
+        # A percent-encoded password reaches the client decoded, and the '%' it
+        # decodes to must be written verbatim — the default ConfigParser
+        # BasicInterpolation would otherwise reject it.
         with tempfile.TemporaryDirectory() as tmp_dir:
             defaults_file = pathlib.Path(tmp_dir) / "mysql.cnf"
-            # urlparse keeps percent-encoding raw, so the value entering
-            # ConfigParser literally contains '%'.
-            parsed = urlparse("mysql+pymysql://privacyidea:ab%25cd@127.0.0.1/privacyidea_test")
-            self.assertEqual(parsed.password, "ab%25cd")
+            url = make_url("mysql+pymysql://privacyidea:ab%25cd@127.0.0.1/privacyidea_test")
+            self.assertEqual("ab%cd", url.password)
 
-            _write_mysql_defaults(defaults_file, parsed)
+            _write_mysql_defaults(defaults_file, url)
 
             cp = configparser.ConfigParser(interpolation=None)
             cp.read(defaults_file)
-            self.assertEqual(cp["client"]["password"], "ab%25cd")
+            self.assertEqual('"ab%cd"', cp["client"]["password"])
+
+    def test_07a_mysql_defaults_quotes_values_for_the_option_file_parser(self):
+        """
+        Values in a MySQL option file are quoted and their backslashes doubled:
+        an unquoted value ends at a '#', which would truncate the password, and
+        the option file parser expands backslash escapes inside the value.
+        """
+        import configparser
+        from sqlalchemy.engine.url import make_url
+        from privacyidea.cli.pimanage.backup import _write_mysql_defaults
+
+        for encoded, quoted in [("ab%23cd", '"ab#cd"'),
+                                ("ab%5Ccd", '"ab\\\\cd"'),
+                                ("ab cd", '"ab cd"')]:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                defaults_file = pathlib.Path(tmp_dir) / "mysql.cnf"
+                url = make_url(f"mysql+pymysql://privacyidea:{encoded}@127.0.0.1/privacyidea_test")
+
+                _write_mysql_defaults(defaults_file, url)
+
+                cp = configparser.ConfigParser(interpolation=None)
+                cp.read(defaults_file)
+                self.assertEqual(quoted, cp["client"]["password"], encoded)
 
     def test_08_backup_create_aborts_on_dump_failure(self):
         """
@@ -418,7 +447,8 @@ class PIManageBackupTestCase(CliTestCase):
 
             runner = self.app.test_cli_runner()
             with mock.patch("privacyidea.cli.pimanage.backup.tarfile.open",
-                            side_effect=self._make_fake_tarfile(live_pi_cfg, backup_uri)):
+                            side_effect=self._make_fake_tarfile(live_pi_cfg, backup_uri,
+                                                                dump_suffix=".sql")):
                 with mock.patch("privacyidea.cli.pimanage.backup.subprocess.run",
                                 side_effect=failing_mysql):
                     result = runner.invoke(pi_manage, [
@@ -429,6 +459,262 @@ class PIManageBackupTestCase(CliTestCase):
             # The dump must be kept for inspection, not unlinked.
             self.assertTrue(sqlfile.exists(),
                             "dump file was deleted despite the restore failing")
+
+    def test_10_backend_family_covers_all_drivers_of_an_engine(self):
+        """
+        The engine is derived from the SQLAlchemy backend name, so every driver
+        of a supported engine maps to the same backup implementation, and an
+        engine without backup support is rejected with a readable message.
+        """
+        from privacyidea.cli.pimanage.backup import (MYSQL, POSTGRESQL, SQLITE, _backend_family,
+                                                     _database_url)
+
+        for uri, expected in [
+                ("sqlite:////var/lib/privacyidea/data.sqlite", SQLITE),
+                ("mysql+pymysql://u:p@127.0.0.1/pi", MYSQL),
+                ("mysql+mysqldb://u:p@127.0.0.1/pi", MYSQL),
+                ("mariadb+pymysql://u:p@127.0.0.1/pi", MYSQL),
+                ("postgresql://u:p@127.0.0.1/pi", POSTGRESQL),
+                ("postgresql+psycopg2://u:p@127.0.0.1/pi", POSTGRESQL),
+                ("postgresql+psycopg://u:p@127.0.0.1/pi", POSTGRESQL)]:
+            self.assertEqual(expected, _backend_family(_database_url(uri)), uri)
+
+        with self.assertRaises(SystemExit) as cm:
+            _backend_family(_database_url("oracle+oracledb://u:p@127.0.0.1/pi"))
+        self.assertEqual(2, cm.exception.code)
+
+    def test_11_database_url_rejects_unusable_uris(self):
+        """
+        A missing, unparsable or database-less URI aborts with exit code 2
+        instead of running a client command against nothing, and the password is
+        not echoed while doing so.
+        """
+        from privacyidea.cli.pimanage.backup import _database_url
+
+        for uri in [None, "", "://nonsense", "mysql+pymysql://u:secret@127.0.0.1/"]:
+            with self.assertRaises(SystemExit) as cm:
+                _database_url(uri)
+            self.assertEqual(2, cm.exception.code, uri)
+
+    def test_12_postgresql_dump_and_restore_command(self):
+        """
+        The PostgreSQL dump is taken with pg_dump and replayed with psql. The
+        dump has to be replayable into a database that still holds the old
+        schema (--clean --if-exists) and by a role that owns neither the schema
+        nor its objects (--no-owner, --no-privileges, --no-comments), the
+        restore has to be all-or-nothing (--single-transaction with
+        ON_ERROR_STOP), and neither command may wait for a password prompt
+        (--no-password). The password is passed in the environment, never on the
+        command line.
+        """
+        import unittest.mock as mock
+        from privacyidea.cli.pimanage.backup import (_dump_postgresql, _restore_postgresql,
+                                                     _database_url)
+
+        url = _database_url("postgresql+psycopg2://pi:se%40cret@db.example.net:5433/pi_test?sslmode=require")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sqlfile = pathlib.Path(tmp_dir) / "dbdump-20240101-1200.pgsql"
+            sqlfile.write_text("-- dump\n")
+            calls = []
+
+            def record(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+                calls.append((cmd, kwargs))
+                result = mock.MagicMock()
+                result.returncode = 0
+                return result
+
+            with mock.patch("privacyidea.cli.pimanage.backup.subprocess.run", side_effect=record):
+                _dump_postgresql(url, sqlfile)
+                _restore_postgresql(url, sqlfile)
+
+        dump_cmd, dump_kwargs = calls[0]
+        restore_cmd, restore_kwargs = calls[1]
+
+        self.assertEqual("pg_dump", dump_cmd[0])
+        for option in ["--clean", "--if-exists", "--no-owner", "--no-privileges", "--no-comments",
+                       "--no-password"]:
+            self.assertIn(option, dump_cmd)
+        self.assertEqual("pi_test", dump_cmd[dump_cmd.index("--dbname") + 1])
+        self.assertEqual("db.example.net", dump_cmd[dump_cmd.index("--host") + 1])
+        self.assertEqual("5433", dump_cmd[dump_cmd.index("--port") + 1])
+        self.assertEqual("pi", dump_cmd[dump_cmd.index("--username") + 1])
+
+        self.assertEqual("psql", restore_cmd[0])
+        self.assertIn("--single-transaction", restore_cmd)
+        self.assertIn("--no-psqlrc", restore_cmd)
+        self.assertEqual("ON_ERROR_STOP=on", restore_cmd[restore_cmd.index("--set") + 1])
+        self.assertIn("--no-password", restore_cmd)
+
+        for cmd, kwargs in (calls[0], calls[1]):
+            # The decoded password goes into the environment, so it shows up
+            # neither in the process list nor in a file inside the backup.
+            self.assertEqual("se@cret", kwargs["env"]["PGPASSWORD"])
+            self.assertEqual("require", kwargs["env"]["PGSSLMODE"])
+            self.assertNotIn("se@cret", " ".join(cmd))
+
+        # A successful restore consumes the extracted dump.
+        self.assertFalse(sqlfile.exists())
+
+    def test_13_postgresql_connection_args_omit_unset_parts(self):
+        """
+        A URI without host and port connects over the local socket, so neither
+        option may be passed. Connection parameters that cannot be applied are
+        reported instead of being dropped silently.
+        """
+        from privacyidea.cli.pimanage.backup import (_database_url, _postgresql_connection_args,
+                                                     _postgresql_env)
+
+        url = _database_url("postgresql:///pi_test?host=/var/run/postgresql&keepalives=1")
+        args = _postgresql_connection_args(url)
+        self.assertNotIn("--host", args)
+        self.assertNotIn("--port", args)
+        self.assertNotIn("--username", args)
+
+        env = _postgresql_env(url)
+        self.assertEqual("/var/run/postgresql", env["PGHOST"])
+        self.assertNotIn("PGPASSWORD", env)
+
+        # A host in the query overrides the host of the URI for SQLAlchemy, so
+        # privacyIDEA connects to the socket -- passing --host would send the
+        # backup to the TCP host instead, because it beats PGHOST.
+        url = _database_url("postgresql://pi@dbhost:5432/pi_test?host=/var/run/postgresql")
+        args = _postgresql_connection_args(url)
+        self.assertNotIn("--host", args)
+        self.assertNotIn("dbhost", args)
+        self.assertEqual("/var/run/postgresql", _postgresql_env(url)["PGHOST"])
+
+    def test_14_postgresql_dump_failure_keeps_no_partial_dump(self):
+        """
+        A failed pg_dump must not be packaged as a successful backup: the
+        command exits non-zero, no archive is written and the partial dump is
+        removed.
+        """
+        import unittest.mock as mock
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = pathlib.Path(tmp_dir)
+            backup_dir = tmp / "backup"
+            config_dir = tmp / "config"
+            config_dir.mkdir()
+            enc_file = tmp / "enckey"
+            enc_file.write_bytes(b"x" * 96)
+
+            def failing_run(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+                # pg_dump writes a partial dump and then exits non-zero, so the
+                # cleanup that removes the partial file runs.
+                pathlib.Path(cmd[cmd.index("--file") + 1]).write_text("-- partial\n")
+                result = mock.MagicMock()
+                result.returncode = 1
+                return result
+
+            runner = self.app.test_cli_runner()
+            with mock.patch.dict(self.app.config, {
+                    "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg2://u:p@localhost/pi_test",
+                    "PI_ENCFILE": str(enc_file)}):
+                with mock.patch("privacyidea.cli.pimanage.backup.subprocess.run",
+                                side_effect=failing_run):
+                    result = runner.invoke(pi_manage, [
+                        "backup", "create",
+                        "-d", str(backup_dir),
+                        "-c", str(config_dir)])
+
+            self.assertNotEqual(result.exit_code, 0, result.output)
+            self.assertIn("Database dump failed", result.output, result.output)
+            written = list(backup_dir.glob("*.tgz")) if backup_dir.exists() else []
+            self.assertEqual([], written,
+                             f"a backup file was written despite the dump failing: {written}")
+            leftover = list(backup_dir.glob("*.pgsql")) if backup_dir.exists() else []
+            self.assertEqual([], leftover,
+                             f"a partial dump file was left behind: {leftover}")
+
+    def test_15_missing_client_command_names_the_package(self):
+        """
+        On an installation without the database client package, the command
+        names the missing binary and the package to install instead of failing
+        with a traceback.
+        """
+        import unittest.mock as mock
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = pathlib.Path(tmp_dir)
+            config_dir = tmp / "config"
+            config_dir.mkdir()
+            enc_file = tmp / "enckey"
+            enc_file.write_bytes(b"x" * 96)
+
+            runner = self.app.test_cli_runner()
+            with mock.patch.dict(self.app.config, {
+                    "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg2://u:p@localhost/pi_test",
+                    "PI_ENCFILE": str(enc_file)}):
+                with mock.patch("privacyidea.cli.pimanage.backup.subprocess.run",
+                                side_effect=FileNotFoundError("pg_dump")):
+                    result = runner.invoke(pi_manage, [
+                        "backup", "create",
+                        "-d", str(tmp / "backup"),
+                        "-c", str(config_dir)])
+
+            self.assertEqual(2, result.exit_code, result.output)
+            self.assertIn("Could not find the 'pg_dump' command", result.output, result.output)
+            self.assertIn("postgresql-client", result.output, result.output)
+
+    def test_16_restore_refuses_a_dump_from_another_engine(self):
+        """
+        A dump can only be replayed by the engine that wrote it. Restoring a
+        MySQL dump onto a PostgreSQL URI has to abort before any client command
+        runs, so the target database is left untouched.
+        """
+        import unittest.mock as mock
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = pathlib.Path(tmp_dir)
+            live_pi_cfg = tmp / "pi.cfg"
+            backup_uri = "postgresql+psycopg2://u:p@localhost/pi_test"
+
+            runner = self.app.test_cli_runner()
+            with mock.patch("privacyidea.cli.pimanage.backup.tarfile.open",
+                            side_effect=self._make_fake_tarfile(live_pi_cfg, backup_uri,
+                                                                dump_suffix=".sql")):
+                with mock.patch("privacyidea.cli.pimanage.backup.subprocess.run") as run_mock:
+                    result = runner.invoke(pi_manage, ["backup", "restore", "ignored.tgz"])
+
+            self.assertEqual(2, result.exit_code, result.output)
+            self.assertIn("MySQL/MariaDB dump", result.output, result.output)
+            self.assertIn("PostgreSQL", result.output, result.output)
+            run_mock.assert_not_called()
+
+    def test_17_mysql_restore_streams_the_dump_without_decoding(self):
+        """
+        The dump is handed to the mysql client as an open binary file. It
+        therefore reaches the client byte for byte, whatever encoding it was
+        written in, and its size is bounded by the disk rather than by the
+        memory of the restoring process.
+        """
+        import unittest.mock as mock
+        from privacyidea.cli.pimanage.backup import _database_url, _restore_mysql
+
+        # Latin-1 encoded content, which cannot be decoded as UTF-8.
+        dump_bytes = "INSERT INTO t VALUES ('Müller');\n".encode("latin1")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = pathlib.Path(tmp_dir)
+            sqlfile = tmp / "dbdump-20240101-1200.sql"
+            sqlfile.write_bytes(dump_bytes)
+            seen = {}
+
+            def record(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+                seen["stdin"] = kwargs["stdin"].read()
+                result = mock.MagicMock()
+                result.returncode = 0
+                return result
+
+            with mock.patch("privacyidea.cli.pimanage.backup.subprocess.run", side_effect=record):
+                _restore_mysql(_database_url("mysql+pymysql://u:p@localhost/pi_test"), tmp, sqlfile)
+
+            self.assertEqual(dump_bytes, seen["stdin"])
+            # A successful restore consumes the extracted dump.
+            self.assertFalse(sqlfile.exists())
+
 
 class PIManageRealmTestCase(CliTestCase):
     def test_01_pimanage_realm_help(self):

--- a/tests/cli/test_cli_pimanage.py
+++ b/tests/cli/test_cli_pimanage.py
@@ -356,9 +356,11 @@ class PIManageBackupTestCase(CliTestCase):
 
     def test_07a_mysql_defaults_quotes_values_for_the_option_file_parser(self):
         """
-        Values in a MySQL option file are quoted and their backslashes doubled:
-        an unquoted value ends at a '#', which would truncate the password, and
-        the option file parser expands backslash escapes inside the value.
+        Values in a MySQL option file are quoted, their backslashes doubled and
+        their double quotes escaped: an unquoted value ends at a '#', which
+        would truncate the password, the option file parser expands backslash
+        escapes inside the value, and an unescaped '"' ends the quoted part, so
+        that a '#' behind it starts a comment again.
         """
         import configparser
         from sqlalchemy.engine.url import make_url
@@ -366,6 +368,8 @@ class PIManageBackupTestCase(CliTestCase):
 
         for encoded, quoted in [("ab%23cd", '"ab#cd"'),
                                 ("ab%5Ccd", '"ab\\\\cd"'),
+                                ("ab%22cd", '"ab\\"cd"'),
+                                ("ab%22%23cd", '"ab\\"#cd"'),
                                 ("ab cd", '"ab cd"')]:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 defaults_file = pathlib.Path(tmp_dir) / "mysql.cnf"
@@ -557,33 +561,42 @@ class PIManageBackupTestCase(CliTestCase):
         # A successful restore consumes the extracted dump.
         self.assertFalse(sqlfile.exists())
 
-    def test_13_postgresql_connection_args_omit_unset_parts(self):
+    def test_13_postgresql_connection_args_follow_the_driver(self):
         """
-        A URI without host and port connects over the local socket, so neither
-        option may be passed. Connection parameters that cannot be applied are
-        reported instead of being dropped silently.
+        The client is pointed at the database the driver of privacyIDEA would
+        connect to: a URI without host and port connects over the local socket,
+        so neither option may be passed; a host in the query part replaces the
+        host of the URI; and a host given more than once - the failover syntax
+        of SQLAlchemy - reaches the client as the multi-host list of libpq,
+        instead of only its last entry. Connection parameters that cannot be
+        applied are reported instead of being dropped silently.
         """
         from privacyidea.cli.pimanage.backup import (_database_url, _postgresql_connection_args,
-                                                     _postgresql_env)
+                                                     _postgresql_driver_parameters, _postgresql_env)
 
-        url = _database_url("postgresql:///pi_test?host=/var/run/postgresql&keepalives=1")
-        args = _postgresql_connection_args(url)
+        def args_and_env(uri: str) -> tuple[list[str], dict[str, str]]:
+            parameters = _postgresql_driver_parameters(_database_url(uri))
+            return _postgresql_connection_args(parameters), _postgresql_env(parameters)
+
+        args, env = args_and_env("postgresql:///pi_test?keepalives=1")
         self.assertNotIn("--host", args)
         self.assertNotIn("--port", args)
         self.assertNotIn("--username", args)
-
-        env = _postgresql_env(url)
-        self.assertEqual("/var/run/postgresql", env["PGHOST"])
         self.assertNotIn("PGPASSWORD", env)
 
-        # A host in the query overrides the host of the URI for SQLAlchemy, so
-        # privacyIDEA connects to the socket -- passing --host would send the
-        # backup to the TCP host instead, because it beats PGHOST.
-        url = _database_url("postgresql://pi@dbhost:5432/pi_test?host=/var/run/postgresql")
-        args = _postgresql_connection_args(url)
-        self.assertNotIn("--host", args)
+        # A socket directory given in the query is where privacyIDEA connects.
+        args, _ = args_and_env("postgresql:///pi_test?host=/var/run/postgresql")
+        self.assertEqual("/var/run/postgresql", args[args.index("--host") + 1])
+
+        # ... and it replaces the host of the URI, rather than being ignored.
+        args, _ = args_and_env("postgresql://pi@dbhost:5432/pi_test?host=/var/run/postgresql")
+        self.assertEqual("/var/run/postgresql", args[args.index("--host") + 1])
         self.assertNotIn("dbhost", args)
-        self.assertEqual("/var/run/postgresql", _postgresql_env(url)["PGHOST"])
+
+        # A repeated host is a list of servers to try, not a single host.
+        args, _ = args_and_env("postgresql://pi@/pi_test?host=h1:5432&host=h2:5433")
+        self.assertEqual("h1,h2", args[args.index("--host") + 1])
+        self.assertEqual("5432,5433", args[args.index("--port") + 1])
 
     def test_14_postgresql_dump_failure_keeps_no_partial_dump(self):
         """

--- a/tests/cli/test_cli_pimanage.py
+++ b/tests/cli/test_cli_pimanage.py
@@ -22,6 +22,7 @@ import json
 import os
 import pathlib
 import tempfile
+import tarfile
 from collections.abc import Callable
 from typing import Any
 
@@ -683,6 +684,55 @@ class PIManageBackupTestCase(CliTestCase):
             self.assertIn("PostgreSQL", result.output, result.output)
             run_mock.assert_not_called()
 
+    def test_16a_mysql_defaults_file_stays_out_of_the_config_directory(self):
+        """
+        The option file holding the database password is written to a temporary
+        directory, not to the configuration directory: the latter is packed into
+        the archive, and a file left there would keep the password on disk after
+        the command has ended.
+        """
+        import unittest.mock as mock
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = pathlib.Path(tmp_dir)
+            backup_dir = tmp / "backup"
+            config_dir = tmp / "config"
+            config_dir.mkdir()
+            enc_file = tmp / "enckey"
+            enc_file.write_bytes(b"x" * 96)
+            defaults_files = []
+
+            def record(cmd: list[str], **kwargs: Any) -> mock.MagicMock:
+                defaults_file = [a for a in cmd if a.startswith("--defaults-file=")][0]
+                path = pathlib.Path(defaults_file.split("=", 1)[1])
+                defaults_files.append(path)
+                # The file has to exist while the client runs, and hold the password.
+                self.assertIn("s3cret", path.read_text())
+                pathlib.Path(cmd[cmd.index("-r") + 1]).write_text("-- dump\n")
+                result = mock.MagicMock()
+                result.returncode = 0
+                return result
+
+            runner = self.app.test_cli_runner()
+            with mock.patch.dict(self.app.config, {
+                    "SQLALCHEMY_DATABASE_URI": "mysql+pymysql://u:s3cret@localhost/pi_test",
+                    "PI_ENCFILE": str(enc_file)}):
+                with mock.patch("privacyidea.cli.pimanage.backup.subprocess.run",
+                                side_effect=record):
+                    result = runner.invoke(pi_manage, [
+                        "backup", "create",
+                        "-d", str(backup_dir),
+                        "-c", str(config_dir)])
+
+            self.assertEqual(0, result.exit_code, result.output)
+            # Neither in the configuration directory nor in the archive ...
+            self.assertFalse((config_dir / "mysql.cnf").exists())
+            archive = list(backup_dir.glob("*.tgz"))[0]
+            with tarfile.open(archive, "r:gz") as tf:
+                self.assertEqual([], [m.name for m in tf if m.name.endswith("mysql.cnf")])
+            # ... and gone from the temporary directory once the command is done.
+            self.assertFalse(defaults_files[0].exists())
+
     def test_17_mysql_restore_streams_the_dump_without_decoding(self):
         """
         The dump is handed to the mysql client as an open binary file. It
@@ -709,7 +759,7 @@ class PIManageBackupTestCase(CliTestCase):
                 return result
 
             with mock.patch("privacyidea.cli.pimanage.backup.subprocess.run", side_effect=record):
-                _restore_mysql(_database_url("mysql+pymysql://u:p@localhost/pi_test"), tmp, sqlfile)
+                _restore_mysql(_database_url("mysql+pymysql://u:p@localhost/pi_test"), sqlfile)
 
             self.assertEqual(dump_bytes, seen["stdin"])
             # A successful restore consumes the extracted dump.


### PR DESCRIPTION
Fixes #5891.

`pi-manage backup` handled SQLite and MySQL/MariaDB only. With a PostgreSQL `SQLALCHEMY_DATABASE_URI` both commands printed `unsupported SQL syntax: postgresql+psycopg2` and exited 2 — and `backup restore` reached that point only after extracting the archive over `/`, leaving the configuration replaced and the database untouched.

### What this does

The engine is derived from the SQLAlchemy backend name instead of matching the URI scheme against a list of driver strings, so every driver of a supported engine is recognised (`mysql+mysqldb`, `postgresql+psycopg`, …). Each engine has its own dump/restore helper and both commands classify the URI and dispatch. PostgreSQL is dumped with `pg_dump` and restored with `psql`.

Notable flags and the reason for each:

| Flag | Why |
| --- | --- |
| `--clean --if-exists` | without it a plain dump only applies to an *empty* database |
| `--no-owner --no-privileges --no-comments` | lets a role that owns neither the schema nor its objects replay the dump; a comment on the public schema is dumped whenever it differs from the server default, and applying it as a non-owner aborts the whole restore |
| `--single-transaction`, `ON_ERROR_STOP` | all-or-nothing restore instead of a half-restored schema |
| `--no-password` (both commands) | a scheduled backup must fail rather than wait on a password prompt |
| `PGPASSWORD` in the child environment | keeps the password off the command line and out of a file in the config directory, which the archive would contain |

Host and port are omitted when the query part of the URI carries them, because SQLAlchemy lets those override the URI — that is where privacyIDEA itself connects.

The dump's suffix inside the archive now records the engine that wrote it (`.pgsql` is new, `.sql` and `.sqlite` unchanged), and a restore refuses a dump written by another engine instead of feeding it to a client that cannot read it. A missing client command is reported with the package to install instead of a traceback.

### Fixed on the way past

- Parsing with `make_url()` decodes the URI, so a percent-encoded password (`p%40ss`) no longer reaches the client raw and fails authentication.
- A URI without a host connects over the local socket instead of crashing on `shlex.quote(None)`.
- MySQL option-file values are quoted and their backslashes doubled. An unquoted value ends at a `#` and the parser expands backslash escapes inside the value, so a password containing either made **every** MySQL backup fail with an access-denied error (verified against a live MariaDB).
- The MySQL restore hands the dump to the client as an open binary file instead of reading it into memory and decoding it with the locale encoding — a large dump or one written in another encoding did not survive that.

### Tests, CI, docs

The round-trip test covers PostgreSQL too, gated on the dump client of the respective engine, and restores a second time into the populated database. The migration workflow runs it on the PostgreSQL leg with a client from the PostgreSQL project's repository, since `pg_dump` refuses to dump a server newer than itself and the client Ubuntu ships is older than the `postgres:17` service. `compose-dev.yml` gained the maintained 10.x MariaDB LTS next to 11. The pi-manage chapter now documents the supported engines, the client packages per engine, and what a restore does and does not create — including the MySQL/MariaDB caveat that the dump carries its original database name.

### Verification

Round trips driven through the real CLI against live servers: PostgreSQL 17.9, MariaDB 11 and MariaDB 10.11 (each with its own client). The non-owner restore case was reproduced both ways — psql exit 3 without `--no-comments`, exit 0 with it. `tests/cli/test_cli_pimanage.py`: 50 passed. ruff and zizmor clean.

