### PR TITLE
Speed up the backend test suite

### DIFF
--- a/.github/workflows/unit-tests-redis.yml
+++ b/.github/workflows/unit-tests-redis.yml
@@ -44,7 +44,7 @@ jobs:
     name: Load Python versions
     runs-on: ubuntu-latest
     outputs:
-      min: ${{ steps.load.outputs.min }}
+      max: ${{ steps.load.outputs.max }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -52,11 +52,15 @@ jobs:
       - id: load
         run: |
           set -a; source .github/python-versions.env; set +a
-          echo "min=$MIN" >> "$GITHUB_OUTPUT"
+          echo "max=$MAX" >> "$GITHUB_OUTPUT"
 
   test:
     needs: versions
-    name: 'Redis backend (Python ${{ needs.versions.outputs.min }})'
+    # Runs on the highest supported Python, not the lowest, because this job
+    # collects coverage: from 3.14 on, coverage measures through sys.monitoring
+    # rather than the C tracer, which is far cheaper. The Python matrix in
+    # unit-tests.yml covers the lowest version for everything else.
+    name: 'Redis backend (Python ${{ needs.versions.outputs.max }})'
     permissions:
       checks: write # allow the python tests to mark an action run as failed
     runs-on: ubuntu-latest
@@ -92,10 +96,10 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set up Python ${{ needs.versions.outputs.min }}
+    - name: Set up Python ${{ needs.versions.outputs.max }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
-        python-version: ${{ needs.versions.outputs.min }}
+        python-version: ${{ needs.versions.outputs.max }}
         cache: 'pip'
         cache-dependency-path: |
           requirements.txt

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      min: ${{ steps.load.outputs.min }}
+      max: ${{ steps.load.outputs.max }}
       matrix: ${{ steps.load.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -64,7 +64,7 @@ jobs:
           FULL_MATRIX_ON_SCHEDULE: ${{ inputs.full-matrix-on-schedule }}
         run: |
           set -a; source .github/python-versions.env; set +a
-          echo "min=$MIN" >> "$GITHUB_OUTPUT"
+          echo "max=$MAX" >> "$GITHUB_OUTPUT"
           if [ "$IS_SCHEDULE" = "true" ] && [ "$FULL_MATRIX_ON_SCHEDULE" = "true" ]; then
             echo -n "matrix=" >> "$GITHUB_OUTPUT"
             printf '%s\n' "$ALL" | jq -Rc 'split(" ")' >> "$GITHUB_OUTPUT"
@@ -181,7 +181,7 @@ jobs:
         TEST_DATABASE_URL: ${{ inputs.test-database-url }}
         PYTHONWARNINGS: "once::DeprecationWarning"
         PYTHON_VERSION: ${{ matrix.python-version }}
-        MIN_PYTHON_VERSION: ${{ needs.versions.outputs.min }}
+        COVERAGE_PYTHON_VERSION: ${{ needs.versions.outputs.max }}
         COVERAGE: ${{ inputs.coverage }}
       run: |
         pip freeze
@@ -203,7 +203,7 @@ jobs:
         fi
 
     - name: Codecov upload
-      if: ${{ inputs.coverage && steps.pytest_run.outcome == 'success' && matrix.python-version == needs.versions.outputs.min }}
+      if: ${{ inputs.coverage && steps.pytest_run.outcome == 'success' && matrix.python-version == needs.versions.outputs.max }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage.xml

--- a/privacyidea/config.py
+++ b/privacyidea/config.py
@@ -196,6 +196,17 @@ class TestingConfig(Config):
     PI_ENCFILE_ENC = "tests/testdata/enckey.enc"
     PI_LOGLEVEL = logging.INFO
     PI_GNUPG_HOME = "tests/testdata/gpg"
+    # Loading an RSA private key validates it, which costs roughly 100 ms. The audit key is loaded
+    # again for every signed response and for every audit module instance, so the suite spends
+    # minutes re-validating the same key it ships itself. Signing behaviour is unchanged; only the
+    # repeated validation of a known-good test key is skipped.
+    PI_AUDIT_NO_PRIVATE_KEY_CHECK = True
+    PI_RESPONSE_NO_PRIVATE_KEY_CHECK = True
+    # argon2 is meant to be expensive. The production parameters cost about 200 ms per hash and
+    # spawn four threads each, so under pytest-xdist the workers spend more time in the key
+    # derivation function than in the code under test. Tests that are about the production
+    # parameters override this, see DefaultHashAlgoListTestCase in tests/test_lib_crypto.py.
+    PI_HASH_ALGO_PARAMS = {"argon2__rounds": 1, "argon2__memory_cost": 8, "argon2__parallelism": 1}
     # Disable the /healthz/resolversz probe cache so tests see fresh results
     PI_HEALTHZ_RESOLVER_CACHE_SECONDS = 0
     CACHE_TYPE = "None"

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -224,11 +224,14 @@ def pass_hash(password):
     :type password: str
     :return: The hash string of the password
     """
-    DEFAULT_HASH_ALGO_PARAMS.update(get_app_config_value("PI_HASH_ALGO_PARAMS",
-                                                         default={}))
+    # Merge into a copy: updating DEFAULT_HASH_ALGO_PARAMS in place would let the first app that
+    # configures PI_HASH_ALGO_PARAMS decide the parameters for every app created later in the same
+    # process, since the module-level default is shared.
+    hash_algo_params = dict(DEFAULT_HASH_ALGO_PARAMS)
+    hash_algo_params.update(get_app_config_value("PI_HASH_ALGO_PARAMS", default={}))
     pass_ctx = CryptContext(get_app_config_value("PI_HASH_ALGO_LIST",
                                                  default=DEFAULT_HASH_ALGO_LIST),
-                            **DEFAULT_HASH_ALGO_PARAMS)
+                            **hash_algo_params)
     pw_dig = pass_ctx.hash(password)
     return pw_dig
 

--- a/privacyidea/lib/log.py
+++ b/privacyidea/lib/log.py
@@ -461,6 +461,17 @@ class log_with:
         sensitive_positions = {index for index, name in enumerate(parameter_names)
                                if is_sensitive_key(name)}
 
+        # Also resolved once: the line a function is defined on cannot change while the process
+        # runs, but reading it costs a source file read and parse. Doing that per call made DEBUG
+        # logging pathologically expensive - the three tests that drive the whole API at DEBUG took
+        # two minutes between them, nearly all of it in inspect.getsourcelines.
+        try:
+            definition_line = inspect.getsourcelines(func)[1] + 1
+        except (OSError, TypeError):
+            # No source available (a C function, or a function built at runtime). The code object
+            # still knows where it started, which is what getsourcelines would have reported.
+            definition_line = getattr(getattr(func, "__code__", None), "co_firstlineno", 0) + 1
+
         @functools.wraps(func)
         def log_wrapper(*args, **kwds):
             """
@@ -500,8 +511,7 @@ class log_with:
                 log_args = ()
                 log_kwds = {}
             try:
-                import inspect
-                lno = inspect.getsourcelines(func)[1] + 1
+                lno = definition_line
                 if self.log_entry:
                     self.logger.debug(self.ENTRY_MESSAGE.format(
                         func.__name__, log_args, log_kwds),
@@ -517,8 +527,7 @@ class log_with:
             f_result = func(*args, **kwds)
 
             try:
-                import inspect
-                lno = inspect.getsourcelines(func)[1] + 1
+                lno = definition_line
                 if self.log_exit:
                     # Functions that pass request data along return it, so a result hides the same
                     # keys as an argument. Without this, a parameter dict that was hidden on the

--- a/privacyidea/lib/log.py
+++ b/privacyidea/lib/log.py
@@ -461,16 +461,21 @@ class log_with:
         sensitive_positions = {index for index, name in enumerate(parameter_names)
                                if is_sensitive_key(name)}
 
-        # Also resolved once: the line a function is defined on cannot change while the process
-        # runs, but reading it costs a source file read and parse. Doing that per call made DEBUG
-        # logging pathologically expensive - the three tests that drive the whole API at DEBUG took
-        # two minutes between them, nearly all of it in inspect.getsourcelines.
-        try:
-            definition_line = inspect.getsourcelines(func)[1] + 1
-        except (OSError, TypeError):
-            # No source available (a C function, or a function built at runtime). The code object
-            # still knows where it started, which is what getsourcelines would have reported.
-            definition_line = getattr(getattr(func, "__code__", None), "co_firstlineno", 0) + 1
+        # Resolved on the first DEBUG call and then remembered. The line a function is defined on
+        # cannot change while the process runs, but reading it costs a source file read and parse,
+        # and doing that per call made DEBUG logging pathologically expensive. Resolving it at
+        # decoration time instead would move the cost onto every import: there are ~476 decorated
+        # functions, which measured 123 ms of startup that a process never logging at DEBUG would
+        # pay for nothing.
+        definition_line = None
+
+        def resolve_definition_line() -> int:
+            try:
+                return inspect.getsourcelines(func)[1] + 1
+            except (OSError, TypeError):
+                # No source available (a C function, or one built at runtime). The code object
+                # still knows where it started, which is what getsourcelines would have reported.
+                return getattr(getattr(func, "__code__", None), "co_firstlineno", 0) + 1
 
         @functools.wraps(func)
         def log_wrapper(*args, **kwds):
@@ -486,9 +491,12 @@ class log_with:
             :type kwds: dict
             :return: The wrapped function
             """
+            nonlocal definition_line
             # Exit early if self.logger disregards DEBUG messages.
             if not self.logger.isEnabledFor(logging.DEBUG):
                 return func(*args, **kwds)
+            if definition_line is None:
+                definition_line = resolve_definition_line()
 
             try:
                 # The denylist applies to every decorated function, so a secret is hidden no

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,12 +2,13 @@
 import pathlib
 import unittest
 import mock
-from sqlalchemy import Sequence, text
+from sqlalchemy import Sequence, select, text
+from sqlalchemy.exc import DatabaseError
 from sqlalchemy.orm.session import close_all_sessions
 
 from privacyidea.app import create_app
 from privacyidea.config import TestingConfig
-from privacyidea.models import db, save_config_timestamp
+from privacyidea.models import Token, db, save_config_timestamp
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.realm import set_realm
 from privacyidea.lib.user import User
@@ -118,6 +119,22 @@ def _declared_sequences() -> list:
                    if isinstance(getattr(column, "default", None), Sequence)})
 
 
+def _schema_present() -> bool:
+    """Is the schema already built in this worker's database?
+
+    Reads one row from the table every test touches. A failure means the tables
+    are gone - either this is the first class on the worker, or a class in
+    ``tests/cli`` dropped them - and leaves the transaction unusable on
+    PostgreSQL, so it is rolled back before the caller builds the schema.
+    """
+    try:
+        db.session.execute(select(Token.id).limit(1)).first()
+        return True
+    except DatabaseError:
+        db.session.rollback()
+        return False
+
+
 def _reset_database() -> None:
     """Give the next test class an empty database without rebuilding the schema.
 
@@ -127,11 +144,13 @@ def _reset_database() -> None:
     changes. Creating it once per xdist worker and deleting the rows in between
     leaves each class with the same empty tables for about 45 ms.
 
-    ``create_all()`` still runs every time, because it is nearly free once the
-    tables are there (26 ms against 730 ms to build them) and several classes in
-    ``tests/cli`` call ``db.drop_all()`` in their own teardown. Remembering that
-    the schema had been created would leave every later class on that worker
-    querying tables that no longer exist.
+    The schema is only built when it is actually missing, which one cheap query
+    answers. It cannot simply be built once and remembered: several classes in
+    ``tests/cli`` call ``db.drop_all()`` in their own teardown, and a remembered
+    "already built" would leave every later class on that worker querying tables
+    that no longer exist. Asking the database each time costs about a
+    millisecond and stays correct however the tables went away, where calling
+    ``create_all()`` unconditionally cost ~300 ms per class under parallel load.
 
     PostgreSQL is emptied with ``TRUNCATE`` rather than ``DELETE``. It is not
     only about speed: ``DELETE`` leaves the heap in place, and because an
@@ -157,7 +176,8 @@ def _reset_database() -> None:
     do: ``Sequence`` is ignored there and an emptied table hands out rowid 1
     again by itself.
     """
-    db.create_all()
+    if not _schema_present():
+        db.create_all()
     connection = db.session.connection()
     dialect = db.engine.dialect.name
     is_mysql = dialect in ("mysql", "mariadb")

--- a/tests/base.py
+++ b/tests/base.py
@@ -133,6 +133,18 @@ def _reset_database() -> None:
     the schema had been created would leave every later class on that worker
     querying tables that no longer exist.
 
+    PostgreSQL is emptied with ``TRUNCATE`` rather than ``DELETE``. It is not
+    only about speed: ``DELETE`` leaves the heap in place, and because an
+    ``UPDATE`` writes a new tuple, a row updated after the wipe can end up
+    physically behind a row inserted later. ``get_tokens()`` has no ``ORDER
+    BY``, so tests that read ``tokens[0]`` then see the wrong token - the
+    two-step push enrollment updates its row and stopped coming first.
+    ``TRUNCATE`` recreates the heap, which is what dropping and rebuilding the
+    table used to provide. MySQL/MariaDB cannot use it here, because
+    privacyIDEA's sequences are SEQUENCE-engine tables and ``TRUNCATE`` refuses
+    them; InnoDB returns rows in primary-key order anyway, so ``DELETE`` is
+    equivalent there.
+
     Rows are deleted child-table first (``sorted_tables`` is parent-first) so
     foreign keys stay satisfied. MySQL/MariaDB additionally get the FK check
     switched off, because privacyIDEA has cycles that no single ordering
@@ -152,8 +164,12 @@ def _reset_database() -> None:
     if is_mysql:
         connection.execute(text("SET FOREIGN_KEY_CHECKS=0"))
     try:
-        for table in reversed(db.metadata.sorted_tables):
-            connection.execute(table.delete())
+        if dialect == "postgresql":
+            table_list = ", ".join(f'"{table.name}"' for table in db.metadata.sorted_tables)
+            connection.execute(text(f"TRUNCATE TABLE {table_list} RESTART IDENTITY CASCADE"))
+        else:
+            for table in reversed(db.metadata.sorted_tables):
+                connection.execute(table.delete())
         if dialect != "sqlite":
             for sequence_name in _declared_sequences():
                 connection.execute(text(f"ALTER SEQUENCE {sequence_name} RESTART"))

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,7 @@
 import pathlib
 import unittest
 import mock
+from sqlalchemy import Sequence, text
 from sqlalchemy.orm.session import close_all_sessions
 
 from privacyidea.app import create_app
@@ -104,6 +105,64 @@ class PristineSqliteFixtures:
                 fixture_file.write(data)
 
 
+def _declared_sequences() -> list:
+    """Names of every ``Sequence`` the models attach to a primary key.
+
+    privacyIDEA allocates ids from real database sequences rather than from
+    AUTO_INCREMENT, so emptying the tables is not enough to make the next class
+    start from id 1 again — the sequences have to be restarted too.
+    """
+    return sorted({column.default.name
+                   for table in db.metadata.tables.values()
+                   for column in table.columns
+                   if isinstance(getattr(column, "default", None), Sequence)})
+
+
+def _reset_database() -> None:
+    """Give the next test class an empty database without rebuilding the schema.
+
+    ``db.create_all()`` over the ~57 tables and the matching ``db.drop_all()``
+    cost about 1.9 s per test class against MariaDB, and there are ~325 classes,
+    so the suite spent a fifth of its time recreating a schema that never
+    changes. Creating it once per xdist worker and deleting the rows in between
+    leaves each class with the same empty tables for about 45 ms.
+
+    ``create_all()`` still runs every time, because it is nearly free once the
+    tables are there (26 ms against 730 ms to build them) and several classes in
+    ``tests/cli`` call ``db.drop_all()`` in their own teardown. Remembering that
+    the schema had been created would leave every later class on that worker
+    querying tables that no longer exist.
+
+    Rows are deleted child-table first (``sorted_tables`` is parent-first) so
+    foreign keys stay satisfied. MySQL/MariaDB additionally get the FK check
+    switched off, because privacyIDEA has cycles that no single ordering
+    satisfies.
+
+    The sequences behind the primary keys are restarted as well, so a class
+    still sees ids counting from 1 the way a freshly built schema gave it.
+    Several tests assert on a specific id, and deleting rows alone leaves the
+    sequences where the previous class left them. On SQLite there is nothing to
+    do: ``Sequence`` is ignored there and an emptied table hands out rowid 1
+    again by itself.
+    """
+    db.create_all()
+    connection = db.session.connection()
+    dialect = db.engine.dialect.name
+    is_mysql = dialect in ("mysql", "mariadb")
+    if is_mysql:
+        connection.execute(text("SET FOREIGN_KEY_CHECKS=0"))
+    try:
+        for table in reversed(db.metadata.sorted_tables):
+            connection.execute(table.delete())
+        if dialect != "sqlite":
+            for sequence_name in _declared_sequences():
+                connection.execute(text(f"ALTER SEQUENCE {sequence_name} RESTART"))
+    finally:
+        if is_mysql:
+            connection.execute(text("SET FOREIGN_KEY_CHECKS=1"))
+    db.session.commit()
+
+
 class MyTestCase(unittest.TestCase):
     app = None
     app_context = None
@@ -137,7 +196,7 @@ class MyTestCase(unittest.TestCase):
         cls.app = create_app('testing', pathlib.Path.cwd() / "tests/testdata/test_pi.cfg")
         cls.app_context = cls.app.app_context()
         cls.app_context.push()
-        db.create_all()
+        _reset_database()
 
         # save the current timestamp to the database to avoid hanging cached data
         save_config_timestamp()
@@ -329,7 +388,6 @@ class MyTestCase(unittest.TestCase):
     def tearDownClass(cls):
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
         cls.app_context.pop()
 

--- a/tests/cli/base.py
+++ b/tests/cli/base.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm.session import close_all_sessions
 from privacyidea.app import create_app
 from privacyidea.models import db
 from privacyidea.lib.lifecycle import call_finalizers
+from ..base import _reset_database
 
 
 class CliTestCase(unittest.TestCase):
@@ -34,7 +35,11 @@ class CliTestCase(unittest.TestCase):
         cls.app = create_app(config_name="testing", config_file="", silent=True)
         cls.app_context = cls.app.app_context()
         cls.app_context.push()
-        db.create_all()
+        # Reuse the schema the way tests/base.py does: building and dropping all
+        # 57 tables per class is the single most expensive thing these tests did,
+        # and dropping them also denied the next class on this worker a schema to
+        # reuse.
+        _reset_database()
 
     def tearDown(self):
         db.session.commit()
@@ -44,6 +49,5 @@ class CliTestCase(unittest.TestCase):
     def tearDownClass(cls):
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
         cls.app_context.pop()

--- a/tests/cli/test_cli_cron.py
+++ b/tests/cli/test_cli_cron.py
@@ -24,6 +24,7 @@ from privacyidea.app import create_app
 from privacyidea.models import db
 from privacyidea.lib.lifecycle import call_finalizers
 from privacyidea.cli.tools.cron import cli as privacyidea_cron
+from ..base import _reset_database
 
 
 @pytest.fixture(scope="class")
@@ -31,14 +32,13 @@ def app():
     """Create and configure app instance for testing"""
     app = create_app(config_name="testing", config_file="", silent=True)
     with app.app_context():
-        db.create_all()
+        _reset_database()
 
     yield app
 
     with app.app_context():
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
 
 

--- a/tests/cli/test_cli_pimanage.py
+++ b/tests/cli/test_cli_pimanage.py
@@ -37,6 +37,7 @@ from privacyidea.lib.resolver import (save_resolver, delete_resolver,
                                       get_resolver_list)
 from privacyidea.models import db, Challenge
 from .base import CliTestCase
+from ..base import _reset_database
 from ..base import PWFILE
 
 
@@ -895,14 +896,13 @@ def app():
     """Create and configure app instance for testing"""
     app = create_app(config_name="testing", config_file="", silent=True)
     with app.app_context():
-        db.create_all()
+        _reset_database()
 
     yield app
 
     with app.app_context():
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
 
 

--- a/tests/cli/test_cli_pitokenjanitor.py
+++ b/tests/cli/test_cli_pitokenjanitor.py
@@ -33,6 +33,7 @@ from privacyidea.lib.token import init_token, get_one_token
 from privacyidea.lib.user import User
 from privacyidea.models import db
 from privacyidea.models.token import TokenOwner
+from ..base import _reset_database
 
 
 @pytest.fixture(scope="function")
@@ -40,14 +41,13 @@ def app():
     """Create and configure app instance for testing"""
     app = create_app(config_name="testing", config_file="", silent=True)
     with app.app_context():
-        db.create_all()
+        _reset_database()
 
     yield app
 
     with app.app_context():
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
 
 

--- a/tests/cli/test_cli_pitokenjanitor_customattributes.py
+++ b/tests/cli/test_cli_pitokenjanitor_customattributes.py
@@ -12,18 +12,18 @@ from privacyidea.lib.realm import set_realm
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.user import User
 from privacyidea.models import CustomUserAttribute, db
+from ..base import _reset_database
 
 
 @pytest.fixture(scope="function")
 def app():
     app = create_app(config_name="testing", config_file="", silent=True)
     with app.app_context():
-        db.create_all()
+        _reset_database()
     yield app
     with app.app_context():
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
 
 

--- a/tests/cli/test_cli_pitokenjanitor_deprecated.py
+++ b/tests/cli/test_cli_pitokenjanitor_deprecated.py
@@ -15,6 +15,7 @@ from privacyidea.lib.lifecycle import call_finalizers
 from privacyidea.lib.token import get_tokens
 from privacyidea.lib.tokens.deprecated import DeprecatedTokenClass
 from privacyidea.models import Token, db
+from ..base import _reset_database
 
 
 @pytest.fixture(scope="function")
@@ -22,14 +23,13 @@ def app():
     """Create and configure app instance for testing."""
     app = create_app(config_name="testing", config_file="", silent=True)
     with app.app_context():
-        db.create_all()
+        _reset_database()
 
     yield app
 
     with app.app_context():
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
 
 

--- a/tests/cli/test_cli_pitokenjanitor_internalattributes.py
+++ b/tests/cli/test_cli_pitokenjanitor_internalattributes.py
@@ -12,18 +12,18 @@ from privacyidea.lib.realm import set_realm
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.user import User
 from privacyidea.models import InternalUserAttribute, db
+from ..base import _reset_database
 
 
 @pytest.fixture(scope="function")
 def app():
     app = create_app(config_name="testing", config_file="", silent=True)
     with app.app_context():
-        db.create_all()
+        _reset_database()
     yield app
     with app.app_context():
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
 
 

--- a/tests/cli/test_cli_pitokenjanitor_usersettings.py
+++ b/tests/cli/test_cli_pitokenjanitor_usersettings.py
@@ -14,18 +14,18 @@ from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.user import User
 from privacyidea.lib.usersetting import SUBJECT_LOCAL_ADMIN, SUBJECT_USER
 from privacyidea.models import UserSetting, db
+from ..base import _reset_database
 
 
 @pytest.fixture(scope="function")
 def app():
     app = create_app(config_name="testing", config_file="", silent=True)
     with app.app_context():
-        db.create_all()
+        _reset_database()
     yield app
     with app.app_context():
         call_finalizers()
         close_all_sessions()
-        db.drop_all()
         db.engine.dispose()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import socket
 import tempfile
+from collections.abc import Iterator
 
 # Per-worker DB isolation for pytest-xdist. Must run before any `privacyidea`
 # import, because TestingConfig.SQLALCHEMY_DATABASE_URI is evaluated at class
@@ -226,6 +227,36 @@ def _flush_redis_between_tests():
     runs, where PI_REDIS_URL is unset."""
     yield
     _flush_worker_redis()
+
+
+_push_server_keypairs: dict = {}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _reuse_push_server_keypair() -> Iterator[None]:
+    """Generate the push token's server keypair once per worker instead of per enrollment.
+
+    Finalizing a push enrollment creates a fresh 4096-bit RSA keypair, which costs most of a
+    second. The suite enrolls push tokens roughly a hundred times and none of those tests are
+    about key generation - they check that the key the server reports is the key it stored, and
+    two of them supply a keypair of their own instead. Handing out the same keypair each time is
+    therefore invisible to them.
+
+    Only the name inside ``pushtoken`` is replaced, so ``generate_keypair`` itself stays real for
+    the tests in ``test_lib_crypto.py`` that are about generating keys.
+    """
+    from privacyidea.lib.tokens import pushtoken
+
+    original_generate_keypair = pushtoken.generate_keypair
+
+    def cached_generate_keypair(rsa_keysize: int = 2048) -> tuple[str, str]:
+        if rsa_keysize not in _push_server_keypairs:
+            _push_server_keypairs[rsa_keysize] = original_generate_keypair(rsa_keysize)
+        return _push_server_keypairs[rsa_keysize]
+
+    pushtoken.generate_keypair = cached_generate_keypair
+    yield
+    pushtoken.generate_keypair = original_generate_keypair
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_api_push_validate.py
+++ b/tests/test_api_push_validate.py
@@ -251,8 +251,9 @@ class PushAPITestCase(PushTokenTestMixin, MyApiTestCase):
         # check, if the user has two tokens, now
         tokens = get_tokens(user=User("selfservice", self.realm1))
         self.assertEqual(2, len(tokens))
-        self.assertEqual("push", tokens[0].type)
-        self.assertEqual("spass", tokens[1].type)
+        # get_tokens has no ORDER BY, so the tokens are identified by type rather than by
+        # position. PostgreSQL returns them in the order the rows happen to sit in the table.
+        self.assertEqual({"push", "spass"}, {token.type for token in tokens})
         # authenticate with spass
         with self.app.test_request_context('/validate/check',
                                            method='POST',
@@ -360,9 +361,11 @@ class PushAPITestCase(PushTokenTestMixin, MyApiTestCase):
         # check, if the user has two tokens, now
         tokens = get_tokens(user=User("selfservice", self.realm1))
         self.assertEqual(2, len(tokens))
-        self.assertEqual("push", tokens[0].type)
-        self.assertFalse(tokens[0].is_active())
-        self.assertEqual("hotp", tokens[1].type)
+        # get_tokens has no ORDER BY, so the tokens are identified by type rather than by
+        # position. PostgreSQL returns them in the order the rows happen to sit in the table.
+        tokens_by_type = {token.type: token for token in tokens}
+        self.assertEqual({"push", "hotp"}, set(tokens_by_type))
+        self.assertFalse(tokens_by_type["push"].is_active())
 
         # authenticate with hotp
         with self.app.test_request_context('/validate/check',

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -892,8 +892,14 @@ class SignObjectTestCase(MyTestCase):
         self.assertTrue(so.verify(long_data, long_data_sig, verify_old_sigs=True))
 
 
-class DefaultHashAlgoListTestCase(MyTestCase):
+class DefaultHashAlgoListTestCase(OverrideConfigTestCase):
     """Check if the default hash algorithm list is used."""
+
+    class Config(TestingConfig):
+        # TestingConfig weakens the argon2 parameters so the suite is not dominated by the key
+        # derivation function. This class asserts the parameters a deployment actually gets, so it
+        # drops that override and takes the defaults from privacyidea.lib.crypto.
+        PI_HASH_ALGO_PARAMS = {}
 
     def test_01_default_hash_algorithm_list(self):
         password = "password"

--- a/tests/test_lib_logging.py
+++ b/tests/test_lib_logging.py
@@ -18,7 +18,7 @@
 import logging
 import logging.config
 
-from privacyidea.lib.log import DEFAULT_LOGGING_CONFIG, SecureFormatter
+from privacyidea.lib.log import DEFAULT_LOGGING_CONFIG, SecureFormatter, log_with
 from privacyidea.lib.utils import parse_date
 
 
@@ -48,3 +48,19 @@ def test_log_formatter(caplog, tmp_path):
     assert ("!!Log Entry Secured by SecureFormatter!! Dateformat 2016/.x052/20 "
             "could not be parsed") == caplog.messages[0]
 
+
+
+def test_log_with_falls_back_when_source_is_unavailable(caplog):
+    # log_with reports the line the wrapped function is defined on. A function built at runtime has
+    # no source file to read that from, so the decorator falls back to the code object, and logging
+    # still works instead of failing.
+    namespace = {}
+    exec(compile("def built_at_runtime(value):\n    return value * 2", "<generated>", "exec"), namespace)
+    decorated = log_with(logging.getLogger("test_fallback"))(namespace["built_at_runtime"])
+
+    with caplog.at_level(logging.DEBUG, logger="test_fallback"):
+        assert decorated(21) == 42
+
+    entry = next(record for record in caplog.records if "built_at_runtime" in record.getMessage())
+    # The fallback reports the code object's first line rather than raising.
+    assert entry.s_line == namespace["built_at_runtime"].__code__.co_firstlineno + 1


### PR DESCRIPTION
The backend test suite spent most of its time on work that no test asserts on: cryptography that is deliberately expensive, and a database schema rebuilt from scratch for every test class. This removes that work without changing what any test checks.

## What is slow, and what changed

**Every signed API response re-validated the audit RSA key.** `sign_response` reads `private.pem` and builds a `Sign` object per response, and `Sign.__init__` defaults to `check_private_key=True`, which runs a full RSA primality validation — ~100 ms per load against 0.04 ms without. The suite did this thousands of times for a key it ships itself. The config flags to skip it already existed; `TestingConfig` never set them. Signing behaviour is unchanged.

**argon2 ran with production parameters** (`t=9, m=64 MiB, p=4`): ~200 ms per hash, and `p=4` spawns four threads each, so under `pytest-xdist -n 4` the workers spent more time in the key derivation function than in the code under test.

**The schema was rebuilt per test class** — all 57 tables created and dropped, ~350 times. Classes now get an *empty* database instead of a *new* one, and the schema is built only when it is actually missing.

**`tests/cli` was worse still.** It has its own base class and its own fixtures, none of which inherit from `tests/base.py`, so none of the above reached it. Five pi-token-janitor files used a *function-scoped* fixture that created and dropped all 57 tables **per test**, 75 times over; dropping them also denied the next class on that worker a schema to reuse, so the cost landed twice. That is what made `tests/cli/test_cli_pitokenjanitor.py` the most expensive file in the suite — 354.8s on one run, a fifth of that job's total.

**Push enrollment generated a real 4096-bit RSA keypair per token**, ~100 times. No test is about key generation; they check that the key the server reports is the key it stored, and two files supply a keypair of their own.

**`log_with` re-read the source file on every DEBUG call** to find the decorated function's definition line, which cannot change while the process runs.

**Coverage ran on the oldest Python**, where `sys.monitoring` does not exist, so it was stuck on the C tracer.

## Production changes, called out

Three, none of them test-only:

- **`pass_hash` mutated a module-level dict.** It updated `DEFAULT_HASH_ALGO_PARAMS` in place with the configured parameters, so the first app in a process to set `PI_HASH_ALGO_PARAMS` decided them for every app created later in that process. It now merges into a copy. This is a config leak between apps, and worth a changelog line as a bug fix. It is also load-bearing here: without it a test cannot opt back into the production parameters, because the weakened values leak in from whichever file hashed first.
- **`log_with` resolves the definition line lazily**, on the first DEBUG call, instead of per call. Resolving it at decoration time was tried and rejected: with ~476 decorated functions it added 123 ms to every import, paid even by a process that never logs at DEBUG.
- **Coverage moved to the newest Python.** From CPython 3.14 coverage measures through `sys.monitoring` rather than the C tracer. Measured on 3.13 with the interpreter fixed: no coverage 16.02s, `--cov` with ctrace 23.64s (+48%), `--cov` with sysmon 16.73s (+4.4%). The reports are equivalent — 21086 vs 21088 missed lines of 38004. This applies twice, because both the MariaDB coverage job and the Redis job collect coverage and both ran on the oldest version.

## One test assertion changed

`test_api_push_validate.py` read `tokens[0]` and `tokens[1]` from `get_tokens()`, which has no `ORDER BY`. On MariaDB that is primary-key order, which is why it always worked. On PostgreSQL it is heap order: an `UPDATE` writes a new tuple, and once earlier tests in the same class have left dead tuples behind, the updated row can land ahead of one inserted later. The two-step push enrollment updates its token, so the push token stopped coming first.

Rebuilding the schema per class had been hiding this, but only by luck — which page the new tuple lands in depends on free space and autovacuum, not on anything the test controls. The assertions now pick tokens by type, checking exactly what they checked before without depending on an order the query never promised.

Six similar spots elsewhere index past `[0]` into multi-row results. They pass today and were left alone; the durable fix is to give `get_tokens()` a defined order, which is a production change and its own PR.

## Measurements

CI, pytest step, same measurement on both ends (`Σ` = total CPU-seconds of test work, summed across the four xdist workers):

| job | Σ before | Σ after | wall before | wall after |
| --- | --- | --- | --- | --- |
| MariaDB + coverage | 3682s | **1275s** | 982s | **337s** |
| Redis + coverage | 2162s | **1267s** | 827s | **340s** |
| MariaDB, no coverage | — | 1311s | 739s | 345s |
| PostgreSQL 3.14 | — | 1123s | 682s | 298s |
| PostgreSQL 3.10 | — | 1987s | 718s | 513s |

**The gate goes from ~16 min to ~7 min.**

The PostgreSQL 3.10 row is a slow runner on that particular run, not a regression: Σ was inflated ~68% uniformly, the four workers stayed balanced, and no file stood out. Runner variance of that size has shown up repeatedly across this work (the Redis job ranged 827–1304s before any of these changes), so single-run numbers should not be read too closely.

Python 3.10 is separately and genuinely ~35–40% slower than 3.14 on this suite. Comparing the two PostgreSQL jobs on one commit, neither with coverage: Σ 1185s vs 863s. The gap is uniform across files (median 1.38x) except for the subprocess-bound ones — `test_api_caconnector` 1.03x, `test_scripts` 1.08x — which is the signature of interpreter speed rather than a slow dependency. Nothing here can close that; raising `MIN` past 3.10 will.

Locally, `tests/cli` alone went from 152.31s to 17.72s.

Pass/fail is unchanged throughout, verified on MariaDB, PostgreSQL and SQLite by diffing sorted failure lists rather than comparing counts.

## Not in this PR

- Caching the `Sign` object in `sign_response`, so production stops paying the per-response key validation too.
- `authcache.py` declares its own hardcoded `ROUNDS = 9` and calls `passlib.hash.argon2` directly, so it is untouched. Separately: an admin tuning `PI_HASH_ALGO_PARAMS` today gets no effect on the auth cache, and no warning.
- Giving `get_tokens()` a defined order.
- A session-scoped Flask app; `create_app` is about 2% of what is left.
