### PR TITLE
Roll the resolver session back and log lost metric samples

### DIFF
--- a/privacyidea/lib/metrics.py
+++ b/privacyidea/lib/metrics.py
@@ -199,7 +199,13 @@ def _apply_aggregate(session: Session, metric_name: str, labels_key: str, node: 
         # it, so the aggregate can simply be added to the row that won.
         # Other exceptions (missing table, connection failure, ...) bubble up to the
         # caller's try/except in observe()/inc()/_flush_metric_buffer().
-        _increment_row(session, metric_name, labels_hash, node, window, aggregate)
+        if not _increment_row(session, metric_name, labels_hash, node, window, aggregate):
+            # The row that won the insert is gone again, so there is nothing left to add
+            # the aggregate to. Losing a sample is not worth failing the request over, but
+            # it must not happen silently either: a metric that is quietly short of samples
+            # is worse than one that is visibly missing them.
+            log.warning(f"Lost a metric sample for {metric_name!r}: the row that won the insert "
+                        f"race for window {window} is not there any more.")
 
 
 _BUFFER_KEY = "metric_observations"

--- a/privacyidea/lib/metrics.py
+++ b/privacyidea/lib/metrics.py
@@ -204,8 +204,9 @@ def _apply_aggregate(session: Session, metric_name: str, labels_key: str, node: 
             # the aggregate to. Losing a sample is not worth failing the request over, but
             # it must not happen silently either: a metric that is quietly short of samples
             # is worse than one that is visibly missing them.
-            log.warning(f"Lost a metric sample for {metric_name!r}: the row that won the insert "
-                        f"race for window {window} is not there any more.")
+            log.warning(f"Lost {aggregate['count']} sample(s) of metric {metric_name!r} "
+                        f"(labels {labels_key!r}, node {node!r}, window {window}): the row that won "
+                        f"the insert race is not there any more.")
 
 
 _BUFFER_KEY = "metric_observations"

--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -359,10 +359,18 @@ class IdResolver (UserIdResolver):
             # A DB error here must propagate rather than being logged and swallowed: the caller
             # (_resolve_owner_logins) catches it to fall back to a one-by-one lookup that marks only
             # the users which keep failing as unresolvable. Swallowing it here would make a chunk's
-            # worth of users indistinguishable from ones that genuinely don't exist.
+            # worth of users indistinguishable from ones that genuinely don't exist. A lost
+            # connection leaves the transaction invalid, though, and the session is cached for the
+            # lifetime of the request (get_resolver_object), so it must be rolled back here or the
+            # caller's fallback would run on a session that raises PendingRollbackError instead of
+            # reconnecting.
             conditions = [or_(*userid_filters)]
             conditions = self._append_where_filter(conditions, self.TABLE, self.where)
-            result = self.session.execute(select(self.TABLE).filter(and_(*conditions)))
+            try:
+                result = self.session.execute(select(self.TABLE).filter(and_(*conditions)))
+            except Exception:
+                self.session.rollback()
+                raise
 
             for row in result.mappings():
                 returned_id = convert_column_to_unicode(row.get(userid_column))

--- a/tests/test_lib_metrics.py
+++ b/tests/test_lib_metrics.py
@@ -337,6 +337,24 @@ class RaceToleranceTest(MyTestCase):
 
         self.assertEqual({"race_a": 5, "race_b": 8}, self._counts())
 
+    def test_a_lost_insert_race_whose_row_is_gone_again_is_logged(self):
+        # The recovery UPDATE can match nothing too, if the row that won the race is deleted
+        # or rolled back before it runs. There is nothing left to add the sample to, but a
+        # metric that is quietly short of samples is worse than one that visibly lost them.
+        window = _window_start(_utc_now())
+        db.session.add(MetricAggregate(metric_name="race_c", labels_key="",
+                                       node="", window_start=window,
+                                       count=7, sum_value=0.7, max_value=0.5))
+        db.session.commit()
+
+        with patch.object(metrics, "_increment_row", return_value=0):
+            with self.assertLogs("privacyidea.lib.metrics", level="WARNING") as captured:
+                metrics._write_observations({("race_c", (), "", window): _aggregate(count=5)})
+
+        self.assertIn("Lost a metric sample for 'race_c'", "\n".join(captured.output))
+        # No duplicate row either, and the existing one is untouched.
+        self.assertEqual({"race_c": 7}, self._counts())
+
     def test_a_non_race_failure_does_not_lose_the_other_rows_of_the_batch(self):
         # A lost insert race (above) recovers inside _apply_aggregate itself. Anything else --
         # a lock-wait timeout, a deadlock -- is not: it must still cost only the one key that

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -780,6 +780,27 @@ class SQLResolverTestCase(MyTestCase):
         with mock.patch.object(resolver.session, "execute", side_effect=Exception("the database is not reachable")):
             self.assertRaises(Exception, resolver.get_user_info_batch, ["1", "2"], attributes=["username"])
 
+    def test_13b_get_user_info_batch_rolls_the_session_back_on_a_db_error(self):
+        resolver = SQLResolver()
+        resolver.loadConfig(self.parameters)
+
+        # A lost connection leaves the transaction invalid, and the session is cached for the
+        # lifetime of the request. Without a rollback the one-by-one fallback the caller runs
+        # next would get PendingRollbackError for its first user instead of a reconnect, so
+        # that user would be marked unresolvable even though the backend is reachable again.
+        with mock.patch.object(resolver.session, "rollback") as mock_rollback:
+            with mock.patch.object(resolver.session, "execute",
+                                   side_effect=Exception("the database is not reachable")):
+                self.assertRaises(Exception, resolver.get_user_info_batch, ["1", "2"], attributes=["username"])
+        mock_rollback.assert_called_once()
+
+        # The same holds for the single-user lookup the fallback ends up in
+        with mock.patch.object(resolver.session, "rollback") as mock_rollback:
+            with mock.patch.object(resolver.session, "execute",
+                                   side_effect=Exception("the database is not reachable")):
+                self.assertRaises(Exception, resolver.get_user_info, "1", attributes=["username"])
+        mock_rollback.assert_called_once()
+
     def test_99_testconnection_fail(self):
         resolver = SQLResolver()
         self.parameters['Database'] = "does_not_exist"


### PR DESCRIPTION
Two small robustness fixes found while re-checking review findings from the
userstore batch lookup work. Both are cases where a transient failure loses
data more quietly than it should.

### `SQLIdResolver.get_user_info_batch` does not roll the session back

`get_user_info` wraps its query in `except Exception: self.session.rollback(); raise`,
with a comment explaining that the session is cached for the lifetime of the
request and has to be rolled back or a later call fails on a stale transaction.
`get_user_info_batch` documents the same "must propagate" reasoning but omitted
the rollback.

That matters for connection-loss failures specifically. A failed `SELECT` on its
own does not deactivate a SQLAlchemy 2.0 transaction, but an invalidated
connection does. Verified against MariaDB 11 by killing the connection
mid-session:

```
first failure:  OperationalError (2013, 'Lost connection to MySQL server during query')
second failure: PendingRollbackError Can't reconnect until invalid transaction is rolled back.
after rollback: 1
```

So when the batch lookup dies on a lost connection, the per-user fallback in
`_resolve_owner_logins` runs on a session that raises `PendingRollbackError`
instead of reconnecting. Its first user is marked unresolvable and renders as
`**resolver error**`; `get_user_info`'s own rollback then clears the session and
the rest of the page resolves normally. One spurious error marker per failed
batch, on a backend that is reachable again.

### `_apply_aggregate` discards the rowcount of its recovery UPDATE

After losing an insert race, `_apply_aggregate` re-runs `_increment_row` to add
the aggregate to the row that won. Its return value was ignored, so if that
UPDATE also matches nothing - the winning row deleted or rolled back in between -
the sample disappeared with no error and no log, unlike every other failure path
in this module. It is now logged as a warning. The sample is still lost; the
point is that it stops being lost invisibly.

### Tests

- `test_13b_get_user_info_batch_rolls_the_session_back_on_a_db_error` - asserts
  the rollback on both the batch and the single-user lookup, so the two cannot
  drift apart again.
- `test_a_lost_insert_race_whose_row_is_gone_again_is_logged`

`tests/test_lib_resolver.py` (101), `tests/test_lib_metrics.py` (37),
`tests/test_lib_token_list_lookups.py` and `tests/test_lib_metricscleanup.py`
(16) all pass; ruff is clean on the changed files.

No issue and no milestone: these are internal robustness fixes with no
user-visible behaviour change worth a changelog entry.
