### PR TITLE
standardise dialogue widths

### DIFF
--- a/privacyidea/static_new/src/app/components/configuration/system/system-documentation-dialog/system-documentation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/configuration/system/system-documentation-dialog/system-documentation-dialog.component.html
@@ -16,13 +16,13 @@
 
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-<div class="system-documentation-dialog-container">
-  <h2
-    i18n="@@systemConfig.systemDocumentation"
-    mat-dialog-title
-    >System Documentation</h2
-  >
-  <mat-dialog-content>
+<app-dialog-wrapper
+  width="xl"
+  cancelButtonLabel="Close"
+  i18n-cancelButtonLabel="@@common.close"
+  i18n-title="@@systemConfig.systemDocumentation"
+  title="System Documentation">
+  <div class="system-documentation-dialog-container">
     <p i18n="@@systemConfig.documentationContains"
       >This documentation contains the current configuration of your system in restructured text. You can use this to
       document your installed system.</p
@@ -33,25 +33,16 @@
       <textarea
         #autosize="cdkTextareaAutosize"
         [value]="documentation"
-        cdkAutosizeMaxRows="30"
-        cdkAutosizeMinRows="15"
+        cdkAutosizeMaxRows="20"
+        cdkAutosizeMinRows="10"
         cdkTextareaAutosize
         matInput
         readonly
-        rows="15">
+        rows="10">
       </textarea>
     </mat-form-field>
     <app-copyable [copyText]="documentation">
       <span i18n="@@systemConfig.copySystemDocumentation">Copy System Documentation:</span>
     </app-copyable>
-  </mat-dialog-content>
-
-  <mat-dialog-actions align="end">
-    <button
-      (click)="onClose()"
-      i18n="@@common.close"
-      mat-button
-      >Close</button
-    >
-  </mat-dialog-actions>
-</div>
+  </div>
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/configuration/system/system-documentation-dialog/system-documentation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/configuration/system/system-documentation-dialog/system-documentation-dialog.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@common.close"
   i18n-title="@@systemConfig.systemDocumentation"

--- a/privacyidea/static_new/src/app/components/configuration/system/system-documentation-dialog/system-documentation-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/configuration/system/system-documentation-dialog/system-documentation-dialog.component.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * (c) NetKnights GmbH 2026,  https://netknights.it
+ *
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ **/
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
+import { SystemDocumentationDialogComponent } from "./system-documentation-dialog.component";
+
+describe("SystemDocumentationDialogComponent", () => {
+  let fixture: ComponentFixture<SystemDocumentationDialogComponent>;
+  let dialogRef: MockMatDialogRef<SystemDocumentationDialogComponent>;
+
+  beforeEach(async () => {
+    dialogRef = new MockMatDialogRef<SystemDocumentationDialogComponent>();
+    await TestBed.configureTestingModule({
+      imports: [SystemDocumentationDialogComponent],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: { documentation: "Some documentation" } },
+        { provide: MatDialogRef, useValue: dialogRef }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SystemDocumentationDialogComponent);
+    fixture.detectChanges();
+  });
+
+  it("shows the documentation it was handed, under the shared dialog heading", () => {
+    expect(fixture.nativeElement.querySelector(".pi-dialog-header").textContent).toContain("System Documentation");
+    expect(fixture.nativeElement.querySelector("textarea").value).toBe("Some documentation");
+  });
+
+  it("closes on the footer button the wrapper renders", () => {
+    fixture.nativeElement.querySelector(".pi-dialog-footer button").click();
+
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+});

--- a/privacyidea/static_new/src/app/components/configuration/system/system-documentation-dialog/system-documentation-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/configuration/system/system-documentation-dialog/system-documentation-dialog.component.ts
@@ -17,31 +17,27 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { CdkTextareaAutosize } from "@angular/cdk/text-field";
-import { AfterViewInit, Component, ElementRef, inject, ViewChild } from "@angular/core";
+import { AfterViewInit, Component, ElementRef, ViewChild } from "@angular/core";
 
-import { MatButton } from "@angular/material/button";
-import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
 import { MatFormField, MatLabel } from "@angular/material/form-field";
 import { MatInput } from "@angular/material/input";
 import { CopyableComponent } from "@components/shared/copyable/copyable.component";
+import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 
 @Component({
   selector: "app-system-documentation-dialog",
   templateUrl: "./system-documentation-dialog.component.html",
   styleUrls: ["./system-documentation-dialog.component.scss"],
   standalone: true,
-  imports: [MatDialogModule, MatFormField, MatLabel, MatInput, MatButton, CdkTextareaAutosize, CopyableComponent]
+  imports: [MatFormField, MatLabel, MatInput, CdkTextareaAutosize, CopyableComponent, DialogWrapperComponent]
 })
-export class SystemDocumentationDialogComponent implements AfterViewInit {
+export class SystemDocumentationDialogComponent
+  extends AbstractDialogComponent<{ documentation: string }>
+  implements AfterViewInit
+{
   @ViewChild("autosize", { read: ElementRef }) textareaElement!: ElementRef<HTMLTextAreaElement>;
-  documentation = "";
-
-  public dialogRef = inject(MatDialogRef<SystemDocumentationDialogComponent>);
-  public data: { documentation: string } = inject(MAT_DIALOG_DATA);
-
-  constructor() {
-    this.documentation = this.data.documentation || "";
-  }
+  documentation = this.data.documentation || "";
 
   ngAfterViewInit(): void {
     setTimeout(() => {
@@ -55,9 +51,5 @@ export class SystemDocumentationDialogComponent implements AfterViewInit {
         element.scrollTop = 0;
       }
     });
-  }
-
-  onClose(): void {
-    this.dialogRef.close();
   }
 }

--- a/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.component.html
@@ -21,7 +21,7 @@
   i18n-cancelButtonLabel="@@common.close"
   i18n-title="@@container.containerSuccessfully"
   title="Container Successfully Created"
-  width="xl">
+  width="l">
   <span i18n="@@container.containerWasSuccessfullyCreated"
     >The container was successfully created with serial number
     <a

--- a/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.component.html
@@ -16,12 +16,12 @@
 
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-<h2
-  i18n="@@container.containerSuccessfully"
-  mat-dialog-title
-  >Container Successfully Created</h2
->
-<mat-dialog-content>
+<app-dialog-wrapper
+  cancelButtonLabel="Close"
+  i18n-cancelButtonLabel="@@common.close"
+  i18n-title="@@container.containerSuccessfully"
+  title="Container Successfully Created"
+  width="xl">
   <span i18n="@@container.containerWasSuccessfullyCreated"
     >The container was successfully created with serial number
     <a
@@ -43,7 +43,9 @@
         width="300px" />
     }
     <div class="flex-column gap-16">
-      <p i18n="@@container.pleaseScanQrCode"
+      <p
+        class="dialog-prose"
+        i18n="@@container.pleaseScanQrCode"
         >Please scan the QR code with the privacyIDEA Authenticator App or click this
         <a href="{{ data()?.response?.result?.value?.container_url?.value ?? '' }}">link</a> on your smartphone to
         register your container. It will send the missing registration data to the configured endpoint.</p
@@ -57,4 +59,4 @@
       </button>
     </div>
   </div>
-</mat-dialog-content>
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.component.ts
@@ -18,10 +18,10 @@
  **/
 import { Component, inject, Signal, WritableSignal } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
-import { MatDialogContent, MatDialogTitle } from "@angular/material/dialog";
 import { MatIcon } from "@angular/material/icon";
 import { PiResponse } from "@app/app.component";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 import {
   ContainerRegisterData,
   ContainerService,
@@ -37,7 +37,7 @@ export interface ContainerCreationDialogData {
 
 @Component({
   selector: "app-container-created-dialog",
-  imports: [MatDialogContent, MatDialogTitle, MatButtonModule, MatIcon],
+  imports: [MatButtonModule, MatIcon, DialogWrapperComponent],
   templateUrl: "./container-created-dialog.component.html",
   styleUrl: "./container-created-dialog.component.scss"
 })

--- a/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.wizard.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.wizard.component.html
@@ -16,20 +16,19 @@
 
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-<mat-dialog-content>
+<app-dialog-wrapper
+  (actionTriggered)="onAction()"
+  [actions]="actions"
+  [showCloseButton]="false"
+  i18n-title="@@container.containerSuccessfully"
+  title="Container Successfully Created"
+  width="xl">
   @let postTopHtml = postTopHtml$ | async;
   @if (postTopHtml?.hasContent) {
     <div
       [innerHTML]="postTopHtml?.sanitized"
       class="margin-top-16"></div>
   } @else {
-    <div class="margin-bottom-16">
-      <h3
-        class="margin-8"
-        i18n="@@container.containerSuccessfully"
-        >Container Successfully Created</h3
-      >
-    </div>
     <span i18n="@@container.containerWasSuccessfullyCreated"
       >The container was successfully created with serial number
       <a
@@ -54,7 +53,9 @@
     }
     @if (!postTopHtml?.hasContent && data()?.response?.result?.value?.container_url?.value) {
       <div class="flex-column gap-16">
-        <p i18n="@@container.pleaseScanQrCode"
+        <p
+          class="dialog-prose"
+          i18n="@@container.pleaseScanQrCode"
           >Please scan the QR code with the privacyIDEA Authenticator App or click this
           <a href="{{ data()?.response?.result?.value?.container_url?.value }}">link</a> on your smartphone to register
           your container. It will send the missing registration data to the configured endpoint.</p
@@ -66,15 +67,4 @@
   <div
     [innerHTML]="postBottomHtml$ | async"
     class="margin-bottom-16"></div>
-</mat-dialog-content>
-
-<mat-dialog-actions>
-  <button
-    (click)="authService.logout()"
-    class="action-button-primary button-width-s"
-    mat-button
-    mat-dialog-close
-    i18n="@@common.logout"
-    >Logout</button
-  >
-</mat-dialog-actions>
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.wizard.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.wizard.component.html
@@ -22,7 +22,7 @@
   [showCloseButton]="false"
   i18n-title="@@container.containerSuccessfully"
   title="Container Successfully Created"
-  width="xl">
+  width="l">
   @let postTopHtml = postTopHtml$ | async;
   @if (postTopHtml?.hasContent) {
     <div

--- a/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.wizard.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-created-dialog/container-created-dialog.wizard.component.ts
@@ -19,9 +19,9 @@
 import { AsyncPipe } from "@angular/common";
 import { HttpClient } from "@angular/common/http";
 import { Component, computed, inject, SecurityContext } from "@angular/core";
-import { MatButton } from "@angular/material/button";
-import { MatDialogActions, MatDialogClose, MatDialogContent } from "@angular/material/dialog";
 import { DomSanitizer } from "@angular/platform-browser";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
+import { DialogAction } from "@models/dialog";
 import { environment } from "@env/environment";
 import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { ContainerService, ContainerServiceInterface } from "@services/container/container.service";
@@ -31,11 +31,14 @@ import { ContainerCreatedDialogComponent } from "./container-created-dialog.comp
 
 @Component({
   selector: "app-container-created-wizard-dialog",
-  imports: [MatDialogContent, MatDialogActions, MatDialogClose, MatButton, AsyncPipe],
+  imports: [AsyncPipe, DialogWrapperComponent],
   templateUrl: "./container-created-dialog.wizard.component.html",
   styleUrl: "./container-created-dialog.component.scss"
 })
 export class ContainerCreatedDialogWizardComponent extends ContainerCreatedDialogComponent {
+  protected readonly actions: DialogAction<"logout">[] = [
+    { type: "confirm", label: $localize`:@@common.logout:Logout`, value: "logout", primary: true }
+  ];
   protected override readonly containerService: ContainerServiceInterface = inject(ContainerService);
   public readonly authService: AuthServiceInterface = inject(AuthService);
   private http = inject(HttpClient);
@@ -54,6 +57,11 @@ export class ContainerCreatedDialogWizardComponent extends ContainerCreatedDialo
   });
 
   customizationPath = "/static/public/customize/";
+
+  onAction(): void {
+    this.close();
+    this.authService.logout();
+  }
 
   readonly postTopHtml$ = this.http
     .get(environment.proxyUrl + this.customizationPath + "container-create.wizard.post.top.html", {

--- a/privacyidea/static_new/src/app/components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.component.html
@@ -16,12 +16,11 @@
 
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-<h2
-  i18n="@@container.containerRegistration"
-  mat-dialog-title
-  >Container Registration Completed</h2
->
-<mat-dialog-content>
+<app-dialog-wrapper
+  cancelButtonLabel="Close"
+  i18n-cancelButtonLabel="@@common.close"
+  i18n-title="@@container.containerRegistration"
+  title="Container Registration Completed">
   <span i18n="@@container.containerWasSuccessfully"
     >The container
     <a
@@ -33,12 +32,4 @@
     </a>
     was successfully registered.</span
   >
-</mat-dialog-content>
-<mat-dialog-actions>
-  <button
-    mat-button
-    mat-dialog-close
-    i18n="@@common.close"
-    >Close</button
-  >
-</mat-dialog-actions>
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.component.ts
@@ -18,9 +18,8 @@
  **/
 
 import { Component, inject } from "@angular/core";
-import { MatButton } from "@angular/material/button";
-import { MatDialogActions, MatDialogClose, MatDialogContent, MatDialogTitle } from "@angular/material/dialog";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 import { ContentService, ContentServiceInterface } from "@services/content/content.service";
 
 export interface ContainerRegistrationCompletedDialogData {
@@ -31,7 +30,7 @@ export interface ContainerRegistrationCompletedDialogData {
   selector: "app-container-registration-completed-dialog",
   templateUrl: "./container-registration-completed-dialog.component.html",
   styleUrls: ["./container-registration-completed-dialog.component.scss"],
-  imports: [MatDialogContent, MatDialogTitle, MatDialogActions, MatButton, MatDialogClose]
+  imports: [DialogWrapperComponent]
 })
 export class ContainerRegistrationCompletedDialogComponent extends AbstractDialogComponent<
   ContainerRegistrationCompletedDialogData,

--- a/privacyidea/static_new/src/app/components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.wizard.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.wizard.component.html
@@ -16,20 +16,18 @@
 
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-<mat-dialog-content>
+<app-dialog-wrapper
+  (actionTriggered)="onAction()"
+  [actions]="actions"
+  [showCloseButton]="false"
+  i18n-title="@@container.containerRegistration"
+  title="Container Registration Completed">
   @let registeredHtml = registeredHtml$ | async;
   @if (registeredHtml?.hasContent) {
     <div
       [innerHTML]="registeredHtml?.sanitized"
       class="margin-top-16"></div>
   } @else {
-    <div class="margin-bottom-16">
-      <h3
-        class="margin-8"
-        i18n="@@container.containerRegistration"
-        >Container Registration Completed</h3
-      >
-    </div>
     <span i18n="@@container.containerWasSuccessfully"
       >The container
       <a
@@ -42,14 +40,4 @@
       was successfully registered.</span
     >
   }
-</mat-dialog-content>
-<mat-dialog-actions>
-  <button
-    (click)="authService.logout()"
-    class="action-button-primary button-width-s"
-    mat-button
-    mat-dialog-close
-    i18n="@@common.logout"
-    >Logout</button
-  >
-</mat-dialog-actions>
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.wizard.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-registration-completed-dialog/container-registration-completed-dialog.wizard.component.ts
@@ -20,9 +20,9 @@
 import { AsyncPipe } from "@angular/common";
 import { HttpClient } from "@angular/common/http";
 import { Component, computed, inject, Signal } from "@angular/core";
-import { MatButton } from "@angular/material/button";
-import { MatDialogActions, MatDialogClose, MatDialogContent } from "@angular/material/dialog";
 import { DomSanitizer } from "@angular/platform-browser";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
+import { DialogAction } from "@models/dialog";
 import { environment } from "@env/environment";
 import { AuthService, AuthServiceInterface } from "@services/auth/auth.service";
 import { StringUtils } from "@utils/string.utils";
@@ -33,10 +33,13 @@ import { ContainerRegistrationCompletedDialogComponent } from "./container-regis
   selector: "app-container-registration-completed-dialog-wizard",
   templateUrl: "./container-registration-completed-dialog.wizard.component.html",
   styleUrls: ["./container-registration-completed-dialog.component.scss"],
-  imports: [MatDialogContent, MatDialogActions, MatButton, MatDialogClose, AsyncPipe]
+  imports: [AsyncPipe, DialogWrapperComponent]
 })
 export class ContainerRegistrationCompletedDialogWizardComponent extends ContainerRegistrationCompletedDialogComponent {
   public readonly authService: AuthServiceInterface = inject(AuthService);
+  protected readonly actions: DialogAction<"logout">[] = [
+    { type: "confirm", label: $localize`:@@common.logout:Logout`, value: "logout", primary: true }
+  ];
   private http = inject(HttpClient);
   private sanitizer = inject(DomSanitizer);
 
@@ -55,4 +58,9 @@ export class ContainerRegistrationCompletedDialogWizardComponent extends Contain
         sanitized: this.sanitizer.bypassSecurityTrustHtml(StringUtils.replaceWithTags(raw, this.tagData()))
       }))
     );
+
+  onAction(): void {
+    this.close();
+    this.authService.logout();
+  }
 }

--- a/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.html
@@ -17,6 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="xl"
   title="Container Successfully Created"
   i18n-title="@@container.containerSuccessfully"
   [actions]="dialogActions()"

--- a/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-create/container-tokens-enrolled-dialog/container-tokens-enrolled-dialog.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   title="Container Successfully Created"
   i18n-title="@@container.containerSuccessfully"
   [actions]="dialogActions()"

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   [title]="dialogTitle">
   <div class="flex-row gap-16">
     @if (data()?.response?.result?.value?.container_url?.img) {

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.html
@@ -17,44 +17,43 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="xl"
   [title]="dialogTitle">
-  <mat-dialog-content>
-    <div class="flex-row gap-16">
-      @if (data()?.response?.result?.value?.container_url?.img) {
-        <img
-          i18n-alt="@@common.qrCode"
-          alt="QR Code"
-          class="qr-code margin-top-16"
-          height="300px"
-          src="{{ data()?.response?.result?.value?.container_url?.img }}"
-          width="300px" />
+  <div class="flex-row gap-16">
+    @if (data()?.response?.result?.value?.container_url?.img) {
+      <img
+        i18n-alt="@@common.qrCode"
+        alt="QR Code"
+        class="qr-code margin-top-16"
+        height="300px"
+        src="{{ data()?.response?.result?.value?.container_url?.img }}"
+        width="300px" />
+    }
+    <div class="flex-column gap-16">
+      @if (data()?.rollover) {
+        <p
+          class="dialog-prose"
+          i18n="@@container.pleaseScanQrCodePrivacyidea"
+          >Please scan the QR code with the privacyIDEA Authenticator App or click this
+          <a href="{{ data()?.response?.result?.value?.container_url?.value }}">link</a> on your smartphone to complete
+          the rollover of your container. It will send the missing data to the configured endpoint.</p
+        >
+      } @else {
+        <p
+          class="dialog-prose"
+          i18n="@@container.pleaseScanQrCode"
+          >Please scan the QR code with the privacyIDEA Authenticator App or click this
+          <a href="{{ data()?.response?.result?.value?.container_url?.value }}">link</a> on your smartphone to register
+          your container. It will send the missing registration data to the configured endpoint.</p
+        >
       }
-      <div class="flex-column gap-16">
-        @if (data()?.rollover) {
-          <p
-            class="width-36"
-            i18n="@@container.pleaseScanQrCodePrivacyidea"
-            >Please scan the QR code with the privacyIDEA Authenticator App or click this
-            <a href="{{ data()?.response?.result?.value?.container_url?.value }}">link</a> on your smartphone to
-            complete the rollover of your container. It will send the missing data to the configured endpoint.</p
-          >
-        } @else {
-          <p
-            class="width-36"
-            i18n="@@container.pleaseScanQrCode"
-            >Please scan the QR code with the privacyIDEA Authenticator App or click this
-            <a href="{{ data()?.response?.result?.value?.container_url?.value }}">link</a> on your smartphone to
-            register your container. It will send the missing registration data to the configured endpoint.</p
-          >
-        }
-        <button
-          (click)="regenerateQRCode()"
-          class="action-button-secondary button-width-l"
-          mat-stroked-button>
-          <mat-icon>autorenew</mat-icon>
-          <span i18n="@@common.regenerateQrCode">Regenerate QR Code</span>
-        </button>
-      </div>
+      <button
+        (click)="regenerateQRCode()"
+        class="action-button-secondary button-width-l"
+        mat-stroked-button>
+        <mat-icon>autorenew</mat-icon>
+        <span i18n="@@common.regenerateQrCode">Regenerate QR Code</span>
+      </button>
     </div>
-  </mat-dialog-content>
+  </div>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-finalize-dialog/container-registration-finalize-dialog.component.ts
@@ -18,7 +18,6 @@
  **/
 import { Component, inject, Signal } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
-import { MatDialogContent } from "@angular/material/dialog";
 import { MatIcon } from "@angular/material/icon";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
@@ -29,7 +28,7 @@ import { ContainerService, ContainerServiceInterface } from "@services/container
   selector: "app-container-registration-finalize-dialog",
   templateUrl: "./container-registration-finalize-dialog.component.html",
   styleUrls: ["./container-registration-finalize-dialog.component.scss"],
-  imports: [MatDialogContent, MatIcon, DialogWrapperComponent, MatButtonModule]
+  imports: [MatIcon, DialogWrapperComponent, MatButtonModule]
 })
 export class ContainerRegistrationFinalizeDialogComponent extends AbstractDialogComponent<
   Signal<ContainerRegisterFinalizeData | undefined>,

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.html
@@ -17,7 +17,6 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="l"
   [title]="data.rollover ? 'Container Rollover' : 'Register Container'"
   [actions]="[getAction()]"
   [showCloseButton]="false"

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.html
@@ -17,13 +17,12 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="l"
   [title]="data.rollover ? 'Container Rollover' : 'Register Container'"
   [actions]="[getAction()]"
   [showCloseButton]="false"
   (actionTriggered)="onAction($event)">
-  <mat-dialog-content>
-    <app-container-registration-config
-      [containerHasOwner]="data.containerHasOwner"
-      (validInputChange)="onValidInputChange($event)"></app-container-registration-config>
-  </mat-dialog-content>
+  <app-container-registration-config
+    [containerHasOwner]="data.containerHasOwner"
+    (validInputChange)="onValidInputChange($event)"></app-container-registration-config>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/container/container-registration/container-registration-init-dialog/container-registration-init-dialog.component.ts
@@ -17,7 +17,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { Component, ViewChild } from "@angular/core";
-import { MatDialogContent } from "@angular/material/dialog";
 import { ContainerRegistrationConfigComponent } from "@components/container/container-registration/container-registration-config/container-registration-config.component";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
@@ -38,7 +37,7 @@ export interface ContainerRegistrationInitDialogData {
   selector: "app-container-registration-init-dialog",
   templateUrl: "./container-registration-init-dialog.component.html",
   styleUrls: ["./container-registration-init-dialog.component.scss"],
-  imports: [MatDialogContent, ContainerRegistrationConfigComponent, DialogWrapperComponent]
+  imports: [ContainerRegistrationConfigComponent, DialogWrapperComponent]
 })
 export class ContainerRegistrationInitDialogComponent extends AbstractDialogComponent<ContainerRegistrationInitDialogData> {
   @ViewChild(ContainerRegistrationConfigComponent)

--- a/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.scss
+++ b/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-copy-dialog/container-template-copy-dialog.component.scss
@@ -5,7 +5,6 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  width: 500px;
   padding: 8px 0;
 }
 

--- a/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-delete-dialog/container-template-delete-dialog.component.scss
+++ b/privacyidea/static_new/src/app/components/container/container-templates/dialogs/container-template-delete-dialog/container-template-delete-dialog.component.scss
@@ -4,7 +4,6 @@
   display: flex;
   align-items: flex-start;
   gap: 16px;
-  width: 450px;
   padding: 16px 0;
 
   .warn-icon {

--- a/privacyidea/static_new/src/app/components/shared/dialog/confirmation-dialog/confirmation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/confirmation-dialog/confirmation-dialog.component.html
@@ -31,7 +31,7 @@
     </p>
     <ul>
       @for (item of data.items; track item) {
-        <li>{{ item }}</li>
+        <li class="dialog-break-anywhere">{{ item }}</li>
       }
     </ul>
   </div>

--- a/privacyidea/static_new/src/app/components/shared/dialog/confirmation-dialog/confirmation-dialog.component.scss
+++ b/privacyidea/static_new/src/app/components/shared/dialog/confirmation-dialog/confirmation-dialog.component.scss
@@ -5,10 +5,3 @@ ul {
   column-count: 3;
   column-gap: 32px;
 }
-
-app-dialog-wrapper li {
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  max-width: 100%;
-}

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.html
@@ -1,4 +1,4 @@
-<div class="pi-dialog">
+<div class="pi-dialog pi-dialog-{{ width() }}">
   <div class="pi-dialog-header">
     <h3 class="margin-8">
       @if (icon()) {

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.scss
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.scss
@@ -44,7 +44,3 @@
 .pi-dialog-l {
   --pi-dialog-width: var(--dialog-width-l);
 }
-
-.pi-dialog-xl {
-  --pi-dialog-width: var(--dialog-width-xl);
-}

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.scss
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.scss
@@ -1,6 +1,10 @@
 .pi-dialog {
   --mat-dialog-content-padding: 0 16px 8px 16px;
 
+  // The panel shrink-wraps its content, so the width cap has to live in here. Without it a single
+  // long line of text stretches the dialog across the viewport (#5841).
+  max-width: min(var(--pi-dialog-width, var(--dialog-width-m)), calc(100vw - 2 * 32px));
+
   // The panel already caps the dialog against the viewport and the surface around this scrolls,
   // so the content area must not add a second cap and a second scrollbar inside it.
   .mat-mdc-dialog-content {
@@ -27,8 +31,20 @@
     padding: 16px;
     gap: 8px;
   }
+}
 
-  .pi-dialog-body {
-    margin-left: 16px;
-  }
+.pi-dialog-s {
+  --pi-dialog-width: var(--dialog-width-s);
+}
+
+.pi-dialog-m {
+  --pi-dialog-width: var(--dialog-width-m);
+}
+
+.pi-dialog-l {
+  --pi-dialog-width: var(--dialog-width-l);
+}
+
+.pi-dialog-xl {
+  --pi-dialog-width: var(--dialog-width-xl);
 }

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
@@ -96,11 +96,11 @@ describe("DialogWrapperComponent", () => {
   it("caps its width at the m tier unless the caller picks another", () => {
     expect(nativeElement.querySelector(".pi-dialog")?.classList).toContain("pi-dialog-m");
 
-    fixture.componentRef.setInput("width", "xl");
+    fixture.componentRef.setInput("width", "l");
     fixture.detectChanges();
 
     const dialog = nativeElement.querySelector(".pi-dialog");
-    expect(dialog?.classList).toContain("pi-dialog-xl");
+    expect(dialog?.classList).toContain("pi-dialog-l");
     expect(dialog?.classList).not.toContain("pi-dialog-m");
   });
 

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.spec.ts
@@ -93,6 +93,17 @@ describe("DialogWrapperComponent", () => {
     expect(dialogRef.close).not.toHaveBeenCalled();
   });
 
+  it("caps its width at the m tier unless the caller picks another", () => {
+    expect(nativeElement.querySelector(".pi-dialog")?.classList).toContain("pi-dialog-m");
+
+    fixture.componentRef.setInput("width", "xl");
+    fixture.detectChanges();
+
+    const dialog = nativeElement.querySelector(".pi-dialog");
+    expect(dialog?.classList).toContain("pi-dialog-xl");
+    expect(dialog?.classList).not.toContain("pi-dialog-m");
+  });
+
   it("should display the title", () => {
     const titleEl = nativeElement.querySelector("h3");
     expect(titleEl?.textContent).toContain("Test Title");

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.ts
@@ -38,6 +38,8 @@ export class DialogWrapperComponent<R = unknown> implements OnInit {
 
   title = input.required<string>();
   icon = input<string>();
+  // Width tier, see --dialog-width-* in styles.scss. Default holds ~65 characters of prose.
+  width = input<"s" | "m" | "l" | "xl">("m");
   showCloseButton = input<boolean>(true);
   // Empty by default so the template falls back to the translated <div i18n>Cancel</div>.
   // A hardcoded "Cancel" here would bypass i18n and always render in English.

--- a/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/dialog-wrapper/dialog-wrapper.component.ts
@@ -39,7 +39,7 @@ export class DialogWrapperComponent<R = unknown> implements OnInit {
   title = input.required<string>();
   icon = input<string>();
   // Width tier, see --dialog-width-* in styles.scss. Default holds ~65 characters of prose.
-  width = input<"s" | "m" | "l" | "xl">("m");
+  width = input<"s" | "m" | "l">("m");
   showCloseButton = input<boolean>(true);
   // Empty by default so the template falls back to the translated <div i18n>Cancel</div>.
   // A hardcoded "Cancel" here would bypass i18n and always render in English.

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.html
@@ -20,5 +20,5 @@
   (actionTriggered)="onAction($event)"
   [actions]="actions"
   [title]="data.title">
-  <p class="max-width-600">{{ data.message }}</p>
+  <p class="dialog-prose">{{ data.message }}</p>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-confirmation-dialog/message-confirmation-dialog.component.html
@@ -20,5 +20,5 @@
   (actionTriggered)="onAction($event)"
   [actions]="actions"
   [title]="data.title">
-  <p class="dialog-prose">{{ data.message }}</p>
+  <p>{{ data.message }}</p>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-dialog/message-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-dialog/message-dialog.component.html
@@ -20,13 +20,11 @@
 <app-dialog-wrapper
   [title]="data.title || 'Information'"
   [icon]="data.icon">
-  <mat-dialog-content>
-    <div class="text-center">
-      @for (text of data.texts; track text) {
-        <div>
-          {{ text }}
-        </div>
-      }
-    </div>
-  </mat-dialog-content>
+  <div class="text-center">
+    @for (text of data.texts; track text) {
+      <div>
+        {{ text }}
+      </div>
+    }
+  </div>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/shared/dialog/message-dialog/message-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/dialog/message-dialog/message-dialog.component.ts
@@ -18,7 +18,6 @@
  **/
 
 import { Component } from "@angular/core";
-import { MatDialogContent } from "@angular/material/dialog";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 
@@ -30,7 +29,7 @@ export interface MessageDialogData {
 
 @Component({
   selector: "app-simple-dialog",
-  imports: [MatDialogContent, DialogWrapperComponent],
+  imports: [DialogWrapperComponent],
   templateUrl: "./message-dialog.component.html",
   styleUrl: "./message-dialog.component.scss"
 })

--- a/privacyidea/static_new/src/app/components/shared/subscription-expiry-dialog/subscription-expiry-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/subscription-expiry-dialog/subscription-expiry-dialog.component.html
@@ -1,5 +1,8 @@
-<div class="expiry-container">
-  <h2 i18n="@@subscription.subscriptionExpires">Subscription expires soon</h2>
+<app-dialog-wrapper
+  cancelButtonLabel="Close"
+  i18n-cancelButtonLabel="@@common.close"
+  i18n-title="@@subscription.subscriptionExpires"
+  title="Subscription expires soon">
   <div class="content">
     <p i18n="@@subscription.oneMoreSubscriptions"
       >One or more subscriptions will expire within the next month. Please review your subscriptions.</p
@@ -27,13 +30,4 @@
       }
     </ul>
   </div>
-
-  <div class="actions">
-    <button
-      mat-stroked-button
-      matDialogClose
-      i18n="@@common.close"
-      >Close</button
-    >
-  </div>
-</div>
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/shared/subscription-expiry-dialog/subscription-expiry-dialog.component.scss
+++ b/privacyidea/static_new/src/app/components/shared/subscription-expiry-dialog/subscription-expiry-dialog.component.scss
@@ -1,18 +1,5 @@
-@use "styles";
-
-.expiry-container {
-  max-width: 720px;
-  padding: 16px;
-}
-
-h2 {
-  margin: 0 0 12px;
-}
-
 .content {
   line-height: 1.6;
-  margin-left: 16px;
-  margin-bottom: 12px;
 }
 
 .items {
@@ -23,6 +10,7 @@ h2 {
 
 .row {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   gap: 8px;
 }
@@ -33,11 +21,4 @@ h2 {
 
 .value {
   font-family: monospace;
-}
-
-.actions {
-  margin-top: 16px;
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
 }

--- a/privacyidea/static_new/src/app/components/shared/subscription-expiry-dialog/subscription-expiry-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/subscription-expiry-dialog/subscription-expiry-dialog.component.spec.ts
@@ -17,8 +17,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { MAT_DIALOG_DATA, MatDialogModule } from "@angular/material/dialog";
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
 import { By } from "@angular/platform-browser";
+import { MockMatDialogRef } from "@testing/mock-mat-dialog-ref";
 import {
   SubscriptionExpiryDialogComponent,
   SubscriptionExpiryDialogData
@@ -38,7 +39,10 @@ describe("SubscriptionExpiryDialogComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SubscriptionExpiryDialogComponent, MatDialogModule],
-      providers: [{ provide: MAT_DIALOG_DATA, useValue: dialogData }]
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: dialogData },
+        { provide: MatDialogRef, useValue: new MockMatDialogRef<SubscriptionExpiryDialogComponent>() }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(SubscriptionExpiryDialogComponent);

--- a/privacyidea/static_new/src/app/components/shared/subscription-expiry-dialog/subscription-expiry-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/subscription-expiry-dialog/subscription-expiry-dialog.component.ts
@@ -16,10 +16,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
-import { Component, inject } from "@angular/core";
+import { Component } from "@angular/core";
 
-import { MatButton } from "@angular/material/button";
-import { MAT_DIALOG_DATA, MatDialogClose } from "@angular/material/dialog";
+import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 
 export interface SubscriptionExpiryItem {
   application: string;
@@ -34,13 +34,11 @@ export interface SubscriptionExpiryDialogData {
 @Component({
   selector: "app-subscription-expiry-dialog",
   standalone: true,
-  imports: [MatDialogClose, MatButton],
+  imports: [DialogWrapperComponent],
   templateUrl: "./subscription-expiry-dialog.component.html",
   styleUrl: "./subscription-expiry-dialog.component.scss"
 })
-export class SubscriptionExpiryDialogComponent {
-  readonly data = inject<SubscriptionExpiryDialogData>(MAT_DIALOG_DATA);
-
+export class SubscriptionExpiryDialogComponent extends AbstractDialogComponent<SubscriptionExpiryDialogData> {
   remainingDays(item: SubscriptionExpiryItem): number {
     // timedelta is negative before expiry (days until expiry), positive after; clamp to zero when past expiry
     return Math.max(0, Math.ceil(-item.timedelta));

--- a/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.html
@@ -1,8 +1,12 @@
-<div class="welcome-container">
+<app-dialog-wrapper
+  width="l"
+  (actionTriggered)="onDialogAction($event)"
+  [actions]="dialogActions()"
+  [showCloseButton]="false"
+  [title]="dialogTitle()">
   @if (step() === 0) {
-    <h2 i18n="@@welcome.welcome">Welcome</h2>
     <div
-      class="content"
+      class="content dialog-prose"
       i18n="@@welcome.firstWeWouldLike"
       ><p>First, we would like to give you some background information on privacyIDEA.</p>
       <p>
@@ -17,20 +21,11 @@
         paid programming of new features.
       </p></div
     >
-    <div class="actions">
-      <button
-        (click)="nextWelcome()"
-        i18n="@@common.next"
-        mat-stroked-button
-        >Next</button
-      >
-    </div>
   }
 
   @if (step() === 1) {
-    <h2 i18n="@@welcome.valueOpenSource">The value of open source</h2>
     <div
-      class="content"
+      class="content dialog-prose"
       i18n="@@welcome.youReadingBooks"
       ><p>
         You are reading books, which do not belong to you anymore. Your ebook reader only provides them for the time of
@@ -54,19 +49,10 @@
         >
       </p></div
     >
-    <div class="actions">
-      <button
-        (click)="nextWelcome()"
-        i18n="@@common.next"
-        mat-stroked-button
-        >Next</button
-      >
-    </div>
   }
 
   @if (step() === 2) {
-    <h2 i18n="@@welcome.addedValuePrivacyidea">The added value of privacyIDEA Enterprise Edition</h2>
-    <div class="content">
+    <div class="content dialog-prose">
       <p i18n="@@welcome.accordingAgplv3"
         >According to the
         <a
@@ -124,44 +110,20 @@
         ></p
       >
     </div>
-    <div class="actions">
-      <button
-        (click)="nextWelcome()"
-        i18n="@@common.next"
-        mat-stroked-button
-        >Next</button
-      >
-    </div>
   }
 
   @if (step() === 3) {
-    <h2 i18n="@@welcome.thankYouImproving">Thank you for improving your security!</h2>
     <div
-      class="content"
+      class="content dialog-prose"
       i18n="@@welcome.thankYouUsing"
       ><p>Thank you for using privacyIDEA and making your network and thus this world a more secure place!</p>
       <p>Have fun using privacyIDEA!</p></div
     >
-    <div class="actions">
-      <button
-        (click)="resetWelcome()"
-        mat-stroked-button>
-        <mat-icon>replay</mat-icon>
-        <span i18n="@@welcome.readAgain">Read again</span>
-      </button>
-      <button
-        (click)="nextWelcome()"
-        class="action-button-secondary"
-        mat-stroked-button>
-        <mat-icon>keyboard_arrow_right</mat-icon>
-        <span i18n="@@welcome.diveIn">Dive In!</span>
-      </button>
-    </div>
   }
 
   @if (step() === 4) {
     <div
-      class="content"
+      class="content dialog-prose"
       i18n="@@welcome.youUsingPrivacyidea"
       ><p><b>You are using privacyIDEA with more than 50 users.</b></p> <p>Thank you for your trust!</p>
       <p>
@@ -183,14 +145,5 @@
         paid programming of new features.
       </p></div
     >
-    <div class="actions">
-      <button
-        (click)="nextWelcome()"
-        class="action-button-secondary"
-        mat-stroked-button>
-        <mat-icon>done</mat-icon>
-        <span i18n="@@welcome.okay">Okay</span>
-      </button>
-    </div>
   }
-</div>
+</app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.html
@@ -1,12 +1,11 @@
 <app-dialog-wrapper
-  width="l"
   (actionTriggered)="onDialogAction($event)"
   [actions]="dialogActions()"
   [showCloseButton]="false"
   [title]="dialogTitle()">
   @if (step() === 0) {
     <div
-      class="content dialog-prose"
+      class="content"
       i18n="@@welcome.firstWeWouldLike"
       ><p>First, we would like to give you some background information on privacyIDEA.</p>
       <p>
@@ -25,7 +24,7 @@
 
   @if (step() === 1) {
     <div
-      class="content dialog-prose"
+      class="content"
       i18n="@@welcome.youReadingBooks"
       ><p>
         You are reading books, which do not belong to you anymore. Your ebook reader only provides them for the time of
@@ -52,7 +51,7 @@
   }
 
   @if (step() === 2) {
-    <div class="content dialog-prose">
+    <div class="content">
       <p i18n="@@welcome.accordingAgplv3"
         >According to the
         <a
@@ -114,7 +113,7 @@
 
   @if (step() === 3) {
     <div
-      class="content dialog-prose"
+      class="content"
       i18n="@@welcome.thankYouUsing"
       ><p>Thank you for using privacyIDEA and making your network and thus this world a more secure place!</p>
       <p>Have fun using privacyIDEA!</p></div
@@ -123,7 +122,7 @@
 
   @if (step() === 4) {
     <div
-      class="content dialog-prose"
+      class="content"
       i18n="@@welcome.youUsingPrivacyidea"
       ><p><b>You are using privacyIDEA with more than 50 users.</b></p> <p>Thank you for your trust!</p>
       <p>

--- a/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.scss
+++ b/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.scss
@@ -1,18 +1,4 @@
-@use "styles";
-
-.welcome-container {
-  max-width: 720px;
-  padding: 16px;
-}
-
+// The wrapper supplies the padding, the body indent and the footer; only the prose spacing is ours.
 .content {
   line-height: 1.6;
-  margin-left: 16px;
-}
-
-.actions {
-  margin-top: 16px;
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
 }

--- a/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.spec.ts
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { TestBed } from "@angular/core/testing";
-import { MatDialogRef } from "@angular/material/dialog";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { AuthService } from "@services/auth/auth.service";
 import { MockAuthService } from "@testing/mock-services";
 import { WelcomeDialogServiceMock } from "@testing/mock-services/mock-welcome-dialog-service";
@@ -36,6 +36,7 @@ describe("WelcomeDialogComponent", () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: MatDialogRef, useValue: dialogRefMock },
+        { provide: MAT_DIALOG_DATA, useValue: null },
         { provide: AuthService, useClass: MockAuthService }
       ]
     });
@@ -79,6 +80,28 @@ describe("WelcomeDialogComponent", () => {
 
     component.nextWelcome();
     expect(dialogRefMock.close).toHaveBeenCalled();
+  });
+
+  it("renders the step heading and its buttons in the shared dialog wrapper", () => {
+    const fixture = TestBed.createComponent(WelcomeDialogComponent);
+    const heading = () => fixture.nativeElement.querySelector(".pi-dialog-header").textContent.trim();
+    const buttons = (): string[] =>
+      Array.from(fixture.nativeElement.querySelectorAll(".pi-dialog-footer button")).map((button) =>
+        (button as HTMLElement).textContent!.trim()
+      );
+    fixture.detectChanges();
+
+    expect(heading()).toBe("Welcome");
+    expect(buttons()).toHaveLength(1);
+    expect(buttons()[0]).toContain("Next");
+
+    fixture.componentInstance.step.set(3);
+    fixture.detectChanges();
+
+    expect(heading()).toBe("Thank you for improving your security!");
+    expect(buttons()).toHaveLength(2);
+    expect(buttons()[0]).toContain("Read again");
+    expect(buttons()[1]).toContain("Dive In!");
   });
 
   it("resetWelcome should set step back to 0", () => {

--- a/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.spec.ts
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
-import { TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { AuthService } from "@services/auth/auth.service";
 import { MockAuthService } from "@testing/mock-services";
@@ -24,10 +24,21 @@ import { WelcomeDialogServiceMock } from "@testing/mock-services/mock-welcome-di
 import { WelcomeDialogComponent } from "./welcome-dialog.component";
 
 describe("WelcomeDialogComponent", () => {
+  let fixture: ComponentFixture<WelcomeDialogComponent>;
   let component: WelcomeDialogComponent;
   let dialogRefMock: { close: jest.Mock };
   let welcomeDialogServiceMock: WelcomeDialogServiceMock;
   let authMock: MockAuthService;
+
+  const heading = (): string => fixture.nativeElement.querySelector(".pi-dialog-header").textContent.trim();
+  const buttons = (): HTMLElement[] => Array.from(fixture.nativeElement.querySelectorAll(".pi-dialog-footer button"));
+  const buttonLabels = (): string[] => buttons().map((button) => button.textContent!.trim());
+  const clickButton = (label: string): void => {
+    const button = buttons().find((candidate) => candidate.textContent!.includes(label));
+    expect(button).toBeDefined();
+    button!.click();
+    fixture.detectChanges();
+  };
 
   beforeEach(() => {
     dialogRefMock = { close: jest.fn() };
@@ -42,7 +53,8 @@ describe("WelcomeDialogComponent", () => {
     });
 
     authMock = TestBed.inject(AuthService) as unknown as MockAuthService;
-    component = TestBed.createComponent(WelcomeDialogComponent).componentInstance;
+    fixture = TestBed.createComponent(WelcomeDialogComponent);
+    component = fixture.componentInstance;
   });
 
   it("should start at step 0 by default", () => {
@@ -68,7 +80,6 @@ describe("WelcomeDialogComponent", () => {
   });
 
   it("should allow step 4 when subscriptionStatus is 1, then close on next", () => {
-    component = TestBed.createComponent(WelcomeDialogComponent).componentInstance;
     authMock.authData.set({ ...MockAuthService.MOCK_AUTH_DATA, subscription_status: 1 });
     component.nextWelcome(); // 1
     component.nextWelcome(); // 2
@@ -83,25 +94,54 @@ describe("WelcomeDialogComponent", () => {
   });
 
   it("renders the step heading and its buttons in the shared dialog wrapper", () => {
-    const fixture = TestBed.createComponent(WelcomeDialogComponent);
-    const heading = () => fixture.nativeElement.querySelector(".pi-dialog-header").textContent.trim();
-    const buttons = (): string[] =>
-      Array.from(fixture.nativeElement.querySelectorAll(".pi-dialog-footer button")).map((button) =>
-        (button as HTMLElement).textContent!.trim()
-      );
     fixture.detectChanges();
 
     expect(heading()).toBe("Welcome");
-    expect(buttons()).toHaveLength(1);
-    expect(buttons()[0]).toContain("Next");
+    expect(buttonLabels()).toHaveLength(1);
+    expect(buttonLabels()[0]).toContain("Next");
 
-    fixture.componentInstance.step.set(3);
+    component.step.set(3);
     fixture.detectChanges();
 
     expect(heading()).toBe("Thank you for improving your security!");
-    expect(buttons()).toHaveLength(2);
-    expect(buttons()[0]).toContain("Read again");
-    expect(buttons()[1]).toContain("Dive In!");
+    expect(buttonLabels()).toHaveLength(2);
+    expect(buttonLabels()[0]).toContain("Read again");
+    expect(buttonLabels()[1]).toContain("Dive In!");
+  });
+
+  it("gives the open source and enterprise steps their own headings", () => {
+    component.step.set(1);
+    fixture.detectChanges();
+    expect(heading()).toBe("The value of open source");
+
+    component.step.set(2);
+    fixture.detectChanges();
+    expect(heading()).toBe("The added value of privacyIDEA Enterprise Edition");
+    expect(buttonLabels()).toHaveLength(1);
+    expect(buttonLabels()[0]).toContain("Next");
+  });
+
+  it("closes the subscription step with a single confirm button under the enterprise heading", () => {
+    component.step.set(4);
+    fixture.detectChanges();
+
+    expect(heading()).toBe("The added value of privacyIDEA Enterprise Edition");
+    expect(buttonLabels()).toHaveLength(1);
+    expect(buttonLabels()[0]).toContain("Okay");
+
+    clickButton("Okay");
+    expect(dialogRefMock.close).toHaveBeenCalled();
+  });
+
+  it("restarts on the read again action and advances on every other action", () => {
+    component.step.set(3);
+    fixture.detectChanges();
+
+    clickButton("Read again");
+    expect(component.step()).toBe(0);
+
+    clickButton("Next");
+    expect(component.step()).toBe(1);
   });
 
   it("resetWelcome should set step back to 0", () => {

--- a/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/shared/welcome-dialog/welcome-dialog.component.ts
@@ -16,24 +16,87 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
-import { Component, inject, signal } from "@angular/core";
-import { MatButton } from "@angular/material/button";
+import { Component, computed, inject, signal } from "@angular/core";
 
-import { MatDialogRef } from "@angular/material/dialog";
-import { MatIcon } from "@angular/material/icon";
+import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
+import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
+import { DialogAction } from "@models/dialog";
 import { AuthService } from "@services/auth/auth.service";
+
+type WelcomeAction = "next" | "restart";
 
 @Component({
   selector: "app-welcome-dialog",
   standalone: true,
-  imports: [MatButton, MatIcon],
+  imports: [DialogWrapperComponent],
   templateUrl: "./welcome-dialog.component.html",
   styleUrl: "./welcome-dialog.component.scss"
 })
-export class WelcomeDialogComponent {
-  private dialogRef = inject(MatDialogRef<WelcomeDialogComponent>);
+export class WelcomeDialogComponent extends AbstractDialogComponent<void, void> {
   private auth = inject(AuthService);
   step = signal<number>(0);
+
+  readonly dialogTitle = computed(() => {
+    switch (this.step()) {
+      case 1:
+        return $localize`:@@welcome.valueOpenSource:The value of open source`;
+      // The closing step recommends the Enterprise Edition just like step 2, so it carries the same heading.
+      case 2:
+      case 4:
+        return $localize`:@@welcome.addedValuePrivacyidea:The added value of privacyIDEA Enterprise Edition`;
+      case 3:
+        return $localize`:@@welcome.thankYouImproving:Thank you for improving your security!`;
+      default:
+        return $localize`:@@welcome.welcome:Welcome`;
+    }
+  });
+
+  readonly dialogActions = computed((): DialogAction<WelcomeAction>[] => {
+    if (this.step() === 3) {
+      return [
+        {
+          type: "auxiliary",
+          label: $localize`:@@welcome.readAgain:Read again`,
+          value: "restart",
+          icon: "replay"
+        },
+        {
+          type: "confirm",
+          label: $localize`:@@welcome.diveIn:Dive In!`,
+          value: "next",
+          primary: true,
+          icon: "keyboard_arrow_right"
+        }
+      ];
+    }
+    if (this.step() === 4) {
+      return [
+        {
+          type: "confirm",
+          label: $localize`:@@welcome.okay:Okay`,
+          value: "next",
+          primary: true,
+          icon: "done"
+        }
+      ];
+    }
+    return [
+      {
+        type: "auxiliary",
+        label: $localize`:@@common.next:Next`,
+        value: "next",
+        primary: true
+      }
+    ];
+  });
+
+  onDialogAction(value: WelcomeAction): void {
+    if (value === "restart") {
+      this.resetWelcome();
+    } else {
+      this.nextWelcome();
+    }
+  }
 
   nextWelcome(): void {
     let nextStep = this.step() + 1;
@@ -44,7 +107,7 @@ export class WelcomeDialogComponent {
     }
 
     if (nextStep >= 5) {
-      this.dialogRef.close();
+      this.close();
     } else {
       this.step.set(nextStep);
     }

--- a/privacyidea/static_new/src/app/components/token/resync-otp-token-dialog/resync-otp-token-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/resync-otp-token-dialog/resync-otp-token-dialog.component.html
@@ -21,15 +21,13 @@
   [title]="data ? 'Token Resync Successful' : 'Token Resync Failed'"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@common.close">
-  <mat-dialog-content>
-    <div class="text-center">
-      @if (data) {
-        <p i18n="@@token.tokenWasSuccessfully">The token was successfully synchronized.</p>
-      } @else {
-        <p i18n="@@token.tokenCouldNot"
-          >The token could not be synchronized. Please check the OTP values and try again.</p
-        >
-      }
-    </div>
-  </mat-dialog-content>
+  <div class="text-center">
+    @if (data) {
+      <p i18n="@@token.tokenWasSuccessfully">The token was successfully synchronized.</p>
+    } @else {
+      <p i18n="@@token.tokenCouldNot"
+        >The token could not be synchronized. Please check the OTP values and try again.</p
+      >
+    }
+  </div>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/token/resync-otp-token-dialog/resync-otp-token-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/resync-otp-token-dialog/resync-otp-token-dialog.component.ts
@@ -17,13 +17,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { Component } from "@angular/core";
-import { MatDialogContent } from "@angular/material/dialog";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
 
 @Component({
   selector: "app-resync-otp-token-dialog",
-  imports: [MatDialogContent, DialogWrapperComponent],
+  imports: [DialogWrapperComponent],
   templateUrl: "resync-otp-token-dialog.component.html",
   styleUrl: "resync-otp-token-dialog.component.scss"
 })

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/lost-token/lost-token.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/lost-token/lost-token.component.html
@@ -21,7 +21,7 @@
   [showCloseButton]="false"
   [actions]="[closeAction]"
   [title]="dialogTitle()">
-  <div class="lost-content">
+  <div>
     <p i18n="@@token.ifTokenLostYou"
       >If the token is lost, you can enroll a temporary password based token and give the password to the user. The OTP
       PIN of the old token is still the same.</p

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/lost-token/lost-token.component.scss
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/lost-token/lost-token.component.scss
@@ -11,10 +11,6 @@
   color: var(--mat-sys-primary);
 }
 
-.lost-content {
-  width: 32rem;
-}
-
 .lost-card {
   background: var(--green-light);
   color: white;

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   (actionTriggered)="rolloverToken()"
   [title]="title()"
   [actions]="dialogActions()">

--- a/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-details-actions/token-rollover/token-rollover.component.html
@@ -17,6 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="xl"
   (actionTriggered)="rolloverToken()"
   [title]="title()"
   [actions]="dialogActions()">

--- a/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-hotp-machine-attach-dialog/token-hotp-machine-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-details/token-machine-attach-dialog/token-hotp-machine-attach-dialog/token-hotp-machine-attach-dialog.component.html
@@ -18,6 +18,7 @@
 -->
 
 <app-dialog-wrapper
+  width="s"
   title="Attach Offline Machine"
   i18n-title="@@token.attachOffline"
   (actionTriggered)="onAction($event)"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
@@ -18,6 +18,7 @@
 -->
 
 <app-dialog-wrapper
+  width="xl"
   title="Complete Token Enrollment"
   i18n-title="@@token.completeToken"
   [showCloseButton]="showCloseButton()"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-complete-enrollment/token-complete-enrollment.component.html
@@ -18,7 +18,7 @@
 -->
 
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   title="Complete Token Enrollment"
   i18n-title="@@token.completeToken"
   [showCloseButton]="showCloseButton()"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.html
@@ -17,6 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="xl"
   (actionTriggered)="onAction($event)"
   [actions]="actions()"
   [showCloseButton]="showCloseButton"
@@ -24,53 +25,51 @@
   i18n-cancelButtonLabel="@@common.close"
   i18n-title="@@token.takeActionYour"
   title="Take action on your authenticator">
-  <mat-dialog-content>
-    @if (registrationFailed()) {
+  @if (registrationFailed()) {
+    <p
+      class="dialog-prose"
+      i18n>
+      The registration was not completed. Please try again or cancel the enrollment. Cancelling deletes the token that
+      has already been created for this enrollment.
+    </p>
+  } @else if (
+    data.enrollmentResponse.detail["webAuthnRegisterRequest"] || data.enrollmentResponse.detail.passkey_registration
+  ) {
+    <p
+      class="dialog-prose"
+      i18n="@@token.youNeedConfirmRegistration"
+      >You need to confirm the registration with your authenticator. For an external authenticator, this usually means
+      pushing the button on the authenticator, or replugging it (if there is no button on the authenticator). If you
+      want to use an authenticator that is integrated into your device, look for a dialog box from your operating
+      system. If you do not see anything, please make sure that your authenticator supports WebAuthn.</p
+    >
+  }
+  @if (data.enrollmentResponse.detail.u2fRegisterRequest) {
+    <p
+      class="dialog-prose"
+      i18n="@@token.youNeedConfirm"
+      >You need to confirm the registration with your token either by pushing the blinking button or by replugging your
+      token. This depends on the actual token model.</p
+    >
+  }
+  @if (data.enrollmentResponse.detail.pushurl) {
+    <div class="flex-row gap-16">
+      <img
+        alt="QR Code"
+        class="qr-code"
+        height="300px"
+        i18n-alt="@@common.qrCode"
+        src="{{ data.enrollmentResponse.detail.pushurl.img }}"
+        width="300px" />
       <p
-        class="max-width-600"
-        i18n>
-        The registration was not completed. Please try again or cancel the enrollment. Cancelling deletes the token that
-        has already been created for this enrollment.
-      </p>
-    } @else if (
-      data.enrollmentResponse.detail["webAuthnRegisterRequest"] || data.enrollmentResponse.detail.passkey_registration
-    ) {
-      <p
-        class="max-width-600"
-        i18n="@@token.youNeedConfirmRegistration"
-        >You need to confirm the registration with your authenticator. For an external authenticator, this usually means
-        pushing the button on the authenticator, or replugging it (if there is no button on the authenticator). If you
-        want to use an authenticator that is integrated into your device, look for a dialog box from your operating
-        system. If you do not see anything, please make sure that your authenticator supports WebAuthn.</p
+        class="dialog-prose"
+        i18n="@@token.yourTokenSerialNumber"
+        >Your token with serial number {{ data.enrollmentResponse.detail.serial }} is not completely enrolled, yet.
+        Please scan the QR code with the privacyIDEA Authenticator App or click
+        <a href="{{ data.enrollmentResponse.detail.pushurl.value }}">this link</a> on your smartphone. It will send the
+        missing registration data to the configured endpoint. Please note, that your smartphone needs internet access
+        during the authentication process.</p
       >
-    }
-    @if (data.enrollmentResponse.detail.u2fRegisterRequest) {
-      <p
-        class="max-width-600"
-        i18n="@@token.youNeedConfirm"
-        >You need to confirm the registration with your token either by pushing the blinking button or by replugging
-        your token. This depends on the actual token model.</p
-      >
-    }
-    @if (data.enrollmentResponse.detail.pushurl) {
-      <div class="flex-row gap-16">
-        <img
-          alt="QR Code"
-          class="qr-code"
-          height="300px"
-          i18n-alt="@@common.qrCode"
-          src="{{ data.enrollmentResponse.detail.pushurl.img }}"
-          width="300px" />
-        <p
-          class="max-width-600"
-          i18n="@@token.yourTokenSerialNumber"
-          >Your token with serial number {{ data.enrollmentResponse.detail.serial }} is not completely enrolled, yet.
-          Please scan the QR code with the privacyIDEA Authenticator App or click
-          <a href="{{ data.enrollmentResponse.detail.pushurl.value }}">this link</a> on your smartphone. It will send
-          the missing registration data to the configured endpoint. Please note, that your smartphone needs internet
-          access during the authentication process.</p
-        >
-      </div>
-    }
-  </mat-dialog-content>
+    </div>
+  }
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   (actionTriggered)="onAction($event)"
   [actions]="actions()"
   [showCloseButton]="showCloseButton"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.scss
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.scss
@@ -1,6 +1,0 @@
-@use "styles";
-@use "table";
-
-.max-width-600 {
-  max-width: 600px;
-}

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-firtst-step-dialog/token-enrollment-first-step-dialog.component.ts
@@ -17,7 +17,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  **/
 import { Component, computed, inject, Signal } from "@angular/core";
-import { MatDialogContent } from "@angular/material/dialog";
 import { EnrollmentResponse } from "@app/mappers/token-api-payload/_token-api-payload.mapper";
 import { AbstractDialogComponent } from "@components/shared/dialog/abstract-dialog/abstract-dialog.component";
 import { DialogWrapperComponent } from "@components/shared/dialog/dialog-wrapper/dialog-wrapper.component";
@@ -44,9 +43,8 @@ type FirstStepDialogAction = "retry" | "cancelEnrollment";
 
 @Component({
   selector: "app-token-enrollment-first-step-dialog",
-  imports: [MatDialogContent, DialogWrapperComponent],
-  templateUrl: "./token-enrollment-first-step-dialog.component.html",
-  styleUrl: "./token-enrollment-first-step-dialog.component.scss"
+  imports: [DialogWrapperComponent],
+  templateUrl: "./token-enrollment-first-step-dialog.component.html"
 })
 export class TokenEnrollmentFirstStepDialogComponent extends AbstractDialogComponent<
   TokenEnrollmentFirstStepDialogData,

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@common.close"
   title="{{ title() }}">

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.component.html
@@ -17,6 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="xl"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@common.close"
   title="{{ title() }}">

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@common.close"
   i18n-title="@@token.tokenSuccessfully"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.self-service.component.html
@@ -17,6 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="xl"
   cancelButtonLabel="Close"
   i18n-cancelButtonLabel="@@common.close"
   i18n-title="@@token.tokenSuccessfully"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.html
@@ -17,66 +17,65 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="xl"
   (actionTriggered)="onAction($event)"
   [actions]="actions()"
   [showCloseButton]="false"
   i18n-title="@@token.tokenSuccessfully"
   title="Token Successfully Enrolled">
-  <mat-dialog-content>
-    @let postTopHtml = postTopHtml$ | async;
-    @if (postTopHtml?.hasContent) {
-      <div
-        [innerHTML]="postTopHtml?.sanitized"
-        class="margin-top-16"></div>
-    } @else {
-      <app-token-enrolled-text
-        (switchRoute)="onSwitchRoute()"
-        [rollover]="data.rollover ?? false"
-        [serial]="serial"></app-token-enrolled-text>
+  @let postTopHtml = postTopHtml$ | async;
+  @if (postTopHtml?.hasContent) {
+    <div
+      [innerHTML]="postTopHtml?.sanitized"
+      class="margin-top-16"></div>
+  } @else {
+    <app-token-enrolled-text
+      (switchRoute)="onSwitchRoute()"
+      [rollover]="data.rollover ?? false"
+      [serial]="serial"></app-token-enrolled-text>
+  }
+  <div class="flex-row gap-16">
+    @if (showQRCode() && qrCode) {
+      <img
+        alt="QR Code"
+        class="qr-code"
+        height="300px"
+        i18n-alt="@@common.qrCode"
+        src="{{ qrCode }}"
+        width="300px" />
     }
-    <div class="flex-row gap-16">
-      @if (showQRCode() && qrCode) {
-        <img
-          alt="QR Code"
-          class="qr-code"
-          height="300px"
-          i18n-alt="@@common.qrCode"
-          src="{{ qrCode }}"
-          width="300px" />
-      }
 
-      @if (data.showEnrollData !== false) {
-        <div class="flex-column gap-16">
-          @if (data.response?.detail?.["password"]) {
-            <p i18n="@@token.yourPassword"
-              >Your Password: <strong>{{ data.response?.detail?.["password"] }}</strong
-              >.</p
-            >
-          }
+    @if (data.showEnrollData !== false) {
+      <div class="flex-column gap-16">
+        @if (data.response?.detail?.["password"]) {
+          <p i18n="@@token.yourPassword"
+            >Your Password: <strong>{{ data.response?.detail?.["password"] }}</strong
+            >.</p
+          >
+        }
 
-          @if (data.response?.detail?.otpkey?.value && !data.response?.detail?.["otps"] && showQRCode()) {
-            <app-otp-key
-              [otpKeyBase32]="data.response?.detail?.otpkey?.value_b32 ?? ''"
-              [otpKeyHex]="data.response?.detail?.otpkey?.value ?? ''" />
-          }
+        @if (data.response?.detail?.otpkey?.value && !data.response?.detail?.["otps"] && showQRCode()) {
+          <app-otp-key
+            [otpKeyBase32]="data.response?.detail?.otpkey?.value_b32 ?? ''"
+            [otpKeyHex]="data.response?.detail?.otpkey?.value ?? ''" />
+        }
 
-          @if (data.tokenType === "tiqr") {
-            <app-tiqr-enroll-url [url]="data.response?.detail?.['tiqrenroll']?.value ?? ''" />
-          }
+        @if (data.tokenType === "tiqr") {
+          <app-tiqr-enroll-url [url]="data.response?.detail?.['tiqrenroll']?.value ?? ''" />
+        }
 
-          @if (data.tokenType === "registration") {
-            <app-registration-code [registrationCode]="data.response?.detail?.['registrationcode'] ?? ''" />
-          }
+        @if (data.tokenType === "registration") {
+          <app-registration-code [registrationCode]="data.response?.detail?.['registrationcode'] ?? ''" />
+        }
 
-          @if (data.response?.detail?.["otps"]) {
-            <app-otp-values [otpValues]="data.response?.detail?.['otps'] ?? []" />
-          }
-        </div>
-      }
+        @if (data.response?.detail?.["otps"]) {
+          <app-otp-values [otpValues]="data.response?.detail?.['otps'] ?? []" />
+        }
+      </div>
+    }
 
-      <div
-        [innerHTML]="postBottomHtml$ | async"
-        class="margin-bottom-16"></div>
-    </div>
-  </mat-dialog-content>
+    <div
+      [innerHTML]="postBottomHtml$ | async"
+      class="margin-bottom-16"></div>
+  </div>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.html
@@ -17,7 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   (actionTriggered)="onAction($event)"
   [actions]="actions()"
   [showCloseButton]="false"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment-last-step-dialog/token-enrollment-last-step-dialog.wizard.component.ts
@@ -20,7 +20,6 @@ import { AsyncPipe } from "@angular/common";
 import { HttpClient } from "@angular/common/http";
 import { Component, computed, inject, SecurityContext, Signal } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
-import { MatDialogContent } from "@angular/material/dialog";
 import { DomSanitizer } from "@angular/platform-browser";
 import { Router, RouterLink } from "@angular/router";
 import { ROUTE_PATHS } from "@app/route_paths";
@@ -43,7 +42,6 @@ import { TokenEnrollmentLastStepDialogComponent } from "./token-enrollment-last-
 @Component({
   selector: "app-token-enrollment-last-step-dialog-wizard",
   imports: [
-    MatDialogContent,
     AsyncPipe,
     OtpKeyComponent,
     TiqrEnrollUrlComponent,

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.wizard.component.ts
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-enrollment.wizard.component.ts
@@ -130,8 +130,7 @@ export class TokenEnrollmentWizardComponent extends TokenEnrollmentComponent {
 
     this.dialogService.openDialog({
       component: TokenEnrollmentLastStepDialogWizardComponent,
-      data: this.enrolledDialogData(),
-      configOverride: { maxWidth: "1000px" }
+      data: this.enrolledDialogData()
     });
   }
 }

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
@@ -18,7 +18,7 @@
 -->
 
 <app-dialog-wrapper
-  width="xl"
+  width="l"
   title="Verify Token Enrollment"
   i18n-title="@@token.verifyTokenEnrollment"
   [actions]="dialogActions()"

--- a/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-enrollment/token-verify-enrollment/token-verify-enrollment.component.html
@@ -18,6 +18,7 @@
 -->
 
 <app-dialog-wrapper
+  width="xl"
   title="Verify Token Enrollment"
   i18n-title="@@token.verifyTokenEnrollment"
   [actions]="dialogActions()"

--- a/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/selected-user-attach-dialog/selected-user-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/selected-user-attach-dialog/selected-user-attach-dialog.component.html
@@ -17,6 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="l"
   (actionTriggered)="onAction($event)"
   [actions]="actions()"
   i18n-title="@@token.assignSelectedToken"

--- a/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/selected-user-attach-dialog/selected-user-attach-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/token/token-table/token-table-actions/selected-user-attach-dialog/selected-user-attach-dialog.component.html
@@ -17,7 +17,6 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
-  width="l"
   (actionTriggered)="onAction($event)"
   [actions]="actions()"
   i18n-title="@@token.assignSelectedToken"

--- a/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.html
@@ -21,6 +21,6 @@
   [actions]="actions"
   (actionTriggered)="onAction($event)">
   <div class="margin-right-16">
-    <p class="server-message">{{ data.message }}</p>
+    <p class="dialog-prose dialog-break-anywhere">{{ data.message }}</p>
   </div>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.html
@@ -21,6 +21,6 @@
   [actions]="actions"
   (actionTriggered)="onAction($event)">
   <div class="margin-right-16">
-    <p class="dialog-prose dialog-break-anywhere">{{ data.message }}</p>
+    <p class="dialog-break-anywhere">{{ data.message }}</p>
   </div>
 </app-dialog-wrapper>

--- a/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.scss
+++ b/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.scss
@@ -1,7 +1,0 @@
-@use "styles";
-
-.server-message {
-  max-width: 70ch;
-  overflow-wrap: break-word;
-  word-break: break-word;
-}

--- a/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.ts
+++ b/privacyidea/static_new/src/app/components/user/realm-table/realm-delete-attributes-dialog/realm-delete-attributes-dialog.component.ts
@@ -25,8 +25,7 @@ import { DialogAction } from "@models/dialog";
 @Component({
   selector: "app-realm-delete-attributes-dialog",
   imports: [DialogWrapperComponent],
-  templateUrl: "./realm-delete-attributes-dialog.component.html",
-  styleUrl: "./realm-delete-attributes-dialog.component.scss"
+  templateUrl: "./realm-delete-attributes-dialog.component.html"
 })
 export class RealmDeleteAttributesDialogComponent extends AbstractDialogComponent<
   RealmDeleteAttributesDialogData,

--- a/privacyidea/static_new/src/app/components/user/user-details/user-details-pin-dialog/user-details-pin-dialog.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-details/user-details-pin-dialog/user-details-pin-dialog.component.html
@@ -17,6 +17,7 @@
  SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <app-dialog-wrapper
+  width="s"
   (actionTriggered)="onAction($event)"
   [actions]="dialogActions()"
   [showCloseButton]="false"

--- a/privacyidea/static_new/src/app/components/user/user-table/user-table.component.html
+++ b/privacyidea/static_new/src/app/components/user/user-table/user-table.component.html
@@ -135,14 +135,15 @@
                     }
                     @case ("resolver") {
                       <app-copyable [copyText]="element[column.key]">
-                        <a
-                          (click)="onClickResolver(element[column.key]); $event.preventDefault()"
-                          (keydown.enter)="onClickResolver(element[column.key]); $event.preventDefault()"
-                          [attr.aria-label]="linkLabel(column.label)"
-                          role="button"
-                          tabindex="0">
+                        @if (resolverLinkAllowed()) {
+                          <a
+                            [attr.aria-label]="linkLabel(column.label)"
+                            [routerLink]="resolverLink(element[column.key])">
+                            {{ element[column.key] }}
+                          </a>
+                        } @else {
                           {{ element[column.key] }}
-                        </a>
+                        }
                       </app-copyable>
                     }
                     @default {

--- a/privacyidea/static_new/src/app/components/user/user-table/user-table.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/user/user-table/user-table.component.spec.ts
@@ -150,6 +150,38 @@ describe("UserTableComponent", () => {
     });
   });
 
+  describe("the resolver column", () => {
+    const resolverCellLinks = (): HTMLAnchorElement[] =>
+      Array.from(fixture.nativeElement.querySelectorAll('td a[href^="/users/resolvers/details/"]'));
+
+    const showUser = (allowResolverRead: boolean) => {
+      const authService = TestBed.inject(AuthService) as unknown as MockAuthService;
+      authService.authData.set({
+        ...MockAuthService.MOCK_AUTH_DATA,
+        rights: allowResolverRead ? ["userlist", "resolverread"] : ["userlist"]
+      });
+      mockUserService.usersResource.set(
+        MockPiResponse.fromValue([{ username: "alice", resolver: "ldap1" }] as UserData[]) as never
+      );
+      fixture.detectChanges();
+    };
+
+    it("points the resolver at its configuration page", () => {
+      showUser(true);
+
+      expect(resolverCellLinks().map((link) => link.getAttribute("href"))).toEqual([
+        ROUTE_PATHS.USERS_RESOLVERS_DETAILS + "ldap1"
+      ]);
+    });
+
+    it("names the resolver as plain text where its configuration may not be read", () => {
+      showUser(false);
+
+      expect(resolverCellLinks()).toHaveLength(0);
+      expect(fixture.nativeElement.textContent).toContain("ldap1");
+    });
+  });
+
   it("should create", () => {
     expect(component).toBeTruthy();
   });

--- a/privacyidea/static_new/src/app/components/user/user-table/user-table.component.ts
+++ b/privacyidea/static_new/src/app/components/user/user-table/user-table.component.ts
@@ -50,7 +50,6 @@ import { inlineFilterHint } from "@utils/filter-hint.utils";
 
 import { NgClass } from "@angular/common";
 import { MatIconButton } from "@angular/material/button";
-import { MatDialog } from "@angular/material/dialog";
 import { MatIcon } from "@angular/material/icon";
 import { MatFormField, MatHint, MatInput, MatLabel } from "@angular/material/input";
 import { MatPaginator } from "@angular/material/paginator";
@@ -63,11 +62,9 @@ import { ScrollToTopDirective } from "@components/shared/directives/app-scroll-t
 import { FilterAutocompleteDirective } from "@components/shared/directives/filter-autocomplete.directive";
 import { ScrollEdgesDirective } from "@components/shared/directives/scroll-edges.directive";
 import { TableStateComponent } from "@components/shared/table-state/table-state.component";
-import { UserNewResolverComponent } from "@components/user/user-new-resolver/user-new-resolver.component";
 import { FilterOption } from "@core/models/filter_value_generic/filter-option";
 import { FilterValueGeneric, keywordlessTerms } from "@core/models/filter_value_generic/filter-value-generic";
 import { TableState } from "@core/models/table_state/table-state";
-import { ResolverService } from "@services/resolver/resolver.service";
 import { UserTableActionsComponent } from "./user-table-actions/user-table-actions.component";
 
 const columnKeysMap = [
@@ -140,9 +137,7 @@ export class UserTableComponent implements OnDestroy {
   protected readonly tableUtilsService: TableUtilsServiceInterface = inject(TableUtilsService);
   protected readonly contentService: ContentServiceInterface = inject(ContentService);
   protected readonly userService: UserServiceInterface = inject(UserService);
-  protected readonly resolverService = inject(ResolverService);
   protected readonly authService: AuthServiceInterface = inject(AuthService);
-  protected readonly dialog = inject(MatDialog);
   readonly apiFilterKeys = this.userService.apiFilterKeys;
   readonly filterHint = inlineFilterHint();
   private basePageSizeOptions = [...this.tableUtilsService.pageSizeOptions()];
@@ -244,19 +239,6 @@ export class UserTableComponent implements OnDestroy {
 
   onClickUsername(user: UserData): void {
     this.userService.detailsUser.set({ username: user.username, realm: this.userService.selectedUserRealm() });
-  }
-
-  onClickResolver(resolverName: string): void {
-    const resolver = this.resolverService.resolvers().find((r) => r.resolvername === resolverName);
-    if (resolver) {
-      this.dialog.open(UserNewResolverComponent, {
-        data: { resolver },
-        width: "auto",
-        height: "auto",
-        maxWidth: "100vw",
-        maxHeight: "100vh"
-      });
-    }
   }
 
   // Keeps users where every term matches at least one column (AND across terms, OR across columns).

--- a/privacyidea/static_new/src/app/services/subscription/subscription-expiry.service.ts
+++ b/privacyidea/static_new/src/app/services/subscription/subscription-expiry.service.ts
@@ -53,8 +53,6 @@ export class SubscriptionExpiryService {
         this.dialog.open(SubscriptionExpiryDialogComponent, {
           disableClose: false,
           autoFocus: false,
-          width: "640px",
-          panelClass: "global-dialog-panel",
           data: { items: expiring }
         });
       }

--- a/privacyidea/static_new/src/app/services/welcome/welcome-dialog.service.ts
+++ b/privacyidea/static_new/src/app/services/welcome/welcome-dialog.service.ts
@@ -49,9 +49,7 @@ export class WelcomeDialogService {
         this.opened.set(true);
         this.dialog.open(WelcomeDialogComponent, {
           disableClose: true,
-          autoFocus: false,
-          width: "720px",
-          panelClass: "welcome-dialog-panel"
+          autoFocus: false
         });
       }
     });

--- a/privacyidea/static_new/src/styles/dialog.scss
+++ b/privacyidea/static_new/src/styles/dialog.scss
@@ -15,6 +15,12 @@
   max-height: 82vh;
 }
 
-.width-36 {
-  width: 36rem;
+// Caps a block of dialog prose at a readable measure. It lives here rather than in the wrapper
+// because view encapsulation keeps the wrapper's own styles off the content projected into it.
+.dialog-prose {
+  max-width: 65ch;
+}
+
+.dialog-break-anywhere {
+  overflow-wrap: anywhere;
 }

--- a/privacyidea/static_new/src/styles/dialog.scss
+++ b/privacyidea/static_new/src/styles/dialog.scss
@@ -18,9 +18,5 @@
 // Caps a block of dialog prose at a readable measure. It lives here rather than in the wrapper
 // because view encapsulation keeps the wrapper's own styles off the content projected into it.
 .dialog-prose {
-  max-width: 65ch;
-}
-
-.dialog-break-anywhere {
-  overflow-wrap: anywhere;
+  max-width: var(--dialog-prose-width);
 }

--- a/privacyidea/static_new/src/styles/styles.scss
+++ b/privacyidea/static_new/src/styles/styles.scss
@@ -199,6 +199,11 @@ body {
   --button-width-l: 240px;
   --button-width-xl: 300px;
 
+  --dialog-width-s: 280px;
+  --dialog-width-m: 552px;
+  --dialog-width-l: 648px;
+  --dialog-width-xl: 964px;
+
   --light: #f3f3f3;
 
   --green-brand-base: hsl(72, 100%, 32%);

--- a/privacyidea/static_new/src/styles/styles.scss
+++ b/privacyidea/static_new/src/styles/styles.scss
@@ -199,10 +199,10 @@ body {
   --button-width-l: 240px;
   --button-width-xl: 300px;
 
-  --dialog-width-s: 280px;
-  --dialog-width-m: 552px;
-  --dialog-width-l: 648px;
-  --dialog-width-xl: 964px;
+  --dialog-prose-width: 616px; // the readable measure; coincides with --input-width-xl
+  --dialog-width-s: 280px; // a 2-button footer, = Material's panel min-width
+  --dialog-width-m: calc(var(--dialog-prose-width) + 32px); // + the wrapper's content padding
+  --dialog-width-l: calc(var(--dialog-width-m) + 300px + 16px); // a QR code and its gap beside it
 
   --light: #f3f3f3;
 


### PR DESCRIPTION
To prevent the dialogue from becoming a single long line of text, I added standardised dialogue widths.
S: Material dialog minimum width.
M: The width of two L inputs, which is also a good width for reading.
L: M width plus 300 px extra space for other content, such as a QR code.