### PR TITLE
Nest the per-realm status of the container set-realms response

### DIFF
--- a/READ_BEFORE_UPDATE.md
+++ b/READ_BEFORE_UPDATE.md
@@ -378,6 +378,16 @@
 
   Installations that do not use the User Agent condition are unaffected.
 
+* **HTTP API change** - `POST /container/<serial>/realms` now returns the status of each realm in a `realms`
+  sub-dictionary instead of putting the realm names next to the `deleted` flag. The response was
+  `{"realm1": true, "realm2": false, "deleted": true}` and is now
+  `{"realms": {"realm1": true, "realm2": false}, "deleted": true}`. The `deleted` entry keeps its place and its
+  meaning. The old shape reserved the key `deleted` in the same dictionary that carries the realm names, so a realm
+  that is actually named `deleted` had its status overwritten by the flag: attaching it was reported as a failure, and
+  detaching it was reported as the realm still being attached. Scripts and integrations that read
+  `result.value.<realm>` have to read `result.value.realms.<realm>` instead; the WebUI does not read the response and
+  is unaffected. `pi-token-janitor find ... set_realm` no longer omits a realm named `deleted` from what it reports.
+
 ## Update from 3.12 to 3.13
 
 * `enrollpin` right enforcement has been made stricter. If you try to enroll a token with a PIN but do not have the the

--- a/privacyidea/api/container.py
+++ b/privacyidea/api/container.py
@@ -729,10 +729,11 @@ def set_realms(container_serial):
     :jsonparam realms: comma-separated list of realm names
         (whitespace tolerated; pass an empty string to remove all
         realms).
-    :status 200: dict mapping each attached realm to ``True`` (including
-        realms kept although not requested) and each requested realm that
-        could not be attached to ``False``, plus ``deleted`` (whether any
-        realm was removed), in ``result.value``.
+    :status 200: ``{"realms": {<realm>: <bool>, ...}, "deleted": <bool>}`` in
+        ``result.value``. In ``realms``, each attached realm maps to ``True``
+        (including realms kept although not requested) and each requested realm
+        that could not be attached maps to ``False``. ``deleted`` states whether
+        any realm was removed.
     """
     # Get parameters
     container_realms = get_required(request.all_data, "realms", allow_empty=True)
@@ -759,13 +760,13 @@ def set_realms(container_serial):
                         "success": result.success,
                         "info": info})
 
-    # Response: every attached realm maps to True (including realms that could not be removed and stayed
-    # although not requested), every requested realm that could not be attached maps to False, plus
-    # whether anything was removed. The full breakdown is in the audit info.
-    response = {realm: True for realm in result.attached}
-    response.update({realm: False for realm in result.not_added})
-    response["deleted"] = bool(result.removed)
-    return send_result(response)
+    # Response: the per-realm status lives in its own dictionary so that no realm name can collide with
+    # a status key - a realm may legitimately be called "deleted". Every attached realm maps to True
+    # (including realms that could not be removed and stayed although not requested), every requested
+    # realm that could not be attached maps to False. The full breakdown is in the audit info.
+    realm_status = {realm: True for realm in result.attached}
+    realm_status.update({realm: False for realm in result.not_added})
+    return send_result({"realms": realm_status, "deleted": bool(result.removed)})
 
 
 @container_blueprint.route('<string:container_serial>/info/<key>', methods=['POST'])

--- a/privacyidea/cli/pitokenjanitor/utils/findcontainer.py
+++ b/privacyidea/cli/pitokenjanitor/utils/findcontainer.py
@@ -206,9 +206,8 @@ def set_realm(ctx, realms, add):
     for clist in ctx.obj['containers']:
         for container in clist:
             ret = container.set_realms(realms=realms_list, add=add)
-            ret.pop('deleted', None)
-            successful_realms = [key for key, value in ret.items() if value is True]
-            unsuccessful_realms = [key for key, value in ret.items() if value is False]
+            successful_realms = [realm for realm, success in ret['realms'].items() if success]
+            unsuccessful_realms = [realm for realm, success in ret['realms'].items() if not success]
             if unsuccessful_realms:
                 click.echo(f"realm: {unsuccessful_realms} could not be set for container {container.serial}")
             if successful_realms:

--- a/privacyidea/lib/container.py
+++ b/privacyidea/lib/container.py
@@ -1168,7 +1168,7 @@ def set_container_realms(serial: str, realms: list[str],
                                  not_removed=sorted(attached - requested))
 
 
-def add_container_realms(serial: str, realms: list[str], allowed_realms: list[str] | None) -> dict[str, bool]:
+def add_container_realms(serial: str, realms: list[str], allowed_realms: list[str] | None) -> dict:
     """
     Add the realms to the container realms.
 
@@ -1176,8 +1176,9 @@ def add_container_realms(serial: str, realms: list[str], allowed_realms: list[st
     :param realms: new realms as list of str
     :param allowed_realms: A list of realms the admin is allowed to set, None if all realms are allowed and an
         empty list if none is
-    :returns: Dictionary in the format {realm: success}, the entry 'deleted' indicates whether existing realms were
-              deleted.
+    :returns: Dictionary with the entry 'realms' in the format {realm: success} and the entry 'deleted' indicating
+              whether existing realms were deleted, as returned by
+              :py:meth:`~privacyidea.lib.containerclass.TokenContainerClass.set_realms`.
     """
     container = find_container_by_serial(serial)
 
@@ -1194,7 +1195,7 @@ def add_container_realms(serial: str, realms: list[str], allowed_realms: list[st
 
     # Add realms
     res = container.set_realms(matching_realms, add=True)
-    res.update(res_failed)
+    res["realms"].update(res_failed)
     return res
 
 

--- a/privacyidea/lib/containerclass.py
+++ b/privacyidea/lib/containerclass.py
@@ -192,17 +192,19 @@ class TokenContainerClass:
     def realms(self) -> list[Realm]:
         return self._db_container.realms
 
-    def set_realms(self, realms: list[str], add=False) -> dict[str, bool]:
+    def set_realms(self, realms: list[str], add=False) -> dict:
         """
         Set the realms of the container. If `add` is True, the realms will be added to the existing realms, otherwise
         the existing realms will be removed.
 
         :param realms: List of realm names
         :param add: False if the existing realms shall be removed, True otherwise
-        :return: Dictionary in the format {realm: success}, the entry 'deleted' indicates whether existing realms were
-                 deleted.
+        :return: Dictionary with the entry 'realms' in the format {realm: success} and the entry 'deleted' indicating
+                 whether existing realms were deleted. The per-realm status is nested so that no realm name can
+                 collide with a status key - a realm may legitimately be called "deleted".
         """
-        result = {"deleted": False}
+        realm_status = {}
+        deleted = False
 
         if not realms:
             realms = []
@@ -228,8 +230,7 @@ class TokenContainerClass:
             realms_to_delete = [realm for realm in existing_realms if realm.name in realm_names_to_delete]
             for realm in realms_to_delete:
                 self._db_container.realms.remove(realm)
-            if realms_to_delete:
-                result["deleted"] = True
+            deleted = bool(realms_to_delete)
 
         # Add new realms
         for realm in realms_to_add:
@@ -237,22 +238,22 @@ class TokenContainerClass:
                 stmt = select(Realm).filter_by(name=realm)
                 realm_db = db.session.execute(stmt).scalar_one_or_none()
                 if not realm_db:
-                    result[realm] = False
+                    realm_status[realm] = False
                     log.warning(f"Realm {realm} does not exist. Cannot add it to container {self.serial}.")
                 else:
                     self._db_container.realms.append(realm_db)
-                    result[realm] = True
+                    realm_status[realm] = True
 
         # Set success status for already added realms
         for realm in already_added_realms:
             # If the realms are set completely new, the status for already added realms is True, if they should only be
             # added, the status is False
             # TODO: Not sure whether this makes sense, but this is the actual behaviour ...
-            result[realm] = not add
+            realm_status[realm] = not add
 
         self._db_container.save()
 
-        return result
+        return {"realms": realm_status, "deleted": deleted}
 
     @property
     def registration_state(self) -> RegistrationState:

--- a/tests/cli/test_cli_pitokenjanitor.py
+++ b/tests/cli/test_cli_pitokenjanitor.py
@@ -866,6 +866,23 @@ class TestPiTokenJanitorContainer:
             container = find_container_by_serial("C3")
             assert sorted(container.get_as_dict().get("realms")) == sorted(["realm1", "realm2"])
 
+    def test_container_set_realm_named_like_a_status_key(self, app, containers, realms):
+        """
+        Tests setting a realm that is named like a status key of the set_realms result.
+        """
+        runner = app.test_cli_runner()
+        with app.app_context():
+            set_realm(realm="deleted", resolvers=[{"name": "testresolver"}])
+            db.session.commit()
+
+        result = runner.invoke(findcontainer, ["--serial", "C3", "set_realm", "deleted"])
+        assert result.exit_code == 0
+        assert "Set realm '['deleted']' for container C3" in result.output
+
+        with app.app_context():
+            container = find_container_by_serial("C3")
+            assert container.get_as_dict().get("realms") == ["deleted"]
+
     def test_findcontainer_by_realm(self, app, containers, realms):
         """
         Tests filtering containers by realm.

--- a/tests/test_api_container_api.py
+++ b/tests/test_api_container_api.py
@@ -7,7 +7,7 @@ from privacyidea.lib.containers.container_info import PI_INTERNAL, TokenContaine
 from privacyidea.lib.error import Error
 from privacyidea.lib.policies.actions import PolicyAction
 from privacyidea.lib.policy import set_policy, SCOPE, delete_policy
-from privacyidea.lib.realm import set_default_realm
+from privacyidea.lib.realm import delete_realm, set_default_realm, set_realm
 from privacyidea.lib.resolver import save_resolver
 from privacyidea.lib.token import init_token
 from privacyidea.lib.user import User
@@ -412,8 +412,8 @@ class APIContainer(APIContainerTest):
         result = result["result"]
         self.assertTrue(result["value"])
         self.assertFalse(result["value"]["deleted"])
-        self.assertTrue(result["value"][self.realm1])
-        self.assertTrue(result["value"][self.realm2])
+        self.assertTrue(result["value"]["realms"][self.realm1])
+        self.assertTrue(result["value"]["realms"][self.realm2])
 
         # Set no realm shall remove all realms for the container
         payload = {"realms": ""}
@@ -424,8 +424,8 @@ class APIContainer(APIContainerTest):
         result = result["result"]
         self.assertTrue(result["value"])
         self.assertTrue(result["value"]["deleted"])
-        self.assertNotIn(self.realm1, result["value"].keys())
-        self.assertNotIn(self.realm2, result["value"].keys())
+        self.assertNotIn(self.realm1, result["value"]["realms"])
+        self.assertNotIn(self.realm2, result["value"]["realms"])
 
         delete_container_by_serial(container_serial)
 
@@ -437,11 +437,35 @@ class APIContainer(APIContainerTest):
         self.assert_audit_entry('POST /container/<string:container_serial>/realms', success=0,
                                 container_serial=container_serial, action_detail="realms=realm2",
                                 info="attached=['realm1', 'realm2']; not removed=['realm1']")
-        self.assertTrue(result["result"]["value"][self.realm2])
+        self.assertTrue(result["result"]["value"]["realms"][self.realm2])
         # the user's realm can not be removed, so it stays attached (True) although not requested
-        self.assertTrue(result["result"]["value"][self.realm1])
+        self.assertTrue(result["result"]["value"]["realms"][self.realm1])
 
         delete_container_by_serial(container_serial)
+
+    def test_08a_set_realms_realm_named_like_a_status_key(self):
+        # A realm may be named like one of the status keys of the response. Its per-realm status
+        # lives in its own dictionary, so it stays readable and independent of the status keys.
+        self.setUp_user_realms()
+        set_realm("deleted", [{"name": self.resolvername1}])
+        container_serial = init_container({"type": "generic"})["container_serial"]
+
+        # Attaching the realm succeeds, and nothing was removed
+        result = self.request_assert_success(f'/container/{container_serial}/realms', {"realms": "deleted"},
+                                             self.at, 'POST')
+        value = result["result"]["value"]
+        self.assertTrue(value["realms"]["deleted"])
+        self.assertFalse(value["deleted"])
+
+        # Removing it again is reported as a removal, and the realm is no longer attached
+        result = self.request_assert_success(f'/container/{container_serial}/realms', {"realms": ""},
+                                             self.at, 'POST')
+        value = result["result"]["value"]
+        self.assertNotIn("deleted", value["realms"])
+        self.assertTrue(value["deleted"])
+
+        delete_container_by_serial(container_serial)
+        delete_realm("deleted")
 
     def test_09_set_realms_fail(self):
         # Arrange
@@ -464,7 +488,7 @@ class APIContainer(APIContainerTest):
                                 container_serial=container_serial, action_detail="realms=nonexistingrealm",
                                 info="not added=['nonexistingrealm']")
         result = result.get("result")
-        self.assertFalse(result["value"]["nonexistingrealm"])
+        self.assertFalse(result["value"]["realms"]["nonexistingrealm"])
 
         # Missing container serial
         self.request_assert_405('/container/realms', {"realms": [self.realm1]}, self.at, 'POST')

--- a/tests/test_api_container_helpdesk.py
+++ b/tests/test_api_container_helpdesk.py
@@ -644,7 +644,7 @@ class APIContainerAuthorizationHelpdesk(APIContainerAuthorization):
         self.assert_audit_entry('POST /container/<string:container_serial>/realms', success=0,
                                 container_serial=container_serial, action_detail="realms=realm2",
                                 info="attached=['realm1']; not added=['realm2']; not removed=['realm1']")
-        self.assertFalse(result["result"]["value"]["realm2"])
+        self.assertFalse(result["result"]["value"]["realms"]["realm2"])
         container = find_container_by_serial(container_serial)
         realms = [realm.name for realm in container.realms]
         self.assertSetEqual({self.realm1}, set(realms))
@@ -655,14 +655,14 @@ class APIContainerAuthorizationHelpdesk(APIContainerAuthorization):
         self.assert_audit_entry('POST /container/<string:container_serial>/realms', success=0,
                                 container_serial=container_serial, action_detail="realms=realm2,realm1",
                                 info="attached=['realm1']; not added=['realm2']")
-        self.assertFalse(result["result"]["value"]["realm2"])
-        self.assertTrue(result["result"]["value"]["realm1"])
+        self.assertFalse(result["result"]["value"]["realms"]["realm2"])
+        self.assertTrue(result["result"]["value"]["realms"]["realm1"])
 
         # container in realm1 and realm2, set realm1 (removes realm2 not allowed)
         add_container_realms(container_serial, ["realm1", "realm2"], allowed_realms=None)
         result = self.request_assert_success(f"/container/{container_serial}/realms", {"realms": "realm1"}, self.at)
         # The removal of realm2 is refused (audited as a failure); realm2 stays attached (True).
-        self.assertTrue(result["result"]["value"]["realm2"])
+        self.assertTrue(result["result"]["value"]["realms"]["realm2"])
         self.assert_audit_entry('POST /container/<string:container_serial>/realms', success=0,
                                 container_serial=container_serial, action_detail="realms=realm1",
                                 info="attached=['realm1', 'realm2']; not removed=['realm2']")

--- a/tests/test_lib_tokencontainer.py
+++ b/tests/test_lib_tokencontainer.py
@@ -408,21 +408,21 @@ class TokenContainerManagementTestCase(MyTestCase):
         result = add_container_realms(container_serial, [self.realm1], None)
         # Check return value
         self.assertFalse(result['deleted'])
-        self.assertTrue(result[self.realm1])
+        self.assertTrue(result['realms'][self.realm1])
         # Check realms
         container_realms = [realm.name for realm in container.realms]
         self.assertIn(self.realm1, container_realms)
 
         # Add same realm
         result = add_container_realms(container_serial, [self.realm1], None)
-        self.assertFalse(result[self.realm1])
+        self.assertFalse(result['realms'][self.realm1])
 
         # Add one non-existing realm
         result = add_container_realms(container_serial, ["nonexisting", self.realm2], None)
         # Check return value
         self.assertFalse(result['deleted'])
-        self.assertFalse(result['nonexisting'])
-        self.assertTrue(result[self.realm2])
+        self.assertFalse(result['realms']['nonexisting'])
+        self.assertTrue(result['realms'][self.realm2])
         # Check realms
         container_realms = [realm.name for realm in container.realms]
         self.assertNotIn("nonexisting", container_realms)
@@ -445,7 +445,7 @@ class TokenContainerManagementTestCase(MyTestCase):
         # same as None ("every realm"): nothing is added and the request is reported as failed.
         self.setUp_user_realm3()
         result = add_container_realms(container_serial, [self.realm3], [])
-        self.assertFalse(result[self.realm3])
+        self.assertFalse(result['realms'][self.realm3])
         container_realms = [realm.name for realm in container.realms]
         self.assertNotIn(self.realm3, container_realms)
         self.assertEqual(2, len(container_realms))


### PR DESCRIPTION
`POST /container/<serial>/realms` mapped every realm name to its status and reserved the key
`deleted` in that same dictionary for the flag that says whether realms were removed:

```json
{"realm1": true, "realm2": false, "deleted": true}
```

A realm may legitimately be named `deleted`, and its status was then overwritten by the flag —
inverted in both directions:

* attaching the realm succeeded and removed nothing, so the flag was `false` and the response
  reported the realm as *not* attached;
* removing it answered `{"deleted": true}`, which reads as the realm still being attached.

The status now lives in its own `realms` sub-dictionary, so that no realm name can reach a
status key:

```json
{"realms": {"realm1": true, "realm2": false}, "deleted": true}
```

`deleted` keeps its place and its meaning.

`TokenContainerClass.set_realms` built the same shape independently and is nested the same way.
The `pi-token-janitor find ... set_realm` command worked around the collision by popping
`deleted` off the map, which dropped a realm of that name from both the success and the failure
list — so the realm was attached and the command reported nothing about it. It reads the
sub-dictionary now.

### Compatibility

This changes a response shape that has shipped since 3.10, so `READ_BEFORE_UPDATE.md` says how
to read it: consumers of `result.value.<realm>` have to read `result.value.realms.<realm>`.
Neither WebUI is affected — the old one re-fetches the container after the call, the new one
types the call as `PiResponse<boolean>` and ignores the body.

### Tests

Two new tests pin the collision itself: `test_08a_set_realms_realm_named_like_a_status_key`
creates a realm named `deleted`, attaches and detaches it and asserts the two values are
independent, and `test_container_set_realm_named_like_a_status_key` covers the janitor path.

Green locally: `test_lib_tokencontainer.py`, `test_api_container_api.py`,
`test_api_container_helpdesk.py`, `tests/cli/test_cli_pitokenjanitor.py` (195 passed), plus
`test_api_container_admin.py`, `test_api_container_policy_conditions.py`,
`test_api_lib_policy_container.py`, `test_api_container.py` (128 passed).
