### PR TITLE
Load the audit signing key once per process

### DIFF
--- a/doc/faq/crypto-considerations.rst
+++ b/doc/faq/crypto-considerations.rst
@@ -73,8 +73,8 @@ By default the installer generates 2048bit RSA keys.
 
 If you can assure that the private key has not been tampered with, the config
 entry ``PI_AUDIT_NO_PRIVATE_KEY_CHECK = True`` avoids a time-consuming check during
-loading of the private key. The key is loaded once per worker process, so this
-check is not part of the cost of an individual audit entry
+loading of the private key. The loaded key is kept for the lifetime of the worker
+process, so this check is not part of the cost of an individual audit entry
 (See also :ref:`faq_perf_crypto_audit`).
 
 The audit signing is performed in *lib.crypto:Sign.sign* using SHA2-256 as

--- a/doc/faq/crypto-considerations.rst
+++ b/doc/faq/crypto-considerations.rst
@@ -73,7 +73,9 @@ By default the installer generates 2048bit RSA keys.
 
 If you can assure that the private key has not been tampered with, the config
 entry ``PI_AUDIT_NO_PRIVATE_KEY_CHECK = True`` avoids a time-consuming check during
-loading of the private key (See also :ref:`faq_perf_crypto_audit`).
+loading of the private key. The key is loaded once per worker process, so this
+check is not part of the cost of an individual audit entry
+(See also :ref:`faq_perf_crypto_audit`).
 
 The audit signing is performed in *lib.crypto:Sign.sign* using SHA2-256 as
 hash function.

--- a/doc/faq/performance.rst
+++ b/doc/faq/performance.rst
@@ -97,7 +97,8 @@ the lifetime of the worker process, so this happens once per process and not onc
 per audit entry. If you can be sure that the private key has not been tampered
 with, the config entry ``PI_AUDIT_NO_PRIVATE_KEY_CHECK = True`` in :ref:`cfgfile`
 skips the validation, but it only saves the single check each worker process does
-when it writes its first audit entry.
+on the first request it handles. The audit object is created for every request, so
+that is where the key is loaded, whether or not an audit entry is written.
 
 With the config entry ``PI_AUDIT_NO_SIGN = True`` the signing of the Audit-log
 can be deactivated completely.
@@ -106,9 +107,10 @@ The privacyIDEA Response
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default, privacyIDEA signs every JSON-Response with the private key in
-``PI_AUDIT_KEY_PRIVATE``. The key is loaded and validated once per worker process,
-just like for the audit log, so the config entry
-``PI_RESPONSE_NO_PRIVATE_KEY_CHECK = True`` only skips that one validation.
+``PI_AUDIT_KEY_PRIVATE``. As for the audit log, the key is loaded and validated
+when a worker process signs its first response and is then kept for the lifetime of
+that process, so the config entry ``PI_RESPONSE_NO_PRIVATE_KEY_CHECK = True`` only
+skips that one validation.
 
 The signing of the response can be disabled completely by setting
 ``PI_NO_RESPONSE_SIGN`` to ``True``.

--- a/doc/faq/performance.rst
+++ b/doc/faq/performance.rst
@@ -90,9 +90,14 @@ The Audit-log
 ^^^^^^^^^^^^^
 
 Each entry in the :ref:`audit` log is digitally signed to detect tampering.
-If you can be sure that the private key in ``PI_AUDIT_KEY_PRIVATE`` has not been
-tampered with, you can set the config entry ``PI_AUDIT_NO_PRIVATE_KEY_CHECK = True``
-in :ref:`cfgfile` to improve the performance when loading the key.
+
+Loading the private key from ``PI_AUDIT_KEY_PRIVATE`` validates it, which takes
+considerably longer than creating a signature with it. The loaded key is kept for
+the lifetime of the worker process, so this happens once per process and not once
+per audit entry. If you can be sure that the private key has not been tampered
+with, the config entry ``PI_AUDIT_NO_PRIVATE_KEY_CHECK = True`` in :ref:`cfgfile`
+skips the validation, but it only saves the single check each worker process does
+when it writes its first audit entry.
 
 With the config entry ``PI_AUDIT_NO_SIGN = True`` the signing of the Audit-log
 can be deactivated completely.
@@ -101,8 +106,9 @@ The privacyIDEA Response
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default, privacyIDEA signs every JSON-Response with the private key in
-``PI_AUDIT_KEY_PRIVATE``. To improve the performance when loading the private
-key the config entry ``PI_RESPONSE_NO_PRIVATE_KEY_CHECK`` can be set to ``True``.
+``PI_AUDIT_KEY_PRIVATE``. The key is loaded and validated once per worker process,
+just like for the audit log, so the config entry
+``PI_RESPONSE_NO_PRIVATE_KEY_CHECK = True`` only skips that one validation.
 
 The signing of the response can be disabled completely by setting
 ``PI_NO_RESPONSE_SIGN`` to ``True``.

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -187,8 +187,8 @@ privacyIDEA digitally signs the responses with the private key in
 ``PI_AUDIT_KEY_PRIVATE``. If you can be sure that the private key has
 not been tampered with, you can set the parameter
 ``PI_RESPONSE_NO_PRIVATE_KEY_CHECK`` to ``True`` in order to skip the validation
-of the key. The key is loaded once per worker process, so this only affects the
-first signed response of each process.
+of the key. The loaded key is kept for the lifetime of the worker process, so this
+only affects the first response each worker process signs.
 
 You can disable the signing of the responses completely using the parameter
 ``PI_NO_RESPONSE_SIGN``. Set this to ``True`` to suppress the response signature.
@@ -251,20 +251,30 @@ effective if you also set ``PI_ENGINE_REGISTRY_CLASS`` to ``"shared"``.
 For signing and verifying each Audit entry, the RSA keys in ``PI_AUDIT_KEY_PRIVATE``
 and ``PI_AUDIT_KEY_PUBLIC`` are used. If you can be sure that the private key has
 not been tampered with, you can set the parameter ``PI_AUDIT_NO_PRIVATE_KEY_CHECK``
-to ``True`` in order to skip the validation of the key. The key is loaded once per
-worker process, so this only affects the first audit entry of each process.
+to ``True`` in order to skip the validation of the key. The loaded key is kept for
+the lifetime of the worker process, so this only affects the first request each
+worker process handles.
 
 A key file that is replaced while the server is running is picked up without a
-restart, because the modification time and the size of the key files are checked
-whenever they are used. This includes a secret that is mounted into a container
-and updated by the orchestrator, where the mounted name is a symlink that is
-pointed at a new version of the file.
+restart, because the contents of the key files are read and compared whenever they
+are used. Kubernetes updates a mounted secret by pointing a symlink at a new
+version of the file, which is picked up in the same way.
 
-.. note:: The audit keys are always configured as *file names*. A container
-   deployment therefore has to mount the keypair, for example as
-   ``/run/secrets/audit_key_private`` and ``/run/secrets/audit_key_public``,
-   which the Docker configuration picks up on its own. The key material itself
-   can not be passed in an environment variable.
+.. warning:: Rotating the audit keypair means that every entry written with the
+   previous key is verified against the new public key from then on, so the whole
+   audit log up to the rotation is displayed with the signature *FAIL* - which can
+   not be told apart from a tampered entry. privacyIDEA verifies with a single
+   public key, so entries from before the rotation can not be verified any more
+   once the new key is in place. Worker processes also pick up a new key
+   independently of each other, so entries written during the changeover are split
+   across both keys.
+
+.. note:: The audit keys are always configured as *file names* and never hold the
+   key material itself, so it can not be passed in an environment variable. A
+   container deployment mounts the keypair instead; the Docker configuration picks
+   up ``/run/secrets/audit_key_private`` and ``/run/secrets/audit_key_public`` on
+   its own. Docker secrets are immutable, so rotating one there means a new secret
+   and a new container rather than a replaced file.
 
 If you by any reason want to avoid signing audit entries entirely, you can
 set ``PI_AUDIT_NO_SIGN = True``. If ``PI_AUDIT_NO_SIGN`` is set to ``True``

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -255,7 +255,16 @@ to ``True`` in order to skip the validation of the key. The key is loaded once p
 worker process, so this only affects the first audit entry of each process.
 
 A key file that is replaced while the server is running is picked up without a
-restart.
+restart, because the modification time and the size of the key files are checked
+whenever they are used. This includes a secret that is mounted into a container
+and updated by the orchestrator, where the mounted name is a symlink that is
+pointed at a new version of the file.
+
+.. note:: The audit keys are always configured as *file names*. A container
+   deployment therefore has to mount the keypair, for example as
+   ``/run/secrets/audit_key_private`` and ``/run/secrets/audit_key_public``,
+   which the Docker configuration picks up on its own. The key material itself
+   can not be passed in an environment variable.
 
 If you by any reason want to avoid signing audit entries entirely, you can
 set ``PI_AUDIT_NO_SIGN = True``. If ``PI_AUDIT_NO_SIGN`` is set to ``True``

--- a/doc/installation/system/inifile.rst
+++ b/doc/installation/system/inifile.rst
@@ -185,8 +185,10 @@ captures stderr - typically the webserver's error log.
 
 privacyIDEA digitally signs the responses with the private key in
 ``PI_AUDIT_KEY_PRIVATE``. If you can be sure that the private key has
-not been tampered with, you can set the parameter ``PI_AUDIT_NO_PRIVATE_KEY_CHECK``
-to ``True`` in order to improve the performance when loading the key.
+not been tampered with, you can set the parameter
+``PI_RESPONSE_NO_PRIVATE_KEY_CHECK`` to ``True`` in order to skip the validation
+of the key. The key is loaded once per worker process, so this only affects the
+first signed response of each process.
 
 You can disable the signing of the responses completely using the parameter
 ``PI_NO_RESPONSE_SIGN``. Set this to ``True`` to suppress the response signature.
@@ -249,7 +251,11 @@ effective if you also set ``PI_ENGINE_REGISTRY_CLASS`` to ``"shared"``.
 For signing and verifying each Audit entry, the RSA keys in ``PI_AUDIT_KEY_PRIVATE``
 and ``PI_AUDIT_KEY_PUBLIC`` are used. If you can be sure that the private key has
 not been tampered with, you can set the parameter ``PI_AUDIT_NO_PRIVATE_KEY_CHECK``
-to ``True`` in order to improve the performance when loading the key.
+to ``True`` in order to skip the validation of the key. The key is loaded once per
+worker process, so this only affects the first audit entry of each process.
+
+A key file that is replaced while the server is running is picked up without a
+restart.
 
 If you by any reason want to avoid signing audit entries entirely, you can
 set ``PI_AUDIT_NO_SIGN = True``. If ``PI_AUDIT_NO_SIGN`` is set to ``True``

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -60,7 +60,7 @@ from privacyidea.api.lib.utils import get_all_params, hardening_action_active
 from privacyidea.config import ConfigKey
 from privacyidea.lib.auth import ROLE
 from privacyidea.lib.config import (get_multichallenge_enrollable_types, get_token_class, get_privacyidea_node)
-from privacyidea.lib.crypto import Sign
+from privacyidea.lib.crypto import get_sign_object
 from privacyidea.lib.error import PolicyError, ValidateError
 from privacyidea.lib.info.rss import FETCH_DAYS
 from privacyidea.lib.machine import get_auth_items
@@ -203,9 +203,7 @@ def sign_response(request, response):
     # Disable the costly checking of private RSA keys when loading them.
     check_private_key = not current_app.config.get(ConfigKey.RESPONSE_NO_PRIVATE_KEY_CHECK, False)
     try:
-        with open(private_key_file, 'rb') as file:
-            private_key = file.read()
-        sign_object = Sign(private_key, public_key=None, check_private_key=check_private_key)
+        sign_object = get_sign_object(private_key_file, check_private_key=check_private_key)
     except (OSError, ValueError, TypeError) as e:
         log.info('Could not load private key from '
                  f'file {private_key_file!s}: {e!r}!')

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -57,7 +57,7 @@ from sqlalchemy.sql.expression import FunctionElement
 
 from privacyidea.config import ConfigKey
 from privacyidea.lib.auditmodules.base import Audit as AuditBase, Paginate
-from privacyidea.lib.crypto import Sign
+from privacyidea.lib.crypto import get_sign_object
 from privacyidea.lib.lifecycle import register_finalizer
 from privacyidea.lib.pooling import get_engine
 from privacyidea.lib.utils import censor_connect_string
@@ -206,10 +206,9 @@ class Audit(AuditBase):
         # Disable the costly checking of private RSA keys when loading them.
         self.check_private_key = not self.config.get(ConfigKey.AUDIT_NO_PRIVATE_KEY_CHECK, False)
         if self.sign_data:
-            self.read_keys(self.config.get(ConfigKey.AUDIT_KEY_PUBLIC),
-                           self.config.get(ConfigKey.AUDIT_KEY_PRIVATE))
-            self.sign_object = Sign(self.private, self.public,
-                                    check_private_key=self.check_private_key)
+            self.sign_object = get_sign_object(self.config.get(ConfigKey.AUDIT_KEY_PRIVATE),
+                                               self.config.get(ConfigKey.AUDIT_KEY_PUBLIC),
+                                               check_private_key=self.check_private_key)
         # Read column_length from the config file
         config_column_length = self.config.get(ConfigKey.AUDIT_SQL_COLUMN_LENGTH, {})
         # fill the missing parts with the default from the models

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -206,8 +206,15 @@ class Audit(AuditBase):
         # Disable the costly checking of private RSA keys when loading them.
         self.check_private_key = not self.config.get(ConfigKey.AUDIT_NO_PRIVATE_KEY_CHECK, False)
         if self.sign_data:
+            public_key_file = self.config.get(ConfigKey.AUDIT_KEY_PUBLIC)
+            if not public_key_file:
+                # The module would still sign, but every entry it reads back would verify as
+                # FAIL, which is indistinguishable from a tampered log. A missing key file is
+                # a configuration error and has to be visible as one.
+                raise TypeError(f"{ConfigKey.AUDIT_KEY_PUBLIC} must name a file containing the "
+                                "public key to verify audit entries with.")
             self.sign_object = get_sign_object(self.config.get(ConfigKey.AUDIT_KEY_PRIVATE),
-                                               self.config.get(ConfigKey.AUDIT_KEY_PUBLIC),
+                                               public_key_file,
                                                check_private_key=self.check_private_key)
         # Read column_length from the config file
         config_column_length = self.config.get(ConfigKey.AUDIT_SQL_COLUMN_LENGTH, {})

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -45,6 +45,7 @@ This lib.crypto is tested in tests/test_lib_crypto.py
 import hmac
 import importlib
 import logging
+import os
 from dataclasses import dataclass
 from hashlib import sha256
 import secrets
@@ -54,6 +55,7 @@ import binascii
 import ctypes
 import base64
 import traceback
+from threading import Lock
 
 from cryptography.hazmat.primitives._serialization import NoEncryption
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey, EllipticCurvePrivateKey
@@ -851,6 +853,87 @@ class Sign:
             log.debug(f"{traceback.format_exc()!s}")
 
         return r
+
+
+_sign_object_lock = Lock()
+
+
+@dataclass
+class _CachedSignObject:
+    """
+    A Sign object together with the version of the key files it was loaded from.
+    """
+    key_file_version: tuple
+    sign_object: Sign
+
+
+def _read_key_file(key_file: str) -> bytes:
+    """
+    Read a key file, if one was given.
+
+    :param key_file: Name of a key file or None
+    :return: The contents of the file, or None if no file was given
+    """
+    if not key_file:
+        return None
+    with open(key_file, "rb") as key_file_handle:
+        return key_file_handle.read()
+
+
+def _get_key_file_version(key_file: str) -> tuple:
+    """
+    Return a value that changes whenever the given key file changes.
+
+    :param key_file: Name of a key file
+    :return: The modification time and the size of the file
+    """
+    file_stat = os.stat(key_file)
+    return file_stat.st_mtime_ns, file_stat.st_size
+
+
+def get_sign_object(private_key_file: str, public_key_file: str = None,
+                    check_private_key: bool = True) -> Sign:
+    """
+    Return a Sign object for the given key files and keep it in the app-local store.
+
+    Loading an RSA private key validates it, which takes about a hundred times longer than
+    creating the signature it enables. The audit log and the response signature use the same
+    key for every request, so the loaded key is kept in the app-local store and shared among
+    all threads of the application. This is safe because a loaded key holds no state between
+    operations: every signature builds its own context.
+
+    A key file that is replaced while the server is running is still picked up, because the
+    modification time and the size of the file are part of the cached entry.
+
+    Failures are not cached. Reading a key file is cheap compared to parsing the key, and a
+    key file that is temporarily unavailable must not disable signing until the next restart.
+
+    :param private_key_file: Name of the file containing the private key in PEM format
+    :param public_key_file: Name of the file containing the public key in PEM format. A Sign
+        object without a public key can sign, but it can not verify a signature.
+    :param check_private_key: Check the private key while loading it
+    :return: a Sign object
+    """
+    if not private_key_file:
+        # Without this, a missing PI_AUDIT_KEY_PRIVATE would yield a Sign object that has no
+        # key and signs everything with an empty signature.
+        raise TypeError("get_sign_object() needs the name of a file containing a private key.")
+    key_files = (private_key_file, public_key_file)
+    key_file_version = tuple(_get_key_file_version(key_file) if key_file else None
+                             for key_file in key_files)
+    cache_key = (private_key_file, public_key_file, check_private_key)
+    sign_objects = get_app_local_store().setdefault("sign_objects", {})
+    # Loading the key is the expensive part, so the lock is held while it happens. Otherwise
+    # every thread that arrives before the first one is done would load the key again.
+    with _sign_object_lock:
+        cached = sign_objects.get(cache_key)
+        if cached is None or cached.key_file_version != key_file_version:
+            sign_object = Sign(_read_key_file(private_key_file), _read_key_file(public_key_file),
+                               check_private_key=check_private_key)
+            cached = _CachedSignObject(key_file_version, sign_object)
+            sign_objects[cache_key] = cached
+            log.debug(f"Loaded the signing keys from {private_key_file!s} and {public_key_file!s}.")
+        return cached.sign_object
 
 
 def create_hsm_object(config):

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -45,7 +45,6 @@ This lib.crypto is tested in tests/test_lib_crypto.py
 import hmac
 import importlib
 import logging
-import os
 from dataclasses import dataclass
 from hashlib import sha256
 import secrets
@@ -861,13 +860,13 @@ _sign_object_lock = Lock()
 @dataclass
 class _CachedSignObject:
     """
-    A Sign object together with the version of the key files it was loaded from.
+    A Sign object together with a fingerprint of the key material it was loaded from.
     """
-    key_file_version: tuple
+    key_material_version: tuple
     sign_object: Sign
 
 
-def _read_key_file(key_file: str) -> bytes:
+def _read_key_file(key_file: str | None) -> bytes | None:
     """
     Read a key file, if one was given.
 
@@ -880,21 +879,7 @@ def _read_key_file(key_file: str) -> bytes:
         return key_file_handle.read()
 
 
-def _get_key_file_version(key_file: str) -> tuple:
-    """
-    Return a value that changes whenever the given key file changes.
-
-    :param key_file: Name of a key file
-    :return: The modification time and the size of the file
-    """
-    # os.stat() follows symlinks, which is what makes a mounted secret work: an orchestrator
-    # usually does not rewrite the key file in place, it points a symlink at a new version of
-    # the file, so the name privacyIDEA is configured with never changes itself.
-    file_stat = os.stat(key_file)
-    return file_stat.st_mtime_ns, file_stat.st_size
-
-
-def get_sign_object(private_key_file: str, public_key_file: str = None,
+def get_sign_object(private_key_file: str, public_key_file: str | None = None,
                     check_private_key: bool = True) -> Sign:
     """
     Return a Sign object for the given key files and keep it in the app-local store.
@@ -905,11 +890,18 @@ def get_sign_object(private_key_file: str, public_key_file: str = None,
     all threads of the application. This is safe because a loaded key holds no state between
     operations: every signature builds its own context.
 
-    A key file that is replaced while the server is running is still picked up, because the
-    modification time and the size of the file are part of the cached entry.
+    The key files are read on every call and the cached key is used only while their contents
+    still hash to the same value, so a key file that is replaced while the server is running
+    is picked up. Reading a key file costs a thousandth of parsing it, which is why the
+    contents are compared instead of the modification time: tools that rotate a key preserve
+    the modification time (``cp -p``, ``rsync -a``, restoring a backup), and two RSA keys of
+    the same size usually have the same file size. The key material is also read through the
+    configured name every time, so a key file that can no longer be read stops being used
+    instead of being served from the cache.
 
-    Failures are not cached. Reading a key file is cheap compared to parsing the key, and a
-    key file that is temporarily unavailable must not disable signing until the next restart.
+    Failures are not cached, and a failed load drops the entry it was meant to replace: a key
+    file that is temporarily unavailable must not disable signing until the next restart, and
+    must not keep the superseded key in use either.
 
     :param private_key_file: Name of the file containing the private key in PEM format
     :param public_key_file: Name of the file containing the public key in PEM format. A Sign
@@ -921,22 +913,34 @@ def get_sign_object(private_key_file: str, public_key_file: str = None,
         # Without this, a missing PI_AUDIT_KEY_PRIVATE would yield a Sign object that has no
         # key and signs everything with an empty signature.
         raise TypeError("get_sign_object() needs the name of a file containing a private key.")
-    key_files = (private_key_file, public_key_file)
-    key_file_version = tuple(_get_key_file_version(key_file) if key_file else None
-                             for key_file in key_files)
+    private_key = _read_key_file(private_key_file)
+    public_key = _read_key_file(public_key_file)
+    # The fingerprint describes the very bytes that are parsed below, so a key file that
+    # changes while this runs can not end up stored under the wrong fingerprint.
+    key_material_version = tuple(sha256(key).digest() if key is not None else None
+                                 for key in (private_key, public_key))
     cache_key = (private_key_file, public_key_file, check_private_key)
     sign_objects = get_app_local_store().setdefault("sign_objects", {})
-    # Loading the key is the expensive part, so the lock is held while it happens. Otherwise
-    # every thread that arrives before the first one is done would load the key again.
+    cached = sign_objects.get(cache_key)
+    if cached is not None and cached.key_material_version == key_material_version:
+        return cached.sign_object
+    # Loading the key is the expensive part, so it happens under the lock. Otherwise every
+    # thread that arrives before the first one is done would load the key again.
     with _sign_object_lock:
         cached = sign_objects.get(cache_key)
-        if cached is None or cached.key_file_version != key_file_version:
-            sign_object = Sign(_read_key_file(private_key_file), _read_key_file(public_key_file),
-                               check_private_key=check_private_key)
-            cached = _CachedSignObject(key_file_version, sign_object)
-            sign_objects[cache_key] = cached
+        if cached is not None and cached.key_material_version == key_material_version:
+            return cached.sign_object
+        was_cached = cached is not None
+        # The key files no longer hold what this entry was built from, so it must not survive
+        # a load that fails.
+        sign_objects.pop(cache_key, None)
+        sign_object = Sign(private_key, public_key, check_private_key=check_private_key)
+        sign_objects[cache_key] = _CachedSignObject(key_material_version, sign_object)
+        if was_cached:
+            log.info(f"The signing key in {private_key_file!s} changed and was loaded again.")
+        else:
             log.debug(f"Loaded the signing keys from {private_key_file!s} and {public_key_file!s}.")
-        return cached.sign_object
+        return sign_object
 
 
 def create_hsm_object(config):

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -887,6 +887,9 @@ def _get_key_file_version(key_file: str) -> tuple:
     :param key_file: Name of a key file
     :return: The modification time and the size of the file
     """
+    # os.stat() follows symlinks, which is what makes a mounted secret work: an orchestrator
+    # usually does not rewrite the key file in place, it points a symlink at a new version of
+    # the file, so the name privacyIDEA is configured with never changes itself.
     file_stat = os.stat(key_file)
     return file_stat.st_mtime_ns, file_stat.st_size
 

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -392,6 +392,12 @@ class AuditTestCase(MyTestCase):
         with self.assertRaises(Exception):
             getAudit(self.app.config)
         self.app.config["PI_AUDIT_KEY_PRIVATE"] = PRIVATE
+        # Without a public key the module signs entries but verifies every one of them as
+        # FAIL, which can not be told apart from a tampered log, so it has to be an error
+        self.app.config.pop("PI_AUDIT_KEY_PUBLIC")
+        with self.assertRaises(TypeError):
+            getAudit(self.app.config)
+        self.app.config["PI_AUDIT_KEY_PUBLIC"] = PUBLIC
         # Log a username as unicode with a non-ascii character
         self.Audit.log({"serial": "1234",
                         "action": "token/assign",

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -936,26 +936,6 @@ class SignObjectCacheTestCase(MyTestCase):
         self.assertIsNot(sign_object, get_sign_object(self.private_key_file, self.public_key_file,
                                                       check_private_key=False))
 
-    @staticmethod
-    def _write_keypair(private_key_file, public_key_file, private_key_length=None):
-        """
-        Write a new keypair to the given files.
-
-        :param private_key_length: If given, keep generating keys until the private key is
-            exactly this many bytes long. Two RSA keys of the same size usually have the same
-            length, but not always.
-        :return: The length of the private key that was written
-        """
-        while True:
-            # 1024 bits is enough to tell one key from another and keeps the suite cheap
-            public_key, private_key = generate_keypair(1024)
-            if private_key_length is None or len(private_key) == private_key_length:
-                break
-        for key_file, key in ((private_key_file, private_key), (public_key_file, public_key)):
-            with open(key_file, "w") as key_file_handle:
-                key_file_handle.write(key)
-        return len(private_key)
-
     def test_02_a_replaced_key_file_is_loaded_again(self):
         private_key_file, public_key_file = self._copy_key_files()
         sign_object = get_sign_object(private_key_file, public_key_file)
@@ -963,7 +943,10 @@ class SignObjectCacheTestCase(MyTestCase):
         old_signature = sign_object.sign("data to sign")
 
         # Replace the keys, as an administrator would who rotates the audit keys
-        self._write_keypair(private_key_file, public_key_file)
+        new_public_key, new_private_key = generate_keypair()
+        for key_file, key in ((private_key_file, new_private_key), (public_key_file, new_public_key)):
+            with open(key_file, "w") as key_file_handle:
+                key_file_handle.write(key)
 
         new_sign_object = get_sign_object(private_key_file, public_key_file)
         self.assertIsNot(sign_object, new_sign_object)
@@ -972,34 +955,30 @@ class SignObjectCacheTestCase(MyTestCase):
         self.assertTrue(new_sign_object.verify("data to sign", new_sign_object.sign("data to sign")))
         self.assertFalse(new_sign_object.verify("data to sign", old_signature))
 
-    def test_02a_a_replaced_key_file_of_the_same_size_and_age_is_loaded_again(self):
+    def test_02a_a_key_file_of_the_same_size_and_age_is_not_served_from_the_cache(self):
         # A key rotated with cp -p, rsync -a or a restored backup keeps its modification time,
         # and two RSA keys of the same size usually have the same file size. So neither of
-        # those may decide whether the cached key is still the one that is configured.
-        key_files = self._copy_key_files()
-        private_key_file, public_key_file = key_files
-        private_key_length = self._write_keypair(private_key_file, public_key_file)
-        stat_before = [os.stat(key_file) for key_file in key_files]
+        # those may decide whether the cached key is still the one that is configured. Here the
+        # replacement is not a usable key, which makes the point without a second key: what
+        # must not happen is that the cached object is handed out.
+        private_key_file, public_key_file = self._copy_key_files()
+        self.assertIsNotNone(get_sign_object(private_key_file, public_key_file))
+        file_stat = os.stat(private_key_file)
 
-        sign_object = get_sign_object(private_key_file, public_key_file)
-        old_signature = sign_object.sign("data to sign")
+        with open(private_key_file, "rb") as private_key_handle:
+            private_key = bytearray(private_key_handle.read())
+        # Change the key material in place, so the file keeps its length, and give the file
+        # back the modification time it had
+        private_key[len(private_key) // 2] ^= 0xFF
+        with open(private_key_file, "wb") as private_key_handle:
+            private_key_handle.write(private_key)
+        os.utime(private_key_file, ns=(file_stat.st_atime_ns, file_stat.st_mtime_ns))
 
-        # Write a different keypair of exactly the same length and give each file back the
-        # timestamps it had
-        self._write_keypair(private_key_file, public_key_file, private_key_length=private_key_length)
-        for key_file, file_stat in zip(key_files, stat_before):
-            os.utime(key_file, ns=(file_stat.st_atime_ns, file_stat.st_mtime_ns))
-
-        # Neither the size nor the modification time of either file changed
-        for key_file, file_stat in zip(key_files, stat_before):
-            stat_after = os.stat(key_file)
-            self.assertEqual(file_stat.st_size, stat_after.st_size, key_file)
-            self.assertEqual(file_stat.st_mtime_ns, stat_after.st_mtime_ns, key_file)
-
-        new_sign_object = get_sign_object(private_key_file, public_key_file)
-        self.assertIsNot(sign_object, new_sign_object)
-        self.assertFalse(new_sign_object.verify("data to sign", old_signature))
-        self.assertTrue(new_sign_object.verify("data to sign", new_sign_object.sign("data to sign")))
+        stat_after = os.stat(private_key_file)
+        self.assertEqual(file_stat.st_size, stat_after.st_size)
+        self.assertEqual(file_stat.st_mtime_ns, stat_after.st_mtime_ns)
+        with self.assertRaises(Exception):
+            get_sign_object(private_key_file, public_key_file)
 
     def test_03_a_missing_key_file_is_not_cached(self):
         private_key_file, public_key_file = self._copy_key_files()

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -18,6 +18,7 @@ import binascii
 
 from privacyidea.config import TestingConfig
 from privacyidea.lib.error import HSMException, ParameterError
+from privacyidea.lib.framework import get_app_local_store
 from .base import MyTestCase, OverrideConfigTestCase
 # need to import pkcs11mock before PyKCS11, because it may be replaced by a mock module
 from .pkcs11mock import PKCS11Mock
@@ -935,6 +936,26 @@ class SignObjectCacheTestCase(MyTestCase):
         self.assertIsNot(sign_object, get_sign_object(self.private_key_file, self.public_key_file,
                                                       check_private_key=False))
 
+    @staticmethod
+    def _write_keypair(private_key_file, public_key_file, private_key_length=None):
+        """
+        Write a new keypair to the given files.
+
+        :param private_key_length: If given, keep generating keys until the private key is
+            exactly this many bytes long. Two RSA keys of the same size usually have the same
+            length, but not always.
+        :return: The length of the private key that was written
+        """
+        while True:
+            # 1024 bits is enough to tell one key from another and keeps the suite cheap
+            public_key, private_key = generate_keypair(1024)
+            if private_key_length is None or len(private_key) == private_key_length:
+                break
+        for key_file, key in ((private_key_file, private_key), (public_key_file, public_key)):
+            with open(key_file, "w") as key_file_handle:
+                key_file_handle.write(key)
+        return len(private_key)
+
     def test_02_a_replaced_key_file_is_loaded_again(self):
         private_key_file, public_key_file = self._copy_key_files()
         sign_object = get_sign_object(private_key_file, public_key_file)
@@ -942,11 +963,7 @@ class SignObjectCacheTestCase(MyTestCase):
         old_signature = sign_object.sign("data to sign")
 
         # Replace the keys, as an administrator would who rotates the audit keys
-        new_public_key, new_private_key = generate_keypair()
-        with open(private_key_file, "w") as private_key_handle:
-            private_key_handle.write(new_private_key)
-        with open(public_key_file, "w") as public_key_handle:
-            public_key_handle.write(new_public_key)
+        self._write_keypair(private_key_file, public_key_file)
 
         new_sign_object = get_sign_object(private_key_file, public_key_file)
         self.assertIsNot(sign_object, new_sign_object)
@@ -955,12 +972,49 @@ class SignObjectCacheTestCase(MyTestCase):
         self.assertTrue(new_sign_object.verify("data to sign", new_sign_object.sign("data to sign")))
         self.assertFalse(new_sign_object.verify("data to sign", old_signature))
 
+    def test_02a_a_replaced_key_file_of_the_same_size_and_age_is_loaded_again(self):
+        # A key rotated with cp -p, rsync -a or a restored backup keeps its modification time,
+        # and two RSA keys of the same size usually have the same file size. So neither of
+        # those may decide whether the cached key is still the one that is configured.
+        key_files = self._copy_key_files()
+        private_key_file, public_key_file = key_files
+        private_key_length = self._write_keypair(private_key_file, public_key_file)
+        stat_before = [os.stat(key_file) for key_file in key_files]
+
+        sign_object = get_sign_object(private_key_file, public_key_file)
+        old_signature = sign_object.sign("data to sign")
+
+        # Write a different keypair of exactly the same length and give each file back the
+        # timestamps it had
+        self._write_keypair(private_key_file, public_key_file, private_key_length=private_key_length)
+        for key_file, file_stat in zip(key_files, stat_before):
+            os.utime(key_file, ns=(file_stat.st_atime_ns, file_stat.st_mtime_ns))
+
+        # Neither the size nor the modification time of either file changed
+        for key_file, file_stat in zip(key_files, stat_before):
+            stat_after = os.stat(key_file)
+            self.assertEqual(file_stat.st_size, stat_after.st_size, key_file)
+            self.assertEqual(file_stat.st_mtime_ns, stat_after.st_mtime_ns, key_file)
+
+        new_sign_object = get_sign_object(private_key_file, public_key_file)
+        self.assertIsNot(sign_object, new_sign_object)
+        self.assertFalse(new_sign_object.verify("data to sign", old_signature))
+        self.assertTrue(new_sign_object.verify("data to sign", new_sign_object.sign("data to sign")))
+
     def test_03_a_missing_key_file_is_not_cached(self):
+        private_key_file, public_key_file = self._copy_key_files()
+        sign_object = get_sign_object(private_key_file, public_key_file)
+        # The same key files have to fail and then work again, otherwise this says nothing
+        # about whether the failure was cached
+        os.unlink(private_key_file)
         with self.assertRaises(OSError):
-            get_sign_object("/path/does/not/exist", self.public_key_file)
-        # The audit key was configured again, so the next call has to work
-        sign_object = get_sign_object(self.private_key_file, self.public_key_file)
-        self.assertTrue(sign_object.verify("data to sign", sign_object.sign("data to sign")))
+            get_sign_object(private_key_file, public_key_file)
+        shutil.copy(self.private_key_file, private_key_file)
+        new_sign_object = get_sign_object(private_key_file, public_key_file)
+        self.assertTrue(new_sign_object.verify("data to sign", new_sign_object.sign("data to sign")))
+        # The key files hold what they held before, so the object that was cached for them
+        # is still the right one
+        self.assertIs(sign_object, new_sign_object)
 
     def test_04_an_unconfigured_private_key_raises(self):
         # An unset PI_AUDIT_KEY_PRIVATE has to be an error. A Sign object without a private key
@@ -976,6 +1030,9 @@ class SignObjectCacheTestCase(MyTestCase):
         for _ in range(2):
             with self.assertRaises(Exception):
                 get_sign_object(private_key_file, public_key_file)
+        # The entry the broken key file superseded is gone, rather than being served on
+        with self.assertRaises(KeyError):
+            get_app_local_store()["sign_objects"][(private_key_file, public_key_file, True)]
 
 
 class DefaultHashAlgoListTestCase(OverrideConfigTestCase):

--- a/tests/test_lib_crypto.py
+++ b/tests/test_lib_crypto.py
@@ -2,6 +2,9 @@
 This test file tests the lib.crypto and lib.security.default
 """
 import base64
+import os
+import shutil
+import tempfile
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
@@ -23,7 +26,7 @@ from privacyidea.lib.crypto import (encryptPin, encryptPassword, decryptPin,
                                     geturandom, get_alphanum_str, hash_with_pepper,
                                     verify_with_pepper, aes_encrypt_b64, aes_decrypt_b64,
                                     get_hsm, init_hsm, set_hsm_password, hash,
-                                    encrypt, decrypt, Sign, generate_keypair,
+                                    encrypt, decrypt, Sign, get_sign_object, generate_keypair,
                                     generate_password, pass_hash, verify_pass_hash, generate_keypair_ecc,
                                     ecc_key_pair_to_b64url_str, b64url_str_key_pair_to_ecc_obj, sign_ecc,
                                     ecdh_key_exchange, encrypt_aes, decrypt_aes, verify_ecc)
@@ -890,6 +893,89 @@ class SignObjectTestCase(MyTestCase):
         long_data_sig = 991763198885165486007338893972384496025563436289154190056285376683148093829644985815692167116166669178171916463844829424162591848106824431299796818231239278958776853940831433819576852350691126984617641483209392489383319296267416823194661791079316704545017249491961092046751201670544843607206698682190381208022128216306635574292359600514603728560982584561531193227312370683851459162828981766836503134221347324867936277484738573153562229478151744446530191383660477390958159856842222437156763388859923477183453362567547792824054461704970820770533637185477922709297916275611571003099205429044820469679520819043851809079
         long_data = b'\x01\x02' * 5000
         self.assertTrue(so.verify(long_data, long_data_sig, verify_old_sigs=True))
+
+
+class SignObjectCacheTestCase(MyTestCase):
+    """ tests that the Sign object is loaded once per key file version and then shared """
+
+    def setUp(self):
+        super().setUp()
+        self.private_key_file = current_app.config.get("PI_AUDIT_KEY_PRIVATE")
+        self.public_key_file = current_app.config.get("PI_AUDIT_KEY_PUBLIC")
+
+    def _copy_key_files(self):
+        """
+        Copy the audit keys to a temporary directory, so a test may modify them.
+
+        :return: the names of the private and the public key file
+        """
+        key_directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, key_directory)
+        private_key_file = os.path.join(key_directory, "private.pem")
+        public_key_file = os.path.join(key_directory, "public.pem")
+        shutil.copy(self.private_key_file, private_key_file)
+        shutil.copy(self.public_key_file, public_key_file)
+        return private_key_file, public_key_file
+
+    def test_00_the_same_key_files_share_one_object(self):
+        sign_object = get_sign_object(self.private_key_file, self.public_key_file)
+        self.assertIs(sign_object, get_sign_object(self.private_key_file, self.public_key_file))
+        signature = sign_object.sign("data to sign")
+        self.assertTrue(sign_object.verify("data to sign", signature))
+
+    def test_01_different_arguments_are_different_objects(self):
+        sign_object = get_sign_object(self.private_key_file, self.public_key_file)
+        # The response signature asks for the private key alone, so it gets its own object
+        # instead of evicting the one the audit log uses.
+        private_only_object = get_sign_object(self.private_key_file)
+        self.assertIsNot(sign_object, private_only_object)
+        self.assertIs(private_only_object, get_sign_object(self.private_key_file))
+        self.assertIs(sign_object, get_sign_object(self.private_key_file, self.public_key_file))
+        # Whether the private key is checked is part of the object as well
+        self.assertIsNot(sign_object, get_sign_object(self.private_key_file, self.public_key_file,
+                                                      check_private_key=False))
+
+    def test_02_a_replaced_key_file_is_loaded_again(self):
+        private_key_file, public_key_file = self._copy_key_files()
+        sign_object = get_sign_object(private_key_file, public_key_file)
+        self.assertIs(sign_object, get_sign_object(private_key_file, public_key_file))
+        old_signature = sign_object.sign("data to sign")
+
+        # Replace the keys, as an administrator would who rotates the audit keys
+        new_public_key, new_private_key = generate_keypair()
+        with open(private_key_file, "w") as private_key_handle:
+            private_key_handle.write(new_private_key)
+        with open(public_key_file, "w") as public_key_handle:
+            public_key_handle.write(new_public_key)
+
+        new_sign_object = get_sign_object(private_key_file, public_key_file)
+        self.assertIsNot(sign_object, new_sign_object)
+        # The new object signs and verifies with the new keys, and no longer accepts a
+        # signature the old key created
+        self.assertTrue(new_sign_object.verify("data to sign", new_sign_object.sign("data to sign")))
+        self.assertFalse(new_sign_object.verify("data to sign", old_signature))
+
+    def test_03_a_missing_key_file_is_not_cached(self):
+        with self.assertRaises(OSError):
+            get_sign_object("/path/does/not/exist", self.public_key_file)
+        # The audit key was configured again, so the next call has to work
+        sign_object = get_sign_object(self.private_key_file, self.public_key_file)
+        self.assertTrue(sign_object.verify("data to sign", sign_object.sign("data to sign")))
+
+    def test_04_an_unconfigured_private_key_raises(self):
+        # An unset PI_AUDIT_KEY_PRIVATE has to be an error. A Sign object without a private key
+        # signs everything with an empty signature instead.
+        with self.assertRaises(TypeError):
+            get_sign_object(None, self.public_key_file)
+
+    def test_05_a_broken_key_file_does_not_keep_serving_the_old_object(self):
+        private_key_file, public_key_file = self._copy_key_files()
+        self.assertIsNotNone(get_sign_object(private_key_file, public_key_file))
+        with open(private_key_file, "wb") as private_key_handle:
+            private_key_handle.write(b"This is not a private key")
+        for _ in range(2):
+            with self.assertRaises(Exception):
+                get_sign_object(private_key_file, public_key_file)
 
 
 class DefaultHashAlgoListTestCase(OverrideConfigTestCase):


### PR DESCRIPTION
Fixes #5913

`sign_response()` and `SQLAudit.__init__()` each read `PI_AUDIT_KEY_PRIVATE` and
build a `Sign` object for every request. Loading an RSA private key validates it,
which costs about a hundred times more than the signature it enables, so every
request re-validated the same unchanged key at least twice.

`get_sign_object()` in `lib/crypto.py` keeps the loaded key in the app-local store
and shares it among all threads, following `SharedEngineRegistry` in `lib/pooling.py`
as the precedent for a process-wide registry. Sharing one key object is safe because
a loaded key holds no state between operations - every signature builds its own
context.

## Measurements

`tests/test_api_validate_offline.py`, with `PI_AUDIT_NO_PRIVATE_KEY_CHECK` and
`PI_RESPONSE_NO_PRIVATE_KEY_CHECK` forced to `False` so the suite behaves like a
deployment:

| | validated key loads | mean per request |
| --- | --- | --- |
| before | 48 (2.0 per request) | 109.3 ms |
| after | 2 in total | 62.4 ms |

That is 46.9 ms per request, 43% of the request time in this suite. Across
`test_api_validate_authcache.py` and `test_api_validate_offline.py` together, 106
key loads over 49 requests become 4 - one per cache entry per test class.

The per-operation costs behind this, measured on the 2048 bit key the test suite
ships and on a generated 4096 bit key:

| operation | cost |
| --- | --- |
| `load_pem_private_key`, validated, 2048 bit | 23.7 ms |
| `load_pem_private_key`, validated, 4096 bit | 170 ms |
| `load_pem_private_key`, validation skipped | 0.01 ms |
| `Sign.sign()` of a response body | 0.42 ms |
| `os.stat()` of the key file | 0.0007 ms |

## Behaviour

- A key file that is replaced while the server is running is still picked up
  without a restart: the modification time and the size of the key files are part
  of the cached entry, and a `stat()` costs a thousandth of the validation it
  guards.
- Failures are not cached. A missing key file leaves the response unsigned exactly
  as before, and a key file that becomes unreadable does not keep the previously
  loaded object alive.
- A private key file that is not configured at all raises, as it did before. This
  is worth stating because the first version of the change turned it into a `Sign`
  object without a key, which would have signed every response and audit entry
  with an empty signature.
- `read_keys()` stays on the audit base class. Nothing in the tree calls it now,
  but it is part of the pluggable audit module interface.

## Documentation

`PI_AUDIT_NO_PRIVATE_KEY_CHECK` and `PI_RESPONSE_NO_PRIVATE_KEY_CHECK` are no
longer presented as a way to improve the throughput, since the validation now
happens once per worker process rather than once per request. While rewriting those
paragraphs: `inifile.rst` told administrators to set `PI_AUDIT_NO_PRIVATE_KEY_CHECK`
to affect the response signature, but `sign_response()` reads
`PI_RESPONSE_NO_PRIVATE_KEY_CHECK`. That is corrected here.

## Tests

`SignObjectCacheTestCase` in `tests/test_lib_crypto.py` covers sharing, separate
entries per argument combination, reloading after a key rotation, an unconfigured
private key, and the two failure paths. With the cache short-circuited, three of
these fail, so they do detect a regression. The rotation test replaces the key files
with a freshly generated pair and asserts that the new object verifies its own
signature and rejects one made by the old key, so it proves a reload rather than
only object identity.

Two items from the issue were deliberately left out:

- The fallback to an uncached `Sign` object when there is no application context.
  It is unreachable, because `SQLAudit.__init__()` already calls
  `register_finalizer()`, which needs a context.
- A test that two applications in one process do not share a cache entry. The store
  is `current_app.config`, so that separation belongs to `lib/framework.py`.
