### PR TITLE
Shape the RADIUS response after conditional access has decided

### DIFF
--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -623,7 +623,7 @@ def shape_radius_response(request, response):
     Apply :func:`construct_radius_response` to ``/validate/radiuscheck``, shaping it into the RADIUS empty-body
     ``204``/``400`` form.
 
-    Applied from ``after_request`` for the same reason as :func:`mask_validate_error_response` - so an error
+    Applied from ``after_request`` for the same reason as :func:`mask_authentication_error_response` - so an error
     response built by an error handler is shaped too - but **after**
     :func:`~privacyidea.api.lib.conditional_access.surface_conditional_access_message`, because dropping the JSON
     body also drops the verdict conditional access still has to correct.
@@ -677,7 +677,7 @@ def auth_error(error):
 
         # The specific message is written to the audit log here; masking the
         # client-facing response (hide_specific_error_message) is applied
-        # centrally in shape_validate_error_response (see after_request).
+        # centrally in mask_authentication_error_response (see after_request).
         g.audit_object.add_to_log({"info": message}, add_with_comma=True)
 
     return send_error(error.message, error_code=error.id, details=error.details), get_auth_error_status_code(error)

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -559,14 +559,19 @@ def after_request(response):
     This function is called after a request
     :return: The response
     """
-    response = shape_validate_error_response(request, response)
+    response = mask_authentication_error_response(request, response)
 
     # Report what conditional access did to this request, if anything. Central rather than per endpoint for two
     # reasons: this also runs for a response an *error handler* built, where every post-policy is skipped, and no
-    # gated endpoint can forget to opt in. One lookup and it is done for every request. After the shaping above,
+    # gated endpoint can forget to opt in. One lookup and it is done for every request. After the masking above,
     # which is where hide_specific_error_message has its say, so a notification composes onto what survived it -
     # and before sign_response, which the decorator above applies to whatever this function returns.
     response = surface_conditional_access_message(response)
+
+    # Last of the three, because it drops the JSON body: conditional access has to have had its say on the verdict
+    # before the body carrying it is thrown away, or a request that authenticates *and* trips a restriction in one
+    # breath would be answered 204 while /validate/check answers the same request with a rejection.
+    response = shape_radius_response(request, response)
 
     # Strip version information before signing if the hide_version policy
     # is active and no user is logged in.
@@ -579,41 +584,56 @@ def after_request(response):
     return response
 
 
-def shape_validate_error_response(request, response):
+def _shaped_rule(request) -> str | None:
     """
-    Single source of truth for the two response-shaping policies of the
-    authentication endpoints. They must run on *every* response - normal returns
-    and the error responses built by the error handlers in this module alike -
-    but the ``@postpolicy`` chain of the view only runs when the view *returns*.
+    The route whose response is about to be shaped, or ``None`` when there is nothing to shape.
 
-    ``after_request`` is the single choke point every response flows through
-    (this is also how ``sign_response`` manages to sign error responses), so
-    both policies are applied here once instead of being duplicated as
-    ``@postpolicy`` decorators on the views and, for the error path, inline in
-    the error handlers:
+    Flask answers OPTIONS itself, without dispatching to the view, so such a request carries no authentication
+    outcome - only the Allow header, which must survive.
+    """
+    if request.method == "OPTIONS":
+        return None
+    return getattr(getattr(request, "url_rule", None), "rule", None)
 
-    * :func:`construct_radius_response` shapes ``/validate/radiuscheck`` into the
-      RADIUS empty-body ``204``/``400`` form.
-    * :func:`hide_specific_error_message` masks the specific failure reason on
-      ``/validate/check`` and ``/auth`` when the policy is active.
 
-    Both are no-ops for a successful authentication and only act on the route
-    they belong to, so unrelated endpoints (and ``/auth/rights``, ``/validate/*``
-    other than ``check``) are left untouched.
+def mask_authentication_error_response(request, response):
+    """
+    Apply :func:`hide_specific_error_message` to the two endpoints that authenticate a credential.
+
+    It must run on *every* response - normal returns and the error responses built by the error handlers in this
+    module alike - but the ``@postpolicy`` chain of the view only runs when the view *returns*. ``after_request``
+    is the single choke point every response flows through (this is also how ``sign_response`` manages to sign
+    error responses), so it is applied here once instead of being duplicated as a ``@postpolicy`` decorator on the
+    views and, for the error path, inline in the error handlers.
+
+    A no-op for a successful authentication and only on the routes it belongs to, so unrelated endpoints (and
+    ``/auth/rights``, ``/validate/*`` other than ``check``) are left untouched.
+
+    :param request: the request object
+    :param response: the response object
+    :return: the (possibly modified) response
+    """
+    if _shaped_rule(request) in ("/validate/check", "/auth"):
+        return hide_specific_error_message(request, response)
+    return response
+
+
+def shape_radius_response(request, response):
+    """
+    Apply :func:`construct_radius_response` to ``/validate/radiuscheck``, shaping it into the RADIUS empty-body
+    ``204``/``400`` form.
+
+    Applied from ``after_request`` for the same reason as :func:`mask_validate_error_response` - so an error
+    response built by an error handler is shaped too - but **after**
+    :func:`~privacyidea.api.lib.conditional_access.surface_conditional_access_message`, because dropping the JSON
+    body also drops the verdict conditional access still has to correct.
 
     :param request: the request object
     :param response: the response object
     :return: the (possibly replaced) response
     """
-    # Flask answers OPTIONS itself, without dispatching to the view, so there is
-    # no authentication outcome to shape - only the Allow header, which must survive.
-    if request.method == "OPTIONS":
-        return response
-    rule = getattr(getattr(request, "url_rule", None), "rule", None)
-    if rule == "/validate/radiuscheck":
+    if _shaped_rule(request) == "/validate/radiuscheck":
         return construct_radius_response(request, response)
-    if rule in ("/validate/check", "/auth"):
-        return hide_specific_error_message(request, response)
     return response
 
 

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -56,8 +56,7 @@ from urllib.parse import quote
 from flask import g, current_app, Request
 from flask_babel import _, lazy_gettext
 
-from privacyidea.api.lib.utils import (get_all_params, log_authentication, hardening_action_active,
-                                       GENERIC_AUTH_FAILURE)
+from privacyidea.api.lib.utils import get_all_params, log_authentication, hardening_action_active
 from privacyidea.lib.conditional_access.authentication_event_types import (AuthEventType, AuthEventReason,
                                                                           build_reason_detail)
 from privacyidea.lib.conditional_access.request_context import get_ca_context, claimed_ca_message

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -893,7 +893,7 @@ def hide_specific_error_message(request, response):
 
     This is the single implementation of the masking behaviour. It is applied
     once, centrally, from the shared after-request handler
-    (:func:`privacyidea.api.before_after.shape_validate_error_response`) for the
+    (:func:`privacyidea.api.before_after.mask_authentication_error_response`) for the
     ``/validate/check`` and ``/auth`` endpoints, so it has to handle every shape
     a failed-authentication response can take:
 

--- a/tests/test_api_conditional_access.py
+++ b/tests/test_api_conditional_access.py
@@ -142,6 +142,13 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
             self.assertEqual(200, response.status_code, response)
             return response.json
 
+    def _radiuscheck(self, data: dict) -> int:
+        """The status code is the whole answer at /validate/radiuscheck: 204 authenticated, 400 anything else."""
+        with self.app.test_request_context('/validate/radiuscheck', method='POST', data=data):
+            response = self.app.full_dispatch_request()
+            self.assertEqual(b"", response.data, response.data)
+            return response.status_code
+
     def _outcome_statistics(self, query_string: dict | None = None, status: int = 200) -> dict:
         """Read the outcome history over a window around now, since the rows written here take the current time."""
         query = {"start_time": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
@@ -172,13 +179,15 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
 
     @staticmethod
     def _make_lock_policy(*, counter_type, threshold: int, duration: int, window: int = 3600,
-                          dry_run: bool = False, priority: int = 1, error_message: str | None = None) -> None:
+                          dry_run: bool = False, priority: int = 1, error_message: str | None = None,
+                          reset_on_success: bool | None = None) -> None:
         create_conditional_access_policy(
             name="ca_lock", time_window_seconds=window,
             counter_types_to_track=_counter_types(counter_type),
             stages=[{"failure_threshold": threshold, "error_message": error_message,
                      "actions": [{"action_type": str(ConditionalAccessAction.LOCK_USER), "action_value": duration}]}],
-            target=ConditionalAccessTarget.USER, dry_run=dry_run, priority=priority)
+            target=ConditionalAccessTarget.USER, dry_run=dry_run, priority=priority,
+            reset_on_success=reset_on_success)
 
     @staticmethod
     def _make_block_ip_policy(*, counter_type, threshold: int, duration: int, window: int = 3600,
@@ -628,6 +637,25 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self.assertEqual(after["result"], tripping["result"], tripping)
         self.assertEqual(after["detail"], tripping["detail"], tripping)
         self.assertEqual(str(GENERIC_AUTH_FAILURE), tripping["detail"]["message"], tripping)
+
+    def test_a_tripping_request_is_refused_at_radiuscheck_too(self):
+        # /validate/radiuscheck answers with a status code and an empty body, so construct_radius_response drops the
+        # JSON body - and with it the verdict. It therefore has to run *after* the conditional-access response hook,
+        # or the request that writes a restriction is answered 204 while /validate/check answers the very same
+        # request with a rejection: the RADIUS client would authenticate the user on the request that locks them.
+        #
+        # A rate limit is the reachable shape of "authenticates and trips in one breath": LOGIN_SUCCESS is trackable
+        # and reset_on_success=False keeps the success from clearing the counter it just fed.
+        self._make_lock_policy(counter_type=AuthEventType.LOGIN_SUCCESS, threshold=2, duration=600,
+                               reset_on_success=False)
+        # First success: one event, below the threshold, so nothing is refused and the adapter is told "authenticated".
+        self.assertEqual(204, self._radiuscheck({"user": "cornelius", "pass": "pin755224"}))
+        self.assertFalse(is_user_locked(self.user))
+
+        # Second success reaches the threshold and locks. Same endpoint, same kind of request - the only difference
+        # is that this one tripped the restriction, and that has to reach the status code.
+        self.assertEqual(400, self._radiuscheck({"user": "cornelius", "pass": "pin287082"}))
+        self.assertTrue(is_user_locked(self.user))
 
     def test_hide_specific_error_message_still_masks_an_ordinary_token_failure(self):
         # The policy keeps doing its job on everything that is not conditional access's: a wrong PIN is still


### PR DESCRIPTION
`/validate/radiuscheck` answered **204** on a request that authenticated *and* tripped a                      
  conditional-access restriction in the same breath, while `/validate/check` answers the very                   
  same request with a rejection. The RADIUS client authenticated the user on the request that                   
  locked them.                                                                                                  
                                                                                                                
  `construct_radius_response` drops the JSON body, and `surface_conditional_access_message`                     
  returns early on a response that is not JSON — so the hook that had to correct the verdict                    
  never ran on that route. The shaping is split in two: `hide_specific_error_message` keeps                     
  running before the hook (a notification has to compose onto whatever survived the masking),                   
  the RADIUS shaping now runs after it.                                                                         
                                                                                                                
  **Scope of the bug:** the authentication-log row and the lock itself were always written, by                  
  `finalize()` at request teardown, so only the verdict on the response was wrong — every                       
  *later* request is refused by the pre-check as normal. Reachable with a policy tracking                       
  `LOGIN_SUCCESS` and `reset_on_success=False` (a rate limit); a failure-counting policy cannot                 
  hit it, since a failed authentication is an empty 400 either way.

### Review attention                                                                                          
                                                                                                                
  The ordering in `after_request` is a three-way constraint, not a preference:                                  
  `hide_specific_error_message` → `surface_conditional_access_message` → `construct_radius_response`.           
  Moving either shaper across the hook reintroduces one of the two bugs. 