### PR TITLE
CA - cap the truncation overflow the authentication log keeps in other_info

### DIFF
--- a/privacyidea/lib/conditional_access/authentication_log.py
+++ b/privacyidea/lib/conditional_access/authentication_log.py
@@ -154,18 +154,32 @@ def naive_utc(value: datetime) -> datetime:
 class _TruncatedValue:
     """
     Result of truncating one column value: *stored* goes into the column, *overflow* is the part that did not fit and
-    is preserved in the entry's ``other_info`` (see :func:`_store_overflow`) so no information is lost. *overflow* is
-    ``None`` when nothing was cut.
+    is recorded in the entry's ``other_info`` (see :func:`_describe_overflow`, :func:`_store_overflow`) so no cut goes
+    unrecorded. *overflow* is ``None`` when nothing was cut.
     """
     stored: str | None
     overflow: str | None
+
+
+def _split_at(value: str, max_length: int, separator: str | None = None) -> tuple[str, str]:
+    """
+    Split *value*, which is longer than *max_length*, into the part that fits and the remainder.
+
+    With a *separator*, the cut is made on the last separator that fits, so neither part holds a broken item; a value
+    whose first item alone is too long has none that fits and is cut mid-item after all.
+    """
+    if separator:
+        cut = value.rfind(separator, 0, max_length + 1)
+        if cut > 0:
+            return value[:cut], value[cut + len(separator):]
+    return value[:max_length], value[max_length:]
 
 
 def _truncate(column: str, value: Any, separator: str | None = None) -> _TruncatedValue:
     """
     Convert *value* to a string and truncate it to the length of the given column of the authentication_log table, so a
     pathological value (e.g. a very long User-Agent or login name) can never overflow the column on insert. The cut-off
-    remainder is returned alongside the stored value rather than discarded.
+    remainder is returned alongside the stored value, for the caller to record (see :func:`_row_values`).
 
     :param column: the column name, a key of
         ``authentication_log_column_length`` in :mod:`privacyidea.models.authentication_log`
@@ -182,16 +196,33 @@ def _truncate(column: str, value: Any, separator: str | None = None) -> _Truncat
     if len(value) <= max_length:
         return _TruncatedValue(value, None)
     log.debug(f"Truncating authentication log column {column!r} to {max_length} characters.")
-    if separator:
-        cut = value.rfind(separator, 0, max_length + 1)
-        if cut > 0:
-            return _TruncatedValue(value[:cut], value[cut + len(separator):])
-    return _TruncatedValue(value[:max_length], value[max_length:])
+    return _TruncatedValue(*_split_at(value, max_length, separator))
+
+
+# How much of the cut-off remainder ``other_info["truncated"]`` keeps verbatim. Anything past this is summarized
+# (see _describe_overflow), because other_info is unbounded JSON on a write path any client can reach: a column holds
+# a fixed number of characters, but a value that overflows it - a login name, an unknown realm, a ``client_id`` label -
+# is bounded only by the request body, so keeping every remainder whole would let the request decide how large a row
+# is, and a large enough one would fail the insert the truncation exists to protect. A cut of realistic size (a long
+# resolver name, the serials that did not fit) stays well below this and is kept in full.
+_MAX_OVERFLOW_LENGTH = 256
+
+
+def _describe_overflow(overflow: str, separator: str | None = None) -> str:
+    """
+    What ``other_info["truncated"]`` records for a cut value: the remainder itself, or - once past
+    :data:`_MAX_OVERFLOW_LENGTH` - as much of it as is kept plus how many characters follow, as
+    ``"...(N more characters)"``. *separator* cuts the kept part on an item boundary, as it does for the column.
+    """
+    if len(overflow) <= _MAX_OVERFLOW_LENGTH:
+        return overflow
+    kept, rest = _split_at(overflow, _MAX_OVERFLOW_LENGTH, separator)
+    return f"{kept}...({len(rest)} more characters)"
 
 
 def _store_overflow(other_info: dict | None, overflow: dict[str, str]) -> dict | None:
     """
-    Fold any truncation overflow into a copy of *other_info* under the ``truncated`` key so it is preserved without
+    Fold any truncation overflow into a copy of *other_info* under the ``truncated`` key so it is recorded without
     clobbering caller-supplied keys, merging with overflow already recorded there. Returns *other_info* unchanged when
     nothing overflowed.
     """
@@ -296,8 +327,8 @@ _TRUNCATED_COLUMNS = {
 def _row_values(event: PendingAuthEvent) -> dict:
     """
     The column values to store for *event*: every column truncated to its length, with the cut-off remainder folded
-    into ``other_info`` so nothing is silently lost. Shared by the insert and the update path, so an amended event is
-    truncated exactly like a fresh one.
+    into ``other_info`` - up to :data:`_MAX_OVERFLOW_LENGTH` of it, the rest as a count - so no cut goes unrecorded.
+    Shared by the insert and the update path, so an amended event is truncated exactly like a fresh one.
     """
     stored: dict[str, str | None] = {}
     overflow: dict[str, str] = {}
@@ -305,7 +336,7 @@ def _row_values(event: PendingAuthEvent) -> dict:
         result = _truncate(column, getattr(event, column), separator=separator)
         stored[column] = result.stored
         if result.overflow is not None:
-            overflow[column] = result.overflow
+            overflow[column] = _describe_overflow(result.overflow, separator)
     # ip_chain is JSON rather than a truncated string, but still a column of the row, so it belongs in the
     # dict that both the insert and the update path treat as the authoritative column set.
     return {**stored, "ip_chain": event.ip_chain, "other_info": _store_overflow(event.other_info, overflow)}

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.spec.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.spec.ts
@@ -251,6 +251,12 @@ describe("AuthenticationLog", () => {
       "PISP0003",
       "PISP0004"
     ]);
+    // An overflow the backend had to cap ends in a count of what it left out, which is not a token.
+    expect(component.usedSerials(withOverflow({ truncated: { serial: "PISP0003...(90 more characters)" } }))).toEqual([
+      "PISP0001",
+      "PISP0002",
+      "PISP0003"
+    ]);
     // other_info is free-form, so anything of an unexpected shape leaves the column's own serials standing.
     expect(component.usedSerials(withOverflow(null))).toEqual(["PISP0001", "PISP0002"]);
     expect(component.usedSerials(withOverflow({ truncated: "PISP0003" }))).toEqual(["PISP0001", "PISP0002"]);

--- a/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.ts
+++ b/privacyidea/static_new/src/app/components/logs/authentication-log/authentication-log.ts
@@ -168,7 +168,12 @@ const columnKeysMap: { key: string; label: string; filterable: boolean; sortable
 // their rendering logic.
 const INFO_COLUMN_KEYS = ["conditional_access_outcomes", "other_info"];
 
-// The serials cut off an entry's serial column, which the backend preserves under other_info.truncated rather than
+// The marker the backend appends when an overflow was itself too long to keep whole ("...(500 more characters)", see
+// _describe_overflow in lib/conditional_access/authentication_log.py). It names no token, so it is dropped before the
+// overflow is read as a serial list.
+const OVERFLOW_MARKER = /\.\.\.\(\d+ more characters\)$/;
+
+// The serials cut off an entry's serial column, which the backend records under other_info.truncated rather than
 // discarding (see _store_overflow in lib/conditional_access/authentication_log.py). A free-form JSON column, so
 // every level is checked rather than trusted - isRecord (./reason-detail) does the same check for the other free-form
 // column on this row, other_info.reason_detail.
@@ -176,7 +181,7 @@ function truncatedSerial(info: AuthenticationLogEntry["other_info"]): string | n
   const truncated = info?.["truncated"];
   if (!isRecord(truncated)) return null;
   const serial = truncated["serial"];
-  return typeof serial === "string" ? serial : null;
+  return typeof serial === "string" ? serial.replace(OVERFLOW_MARKER, "") : null;
 }
 
 // The Conditional access column filters on three keys at once, hence a header menu instead of the single-key toggle

--- a/tests/test_lib_authentication_log.py
+++ b/tests/test_lib_authentication_log.py
@@ -27,6 +27,8 @@ from privacyidea.lib.conditional_access.authentication_log import (
     AuthenticationLogVisibilityScope,
     AuthLogUserRole,
     PendingAuthEvent,
+    _MAX_OVERFLOW_LENGTH,
+    _describe_overflow,
     cleanup_authentication_log,
     delete_authentication_log_event,
     delete_authentication_logs,
@@ -537,7 +539,7 @@ class AuthenticationLogTestCase(MyTestCase):
 
     def test_overflow_is_preserved_in_other_info(self):
         # The part of a value that does not fit the column is preserved as the cut-off remainder under
-        # other_info["truncated"][column] instead of being lost.
+        # other_info["truncated"][column], so a name cut mid-way can still be reconstructed.
         max_resolver = authentication_log_column_length["resolver"]
         event_id = log_authentication_event(event_type=AuthEventType.LOGIN_SUCCESS,
                                             resolver="R" * max_resolver + "OVERFLOW")
@@ -545,6 +547,30 @@ class AuthenticationLogTestCase(MyTestCase):
         assert entry is not None
         self.assertEqual("R" * max_resolver, entry.resolver)
         self.assertEqual({"truncated": {"resolver": "OVERFLOW"}}, entry.other_info)
+
+    def test_long_overflow_is_capped_with_a_count(self):
+        # A remainder longer than _MAX_OVERFLOW_LENGTH is kept up to that length and the rest counted, so a value the
+        # client chose - its client_id label, the login name and realm of a user that does not resolve - cannot decide
+        # how large the row's unbounded JSON is. 100 KB in, a bounded row out.
+        columns = ("client_label", "username", "realm")
+        event_id = log_authentication_event(event_type=AuthEventType.USER_UNKNOWN,
+                                            **{column: "X" * 100000 for column in columns})
+        entry = get_authentication_log_event(event_id)
+        assert entry is not None
+        expected = {}
+        for column in columns:
+            max_length = authentication_log_column_length[column]
+            self.assertEqual("X" * max_length, getattr(entry, column), column)
+            dropped = 100000 - max_length - _MAX_OVERFLOW_LENGTH
+            expected[column] = f"{'X' * _MAX_OVERFLOW_LENGTH}...({dropped} more characters)"
+        self.assertEqual({"truncated": expected}, entry.other_info)
+
+    def test_capped_overflow_of_a_list_keeps_whole_items(self):
+        # The kept part of an overflow is cut on the column's separator too, so a capped serial overflow still names
+        # whole serials: 40 serials of 8 characters overflow the cap inside the 29th, which is left out entirely.
+        overflow = ",".join(["TOK00001"] * 40)
+        self.assertEqual(f"{','.join(['TOK00001'] * 28)}...({len(overflow) - 252} more characters)",
+                         _describe_overflow(overflow, ","))
 
     def test_overflow_merges_with_caller_other_info(self):
         # Overflow is folded into the caller's other_info under "truncated" without clobbering the caller's own keys.


### PR DESCRIPTION
### The problem                                                                                                   
                                                                                                                
  Every string column of an authentication_log row is truncated to its column length, and the cut-off remainder 
  was folded whole into other_info["truncated"][column] — a mapped_column(JSON) with no cap. No column could    
  overflow, but the row's size was decided by whatever the request sent.                                        
                                                                                                                
  That matters because the values which actually overflow are mostly the client's own:                          
                                                                                                                
  - client_label prefers the client_id request parameter over the User-Agent (api/lib/utils.py:453).            
    max_content_length is unset, so a JSON body is bounded only by the reverse proxy — 1 MB with nginx's        
    default, unlimited with Apache's.                                                                           
  - username and realm are the same on /validate/check: User() keeps an unknown realm, merely lowercased        
    (lib/user.py:99), so a USER_UNKNOWN row carried both remainders in full.                                    
                                                                                                                
  So an unauthenticated endpoint wrote attacker-sized JSON, once per attempt. It also partly defeated the reason
  the truncation exists: the overflow moved into a column whose limit is far higher but still finite            
  (max_allowed_packet), and write_authentication_events swallows a failed insert — a large enough value would   
  lose every row that request staged, silently. 

### The change                                                                                                    
                                                                                                                
  One rule for every column, no per-column policy:                                                              
                                                                                                                
  - _describe_overflow keeps the remainder verbatim while it fits _MAX_OVERFLOW_LENGTH (256), and otherwise     
    keeps as much as fits plus a count: "TOK00001,TOK00002...(98720 more characters)".                          
  - _split_at, factored out of _truncate and shared with it, cuts the kept part on the column's separator, so a 
    capped serial overflow still names whole serials rather than half of one.                                   
  - _TRUNCATED_COLUMNS is unchanged — still just the separator per column.                                      
  - truncatedSerial strips the trailing marker before reading the overflow as a serial list, so the used-serials
    dialog does not file it as a token.                                                                         
                                                                                                                
  A row's overflow is now bounded by the schema (~280 characters per overflowing column) instead of by the      
  request body. A cut of realistic size — a long resolver name, the serials that did not fit — is still recorded
  in full, so nothing changes for the cases the overflow was added for; the pre-existing verbatim-overflow      
  tests are untouched, which is the point of a cap over a provenance-based rule. 