### PR TITLE
Release CA connection

### DIFF
--- a/privacyidea/api/lib/conditional_access.py
+++ b/privacyidea/api/lib/conditional_access.py
@@ -84,6 +84,7 @@ from privacyidea.lib.conditional_access.engine import (get_user_lock, get_ip_blo
                                                        render_error_message, restriction_messages, AccessDecision,
                                                        ConditionalAccessAction, RestrictionStatus, StageMessage)
 from privacyidea.lib.conditional_access.policy import default_error_message
+from privacyidea.lib.conditional_access.session import release_ca_connection
 from privacyidea.lib.conditional_access.request_context import (ConditionalAccessContext, PostEvaluation,
                                                                  RejectionShape, get_ca_context, peek_ca_context)
 from privacyidea.lib.error import AuthError, Error
@@ -139,41 +140,50 @@ def _evaluate_rejection(user: User) -> "Rejection | None":
     return ``None`` and the request continues. ``g.client_ip`` is the source IP checked.
 
     Reads clear an expired row as they go, so a lock that has run out is not treated as one.
+
+    The conditional-access connection is released on the way out: this is the only read the pre-check
+    does, and holding it for the rest of a request it let through occupies a second connection out of
+    ``db.session``'s pool (see :func:`~privacyidea.lib.conditional_access.session.release_ca_connection`).
     """
-    # Resolved once per request and kept on the context, which is the single place it lives: this pre-check reads
-    # it back below, and the post-response evaluation reads the same value, so both halves of one request word a
-    # rejection the same way.
-    context = get_ca_context()
-    context.use_default_error_message = show_default_ca_error_message(user)
-    lockout = get_user_lock(user, clear_expired=True)
-    ip_block = get_ip_block(g.client_ip, clear_expired=True)
-    binding = _binding_event_type(lockout, ip_block)
-    if binding:
-        subject = f"locked user {user!r}" if binding is AuthEventType.USER_LOCKED else f"blocked IP {g.client_ip!r}"
-        log.info(f"Rejecting {request.path} for {subject}.")
-        # Every restriction in force that carries an error message is reported, not only the binding one: an
-        # account lock and an address block are independent facts, resolved differently, so telling the user
-        # about one leaves them to discover the other by failing again. Worded the same on both, it is said once
-        # (restriction_messages de-duplicates).
-        messages = restriction_messages(lockout, ip_block, use_default_error_message=context.use_default_error_message)
-        return Rejection(binding, _audit_reason(lockout, ip_block),
-                         " ".join(message.text for message in messages) or None,
-                         _additional_event_types(binding, lockout, ip_block))
-    decision = evaluate_access_decision(build_ca_context(user))
-    # A DENY decision is part of this request's history, but no authentication-log row exists yet to record it against
-    # (and a dry-run DENY lets the request continue, so its row comes later). The context holds the outcomes until the
-    # request stages the event they belong to - which, for an enforced DENY, is the row the caller writes next.
-    context.add_outcomes(decision.outcomes)
-    if decision.decision == AccessDecision.DENY:
-        log.info(f"Denying {request.path} for {user!r} by conditional-access policy.")
-        # A DENY persists nothing, so its error message comes straight off the deciding stage - or, with none, off
-        # the default error message for a denial.
-        template = decision.error_message
-        if not template and context.use_default_error_message:
-            template = default_error_message(ConditionalAccessAction.DENY)
-        return Rejection(AuthEventType.ACCESS_DENIED, "Rejected: denied by conditional-access policy",
-                         render_error_message(template))
-    return None
+    try:
+        # Resolved once per request and kept on the context, which is the single place it lives: this pre-check reads
+        # it back below, and the post-response evaluation reads the same value, so both halves of one request word a
+        # rejection the same way.
+        context = get_ca_context()
+        context.use_default_error_message = show_default_ca_error_message(user)
+        lockout = get_user_lock(user, clear_expired=True)
+        ip_block = get_ip_block(g.client_ip, clear_expired=True)
+        binding = _binding_event_type(lockout, ip_block)
+        if binding:
+            subject = f"locked user {user!r}" if binding is AuthEventType.USER_LOCKED else f"blocked IP {g.client_ip!r}"
+            log.info(f"Rejecting {request.path} for {subject}.")
+            # Every restriction in force that carries an error message is reported, not only the binding one: an
+            # account lock and an address block are independent facts, resolved differently, so telling the user
+            # about one leaves them to discover the other by failing again. Worded the same on both, it is said once
+            # (restriction_messages de-duplicates).
+            messages = restriction_messages(lockout, ip_block,
+                                            use_default_error_message=context.use_default_error_message)
+            return Rejection(binding, _audit_reason(lockout, ip_block),
+                             " ".join(message.text for message in messages) or None,
+                             _additional_event_types(binding, lockout, ip_block))
+        decision = evaluate_access_decision(build_ca_context(user))
+        # A DENY decision is part of this request's history, but no authentication-log row exists yet to record it
+        # against (and a dry-run DENY lets the request continue, so its row comes later). The context holds the
+        # outcomes until the request stages the event they belong to - which, for an enforced DENY, is the row the
+        # caller writes next.
+        context.add_outcomes(decision.outcomes)
+        if decision.decision == AccessDecision.DENY:
+            log.info(f"Denying {request.path} for {user!r} by conditional-access policy.")
+            # A DENY persists nothing, so its error message comes straight off the deciding stage - or, with none, off
+            # the default error message for a denial.
+            template = decision.error_message
+            if not template and context.use_default_error_message:
+                template = default_error_message(ConditionalAccessAction.DENY)
+            return Rejection(AuthEventType.ACCESS_DENIED, "Rejected: denied by conditional-access policy",
+                             render_error_message(template))
+        return None
+    finally:
+        release_ca_connection()
 
 
 # --- /validate/*: return the rejection as a response ---------------------------------------------------------------

--- a/privacyidea/lib/conditional_access/request_context.py
+++ b/privacyidea/lib/conditional_access/request_context.py
@@ -414,10 +414,11 @@ class ConditionalAccessContext:
 
         The evaluation counts events over the authentication log, so it must run **after** :meth:`flush` - otherwise
         the count would miss the very event that triggered it. That ordering also keeps the counts from reading a stale
-        snapshot: the pre-checks opened a read transaction, and under MySQL/MariaDB's REPEATABLE READ it would hide
-        rows a concurrent request committed since - but the flush commits, and a commit ends the transaction, so the
-        counts start from a fresh view on every backend. Should a caller ever reach here *without* a preceding commit,
-        that no longer holds and the read view has to be ended explicitly first.
+        snapshot: under MySQL/MariaDB's REPEATABLE READ an open read transaction hides rows a concurrent request
+        committed since it began, and the flush commits, so the counts start from a fresh view on every backend. The
+        pre-check leaves none open either, having released its connection
+        (:func:`~privacyidea.lib.conditional_access.session.release_ca_connection`). Should a caller ever reach here
+        *without* a preceding commit, that no longer holds and the read view has to be ended explicitly first.
 
         Every error is swallowed: this only writes state that the *next* request consults and must never affect the
         response that already completed.

--- a/privacyidea/lib/conditional_access/session.py
+++ b/privacyidea/lib/conditional_access/session.py
@@ -24,6 +24,8 @@ it. Both effects are invisible at the call site, which is why these writes get a
 
 The session is bound to the very same engine as ``db.session`` -- same database, same connection pool. Only the
 transaction is separate; nothing here implies (or supports) storing the conditional-access tables elsewhere.
+Sharing the pool is what makes :func:`release_ca_connection` worth calling: a caller that is done reading hands
+the connection back rather than holding it beside ``db.session``'s own until teardown.
 """
 import logging
 from collections.abc import Iterator
@@ -61,6 +63,31 @@ def get_ca_session() -> Session:
         store[_SESSION_KEY] = session
         register_finalizer(close_ca_session)
     return session
+
+
+def release_ca_connection() -> None:
+    """
+    End the current transaction of the conditional-access session, returning its connection to the pool while
+    keeping the session itself usable.
+
+    The authentication pre-check reads the lock, the block and the policies and then hands the request on. Its
+    reads open a transaction that nothing commits, so without this the connection stays checked out until
+    teardown -- alongside ``db.session``'s own, out of the same pool -- for the whole request, while the only
+    conditional-access work left is the write at teardown. Releasing it here hands it back for the duration of the
+    request the pre-check just let through, and the next use opens a fresh transaction.
+
+    It also ends the read view: under MySQL/MariaDB's REPEATABLE READ an open transaction hides rows a concurrent
+    request committed since it began, which is exactly what the counts at teardown must not read (see
+    :meth:`~privacyidea.lib.conditional_access.request_context.ConditionalAccessContext.run_post_eval`).
+
+    Safe for the pre-check because it carries nothing persistent forward: the restrictions come back as plain
+    dataclasses and the outcomes it stages are transient (see
+    :func:`~privacyidea.lib.conditional_access.outcome_log.outcome_for_stage`). A caller holding an instance it
+    still means to read must not use this.
+    """
+    session = get_request_local_store().get(_SESSION_KEY)
+    if session is not None:
+        session.close()
 
 
 def close_ca_session(*_args) -> None:

--- a/tests/test_api_conditional_access.py
+++ b/tests/test_api_conditional_access.py
@@ -24,6 +24,7 @@ policy stage and lock the user.
 from unittest import mock
 from datetime import datetime, timedelta, timezone
 
+from privacyidea.api.lib import conditional_access as ca_gate
 from privacyidea.api.lib.utils import GENERIC_AUTH_FAILURE
 from privacyidea.lib.error import Error
 from privacyidea.lib.conditional_access.conditions import ConditionOperator, ConditionType
@@ -1790,6 +1791,26 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         # Teardown runs whether or not the request succeeded, so a request that ends in an error still logs its event.
         body = self._check({"user": "cornelius", "pass": "wrongpin000000"})
         self.assertFalse(body["result"]["value"], body)
+        self.assertEqual(1, len(get_authentication_logs()))
+
+    def test_the_gate_hands_its_connection_back_before_the_request_continues(self):
+        # The pre-check reads on the conditional-access session, which shares db.session's pool. Holding that
+        # connection for the rest of a request it let through would occupy two of the pool per request, so the gate
+        # ends its transaction on the way out and the write at teardown opens a fresh one.
+        observed = []
+        release = ca_gate.release_ca_connection
+
+        def observing_release():
+            observed.append(get_ca_session().in_transaction())
+            release()
+            observed.append(get_ca_session().in_transaction())
+
+        with mock.patch.object(ca_gate, "release_ca_connection", observing_release):
+            body = self._check({"user": "cornelius", "pass": "wrongpin000000"})
+
+        self.assertFalse(body["result"]["value"], body)
+        self.assertListEqual([True, False], observed)
+        # Released, not closed: the row the request stages is still written.
         self.assertEqual(1, len(get_authentication_logs()))
 
 

--- a/tests/test_lib_conditional_access_session.py
+++ b/tests/test_lib_conditional_access_session.py
@@ -24,7 +24,9 @@ from sqlalchemy.exc import OperationalError
 from unittest import mock
 
 from privacyidea.lib.conditional_access.authentication_event_types import AuthEventType
-from privacyidea.lib.conditional_access.session import close_ca_session, get_ca_session, guarded_write
+from privacyidea.lib.framework import get_request_local_store
+from privacyidea.lib.conditional_access.session import (_SESSION_KEY, close_ca_session, get_ca_session,
+                                                        guarded_write, release_ca_connection)
 from privacyidea.lib.lifecycle import call_finalizers
 from privacyidea.models import db
 from privacyidea.models.authentication_log import AuthenticationLog
@@ -80,6 +82,34 @@ class ConditionalAccessSessionTestCase(MyTestCase):
         # close() expunges the identity map, and the session is dropped so the next call opens a new one.
         self.assertNotIn(entry, session)
         self.assertIsNot(session, get_ca_session())
+
+    def test_08_release_returns_the_connection_and_keeps_the_session(self):
+        session = get_ca_session()
+        session.scalars(select(AuthenticationLog)).all()
+        # A read opens a transaction, and the connection is checked out for as long as it is open.
+        self.assertTrue(session.in_transaction())
+
+        release_ca_connection()
+
+        self.assertFalse(session.in_transaction())
+        # Unlike close_ca_session, the session itself survives and the next read opens a fresh transaction on it.
+        self.assertIs(session, get_ca_session())
+        self.assertListEqual([], session.scalars(select(AuthenticationLog)).all())
+        self.assertTrue(session.in_transaction())
+
+    def test_09_release_without_a_session_is_a_no_op(self):
+        close_ca_session()
+        # Must neither raise nor open a session just to release it.
+        release_ca_connection()
+        self.assertNotIn(_SESSION_KEY, get_request_local_store())
+
+    def test_10_release_does_not_commit_pending_writes(self):
+        session = get_ca_session()
+        session.add(AuthenticationLog(event_type=AuthEventType.LOGIN_SUCCESS, username="carol"))
+
+        release_ca_connection()
+
+        self.assertListEqual([], db.session.scalars(select(AuthenticationLog)).all())
 
     def test_07_closer_registered_as_appcontext_teardown(self):
         # Covers callers with no request (pi-manage, scripts, periodic tasks), where call_finalizers() never runs.


### PR DESCRIPTION
The authentication pre-check reads on the conditional-access session, which shares db.session's connection    
  pool. Those reads held their connection until request teardown, so every gated authentication occupied two    
  connections out of that pool for its whole duration. The gate now hands the connection back as soon as it has 
  decided.                                                                                                      
                                                                                                                
  No config, no schema change, no API change.                                                                   
                                                                                                                
  Why                                                                                                           
                                                                                                                
  - The conditional-access session is bound to the very same engine as db.session — same database, same pool    
    (session.py). Only the transaction is separate.                                                             
  - Its reads autobegin a transaction, and on the read-only path nothing commits it: get_user_lock, get_ip_block
    and evaluate_access_decision leave it open, so the connection stayed checked out from the gate to           
    close_ca_session at teardown, beside db.session's own.                                                      
  - The gate is the first thing to act on every gated endpoint — /validate/check, /radiuscheck,                 
    /triggerchallenge, /initialize, /auth, /ttype/push — so this was every authentication, not an edge case.    
  - And it bought nothing: the only conditional-access work left after the gate is the write at teardown, which 
    opens its own transaction regardless.

What changed                                                                                                  
                                                                                                                
  - release_ca_connection() (lib/conditional_access/session.py) ends the session's current transaction and      
    returns the connection to the pool, while keeping the session itself usable — unlike close_ca_session, which
    also drops it from the request-local store. The next use opens a fresh transaction.                         
  - _evaluate_rejection calls it in a finally. One call site covers all three entry points — the /validate/*    
    gate, the /auth login gate and /ttype/push via conditional_access_rejection — and covers the raising path   
    too, instead of leaving that to teardown.                                                                   
                                                                                                                
Why it is safe                                                                                                
                                                                                                                
  - The pre-check is read-only. Its one write, the defensive clear_expired delete, already commits through      
    guarded_write before this runs.                                                                             
  - Nothing persistent crosses the boundary: restrictions come back as plain RestrictionStatus dataclasses, the 
    decision's error message is a string, and the outcomes staged on the context are transient                  
    (outcome_for_stage), so expire_on_commit has nothing to expire.                                             
  - The precondition is stated on the function: a caller still holding an instance it means to read must not use
    it. 

Side benefit: the read view ends with it                                                                      
                                                                                                                
  run_post_eval's counts must not read a stale snapshot — under MySQL/MariaDB's REPEATABLE READ an open read    
  transaction hides rows a concurrent request committed since it began. That previously held only because the   
  flush's commit happened to end the transaction the pre-check had left open. The pre-check now leaves none, and
  the docstring says so rather than describing a dependency.                                                    
                                                                                                                
  Deliberately not changed                                                                                      
                                                                                                                
  - No "is conditional access configured?" early-out. The pre-check still always reads the lock, the block and  
    the policies. Locks and blocks are administrable without any policy at all (POST                            
    conditionalaccess/lock/user, POST conditionalaccess/blocklist), so an early-out would skip enforcement of   
    state an admin set by hand. The reads are two primary-key lookups plus a select on an enabled-filtered      
    table.                                                                                                      
  - Peak connections per request is unchanged. The authentication-log row is staged unconditionally and written 
    on this session at teardown, so a second checkout always existed. What changes is how long it is held — the 
    whole request before, the teardown window now. 