### PR TITLE
Pin the conditional-access error_message columns to a case-sensitive collation

### DIFF
--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -56,8 +56,7 @@ from urllib.parse import quote
 from flask import g, current_app, Request
 from flask_babel import _, lazy_gettext
 
-from privacyidea.api.lib.utils import (get_all_params, log_authentication, hardening_action_active,
-                                       GENERIC_AUTH_FAILURE)
+from privacyidea.api.lib.utils import get_all_params, log_authentication, hardening_action_active
 from privacyidea.lib.conditional_access.authentication_event_types import (AuthEventType, AuthEventReason,
                                                                           build_reason_detail)
 from privacyidea.lib.conditional_access.request_context import get_ca_context, claimed_ca_message

--- a/privacyidea/migrations/versions/0147d78cbace_authentication_log.py
+++ b/privacyidea/migrations/versions/0147d78cbace_authentication_log.py
@@ -20,6 +20,31 @@ down_revision = 'b8c9d0e1f2a3'
 branch_labels = None
 depends_on = None
 
+INDEXES = {
+    'authentication_log': [
+        ('ix_authlog_user_event_time', ['resolver', 'uid', 'realm', 'event_type', 'timestamp']),
+        ('ix_authlog_ip_event_time', ['source_ip', 'event_type', 'timestamp']),
+        # Serves PER_ATTEMPT counting (count_user_attempts / count_ip_attempts): a subject's rows range-scanned by
+        # time, no event_type predicate.
+        ('ix_authlog_user_time', ['resolver', 'uid', 'realm', 'timestamp']),
+        ('ix_authlog_ip_time', ['source_ip', 'timestamp']),
+        # The TCP peer is the second pivot a forensic query starts from - "what came from this machine",
+        # whatever it claimed to be forwarding for.
+        ('ix_authlog_peer_ip_time', ['peer_ip', 'timestamp']),
+        # The one index not scoped to a subject: the statistics query and the retention delete both range over
+        # timestamp alone, and the indexes above cannot serve that.
+        ('ix_authlog_time', ['timestamp']),
+    ],
+    'authentication_log_reason': [
+        # The lookup that loads a log page's reasons and the one the delete paths use to remove an entry's
+        # reasons with it.
+        ('ix_authlog_reason_authlog', ['auth_log_id']),
+        # The filter "every entry with this reason": reason first, so the EXISTS that matches it seeks rather than
+        # scans, with auth_log_id alongside so it is answered from the index.
+        ('ix_authlog_reason_reason', ['reason', 'auth_log_id']),
+    ],
+}
+
 
 def _unicode_case_sensitive(length):
     """
@@ -35,121 +60,109 @@ def _unicode_case_sensitive(length):
                                            "mysql", "mariadb")
 
 
+def _existing_tables() -> set[str]:
+    """
+    The names of the tables that already exist, lower-cased.
+
+    Reflected once per migration rather than once per table: on a normal run nothing exists yet, so this
+    single catalog read is all the guard below costs. Lower-cased because Oracle folds unquoted identifiers
+    to upper case and the inspector reflects them back lower-cased (mirrors models.db.sequence_exists).
+    """
+    return {name.lower() for name in sa.inspect(op.get_bind()).get_table_names()}
+
+
+def _create_table(existing_tables: set[str], table_name: str, *columns) -> None:
+    """
+    Create the table unless it is already there, then add each of its INDEXES that is absent.
+
+    Presence is established by reflection rather than by swallowing an "already exists" error, which Oracle
+    never says: it reports an existing object as ORA-00955 ("name is already used by an existing object").
+    models.db.sequence_exists reflects for the same reason.
+
+    The indexes are created by statements of their own and are deliberately not declared inline in the
+    CREATE TABLE: every statement here autocommits (see migrations/env.py), so a run that created the table
+    and then failed would leave the table behind, and a guard that keyed the indexes off the table's absence
+    would skip them for good once Alembic stamped the revision. These indexes in particular are what keeps
+    the conditional-access counting queries (engine._policy_count / _policy_count_ip) off a full table scan
+    on every single authentication.
+    """
+    if table_name.lower() in existing_tables:
+        print(f"Table '{table_name}' already exists.")
+        existing_indexes = {(index["name"] or "").lower()
+                            for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+    else:
+        op.create_table(table_name, *columns)
+        existing_indexes = set()
+
+    for index_name, index_columns in INDEXES.get(table_name, ()):
+        if index_name.lower() in existing_indexes:
+            print(f"Index '{index_name}' already exists.")
+        else:
+            op.create_index(index_name, table_name, index_columns)
+
+
 def upgrade():
-    try:
-        # The column lengths must match privacyidea.models.authentication_log.authentication_log_column_length.
-        # The columns in the composite index below (resolver, uid, realm, event_type) are kept small enough that the
-        # index stays below the 3072-byte InnoDB key limit of MySQL/MariaDB with utf8mb4:
-        # (120+320+255+40)*4 + 8 (timestamp) = 2948 bytes. The non-indexed columns (client_label, serial) are sized
-        # generously to avoid truncation. transaction_id matches the challenge table's 64 chars, and endpoint is sized
-        # past the longest route privacyIDEA registers.
-        op.create_table(
-            'authentication_log',
-            sa.Column('id', BigIntegerType, sa.Identity(always=False), nullable=False),
-            sa.Column('resolver', _unicode_case_sensitive(120), nullable=True),
-            sa.Column('uid', _unicode_case_sensitive(320), nullable=True),
-            sa.Column('realm', _unicode_case_sensitive(255), nullable=True),
-            sa.Column('username', _unicode_case_sensitive(255), nullable=True),
-            sa.Column('user_role', _unicode_case_sensitive(30), nullable=True),
-            sa.Column('event_type', _unicode_case_sensitive(40), nullable=False),
-            # Microseconds on every backend, because the attempt reduction in lib.conditional_access.engine orders
-            # an attempt's rows by (timestamp, id).
-            sa.Column('timestamp',
-                      sa.DateTime().with_variant(mysql.DATETIME(fsp=6), "mysql", "mariadb")
-                      .with_variant(oracle.TIMESTAMP(), "oracle"),
-                      nullable=False),
-            sa.Column('source_ip', _unicode_case_sensitive(50), nullable=True),
-            sa.Column('peer_ip', _unicode_case_sensitive(50), nullable=True),
-            sa.Column('source_ip_source', _unicode_case_sensitive(40), nullable=True),
-            sa.Column('client_label', _unicode_case_sensitive(1024), nullable=True),
-            sa.Column('client_label_source', _unicode_case_sensitive(40), nullable=True),
-            sa.Column('ip_chain', sa.JSON(), nullable=True),
-            sa.Column('endpoint', _unicode_case_sensitive(255), nullable=True),
-            sa.Column('serial', _unicode_case_sensitive(1024), nullable=True),
-            sa.Column('transaction_id', _unicode_case_sensitive(64), nullable=True),
-            sa.Column('attempt_id', _unicode_case_sensitive(64), nullable=True),
-            sa.Column('other_info', sa.JSON(), nullable=True),
-            sa.PrimaryKeyConstraint('id'),
-        )
-        op.create_index('ix_authlog_user_event_time', 'authentication_log',
-                        ['resolver', 'uid', 'realm', 'event_type', 'timestamp'])
-        op.create_index('ix_authlog_ip_event_time', 'authentication_log',
-                        ['source_ip', 'event_type', 'timestamp'])
-        # Serves PER_ATTEMPT counting (count_user_attempts / count_ip_attempts): a subject's rows range-scanned by
-        # time, no event_type predicate.
-        op.create_index('ix_authlog_user_time', 'authentication_log',
-                        ['resolver', 'uid', 'realm', 'timestamp'])
-        op.create_index('ix_authlog_ip_time', 'authentication_log',
-                        ['source_ip', 'timestamp'])
-        # The TCP peer is the second pivot a forensic query starts from - "what came from this machine",
-        # whatever it claimed to be forwarding for.
-        op.create_index('ix_authlog_peer_ip_time', 'authentication_log',
-                        ['peer_ip', 'timestamp'])
-        # The one index not scoped to a subject: the statistics query and the retention delete both range over
-        # timestamp alone, and the indexes above cannot serve that.
-        op.create_index('ix_authlog_time', 'authentication_log', ['timestamp'])
+    existing_tables = _existing_tables()
 
-    except (OperationalError, ProgrammingError) as ex:
-        if "already exists" in str(ex.orig).lower():
-            print("Table 'authentication_log' already exists.")
-        else:
-            print("Could not add table 'authentication_log' to database.")
-            raise
+    # The column lengths must match privacyidea.models.authentication_log.authentication_log_column_length.
+    # The columns in the composite index below (resolver, uid, realm, event_type) are kept small enough that the
+    # index stays below the 3072-byte InnoDB key limit of MySQL/MariaDB with utf8mb4:
+    # (120+320+255+40)*4 + 8 (timestamp) = 2948 bytes. The non-indexed columns (client_label, serial) are sized
+    # generously to avoid truncation. transaction_id matches the challenge table's 64 chars, and endpoint is sized
+    # past the longest route privacyIDEA registers.
+    _create_table(
+        existing_tables,
+        'authentication_log',
+        sa.Column('id', BigIntegerType, sa.Identity(always=False), nullable=False),
+        sa.Column('resolver', _unicode_case_sensitive(120), nullable=True),
+        sa.Column('uid', _unicode_case_sensitive(320), nullable=True),
+        sa.Column('realm', _unicode_case_sensitive(255), nullable=True),
+        sa.Column('username', _unicode_case_sensitive(255), nullable=True),
+        sa.Column('user_role', _unicode_case_sensitive(30), nullable=True),
+        sa.Column('event_type', _unicode_case_sensitive(40), nullable=False),
+        # Microseconds on every backend, because the attempt reduction in lib.conditional_access.engine orders
+        # an attempt's rows by (timestamp, id).
+        sa.Column('timestamp',
+                  sa.DateTime().with_variant(mysql.DATETIME(fsp=6), "mysql", "mariadb")
+                  .with_variant(oracle.TIMESTAMP(), "oracle"),
+                  nullable=False),
+        sa.Column('source_ip', _unicode_case_sensitive(50), nullable=True),
+        sa.Column('peer_ip', _unicode_case_sensitive(50), nullable=True),
+        sa.Column('source_ip_source', _unicode_case_sensitive(40), nullable=True),
+        sa.Column('client_label', _unicode_case_sensitive(1024), nullable=True),
+        sa.Column('client_label_source', _unicode_case_sensitive(40), nullable=True),
+        sa.Column('ip_chain', sa.JSON(), nullable=True),
+        sa.Column('endpoint', _unicode_case_sensitive(255), nullable=True),
+        sa.Column('serial', _unicode_case_sensitive(1024), nullable=True),
+        sa.Column('transaction_id', _unicode_case_sensitive(64), nullable=True),
+        sa.Column('attempt_id', _unicode_case_sensitive(64), nullable=True),
+        sa.Column('other_info', sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
 
-    try:
-        # Why an authentication rarely fails for exactly one reason is on AuthenticationLogReason itself. A table of
-        # its own rather than a column on the parent: "every NO_USABLE_TOKEN caused by the failcounter" has to be a
-        # plain indexed predicate, and a request can produce more than one reason.
-        op.create_table(
-            'authentication_log_reason',
-            sa.Column('id', BigIntegerType, sa.Identity(always=False), nullable=False),
-            sa.Column('auth_log_id', BigIntegerType, nullable=False),
-            sa.Column('reason', _unicode_case_sensitive(40), nullable=False),
-            sa.ForeignKeyConstraint(['auth_log_id'], ['authentication_log.id'], ondelete='CASCADE'),
-            sa.PrimaryKeyConstraint('id'),
-        )
-        # The lookup that loads a log page's reasons and the one the delete paths use to remove an entry's
-        # reasons with it.
-        op.create_index('ix_authlog_reason_authlog', 'authentication_log_reason', ['auth_log_id'])
-        # The filter "every entry with this reason": reason first, so the EXISTS that matches it seeks rather than
-        # scans, with auth_log_id alongside so it is answered from the index.
-        op.create_index('ix_authlog_reason_reason', 'authentication_log_reason', ['reason', 'auth_log_id'])
-
-    except (OperationalError, ProgrammingError) as ex:
-        if "already exists" in str(ex.orig).lower():
-            print("Table 'authentication_log_reason' already exists.")
-        else:
-            print("Could not add table 'authentication_log_reason' to database.")
-            raise
+    # Why an authentication rarely fails for exactly one reason is on AuthenticationLogReason itself. A table of
+    # its own rather than a column on the parent: "every NO_USABLE_TOKEN caused by the failcounter" has to be a
+    # plain indexed predicate, and a request can produce more than one reason.
+    _create_table(
+        existing_tables,
+        'authentication_log_reason',
+        sa.Column('id', BigIntegerType, sa.Identity(always=False), nullable=False),
+        sa.Column('auth_log_id', BigIntegerType, nullable=False),
+        sa.Column('reason', _unicode_case_sensitive(40), nullable=False),
+        sa.ForeignKeyConstraint(['auth_log_id'], ['authentication_log.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
 
 
 def downgrade():
-    try:
-        op.drop_table('authentication_log_reason')
-
-    except (OperationalError, ProgrammingError) as ex:
-        msg = str(ex.orig).lower()
-        if "no such table" in msg or "unknown table" in msg or "does not exist" in msg:
-            print("Table 'authentication_log_reason' already removed.")
-        else:
-            print("Could not remove table 'authentication_log_reason'.")
-            raise
-
-    try:
-        with op.batch_alter_table('authentication_log', schema=None) as batch_op:
-            batch_op.drop_index('ix_authlog_user_event_time')
-            batch_op.drop_index('ix_authlog_ip_event_time')
-            batch_op.drop_index('ix_authlog_user_time')
-            batch_op.drop_index('ix_authlog_ip_time')
-            batch_op.drop_index('ix_authlog_peer_ip_time')
-            batch_op.drop_index('ix_authlog_time')
-
-        op.drop_table('authentication_log')
-
-    except (OperationalError, ProgrammingError) as ex:
-        msg = str(ex.orig).lower()
-        if "no such table" in msg or "unknown table" in msg or "does not exist" in msg:
-            print("Table 'authentication_log' already removed.")
-        else:
-            print("Could not remove table 'authentication_log'.")
-            raise
+    # Children before parents because of the foreign key. The indexes and identities go with their table.
+    for table_name in ['authentication_log_reason', 'authentication_log']:
+        try:
+            op.drop_table(table_name)
+        except (OperationalError, ProgrammingError) as ex:
+            msg = str(ex.orig).lower()
+            if "no such table" in msg or "unknown table" in msg or "does not exist" in msg:
+                print(f"Table '{table_name}' already removed.")
+            else:
+                print(f"Could not remove table '{table_name}'.")
+                raise

--- a/privacyidea/migrations/versions/173d32328846_conditional_access_policies.py
+++ b/privacyidea/migrations/versions/173d32328846_conditional_access_policies.py
@@ -14,6 +14,7 @@ Create Date: 2026-06-03 00:00:00.000000
 """
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import mysql
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 # revision identifiers, used by Alembic.
@@ -38,6 +39,21 @@ INDEXES = {
         ('ix_conditional_access_stage_actions_stage_id', ['stage_id']),
     ],
 }
+
+
+def _unicode_case_sensitive(length: int) -> sa.Unicode:
+    """
+    A case-sensitive string column type (mirrors models.utils.case_sensitive_unicode).
+
+    MySQL/MariaDB's server-default collation is typically case-insensitive (*_ci) while SQLite, PostgreSQL and
+    Oracle compare case-sensitively, so an unpinned column would match differently per backend. Used for
+    error_message alone among these config columns: it is the wording the state tables snapshot and filter on
+    (user_lock_state.error_message), so all three copies of a message compare by the same rule. Pinning to
+    utf8mb4_bin gives that rule everywhere. Kept self-contained here (not imported from the model) so the
+    migration stays a stable snapshot.
+    """
+    return sa.Unicode(length).with_variant(mysql.VARCHAR(length, charset="utf8mb4", collation="utf8mb4_bin"),
+                                           "mysql", "mariadb")
 
 
 def _id_column():
@@ -140,7 +156,7 @@ def upgrade():
         _id_column(),
         sa.Column('policy_id', sa.Integer(), nullable=False),
         sa.Column('name', sa.Unicode(length=255), nullable=True),
-        sa.Column('error_message', sa.Unicode(length=500), nullable=True),
+        sa.Column('error_message', _unicode_case_sensitive(500), nullable=True),
         sa.Column('failure_threshold', sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(['policy_id'], ['conditional_access_policies.id'], ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('id'),

--- a/privacyidea/migrations/versions/173d32328846_conditional_access_policies.py
+++ b/privacyidea/migrations/versions/173d32328846_conditional_access_policies.py
@@ -27,6 +27,18 @@ TABLES = ['conditional_access_stage_actions', 'conditional_access_policy_stages'
           'conditional_access_policy_conditions', 'conditional_access_policy_counter_types',
           'conditional_access_policies']
 
+INDEXES = {
+    'conditional_access_policy_counter_types': [
+        ('ix_ca_counter_type_lookup', ['counter_type', 'policy_id']),
+    ],
+    'conditional_access_policy_conditions': [
+        ('ix_conditional_access_policy_conditions_policy_id', ['policy_id']),
+    ],
+    'conditional_access_stage_actions': [
+        ('ix_conditional_access_stage_actions_stage_id', ['stage_id']),
+    ],
+}
+
 
 def _id_column():
     """
@@ -41,19 +53,49 @@ def _id_column():
     return sa.Column('id', sa.Integer(), sa.Identity(always=False), nullable=False)
 
 
-def _create_table(table_name, *columns):
-    try:
+def _existing_tables() -> set[str]:
+    """
+    The names of the tables that already exist, lower-cased.
+
+    Reflected once per migration rather than once per table: on a normal run nothing exists yet, so this
+    single catalog read is all the guard below costs. Lower-cased because Oracle folds unquoted identifiers
+    to upper case and the inspector reflects them back lower-cased (mirrors models.db.sequence_exists).
+    """
+    return {name.lower() for name in sa.inspect(op.get_bind()).get_table_names()}
+
+
+def _create_table(existing_tables: set[str], table_name: str, *columns) -> None:
+    """
+    Create the table unless it is already there, then add each of its INDEXES that is absent.
+
+    Presence is established by reflection rather than by swallowing an "already exists" error, which Oracle
+    never says: it reports an existing object as ORA-00955 ("name is already used by an existing object").
+    models.db.sequence_exists reflects for the same reason.
+
+    The indexes are created by statements of their own and are deliberately not declared inline in the
+    CREATE TABLE: every statement here autocommits (see migrations/env.py), so a run that created the table
+    and then failed would leave the table behind, and a guard that keyed the indexes off the table's absence
+    would skip them for good once Alembic stamped the revision.
+    """
+    if table_name.lower() in existing_tables:
+        print(f"Table '{table_name}' already exists.")
+        existing_indexes = {(index["name"] or "").lower()
+                            for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+    else:
         op.create_table(table_name, *columns)
-    except (OperationalError, ProgrammingError) as ex:
-        if "already exists" in str(ex.orig).lower():
-            print(f"Table '{table_name}' already exists.")
+        existing_indexes = set()
+
+    for index_name, index_columns in INDEXES.get(table_name, ()):
+        if index_name.lower() in existing_indexes:
+            print(f"Index '{index_name}' already exists.")
         else:
-            print(f"Could not add table '{table_name}' to database.")
-            raise
+            op.create_index(index_name, table_name, index_columns)
 
 
 def upgrade():
+    existing_tables = _existing_tables()
     _create_table(
+        existing_tables,
         'conditional_access_policies',
         _id_column(),
         sa.Column('name', sa.Unicode(length=255), nullable=False),
@@ -69,6 +111,7 @@ def upgrade():
         sa.UniqueConstraint('priority', name='uq_ca_policy_priority'),
     )
     _create_table(
+        existing_tables,
         'conditional_access_policy_counter_types',
         _id_column(),
         sa.Column('policy_id', sa.Integer(), nullable=False),
@@ -76,9 +119,9 @@ def upgrade():
         sa.ForeignKeyConstraint(['policy_id'], ['conditional_access_policies.id'], ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('policy_id', 'counter_type', name='uq_ca_counter_type_policy'),
-        sa.Index('ix_ca_counter_type_lookup', 'counter_type', 'policy_id'),
     )
     _create_table(
+        existing_tables,
         'conditional_access_policy_conditions',
         _id_column(),
         sa.Column('policy_id', sa.Integer(), nullable=False),
@@ -90,9 +133,9 @@ def upgrade():
         # A policy carries at most one condition of each type; they are ANDed, so a
         # second one on the same value could only narrow to a contradiction.
         sa.UniqueConstraint('policy_id', 'condition_type', name='uq_ca_condition_policy'),
-        sa.Index('ix_conditional_access_policy_conditions_policy_id', 'policy_id'),
     )
     _create_table(
+        existing_tables,
         'conditional_access_policy_stages',
         _id_column(),
         sa.Column('policy_id', sa.Integer(), nullable=False),
@@ -105,6 +148,7 @@ def upgrade():
                             name='uq_ca_stage_policy_threshold'),
     )
     _create_table(
+        existing_tables,
         'conditional_access_stage_actions',
         _id_column(),
         sa.Column('stage_id', sa.Integer(), nullable=False),
@@ -113,7 +157,6 @@ def upgrade():
         sa.Column('retrigger_above_threshold', sa.Boolean(), nullable=False),
         sa.ForeignKeyConstraint(['stage_id'], ['conditional_access_policy_stages.id'], ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('id'),
-        sa.Index('ix_conditional_access_stage_actions_stage_id', 'stage_id'),
     )
 
 

--- a/privacyidea/migrations/versions/b2f5c9e1a7d4_block_list.py
+++ b/privacyidea/migrations/versions/b2f5c9e1a7d4_block_list.py
@@ -26,19 +26,36 @@ depends_on = None
 TABLES = ['block_list']
 
 
-def _create_table(table_name, *columns):
-    try:
-        op.create_table(table_name, *columns)
-    except (OperationalError, ProgrammingError) as ex:
-        if "already exists" in str(ex.orig).lower():
-            print(f"Table '{table_name}' already exists.")
-        else:
-            print(f"Could not add table '{table_name}' to database.")
-            raise
+def _existing_tables() -> set[str]:
+    """
+    The names of the tables that already exist, lower-cased.
+
+    Reflected once per migration rather than once per table: on a normal run nothing exists yet, so this
+    single catalog read is all the guard below costs. Lower-cased because Oracle folds unquoted identifiers
+    to upper case and the inspector reflects them back lower-cased (mirrors models.db.sequence_exists).
+    """
+    return {name.lower() for name in sa.inspect(op.get_bind()).get_table_names()}
+
+
+def _create_table(existing_tables: set[str], table_name: str, *columns) -> None:
+    """
+    Create the table unless it is already there -- a schema bootstrapped from the models with create_all
+    before this migration ran carries it.
+
+    Presence is established by reflection rather than by swallowing an "already exists" error, which Oracle
+    never says: it reports an existing object as ORA-00955 ("name is already used by an existing object").
+    models.db.sequence_exists reflects for the same reason.
+    """
+    if table_name.lower() in existing_tables:
+        print(f"Table '{table_name}' already exists.")
+        return
+    op.create_table(table_name, *columns)
 
 
 def upgrade():
+    existing_tables = _existing_tables()
     _create_table(
+        existing_tables,
         'block_list',
         sa.Column('ip', sa.Unicode(length=50), nullable=False),
         sa.Column('block_expires_at', sa.DateTime(), nullable=True),

--- a/privacyidea/migrations/versions/b2f5c9e1a7d4_block_list.py
+++ b/privacyidea/migrations/versions/b2f5c9e1a7d4_block_list.py
@@ -15,6 +15,7 @@ Create Date: 2026-06-10 00:00:00.000000
 """
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import mysql
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 # revision identifiers, used by Alembic.
@@ -24,6 +25,20 @@ branch_labels = None
 depends_on = None
 
 TABLES = ['block_list']
+
+
+def _unicode_case_sensitive(length: int) -> sa.Unicode:
+    """
+    A case-sensitive string column type (mirrors models.utils.case_sensitive_unicode).
+
+    MySQL/MariaDB's server-default collation is typically case-insensitive (*_ci) while SQLite, PostgreSQL and
+    Oracle compare case-sensitively, so an unpinned column would match differently per backend. The message is
+    filter material -- the sibling user_lock_state table already filters on it -- and one uniform rule everywhere
+    is worth more than the server default. Pinning to utf8mb4_bin gives that rule. Kept self-contained here (not
+    imported from the model) so the migration stays a stable snapshot.
+    """
+    return sa.Unicode(length).with_variant(mysql.VARCHAR(length, charset="utf8mb4", collation="utf8mb4_bin"),
+                                           "mysql", "mariadb")
 
 
 def _existing_tables() -> set[str]:
@@ -60,7 +75,7 @@ def upgrade():
         sa.Column('ip', sa.Unicode(length=50), nullable=False),
         sa.Column('block_expires_at', sa.DateTime(), nullable=True),
         sa.Column('block_cause', sa.Unicode(length=20), nullable=False, server_default='POLICY'),
-        sa.Column('error_message', sa.Unicode(length=500), nullable=True),
+        sa.Column('error_message', _unicode_case_sensitive(500), nullable=True),
         sa.Column('blocked_at', sa.DateTime(), nullable=False),
         sa.PrimaryKeyConstraint('ip'),
     )

--- a/privacyidea/migrations/versions/c1a9f7e2b840_user_lock_state.py
+++ b/privacyidea/migrations/versions/c1a9f7e2b840_user_lock_state.py
@@ -34,9 +34,10 @@ def _unicode_case_sensitive(length):
     The identity columns (resolver/uid/realm/username) are the user-lock visibility boundary: a
     user-scoped read policy filters on them. On MySQL/MariaDB the server-default collation is typically
     case-insensitive (*_ci), which would make that boundary match case-insensitively -- a fail-open
-    authorization risk. Pinning to utf8mb4_bin makes matching case-sensitive; SQLite, PostgreSQL and Oracle
-    already compare case-sensitively by default. Kept self-contained here so the migration stays a stable
-    snapshot.
+    authorization risk. error_message is pinned for the weaker reason that it is a filter value too, and a
+    filter must not answer differently per backend. Pinning to utf8mb4_bin makes matching case-sensitive;
+    SQLite, PostgreSQL and Oracle already compare case-sensitively by default. Kept self-contained here so
+    the migration stays a stable snapshot.
     """
     return sa.Unicode(length).with_variant(mysql.VARCHAR(length, charset="utf8mb4", collation="utf8mb4_bin"),
                                            "mysql", "mariadb")
@@ -79,7 +80,7 @@ def upgrade():
         sa.Column('username', _unicode_case_sensitive(255), nullable=True),
         sa.Column('lock_expires_at', sa.DateTime(), nullable=True),
         sa.Column('lock_cause', sa.Unicode(length=20), nullable=False, server_default='POLICY'),
-        sa.Column('error_message', sa.Unicode(length=500), nullable=True),
+        sa.Column('error_message', _unicode_case_sensitive(500), nullable=True),
         sa.Column('locked_at', sa.DateTime(), nullable=False),
         sa.PrimaryKeyConstraint('resolver', 'uid', 'realm'),
     )

--- a/privacyidea/migrations/versions/c1a9f7e2b840_user_lock_state.py
+++ b/privacyidea/migrations/versions/c1a9f7e2b840_user_lock_state.py
@@ -42,19 +42,36 @@ def _unicode_case_sensitive(length):
                                            "mysql", "mariadb")
 
 
-def _create_table(table_name, *columns):
-    try:
-        op.create_table(table_name, *columns)
-    except (OperationalError, ProgrammingError) as ex:
-        if "already exists" in str(ex.orig).lower():
-            print(f"Table '{table_name}' already exists.")
-        else:
-            print(f"Could not add table '{table_name}' to database.")
-            raise
+def _existing_tables() -> set[str]:
+    """
+    The names of the tables that already exist, lower-cased.
+
+    Reflected once per migration rather than once per table: on a normal run nothing exists yet, so this
+    single catalog read is all the guard below costs. Lower-cased because Oracle folds unquoted identifiers
+    to upper case and the inspector reflects them back lower-cased (mirrors models.db.sequence_exists).
+    """
+    return {name.lower() for name in sa.inspect(op.get_bind()).get_table_names()}
+
+
+def _create_table(existing_tables: set[str], table_name: str, *columns) -> None:
+    """
+    Create the table unless it is already there -- a schema bootstrapped from the models with create_all
+    before this migration ran carries it.
+
+    Presence is established by reflection rather than by swallowing an "already exists" error, which Oracle
+    never says: it reports an existing object as ORA-00955 ("name is already used by an existing object").
+    models.db.sequence_exists reflects for the same reason.
+    """
+    if table_name.lower() in existing_tables:
+        print(f"Table '{table_name}' already exists.")
+        return
+    op.create_table(table_name, *columns)
 
 
 def upgrade():
+    existing_tables = _existing_tables()
     _create_table(
+        existing_tables,
         'user_lock_state',
         sa.Column('resolver', _unicode_case_sensitive(120), nullable=False),
         sa.Column('uid', _unicode_case_sensitive(320), nullable=False),

--- a/privacyidea/migrations/versions/d3e8b1c47f92_conditional_access_outcome.py
+++ b/privacyidea/migrations/versions/d3e8b1c47f92_conditional_access_outcome.py
@@ -35,6 +35,13 @@ depends_on = None
 
 TABLE = 'conditional_access_outcome'
 
+INDEXES = {
+    TABLE: [
+        ('ix_ca_outcome_authlog', ['auth_log_id']),
+        ('ix_ca_outcome_action', ['action_type']),
+    ],
+}
+
 
 def _unicode_case_sensitive(length: int) -> sa.Unicode:
     """
@@ -50,32 +57,63 @@ def _unicode_case_sensitive(length: int) -> sa.Unicode:
                                            "mysql", "mariadb")
 
 
-def upgrade():
-    try:
-        # The column lengths must match
-        # privacyidea.models.conditional_access_outcome.conditional_access_outcome_column_length.
-        op.create_table(
-            TABLE,
-            sa.Column('id', BigIntegerType, sa.Identity(always=False), nullable=False),
-            sa.Column('auth_log_id', BigIntegerType, nullable=False),
-            sa.Column('action_type', _unicode_case_sensitive(100), nullable=False),
-            sa.Column('dry_run', sa.Boolean(), nullable=False),
-            sa.Column('policy_name', _unicode_case_sensitive(255), nullable=False),
-            sa.Column('threshold', sa.Integer(), nullable=False),
-            sa.Column('event_count', sa.Integer(), nullable=False),
-            sa.Column('stage_name', _unicode_case_sensitive(255), nullable=True),
-            sa.Column('info', sa.JSON(), nullable=True),
-            sa.ForeignKeyConstraint(['auth_log_id'], ['authentication_log.id'], ondelete='CASCADE'),
-            sa.PrimaryKeyConstraint('id'),
-            sa.Index('ix_ca_outcome_authlog', 'auth_log_id'),
-            sa.Index('ix_ca_outcome_action', 'action_type'),
-        )
-    except (OperationalError, ProgrammingError) as ex:
-        if "already exists" in str(ex.orig).lower():
-            print(f"Table '{TABLE}' already exists.")
+def _existing_tables() -> set[str]:
+    """
+    The names of the tables that already exist, lower-cased.
+
+    Reflected once per migration rather than once per table: on a normal run nothing exists yet, so this
+    single catalog read is all the guard below costs. Lower-cased because Oracle folds unquoted identifiers
+    to upper case and the inspector reflects them back lower-cased (mirrors models.db.sequence_exists).
+    """
+    return {name.lower() for name in sa.inspect(op.get_bind()).get_table_names()}
+
+
+def _create_table(existing_tables: set[str], table_name: str, *columns) -> None:
+    """
+    Create the table unless it is already there, then add each of its INDEXES that is absent.
+
+    Presence is established by reflection rather than by swallowing an "already exists" error, which Oracle
+    never says: it reports an existing object as ORA-00955 ("name is already used by an existing object").
+    models.db.sequence_exists reflects for the same reason.
+
+    The indexes are created by statements of their own and are deliberately not declared inline in the
+    CREATE TABLE: every statement here autocommits (see migrations/env.py), so a run that created the table
+    and then failed would leave the table behind, and a guard that keyed the indexes off the table's absence
+    would skip them for good once Alembic stamped the revision.
+    """
+    if table_name.lower() in existing_tables:
+        print(f"Table '{table_name}' already exists.")
+        existing_indexes = {(index["name"] or "").lower()
+                            for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+    else:
+        op.create_table(table_name, *columns)
+        existing_indexes = set()
+
+    for index_name, index_columns in INDEXES.get(table_name, ()):
+        if index_name.lower() in existing_indexes:
+            print(f"Index '{index_name}' already exists.")
         else:
-            print(f"Could not add table '{TABLE}' to database.")
-            raise
+            op.create_index(index_name, table_name, index_columns)
+
+
+def upgrade():
+    # The column lengths must match
+    # privacyidea.models.conditional_access_outcome.conditional_access_outcome_column_length.
+    _create_table(
+        _existing_tables(),
+        TABLE,
+        sa.Column('id', BigIntegerType, sa.Identity(always=False), nullable=False),
+        sa.Column('auth_log_id', BigIntegerType, nullable=False),
+        sa.Column('action_type', _unicode_case_sensitive(100), nullable=False),
+        sa.Column('dry_run', sa.Boolean(), nullable=False),
+        sa.Column('policy_name', _unicode_case_sensitive(255), nullable=False),
+        sa.Column('threshold', sa.Integer(), nullable=False),
+        sa.Column('event_count', sa.Integer(), nullable=False),
+        sa.Column('stage_name', _unicode_case_sensitive(255), nullable=True),
+        sa.Column('info', sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(['auth_log_id'], ['authentication_log.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
 
 
 def downgrade():

--- a/privacyidea/models/conditional_access_policy.py
+++ b/privacyidea/models/conditional_access_policy.py
@@ -223,7 +223,7 @@ class ConditionalAccessPolicyStage(MethodsMixin, db.Model):
     name: Mapped[str | None] = mapped_column(Unicode(255), nullable=True)
     # Optional error text shown to the end user when a request is turned away by
     # this stage. NULL (or blank) means nothing is surfaced, which is the default.
-    error_message: Mapped[str | None] = mapped_column(Unicode(500), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(case_sensitive_unicode(500), nullable=True)
     failure_threshold: Mapped[int] = mapped_column(Integer, nullable=False)
 
     policy: Mapped["ConditionalAccessPolicy"] = relationship("ConditionalAccessPolicy", back_populates="stages")
@@ -312,7 +312,7 @@ class UserLockState(MethodsMixin, db.Model):
     # survives the policy being edited or deleted, costs no join on the authentication path, and works
     # for a lock no policy wrote. NULL means say nothing. {duration} is left as written on a permanent
     # lock, which has no remaining time to substitute.
-    error_message: Mapped[str | None] = mapped_column(Unicode(500), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(case_sensitive_unicode(500), nullable=True)
     # When the lock was applied; refreshed on each (re)lock, so it reflects the start of the
     # current active lock rather than a generic audit timestamp.
     locked_at: Mapped[datetime] = mapped_column(
@@ -349,7 +349,7 @@ class BlockList(MethodsMixin, db.Model):
     # Who imposed this block, the IP counterpart of :attr:`UserLockState.lock_cause`.
     block_cause: Mapped[str] = mapped_column(Unicode(20), default=RestrictionCause.POLICY, nullable=False)
     # The message template to show while this block is in force; see UserLockState.error_message.
-    error_message: Mapped[str | None] = mapped_column(Unicode(500), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(case_sensitive_unicode(500), nullable=True)
     # When the block was applied; refreshed on each (re)block, so it reflects the start of the
     # current active block rather than a generic audit timestamp.
     blocked_at: Mapped[datetime] = mapped_column(

--- a/tests/test_lib_conditional_access_state.py
+++ b/tests/test_lib_conditional_access_state.py
@@ -22,6 +22,8 @@ the live user-lock state and blocklist entries.
 """
 from datetime import timedelta
 
+from sqlalchemy.dialects import mysql
+
 from privacyidea.lib.conditional_access.authentication_log import AuthenticationLogVisibilityScope
 from privacyidea.lib.conditional_access.authentication_event_types import RestrictionCause
 from privacyidea.lib.error import ParameterError
@@ -227,6 +229,27 @@ class UserLockStateTestCase(MyTestCase):
         matched = list_locked_users(error_messages=["locked. contact your administrator."], case_insensitive=True)
         self.assertEqual(1, len(matched))
         self.assertEqual("cornelius", matched[0]["username"])
+
+    def test_migrations_pin_error_message_to_a_case_sensitive_mysql_collation(self):
+        # The test above only proves the ORM model (db.create_all()) is case-sensitive; SQLite is
+        # case-sensitive by default regardless, so it can't catch a MySQL-only collation regression. This
+        # reads the actual migration modules that create these tables and checks the column type they build,
+        # independent of whichever backend the test suite itself runs on.
+        import importlib
+
+        migrations_and_tables = [
+            ("privacyidea.migrations.versions.173d32328846_conditional_access_policies",
+             "conditional_access_policy_stages"),
+            ("privacyidea.migrations.versions.c1a9f7e2b840_user_lock_state", "user_lock_state"),
+            ("privacyidea.migrations.versions.b2f5c9e1a7d4_block_list", "block_list"),
+        ]
+        for module_name, table_name in migrations_and_tables:
+            module = importlib.import_module(module_name)
+            column_type = module._unicode_case_sensitive(500)
+            mysql_variant = column_type.dialect_impl(mysql.dialect())
+            self.assertEqual("utf8mb4_bin", mysql_variant.collation,
+                             f"{module_name} (table {table_name!r}) no longer pins error_message "
+                             "to a case-sensitive MySQL collation")
 
     def test_list_locked_users_default_returns_all_states(self):
         # No states filter -> everything, including expired records.

--- a/tests/test_lib_conditional_access_state.py
+++ b/tests/test_lib_conditional_access_state.py
@@ -218,6 +218,16 @@ class UserLockStateTestCase(MyTestCase):
         self.assertEqual(1, len(matched))
         self.assertEqual("cornelius", matched[0]["username"])
 
+    def test_list_locked_users_wording_filter_matches_case_sensitively(self):
+        # An exact filter value matches case-sensitively on every backend: error_message is pinned to
+        # utf8mb4_bin, so MySQL/MariaDB's default (*_ci, and accent-insensitive too) cannot widen it. Only
+        # case_insensitive opts in - a wildcard value goes through ILIKE and is case-insensitive anyway.
+        self._lock(utc_now() + timedelta(seconds=600), error_message="Locked. Contact your administrator.")
+        self.assertListEqual([], list_locked_users(error_messages=["locked. contact your administrator."]))
+        matched = list_locked_users(error_messages=["locked. contact your administrator."], case_insensitive=True)
+        self.assertEqual(1, len(matched))
+        self.assertEqual("cornelius", matched[0]["username"])
+
     def test_list_locked_users_default_returns_all_states(self):
         # No states filter -> everything, including expired records.
         self._lock(utc_now() - timedelta(seconds=60))


### PR DESCRIPTION
Based on #5917 to avoid merge conflicts since both touch the migration scripts. So first merge #5917 before reviewing this one

### What                                                                                                          
                                                                                                                
  The three error_message columns — the stage template and the user_lock_state / block_list snapshots of it —   
  were plain Unicode, so on MySQL/MariaDB they inherited the server-default *_ci collation while every other    
  backend compares case-sensitively. They are now pinned to utf8mb4_bin, like the identity columns beside them. 
                                                                                                                
 ### Why                                                                                                           
                                                                                                                
  user_lock_state.error_message is a filter value: GET conditional_access/lock/users?error_messages= runs it    
  through the same match_condition as realm/resolver/username, and that function's contract is that an exact    
  filter value matches case-sensitively on every backend. An unpinned column could not keep that promise — on   
  MariaDB the filter also matched case-variants, and under 11.4's default UCA collation accent-variants as well 
  (café finding cafe). The authorization boundary was never affected: _visibility_condition filters only on the 
  already-pinned columns.                                                                                       
                                                                                                                
  block_list.error_message and the stage template have no filter today; they are pinned with it so all three    
  copies of one message compare by the same rule, and a blocklist message filter later needs no schema change.  
                                                                                                                
###  Changes                                                                                                       
                                                                                                                
  - models/conditional_access_policy.py — ConditionalAccessPolicyStage, UserLockState, BlockList: error_message 
    → case_sensitive_unicode(500)                                                                               
  - migrations/versions/173d32328846, c1a9f7e2b840, b2f5c9e1a7d4 — same via each migration's local              
    _unicode_case_sensitive(500); the two files that lacked the helper now carry it, and each docstring says why
    that column and not its siblings                                                                            
  - tests/test_lib_conditional_access_state.py — test_list_locked_users_wording_filter_matches_case_sensitively:
    an all-lowercase exact filter finds nothing, case_insensitive=True finds the row

### Not changed, deliberately                                                                                     
                                                                                                                
  block_list.ip (every writer stores the canonical form — block_ip normalizes through ipaddress.ip_address, the 
  engine uses the already-canonical source_ip), and lock_cause / block_cause (validated against a fixed set     
  before reaching SQL). A pin there would change no query's answer.                                             
                                                                                                                
###  Cost and risk                                                                                                 
                                                                                                                
  None of the three columns is indexed, so no key-length ceiling; nothing compares them against another column  
  or unions the tables, so no "illegal mix of collations"; the migrations are unreleased, so this edits CREATE  
  TABLE rather than adding an ALTER. The one behavioural change is the intended one — exact filter values stop  
  matching case-variants on MySQL/MariaDB, with *wildcard* (ILIKE) and case_insensitive=1 still the opt-ins.    
  