### PR TITLE
CA - tripping request pass normally without any CA error adoption

### DIFF
--- a/doc/conditional_access/error_messages.rst
+++ b/doc/conditional_access/error_messages.rst
@@ -37,11 +37,23 @@ The error message of a stage
 
 Each stage of a :ref:`conditional access policy <conditional_access_policies_stages>`
 has one optional **error message** - free text, at most 500 characters. It is
-shown when a request is turned away while that stage applies, including on the
-later attempts that a lock or block written by that stage refuses.
+shown on a request that is turned away *before* the password or OTP is checked:
+while a lock or block written by that stage is in force, or when that stage
+denies access.
 
-There is one field per stage rather than one per action, because a stage can
-lock the user, block the address and send two emails at once; the administrator
+.. important:: It is **not** shown on the request that trips the stage. That
+   request has already been answered on its own merits - its own failure, its own
+   challenge, even its own success - and the lock or block it wrote applies from
+   the next request onwards. See :ref:`conditional_access_evaluation`.
+
+This has a consequence worth planning for: a stage that **only notifies** - one
+carrying nothing but ``EMAIL_USER`` or ``EMAIL_ADMIN`` - turns no request away at
+any point, so there is never a moment at which its error message could be shown.
+Such a stage is silent whatever is written on it, and the policy editor points
+that out.
+
+There is one field per stage rather than one per action, because a stage can lock
+the user, block the address and send two emails at once; the administrator
 writing one sentence for the stage decides what all of that should sound like.
 
 ``{duration}`` is the only tag substituted, with the time remaining **at the
@@ -54,32 +66,35 @@ Every other brace expression is left exactly as written, so braces in ordinary
 prose need no escaping. That also means a mistyped tag is shown to the user as
 written; the policy editor points out an unrecognised tag but does not refuse to
 save it. ``{duration}`` itself is only substituted where there *is* a remaining
-time. On a permanent lock or block, on a ``DENY`` and on a stage that only
-notified there is none, so the tag is shown as written - the editor flags that
-combination too.
+time. A permanent lock or block has none, and a ``DENY`` counts down nothing at
+all, so there the tag is shown as written - the editor flags that combination
+too.
 
 In the WebUI the field is under each stage of *Policies → Conditional Access*,
 behind the *Show specific error message* checkbox. The refresh button next to it
 replaces the text with the suggested wording for the stage's current actions,
-which is the same wording ``show_default_ca_error_message`` would apply.
+which is the same wording ``show_default_ca_error_message`` would apply. A stage
+that carries wording but nothing that could ever show it - no lock, no block, no
+``DENY`` - is flagged there as well.
 
 Using the default wording instead
 ---------------------------------
 
 Writing a message on every stage of every policy is tedious, and for most
 installations the wording would be the same everywhere. The
-``show_default_ca_error_message`` policy is the short form: with it set, a stage
-that carries no error message of its own is described by privacyIDEA's default
-wording for what it actually did, for example
+``show_default_ca_error_message`` policy is the short form: with it set, a
+restriction that carries no error message of its own is described by privacyIDEA's
+default wording for what it is, for example
 
 * *Your account is temporarily locked. Please try again in about 10 minute(s).*
 * *Access from your IP address has been blocked. Please contact your administrator.*
 * *Access has been denied.*
-* *Your administrator has been notified by email.*
 
 See :ref:`policy_show_default_ca_error_message` for the policy itself. Unlike a
-stage's error message, the default wording is per *action*, so a stage that locks
-the user and notifies them reports both, one sentence per action. It is also
+stage's error message, the default wording is per *action*, and there is wording
+only for the actions that turn a request away: the four lock and block actions and
+``DENY``. A notification is a one-off event that no restriction records, so a stage
+that locks the user *and* emails them is described by the lock alone. It is also
 applied live rather than stored, so it covers the locks and blocks that already
 exist - see :ref:`conditional_access_error_messages_snapshot`.
 
@@ -105,9 +120,10 @@ the restriction that lasts longest, and the other one is recorded in the entry's
 honest about both without pretending the second one is filterable - only
 ``event_type`` is.
 
-A stage that only **notified** refused nothing, so its message does not replace
-anything. The credential failure is still the reason the request failed and keeps
-its own message and details, with the notification appended to it.
+Only a restriction is described. A stage that merely **notified** refused nothing
+and left nothing behind for a later request to be refused by, so no request ever
+carries wording for it - the failure that happened to trip it keeps its own
+message and details, unchanged.
 
 .. _conditional_access_error_messages_snapshot:
 
@@ -183,10 +199,12 @@ silent rejection carries none either.
 rather than attempting an authentication - and so never produces a rejection
 message.
 
-The request that *creates* a lock is answered exactly as the requests the lock
-then refuses: the same body, the same wording, and nothing of the credential
-failure it overtook. The message is failure-only in every case and is never shown
-on a successful login.
+The request that *creates* a lock is the one exception to all of this: it carries
+no conditional access wording at all. It is answered exactly as it would have been
+had no stage tripped - the token's own failure reason, or the challenge it was
+about to hand out - and the lock speaks from the next request onwards. A silent
+restriction is therefore undetectable at the moment it is written, the response
+being the one the request had coming either way.
 
 .. _conditional_access_error_messages_masking:
 
@@ -219,8 +237,8 @@ The reverse case follows the same rule from the other side. A **silent** rejecti
 * ``hide_specific_error_message`` replaces it with its own generic message, which
   is the same sentence a silent rejection already carried.
 * ``no_detail_on_fail`` strips the ``detail`` from a ``/validate/check``
-  response, and a silent rejection then says nothing rather than putting a
-  generic message back where that policy has just removed one.
+  response, so a silent rejection ends up saying nothing at all - it had only the
+  generic sentence to lose.
 
 To keep conditional access invisible, therefore, simply leave the error messages
 empty and do not set ``show_default_ca_error_message`` - that is the default. The

--- a/doc/conditional_access/evaluation.rst
+++ b/doc/conditional_access/evaluation.rst
@@ -29,6 +29,19 @@ After the request has been answered, its authentication log entry is evaluated
 against the thresholds. Locks, blocks and notifications are created at this
 point, so they apply from the *next* request onwards.
 
+.. important:: The evaluation never changes the response of the request it
+   evaluates. A request that trips a stage gets the answer it had coming - its own
+   failure, its own challenge, even its own success - and is told nothing about
+   what it triggered. Only the requests that follow meet the lock or block, and
+   only they are refused by it.
+
+   So a threshold of 3 is reached by the third tracked event, and the request that
+   carried it is answered normally; the *fourth* request is the first one refused.
+   A ``DENY`` behaves the same way, for a different reason: it is evaluated before
+   the credentials are checked, against the events already recorded, and this
+   request's own event is not among them yet. Nothing turns away the request that
+   reaches the threshold - if a threshold must bite one attempt earlier, lower it.
+
 Rejection messages
 ------------------
 
@@ -36,6 +49,11 @@ A refused request returns the same generic failure as a wrong password, so the
 client learns nothing about why it failed - the reason is in the
 :ref:`authentication_log` and in the :ref:`audit` log. That is the default and
 it applies to the WebUI login as well as to the ``/validate/`` endpoints.
+
+Only a request refused by one of the three questions above carries a message at
+all. Because the request that writes a restriction is answered normally, a
+restriction reaches a user in exactly one shape: the pre-credential refusal of
+every request after it.
 
 An administrator can choose to say more, either by writing an error message on
 the stage that refuses, or by setting the ``show_default_ca_error_message``

--- a/doc/conditional_access/locks_and_blocks.rst
+++ b/doc/conditional_access/locks_and_blocks.rst
@@ -19,8 +19,8 @@ threshold created, so it lifts only when someone lifts it or its own duration
 runs out.
 
 Each entry also shows the error message the restriction carries - what the
-affected user is being told, or nothing where the stage said nothing. It is a
-copy taken when the restriction was written, see
+affected user is being told on the requests it refuses, or nothing where the stage
+said nothing. It is a copy taken when the restriction was written, see
 :ref:`conditional_access_error_messages_snapshot`.
 
 

--- a/doc/conditional_access/policies.rst
+++ b/doc/conditional_access/policies.rst
@@ -187,10 +187,11 @@ over like any other, so *always* reaches up to the next threshold.
    ``pi-manage conditionalaccess disable-policy <name>`` if it has locked you
    out of the WebUI, see :ref:`conditional_access_policies_cli`.
 
-Each stage also has an optional **error message**, the text an end user sees when
-a request is turned away by that stage. It is empty by default, which keeps a
-rejection indistinguishable from any other failed authentication, see
-:ref:`conditional_access_error_messages`.
+Each stage also has an optional **error message**, the text an end user sees on a
+request that a lock, block or ``DENY`` from that stage turns away - never on the
+request that trips the stage, which is answered on its own merits. It is empty by
+default, which keeps a rejection indistinguishable from any other failed
+authentication, see :ref:`conditional_access_error_messages`.
 
 .. _conditional_access_policies_actions:
 
@@ -215,6 +216,10 @@ Actions
     Notify the user, or an administrator, that the threshold was reached.
     ``EMAIL_USER`` sends to the address in the user store. ``EMAIL_ADMIN`` sends
     to a list of addresses or to the internal administrators.
+
+    Neither turns a request away, so neither is ever reported in a response: a
+    stage carrying nothing but these is silent whatever error message is written
+    on it, see :ref:`conditional_access_error_messages`.
 
     An email action needs the identifier of an :ref:`smtpserver` configuration
     plus subject and body. Subject and body may contain ``{username}``,

--- a/doc/policies/conditional_access.rst
+++ b/doc/policies/conditional_access.rst
@@ -29,8 +29,12 @@ its own **error message** to say, and the generic ``Authentication failed.``
 where none was written. A stage's own error message always takes precedence over
 this policy.
 
-Because the wording is per action, a stage that both restricts and notifies is
-described by one sentence per action, most severe first.
+Because the wording is per action, a stage that restricts more than one thing -
+the user and the source address - is described by one sentence per restriction in
+force, most severe first. There is wording only for the actions that turn a
+request away, so a stage that locks the user *and* emails them is described by the
+lock alone: the email is a one-off event that no lock records, and nothing is left
+to report it on a later request.
 
 The default wording is not stored on the lock or the block it describes - this
 policy is matched on every request - so switching it on or off immediately

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -70,8 +70,7 @@ import jwt
 from flask import (Blueprint, request, current_app, g)
 from flask_babel import _
 
-from privacyidea.api.lib.conditional_access import (compose_failure_message, conditional_access_login_gate,
-                                                    rejection_message)
+from privacyidea.api.lib.conditional_access import conditional_access_login_gate
 from privacyidea.api.lib.policyhelper import check_last_auth_policy, get_realm_for_authentication
 from privacyidea.api.lib.postpolicy import (postpolicy, add_user_detail_to_response, check_tokentype,
                                             check_tokeninfo, check_serial, no_detail_on_success,
@@ -90,7 +89,7 @@ from privacyidea.lib.auth import (check_webui_user, ROLE, verify_db_admin,
 from privacyidea.lib.conditional_access.authentication_event_types import (AuthEventType, AuthEventReason,
                                                                           AUTH_EVENT_TYPE_KEY, build_reason_detail,
                                                                           LOG_TRANSACTION_ID_KEY)
-from privacyidea.lib.conditional_access.request_context import continue_attempt, get_ca_context
+from privacyidea.lib.conditional_access.request_context import continue_attempt
 from privacyidea.lib.config import get_from_config, SYSCONF, ensure_no_config_object, get_privacyidea_node
 from privacyidea.lib.crypto import geturandom, init_hsm
 from privacyidea.lib.error import AuthError, Error, ResourceNotFoundError
@@ -618,45 +617,12 @@ def get_auth_token():
                        internal_admin=internal_admin,
                        reasons=auth_reasons, reason_detail=auth_reason_detail)
 
-    # Feed the classified outcome to the conditional-access engine here, in the view, because this endpoint
-    # *raises* its rejection: the error message, the error id and the details all go into the AuthError below, and
-    # the lock or block this login may have just written is read back for them. The staged row is flushed first,
-    # so the count includes this request's own event. Both halves are guarded and idempotent, so after_request
-    # and teardown find nothing left to do and this can never break the login response.
-    context = get_ca_context()
-    context.flush()
-    evaluation = context.run_post_eval()
-
     if not admin_auth and not user_auth:
-        # If this very request tripped a stage, the evaluation above carries its wording: a restriction replaces
-        # the reason, a notification is appended to it (see compose_failure_message). Anything already in force
-        # was refused by the pre-check before the credentials were ever checked, so there is nothing to read back.
-        # With no wording at all the failure is the ordinary one, which is what keeps a locked account
-        # indistinguishable from a wrong password in everything a human or a client reads: the status, the
-        # message and the detail. Not in the error *id*, deliberately - see the rejection branch below - and
-        # hide_specific_error_message closes even that.
-        details = details or {}
-        message = str(GENERIC_AUTH_FAILURE)
-        error_id = Error.AUTHENTICATE_WRONG_CREDENTIALS
-        if evaluation.restricted:
-            # This login is refused by conditional access rather than by the credential it happened to carry, so it
-            # is answered exactly as the pre-check answers every login after it: the restriction's wording if there
-            # is any, the ordinary failure if not, and nothing else. The details describe the overtaken attempt -
-            # "wrong otp pin" and the token it was aimed at - and a rejection carries none of that. The id drops
-            # WRONG_CREDENTIALS for the same reason: nothing here is a statement about the credential.
-            message = rejection_message(context.rejection_shape, evaluation.messages)
-            details = {}
-            error_id = Error.AUTHENTICATE
-            if evaluation.messages:
-                # Only configured wording is claimed, so hide_specific_error_message shows it instead of its own; a
-                # silent rejection is the ordinary failure and is masked with every other one.
-                context.claim_message(message)
-        elif evaluation.messages:
-            # A stage that only notified refused nothing, so the credential failure is still the reason and keeps
-            # its id and its details; the notification is appended to it.
-            message = compose_failure_message(message, evaluation.messages)
-            context.claim_message(message)
-        raise AuthError(message, id=error_id, details=details)
+        # The ordinary failed login, whatever conditional access made of this request. Anything it had in force
+        # was refused by the pre-check before the credentials were ever checked, and a stage this request trips
+        # applies from the next login onwards - so nothing here is a statement about conditional access, and the
+        # staged row is left to request teardown to flush and evaluate like any other.
+        raise AuthError(GENERIC_AUTH_FAILURE, id=Error.AUTHENTICATE_WRONG_CREDENTIALS, details=details or {})
     else:
         g.audit_object.log({"success": True, "authentication": AUTH_RESPONSE.ACCEPT})
         request.User = user

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -622,7 +622,9 @@ def get_auth_token():
         # was refused by the pre-check before the credentials were ever checked, and a stage this request trips
         # applies from the next login onwards - so nothing here is a statement about conditional access, and the
         # staged row is left to request teardown to flush and evaluate like any other.
-        raise AuthError(GENERIC_AUTH_FAILURE, id=Error.AUTHENTICATE_WRONG_CREDENTIALS, details=details or {})
+        # Resolved to a str here, not left lazy: auth_error hands the message to the audit log, which stores only
+        # str and would drop the whole entry on a lazy proxy.
+        raise AuthError(str(GENERIC_AUTH_FAILURE), id=Error.AUTHENTICATE_WRONG_CREDENTIALS, details=details or {})
     else:
         g.audit_object.log({"success": True, "authentication": AUTH_RESPONSE.ACCEPT})
         request.User = user

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -35,7 +35,6 @@ from .lib.utils import (get_all_params, get_before_request_config, get_optional,
                         logged_in_user_from_token, hide_specific_error_message, construct_radius_response)
 from .container import container_blueprint
 from ..lib.container import find_container_for_token, find_container_by_serial
-from .lib.conditional_access import surface_conditional_access_message
 from ..lib.conditional_access.request_context import peek_ca_context, reset_ca_context
 from ..lib.framework import get_app_config_value
 from ..lib.clients import identify_client_by_key, touch_client
@@ -561,16 +560,6 @@ def after_request(response):
     """
     response = mask_authentication_error_response(request, response)
 
-    # Report what conditional access did to this request, if anything. Central rather than per endpoint for two
-    # reasons: this also runs for a response an *error handler* built, where every post-policy is skipped, and no
-    # gated endpoint can forget to opt in. One lookup and it is done for every request. After the masking above,
-    # which is where hide_specific_error_message has its say, so a notification composes onto what survived it -
-    # and before sign_response, which the decorator above applies to whatever this function returns.
-    response = surface_conditional_access_message(response)
-
-    # Last of the three, because it drops the JSON body: conditional access has to have had its say on the verdict
-    # before the body carrying it is thrown away, or a request that authenticates *and* trips a restriction in one
-    # breath would be answered 204 while /validate/check answers the same request with a rejection.
     response = shape_radius_response(request, response)
 
     # Strip version information before signing if the hide_version policy
@@ -623,10 +612,8 @@ def shape_radius_response(request, response):
     Apply :func:`construct_radius_response` to ``/validate/radiuscheck``, shaping it into the RADIUS empty-body
     ``204``/``400`` form.
 
-    Applied from ``after_request`` for the same reason as :func:`mask_authentication_error_response` - so an error
-    response built by an error handler is shaped too - but **after**
-    :func:`~privacyidea.api.lib.conditional_access.surface_conditional_access_message`, because dropping the JSON
-    body also drops the verdict conditional access still has to correct.
+    Applied from ``after_request`` for the same reason as :func:`mask_authentication_error_response`: so an error
+    response built by an error handler is shaped too.
 
     :param request: the request object
     :param response: the response object

--- a/privacyidea/api/conditional_access.py
+++ b/privacyidea/api/conditional_access.py
@@ -301,9 +301,10 @@ def list_condition_types():
 def list_targets():
     """
     Return the policy targets and, for each, the constraints that depend on the target - the stage actions it allows,
-    the count modes it supports, which of its actions may appear more than once within one stage, and which of its
-    actions contradict each other within one stage - as ``{target: {"actions": [...], "count_modes": [...],
-    "repeatable_actions": [...], "exclusive_action_groups": [[...], ...]}}`` (all sorted; see
+    the count modes it supports, which of its actions may appear more than once within one stage, which of its
+    actions contradict each other within one stage, and which of them a request can ever be told about - as
+    ``{target: {"actions": [...], "count_modes": [...], "repeatable_actions": [...],
+    "exclusive_action_groups": [[...], ...], "reporting_actions": [...]}}`` (all sorted; see
     :func:`~privacyidea.lib.conditional_access.policy.get_target_constraints`).
 
     Requires the admin policy action :ref:`policy_conditional_access_policy_read`.

--- a/privacyidea/api/lib/conditional_access.py
+++ b/privacyidea/api/lib/conditional_access.py
@@ -35,22 +35,17 @@ Silent is the default on all three: a rejection says what an admin configured on
 nothing configured only what every other failed authentication says.
 
 What "like any other failed authentication" *is* differs per endpoint, which is the one thing a gate has to hand on:
-each records a :class:`~privacyidea.lib.conditional_access.request_context.RejectionShape` on the request, so the
-response hook can answer a restriction this very request wrote in the same shape - down to the fields the endpoint
-does not have. ``/ttype/push`` is where that bites: it renders with ``rid`` 1, so it reports no ``authentication``
-verdict, and an ordinary failed answer there carries no ``detail`` at all, so a silent rejection carries none either -
-the opposite of ``/validate/*``, where every failure has one and a silent rejection needs the generic message to have
-one too.
+each passes a :class:`~privacyidea.lib.conditional_access.request_context.RejectionShape` saying how its endpoint
+answers a refusal, down to the fields the endpoint does not have. ``/ttype/push`` is where that bites: it renders
+with ``rid`` 1, so it reports no ``authentication`` verdict, and an ordinary failed answer there carries no
+``detail`` at all, so a silent rejection carries none either - the opposite of ``/validate/*``, where every failure
+has one and a silent rejection needs the generic message to have one too.
 
-A restriction reads the same whichever request meets it. The request that *writes* a lock is answered exactly as the
-requests the lock then refuses - the whole response, not just the wording, and whether or not a stage configured any
-(see :func:`rejection_message`). The failure's own details go with it, since the credential that request happened to
-carry no longer decides anything. The cost is that a silent lock is detectable at the moment it trips, because the
-response changes shape.
-
-A stage that only *notified* is the exception throughout: it refused nothing, so the credential failure is still the
-reason and keeps its own id, message and details, with the notification appended (see
-:func:`compose_failure_message`).
+Only a request refused *here*, before its credentials are checked, is told anything at all. The post-response
+evaluation reports nothing: a request that trips a stage gets the answer it had coming - its own failure, its own
+challenge, its own success - and the restriction it wrote applies from the next request, which these gates then
+refuse. A lock therefore reaches a user in one shape only, and a silent one is not detectable at the moment it
+trips.
 
 Both classify their rejection in the authentication log, since that row is the only thing an admin can filter for: the
 request is turned away before anything else logs an outcome for it. Both link it to the transaction the request
@@ -65,11 +60,8 @@ places that would otherwise mask it read it back through
 :func:`~privacyidea.lib.conditional_access.request_context.claimed_ca_message`:
 :func:`~privacyidea.api.before_after.auth_error` on ``/auth``, and both actions on ``/validate/*``. Only the message
 survives; the rest of the detail is collapsed, which is what those actions are for and costs a rejection nothing.
-
-:func:`surface_conditional_access_message` claims nothing - it runs from ``after_request``, after all three.
 """
 import functools
-import json
 import logging
 from dataclasses import dataclass
 from collections.abc import Callable
@@ -85,13 +77,11 @@ from privacyidea.lib.conditional_access.engine import (get_user_lock, get_ip_blo
                                                        ConditionalAccessAction, RestrictionStatus, StageMessage)
 from privacyidea.lib.conditional_access.policy import default_error_message
 from privacyidea.lib.conditional_access.session import release_ca_connection
-from privacyidea.lib.conditional_access.request_context import (ConditionalAccessContext, PostEvaluation,
-                                                                 RejectionShape, get_ca_context, peek_ca_context)
+from privacyidea.lib.conditional_access.request_context import RejectionShape, get_ca_context
 from privacyidea.lib.error import AuthError, Error
 from privacyidea.lib.policies.actions import PolicyAction
 from privacyidea.lib.policy import Match, SCOPE
 from privacyidea.lib.user import User
-from privacyidea.lib.utils import AUTH_RESPONSE
 
 log = logging.getLogger(__name__)
 
@@ -213,15 +203,13 @@ def conditional_access_precheck(user: User, rejection_value: Any = False) -> Res
     :param rejection_value: what ``result.value`` says on a rejection. ``False`` everywhere except
         ``/validate/triggerchallenge``, where the value is the *number of challenges triggered* rather than a
         boolean - answering that endpoint with ``False`` would change the type of a field its callers may be
-        reading as a number. See :func:`_rejected_value`, which keeps the same promise on the other path.
+        reading as a number.
     """
     shape = RejectionShape(value=rejection_value)
     rejection = conditional_access_rejection(user, shape)
     if rejection is None:
         return None
-    # Rendered by the one renderer both moments of one request use, so the response that *writes* a restriction
-    # cannot be a different shape from the ones the restriction then refuses.
-    return _rejection_response(get_ca_context(), _rejection_wording(shape, rejection.message))
+    return _rejection_response(shape, _rejection_wording(shape, rejection.message))
 
 
 def conditional_access_rejection(user: User, shape: RejectionShape) -> Rejection | None:
@@ -243,12 +231,9 @@ def conditional_access_rejection(user: User, shape: RejectionShape) -> Rejection
 
     :param user: the identity to gate on
     :param shape: how this endpoint answers a refusal (see :class:`~privacyidea.lib.conditional_access.
-        request_context.RejectionShape`). Recorded whether or not this request is refused: should a *later* stage
-        restrict it, the response hook has to answer in the same shape, and by then the endpoint is no longer
-        identifiable.
+        request_context.RejectionShape`)
     :return: the :class:`Rejection` to render, or ``None`` to continue with the normal flow
     """
-    get_ca_context().rejection_shape = shape
     rejection = _evaluate_rejection(user)
     if rejection is None:
         return None
@@ -263,22 +248,6 @@ def conditional_access_rejection(user: User, shape: RejectionShape) -> Rejection
         # its own. A rejection *is* the whole message, so there is no failure reason it could carry past the mask.
         get_ca_context().claim_message(rejection.message)
     return rejection
-
-
-def _rejected_value(value: Any) -> Any:
-    """
-    What ``result.value`` becomes on a request conditional access refused, in the type the endpoint uses.
-
-    ``False`` almost everywhere, because that is what the value already is on a failed authentication. Not on
-    ``/validate/triggerchallenge``, where it is the *number of challenges triggered*: answering that endpoint with
-    a boolean would change the type of a field its callers may be reading as a number, so it gets ``0``. Anything
-    already falsy is left exactly as it stands.
-
-    ``bool`` is a subclass of ``int``, hence the second check - without it every ``True`` would become ``0``.
-    """
-    if not value:
-        return value
-    return 0 if isinstance(value, int) and not isinstance(value, bool) else False
 
 
 def _rejection_wording(shape: RejectionShape, message: str | None, detail_stripped: bool = False) -> str | None:
@@ -333,24 +302,18 @@ def compose_failure_message(existing: str | None, messages: list[StageMessage]) 
     return f"{existing.rstrip('.')}. {joined}" if existing else joined
 
 
-def _rejection_response(context: "ConditionalAccessContext", message: str | None) -> Response:
+def _rejection_response(shape: RejectionShape, message: str | None) -> Response:
     """
-    The response a refused request gets, in the shape the endpoint's gate recorded
+    The response a refused request gets, in the shape its endpoint's gate describes
     (:class:`~privacyidea.lib.conditional_access.request_context.RejectionShape`).
 
-    The one renderer, used by the pre-check and by the response hook alike, so a rejection cannot come out shaped
-    differently depending on which moment produced it. The hook's other case - a restriction on a response that is
-    already a *failure* of this endpoint's own - edits that body in place instead, keeping the ``threadid`` it
-    already carries; everything a renderer would decide is decided here.
+    Nothing of the request it refuses survives: a rejection says the wording and no more, the credentials it
+    carried having never been checked.
 
-    Nothing is carried over from a body this replaces: a rejection says the wording and no more, and an error's
-    own code and detail describe the attempt the rejection overtook.
-
-    :param context: this request's buffer, holding the rejection shape its gate recorded
+    :param shape: how this endpoint answers a refusal
     :param message: the wording, or ``None`` where this endpoint's failures carry no detail (see
         :func:`_rejection_wording`)
     """
-    shape = context.rejection_shape
     if shape.as_error:
         # /auth, the one entry point whose failed authentication is an error response - so its rejection is one
         # too, carrying the generic authentication id and never the endpoint's own. The status stays as the error
@@ -360,102 +323,6 @@ def _rejection_response(context: "ConditionalAccessContext", message: str | None
         return rejection
     # An empty detail is dropped by prepare_result, which is exactly what an endpoint carrying none needs.
     return send_result(shape.value, rid=shape.rid, details={"message": message} if message else {})
-
-
-def surface_conditional_access_message(response):
-    """
-    Report on the response what conditional access just did to this request: refuse it if this very request wrote a
-    restriction, or add what a stage that only notified did.
-
-    Called from :func:`~privacyidea.api.before_after.after_request`: the last point that can still shape a body,
-    and - unlike a decorator - one that also runs for a response an *error handler* built. Being central also means
-    no gated endpoint can forget to opt in.
-
-    Reads the buffer with :func:`~privacyidea.lib.conditional_access.request_context.peek_ca_context` rather than
-    creating one. This runs on every response of every blueprint, and "has no buffer" is exactly the question to
-    ask - a request that authenticated nothing has none - answered in a single lookup.
-
-    Running after the post-policies rather than among them is what makes ``hide_specific_error_message`` and
-    ``no_detail_on_fail`` a non-issue here: they have already had their say, so a notification composes onto
-    whatever survived them and needs no claim to protect it. The gates still claim, their responses being built
-    where those actions can reach them.
-    """
-    context = peek_ca_context()
-    if context is None or not response or not response.is_json:
-        return response
-    try:
-        context.flush()
-        evaluation = context.run_post_eval()
-        content = response.json
-        if evaluation.restricted:
-            return _refuse(response, content, context, evaluation)
-        if evaluation.messages:
-            return _append_notification(response, content, evaluation)
-    except Exception as ex:
-        # Never break an authentication response over the error message of its own rejection.
-        log.warning(f"Could not surface the conditional-access message on this response: {ex!r}")
-    return response
-
-
-def _refuse(response: Response, content: dict, context: "ConditionalAccessContext",
-            evaluation: PostEvaluation) -> Response:
-    """
-    Answer a request that has just written a restriction as the rejection it now is - word for word the answer the
-    pre-check gives every request the restriction refuses after it.
-
-    Keyed on the restriction rather than on having something to say, because a silent lock refuses this request
-    too; and rather than on the response looking like a failure, because ``result.value`` is a *count* on
-    ``/validate/triggerchallenge``, where a request that triggers a challenge and trips a lock in one breath reads
-    as a success. Withdrawing that challenge is not invalidating it: the row is left to expire unanswered, and the
-    client never learns the ``transaction_id``, so it could not use it anyway.
-    """
-    result = content.get("result") or {}
-    detail = content.get("detail") or {}
-    shape = context.rejection_shape
-    if "error" in result or shape.as_error:
-        # The body is the wrong kind to edit into a rejection, so one is built instead. An error body has no
-        # value to falsify - and must not survive anyway, "ERR1007: the token is locked" stating the very reason a
-        # rejection withholds. On /auth the reverse: a refusal there *is* an error response, so even the 200 a
-        # challenge returned before the engine ran (auth.py) has to be replaced by one.
-        return _rejection_response(context, rejection_message(shape, evaluation.messages))
-    # Editable: this endpoint answers a refusal with an ordinary result body, which is what is already in hand.
-    # A detail that is gone was stripped by no_detail_on_fail, and a silent restriction then says nothing rather
-    # than putting a generic message where that action left none.
-    message = rejection_message(shape, evaluation.messages, detail_stripped="detail" not in content)
-    result["value"] = _rejected_value(result.get("value"))
-    if shape.reports_authentication:
-        # Only where the endpoint reports a verdict at all - /ttype/push renders with rid 1 and has no such field.
-        result["authentication"] = AUTH_RESPONSE.REJECT
-    content["result"] = result
-    if message is None:
-        content.pop("detail", None)
-    else:
-        # The threadid stays - it identifies the request rather than describing it. Everything else described what
-        # the rejection overtook: the attempt that failed, or the challenge about to be handed out.
-        kept = {"threadid": detail["threadid"]} if "threadid" in detail else {}
-        content["detail"] = {**kept, "message": message}
-    response.set_data(json.dumps(content))
-    return response
-
-
-def _append_notification(response: Response, content: dict, evaluation: PostEvaluation) -> Response:
-    """
-    Add what a stage that only *notified* did to a response it did not refuse.
-
-    It refused nothing, so the credential failure is still why the request failed and keeps its own id, message and
-    details - a challenge included - with the notification following it (see :func:`compose_failure_message`).
-
-    Left alone on a response that did not fail, the message being failure-only, and on an error, which failed for a
-    reason of its own that the notification merely coincided with.
-    """
-    result = content.get("result") or {}
-    if "error" in result or result.get("value"):
-        return response
-    detail = content.get("detail") or {}
-    detail["message"] = compose_failure_message(detail.get("message"), evaluation.messages)
-    content["detail"] = detail
-    response.set_data(json.dumps(content))
-    return response
 
 
 def conditional_access_gate(identity_resolver: Callable[[], User] | None = None,

--- a/privacyidea/api/lib/conditional_access.py
+++ b/privacyidea/api/lib/conditional_access.py
@@ -70,11 +70,11 @@ from typing import Any
 from flask import request, g, Response
 
 from privacyidea.api.lib.utils import (GENERIC_AUTH_FAILURE, log_authentication, build_ca_context,
-                                      send_error, send_result, get_optional_one_of)
+                                      send_result, get_optional_one_of)
 from privacyidea.lib.conditional_access.authentication_event_types import AuthEventType
 from privacyidea.lib.conditional_access.engine import (get_user_lock, get_ip_block, evaluate_access_decision,
                                                        render_error_message, restriction_messages, AccessDecision,
-                                                       ConditionalAccessAction, RestrictionStatus, StageMessage)
+                                                       ConditionalAccessAction, RestrictionStatus)
 from privacyidea.lib.conditional_access.policy import default_error_message
 from privacyidea.lib.conditional_access.session import release_ca_connection
 from privacyidea.lib.conditional_access.request_context import RejectionShape, get_ca_context
@@ -250,56 +250,21 @@ def conditional_access_rejection(user: User, shape: RejectionShape) -> Rejection
     return rejection
 
 
-def _rejection_wording(shape: RejectionShape, message: str | None, detail_stripped: bool = False) -> str | None:
+def _rejection_wording(shape: RejectionShape, message: str | None) -> str | None:
     """
     What a rejection says on the endpoint *shape* describes, given the wording the restrictions carry.
 
     A configured message is said everywhere. A silent restriction is the interesting half: where an ordinary
     failure carries a ``detail`` it says what every other failed authentication says, because a response *without*
-    one could only have come from conditional access; where an ordinary failure carries none - ``/ttype/push``, or
-    a response ``no_detail_on_fail`` has already stripped - it says nothing, because there the generic message
-    would be that same tell.
+    one could only have come from conditional access; where an ordinary failure carries none - ``/ttype/push`` -
+    it says nothing, because there the generic message would be that same tell.
 
     :param message: the wording the restrictions in force carry, or ``None`` for the normal, silent case
-    :param detail_stripped: whether a post-policy removed the detail this endpoint would otherwise have carried
     :return: the wording, or ``None`` when the rejection carries no detail at all
     """
     if message:
         return message
-    return None if detail_stripped or not shape.carries_detail else str(GENERIC_AUTH_FAILURE)
-
-
-def rejection_message(shape: RejectionShape, messages: list[StageMessage],
-                      detail_stripped: bool = False) -> str | None:
-    """
-    What a request that has just been restricted says: the wording of the restrictions now in force, rendered as
-    :func:`_rejection_wording` renders every rejection on this endpoint.
-
-    Deliberately the same answer :func:`conditional_access_precheck` gives every request after this one. A
-    restriction reads the same whether this request wrote it or an earlier one did, so the request that trips a
-    lock cannot be told apart from the requests the lock then refuses - which is the property that makes a lock
-    say one thing rather than two.
-
-    :param messages: the wording the restrictions carry; empty is the normal, silent case
-    """
-    return _rejection_wording(shape, " ".join(message.text for message in messages) or None, detail_stripped)
-
-
-def compose_failure_message(existing: str | None, messages: list[StageMessage]) -> str:
-    """
-    What a failed authentication should say when conditional access has something to *add* to it.
-
-    Only ever the notification case. A stage that merely notified refused nothing, so the credential failure is
-    still why the request was turned away and its own reason stays the lead; the notification follows it. A
-    restriction is the other case entirely and is not composed at all - it *is* the answer, see
-    :func:`rejection_message`.
-
-    :param existing: the error message the failure already carried, if any
-    :param messages: what conditional access did - **never empty**. A caller with nothing to report leaves its own
-        error message alone rather than asking here, which is also what lets this always answer with a sentence.
-    """
-    joined = " ".join(message.text for message in messages)
-    return f"{existing.rstrip('.')}. {joined}" if existing else joined
+    return None if not shape.carries_detail else str(GENERIC_AUTH_FAILURE)
 
 
 def _rejection_response(shape: RejectionShape, message: str | None) -> Response:
@@ -310,17 +275,14 @@ def _rejection_response(shape: RejectionShape, message: str | None) -> Response:
     Nothing of the request it refuses survives: a rejection says the wording and no more, the credentials it
     carried having never been checked.
 
+    Only the endpoints that *return* their rejection render one here. ``/auth`` raises its own
+    :class:`AuthError` instead (see :func:`_reject_restricted_login`), which the error handler renders as the
+    ``401`` every failed login there returns.
+
     :param shape: how this endpoint answers a refusal
     :param message: the wording, or ``None`` where this endpoint's failures carry no detail (see
         :func:`_rejection_wording`)
     """
-    if shape.as_error:
-        # /auth, the one entry point whose failed authentication is an error response - so its rejection is one
-        # too, carrying the generic authentication id and never the endpoint's own. The status stays as the error
-        # handler set it, which is the 401 every failed login there returns.
-        rejection = send_error(message, error_code=Error.AUTHENTICATE, details={})
-        rejection.status_code = 401
-        return rejection
     # An empty detail is dropped by prepare_result, which is exactly what an endpoint carrying none needs.
     return send_result(shape.value, rid=shape.rid, details={"message": message} if message else {})
 
@@ -469,7 +431,6 @@ def _reject_restricted_login(user: User) -> None:
     ``internal_admin`` comes from the flag ``before_request`` already resolved, so a blocked local admin is recorded as
     ``admin-internal`` rather than falling back to ``user``.
     """
-    get_ca_context().rejection_shape = RejectionShape(as_error=True)
     rejection = _evaluate_rejection(user)
     if rejection is None:
         return

--- a/privacyidea/api/lib/conditional_access.py
+++ b/privacyidea/api/lib/conditional_access.py
@@ -164,9 +164,8 @@ def _evaluate_rejection(user: User) -> "Rejection | None":
     ``db.session``'s pool (see :func:`~privacyidea.lib.conditional_access.session.release_ca_connection`).
     """
     try:
-        # Resolved once per request and kept on the context, which is the single place it lives: this pre-check reads
-        # it back below, and the post-response evaluation reads the same value, so both halves of one request word a
-        # rejection the same way.
+        # Resolved once per request and kept on the context, which is the single place it lives: this pre-check is
+        # its only reader, a restriction being described only on the requests it refuses.
         context = get_ca_context()
         context.use_default_error_message = show_default_ca_error_message(user)
         source_ip = g.get("client_ip")

--- a/privacyidea/api/lib/conditional_access.py
+++ b/privacyidea/api/lib/conditional_access.py
@@ -63,7 +63,7 @@ survives; the rest of the detail is collapsed, which is what those actions are f
 """
 import functools
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from collections.abc import Callable
 from typing import Any
 
@@ -136,7 +136,9 @@ class Rejection:
 
     :ivar event_type: how the authentication log classifies the rejection
     :ivar audit_info: the free-text reason for the audit entry
-    :ivar message: the error message the triggering stage configured, or ``None`` to stay generic
+    :ivar message: what the refused request is told. :func:`_evaluate_rejection` fills in the wording the
+        triggering stage configured, or ``None`` where it configured none; the gate then resolves that against
+        its endpoint's shape (:func:`_rejection_wording`), so what a caller receives is already what to say.
     :ivar other_info: extra fields for the authentication-log row, or ``None``
     """
     event_type: AuthEventType
@@ -253,7 +255,7 @@ def conditional_access_precheck(user: User, rejection_value: Any = False) -> Res
     rejection = conditional_access_rejection(user, shape)
     if rejection is None:
         return None
-    return _rejection_response(shape, _rejection_wording(shape, rejection.message))
+    return _rejection_response(shape, rejection.message)
 
 
 def conditional_access_rejection(user: User, shape: RejectionShape) -> Rejection | None:
@@ -266,12 +268,11 @@ def conditional_access_rejection(user: User, shape: RejectionShape) -> Rejection
     those that can; ``/ttype/push`` is the one that cannot, since the push token hands its result back to
     :func:`~privacyidea.api.ttype.token` as a ``(bool, dict)`` pair that ``prepare_result`` renders.
 
-    Rendering is the caller's because "what an ordinary failure looks like" differs per endpoint, and looking like
-    one is the whole requirement. On ``/validate/*`` every failure carries a ``detail``, so a silent rejection
-    carries the generic message rather than nothing. On ``/ttype/push`` an ordinary failed answer carries no
-    detail at all, so a silent rejection must carry none either - putting the generic message there would be
-    exactly the tell that including it on ``/validate`` avoids. Only wording an admin configured is surfaced
-    unconditionally, on both.
+    Only the envelope is the caller's, because "what an ordinary failure looks like" differs per endpoint and
+    looking like one is the whole requirement. *What it says* is resolved here from *shape*
+    (:func:`_rejection_wording`), so the returned :attr:`Rejection.message` is already the wording this endpoint
+    answers with - carried straight into the response by whoever renders it, with no second reading of the same
+    rule at the call site.
 
     :param user: the identity to gate on
     :param shape: how this endpoint answers a refusal (see :class:`RejectionShape`)
@@ -289,8 +290,10 @@ def conditional_access_rejection(user: User, shape: RejectionShape) -> Rejection
     if rejection.message:
         # Claimed before the post-policies run, so hide_specific_error_message shows this error message rather than
         # its own. A rejection *is* the whole message, so there is no failure reason it could carry past the mask.
+        # Claimed from the configured wording, before the endpoint's stand-in for a silent rejection is filled in
+        # below: a generic rejection is the ordinary failure and must be masked along with every other one.
         get_ca_context().claim_message(rejection.message)
-    return rejection
+    return replace(rejection, message=_rejection_wording(shape, rejection.message))
 
 
 def _rejection_wording(shape: RejectionShape, message: str | None) -> str | None:
@@ -564,7 +567,9 @@ def _reject_restricted_login(user: User) -> None:
     # AUTHENTICATE rather than AUTHENTICATE_WRONG_CREDENTIALS: the credential this request carried may well have
     # been correct - it was never checked. A rejection is refused for a reason of conditional access's own, so it
     # takes the generic authentication-failure id and claims nothing about the credential.
-    raise AuthError(rejection.message or GENERIC_AUTH_FAILURE, id=Error.AUTHENTICATE)
+    # The fallback is resolved to a str, not left lazy: auth_error hands the message to the audit log, which
+    # stores only str and would drop the whole entry on a lazy proxy.
+    raise AuthError(rejection.message or str(GENERIC_AUTH_FAILURE), id=Error.AUTHENTICATE)
 
 
 def conditional_access_login_gate() -> Callable[[Callable], Callable]:

--- a/privacyidea/api/lib/conditional_access.py
+++ b/privacyidea/api/lib/conditional_access.py
@@ -35,8 +35,8 @@ Silent is the default on all three: a rejection says what an admin configured on
 nothing configured only what every other failed authentication says.
 
 What "like any other failed authentication" *is* differs per endpoint, which is the one thing a gate has to hand on:
-each passes a :class:`~privacyidea.lib.conditional_access.request_context.RejectionShape` saying how its endpoint
-answers a refusal, down to the fields the endpoint does not have. ``/ttype/push`` is where that bites: it renders
+each passes a :class:`RejectionShape` saying how its endpoint answers a refusal, down to the fields the endpoint
+does not have. ``/ttype/push`` is where that bites: it renders
 with ``rid`` 1, so it reports no ``authentication`` verdict, and an ordinary failed answer there carries no
 ``detail`` at all, so a silent rejection carries none either - the opposite of ``/validate/*``, where every failure
 has one and a silent rejection needs the generic message to have one too.
@@ -77,13 +77,38 @@ from privacyidea.lib.conditional_access.engine import (get_user_lock, get_ip_blo
                                                        ConditionalAccessAction, RestrictionStatus)
 from privacyidea.lib.conditional_access.policy import default_error_message
 from privacyidea.lib.conditional_access.session import release_ca_connection
-from privacyidea.lib.conditional_access.request_context import RejectionShape, get_ca_context
+from privacyidea.lib.conditional_access.request_context import get_ca_context
 from privacyidea.lib.error import AuthError, Error
 from privacyidea.lib.policies.actions import PolicyAction
 from privacyidea.lib.policy import Match, SCOPE
 from privacyidea.lib.user import User
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RejectionShape:
+    """
+    How one endpoint answers a request conditional access refuses.
+
+    Passed by whichever gate guards the endpoint, because looking like an ordinary failed authentication is the
+    whole requirement and what one looks like differs per endpoint.
+
+    :ivar value: what ``result.value`` says. ``False`` everywhere except ``/validate/triggerchallenge``, where the
+        value is the number of challenges triggered and a boolean would change the type of a field its callers may
+        be reading as a number.
+    :ivar rid: the response id this endpoint renders with. ``prepare_result`` adds ``result.authentication`` only
+        for ``rid > 1``, so a rejection at ``/ttype/push`` - which renders with ``1`` - must not grow a field the
+        endpoint never carries.
+    :ivar carries_detail: whether an ordinary failed authentication here carries a ``detail`` at all. On
+        ``/validate/*`` every failure does, so a silent rejection carries the generic failure to have one too; at
+        ``/ttype/push`` none does, so a silent rejection carries none either - the generic message would be exactly
+        the tell that including it on ``/validate`` avoids.
+    """
+    value: Any = False
+    rid: int = 2
+    carries_detail: bool = True
+
 
 #: How ``/ttype/push`` answers a refused challenge answer. The push token renders its own response through
 #: ``prepare_result`` with ``rid`` 1, so it carries no ``result.authentication``, and an ordinary failed answer there
@@ -230,8 +255,7 @@ def conditional_access_rejection(user: User, shape: RejectionShape) -> Rejection
     unconditionally, on both.
 
     :param user: the identity to gate on
-    :param shape: how this endpoint answers a refusal (see :class:`~privacyidea.lib.conditional_access.
-        request_context.RejectionShape`)
+    :param shape: how this endpoint answers a refusal (see :class:`RejectionShape`)
     :return: the :class:`Rejection` to render, or ``None`` to continue with the normal flow
     """
     rejection = _evaluate_rejection(user)
@@ -270,7 +294,7 @@ def _rejection_wording(shape: RejectionShape, message: str | None) -> str | None
 def _rejection_response(shape: RejectionShape, message: str | None) -> Response:
     """
     The response a refused request gets, in the shape its endpoint's gate describes
-    (:class:`~privacyidea.lib.conditional_access.request_context.RejectionShape`).
+    (:class:`RejectionShape`).
 
     Nothing of the request it refuses survives: a rejection says the wording and no more, the credentials it
     carried having never been checked.

--- a/privacyidea/api/lib/postpolicy.py
+++ b/privacyidea/api/lib/postpolicy.py
@@ -552,14 +552,12 @@ def no_detail_on_fail(request, response):
 
     A conditional-access message is the one thing that survives, exactly as it survives
     :func:`hide_specific_error_message`: this action strips what privacyIDEA volunteers about the attempt, whereas
-    that message is something an admin either wrote on a stage or turned on by policy. Without this a lock said
-    nothing on the request that refused it while saying its piece on the request that wrote it - the same lock,
-    worded two ways, depending on which half of the request answered.
+    that message is something an admin either wrote on a stage or turned on by policy. Without this a lock would
+    say nothing on the very requests it refuses.
 
     Read from the claim (:func:`~privacyidea.lib.conditional_access.request_context.claimed_ca_message`) rather than
-    from the response body, which is what makes the outcome independent of where this action sits relative to the
-    hook that writes that body: the claim always holds the wording as it must read once the specific reason is
-    stripped, so a message appended to "wrong otp pin" cannot carry that reason through here.
+    from the response body: the gate builds its rejection inside the decorator stack, so the claim is what carries
+    the configured wording across this strip.
 
     :param request:
     :param response:

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -933,8 +933,9 @@ def hide_specific_error_message(request, response):
         return response
 
     # A conditional-access message is kept: an admin either wrote it on the stage or turned it on by policy, so it
-    # is not what this action is here to suppress. Taken from the claim rather than from the body, because a stage
-    # that only notified was *appended* to the token's own reason and that reason is exactly what this does suppress.
+    # is not what this action is here to suppress. Taken from the claim rather than from the body: the claim holds
+    # only what conditional access itself said, where the body holds the token's own reason whenever a rejection said
+    # nothing - and that reason is exactly what this does suppress.
     message = claimed_ca_message() or str(GENERIC_AUTH_FAILURE)
     error = result.get("error")
     if isinstance(error, dict):

--- a/privacyidea/lib/conditional_access/context.py
+++ b/privacyidea/lib/conditional_access/context.py
@@ -76,11 +76,6 @@ class CAContext:
         exempt an emergency admin from a pre-auth DENY. See
         :func:`~privacyidea.api.lib.utils.build_ca_context` for where it comes
         from.
-    :ivar use_default_error_message: Whether a rejection with no error message of its own falls back to the
-        default wording for what it did (the ``show_default_ca_error_message`` policy), rather than saying nothing.
-        Not about the generic "Authentication failed." - that is what a rejection with nothing to say ends up
-        carrying, decided in the API layer. Resolved there too, because matching a policy needs Flask and this
-        package deliberately does not.
     Note what is deliberately *absent*: the authentication log's ``client_label``
     (the ``client_id`` parameter, falling back to the User-Agent header). It
     identifies the calling application well enough to be worth recording
@@ -93,4 +88,3 @@ class CAContext:
     source_ip: str | None = None
     endpoint: str | None = None
     user_role: str | None = None
-    use_default_error_message: bool = False

--- a/privacyidea/lib/conditional_access/engine.py
+++ b/privacyidea/lib/conditional_access/engine.py
@@ -373,9 +373,9 @@ class AccessDecisionResult:
     nothing to record.
 
     One type for a single policy's contribution (:func:`_policy_access_decision`) and for the whole evaluation
-    (:func:`evaluate_access_decision`). Hence the default: :attr:`AccessDecision.CONTINUE` reads "this policy has no opinion" for the one and
-    "no policy decided" for the other - which is what ``CONTINUE`` already means, so nothing needs a separate
-    ``None`` to say it.
+    (:func:`evaluate_access_decision`). Hence the default: :attr:`AccessDecision.CONTINUE` reads "this policy has no
+    opinion" for the one and "no policy decided" for the other - which is what ``CONTINUE`` already means, so nothing
+    needs a separate ``None`` to say it.
     """
     decision: AccessDecision = AccessDecision.CONTINUE
     outcomes: list[ConditionalAccessOutcome] = field(default_factory=list)

--- a/privacyidea/lib/conditional_access/engine.py
+++ b/privacyidea/lib/conditional_access/engine.py
@@ -125,11 +125,12 @@ class ConditionalAccessAction(str, Enum):
         return self.value
 
 
-#: Every action that has something to tell the user, most severe first - the one ordering there is. It ranks the
-#: messages of the restrictions a request is refused by (:func:`rank_and_deduplicate`) and orders the suggestions
-#: the policy editor offers (:data:`~privacyidea.lib.conditional_access.policy.DEFAULT_ERROR_MESSAGES`), so an
-#: action reads the same wherever it is met. An action that turns nobody away has nothing to say, so it has no
-#: entry.
+#: Every action, most severe first - the one severity ordering there is, so an action reads the same wherever it
+#: is met. It ranks the messages of the restrictions a request is refused by (:func:`rank_and_deduplicate`) and
+#: orders the suggestions the policy editor offers
+#: (:data:`~privacyidea.lib.conditional_access.policy.DEFAULT_ERROR_MESSAGES`). Both consumers filter it to what
+#: they cover - only a restriction in force or a denial has anything to say - so an action that reports nothing
+#: to the user still belongs here, ranked, against the day it does.
 ACTION_SEVERITY: tuple[ConditionalAccessAction, ...] = (
     ConditionalAccessAction.PERMANENT_LOCK_USER,
     ConditionalAccessAction.PERMANENT_BLOCK_IP,
@@ -143,10 +144,6 @@ ACTION_SEVERITY: tuple[ConditionalAccessAction, ...] = (
 #: Severity rank of each action, mirroring
 #: ``_EVENT_RANK`` in :mod:`~privacyidea.lib.conditional_access.authentication_event_types`.
 _ACTION_RANK: dict[ConditionalAccessAction, int] = {action: rank for rank, action in enumerate(ACTION_SEVERITY)}
-
-#: The actions that only report something, rather than restricting anything. Used to compose the default error message
-#: for what a stage did (see :func:`~privacyidea.lib.conditional_access.policy.compose_default_error_message`).
-NOTIFYING_ACTIONS = frozenset({ConditionalAccessAction.EMAIL_USER, ConditionalAccessAction.EMAIL_ADMIN})
 
 
 class AccessDecision(str, Enum):

--- a/privacyidea/lib/conditional_access/engine.py
+++ b/privacyidea/lib/conditional_access/engine.py
@@ -19,7 +19,7 @@
 import ipaddress
 import logging
 import re
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
@@ -126,9 +126,10 @@ class ConditionalAccessAction(str, Enum):
 
 
 #: Every action that has something to tell the user, most severe first - the one ordering there is. It ranks the
-#: messages a request produced (:func:`rank_and_deduplicate`) and orders the suggestions the policy editor offers
-#: (:data:`~privacyidea.lib.conditional_access.policy.DEFAULT_ERROR_MESSAGES`), so an action reads the same
-#: wherever it is met. An action that turns nobody away has nothing to say, so it has no entry.
+#: messages of the restrictions a request is refused by (:func:`rank_and_deduplicate`) and orders the suggestions
+#: the policy editor offers (:data:`~privacyidea.lib.conditional_access.policy.DEFAULT_ERROR_MESSAGES`), so an
+#: action reads the same wherever it is met. An action that turns nobody away has nothing to say, so it has no
+#: entry.
 ACTION_SEVERITY: tuple[ConditionalAccessAction, ...] = (
     ConditionalAccessAction.PERMANENT_LOCK_USER,
     ConditionalAccessAction.PERMANENT_BLOCK_IP,
@@ -146,16 +147,6 @@ _ACTION_RANK: dict[ConditionalAccessAction, int] = {action: rank for rank, actio
 #: The actions that only report something, rather than restricting anything. Used to compose the default error message
 #: for what a stage did (see :func:`~privacyidea.lib.conditional_access.policy.compose_default_error_message`).
 NOTIFYING_ACTIONS = frozenset({ConditionalAccessAction.EMAIL_USER, ConditionalAccessAction.EMAIL_ADMIN})
-
-
-def most_severe_action(action_types: Iterable[str]) -> ConditionalAccessAction | None:
-    """
-    The most severe of *action_types* by :data:`ACTION_SEVERITY`, or ``None`` when none of them ranks - an
-    action with nothing to say, or one added to :class:`ConditionalAccessAction` without an entry there. So a
-    caller never has to know which actions are covered.
-    """
-    carried = {str(action_type) for action_type in action_types}
-    return next((action for action in ACTION_SEVERITY if action.value in carried), None)
 
 
 class AccessDecision(str, Enum):
@@ -219,12 +210,6 @@ RESTRICTION_ACTIONS: dict[tuple[ConditionalAccessTarget, bool], ConditionalAcces
     (ConditionalAccessTarget.SOURCE_IP, True): ConditionalAccessAction.PERMANENT_BLOCK_IP,
 }
 
-#: The targets a restricting action writes to, so a stage that sets out to enforce is described from the row that
-#: ends up in force rather than by the action that aimed at it (see :func:`_restrictions_in_force`).
-RESTRICTED_TARGET_BY_ACTION: dict[ConditionalAccessAction, ConditionalAccessTarget] = {
-    action: target for (target, _permanent), action in RESTRICTION_ACTIONS.items()
-}
-
 
 @dataclass(frozen=True)
 class RestrictionStatus:
@@ -277,12 +262,13 @@ def _render_duration(restriction: "RestrictionStatus") -> str:
 @dataclass(frozen=True)
 class StageMessage:
     """
-    One user-facing message a triggered stage produced, already rendered.
+    One user-facing message describing a restriction in force, already rendered (see
+    :func:`restriction_messages`).
 
-    :ivar text: what to show; ``{duration}`` is substituted here, where the duration just written is known.
+    :ivar text: what to show; ``{duration}`` is substituted here, against the time the restriction has left now.
     :ivar action: the action this message is about, which ranks it (:data:`ACTION_SEVERITY`) so a caller showing
-        several leads with the one the user can do least about. Read off the one thing that happened rather than
-        derived a second time.
+        several leads with the one the user can do least about. Named by the row's own target and expiry rather
+        than by the action that happened to write it (see :data:`RESTRICTION_ACTIONS`).
     """
     text: str
     action: ConditionalAccessAction
@@ -331,14 +317,11 @@ def rank_and_deduplicate(messages: list["StageMessage"]) -> list["StageMessage"]
     """
     The messages to show, ordered by :data:`ACTION_SEVERITY` and with each distinct sentence kept once.
 
-    Ranked before de-duplicating, so where an admin configured the same sentence on a notify-only stage and on a
-    locking one, the copy kept is the one labelled with the severer action - and a reader of the result sees the
-    ranking the stage earned. The sort is stable, so messages of equal severity stay in the order they were
-    collected in. A message about an action with no rank sorts last, so an oversight in :data:`ACTION_SEVERITY`
-    costs the order rather than the message.
-
-    Used by both paths that describe a restriction - the post-response evaluation and the pre-check that refuses
-    the requests after it - so the same state cannot be worded differently depending on which one answers.
+    Ranked before de-duplicating, so where the same sentence stands on a user lock and on a source-IP block, the
+    copy kept is the one labelled with the severer action - and a reader of the result sees the ranking the
+    restriction earned. The sort is stable, so messages of equal severity stay in the order they were collected
+    in. A message about an action with no rank sorts last, so an oversight in :data:`ACTION_SEVERITY` costs the
+    order rather than the message.
     """
     seen: set[str] = set()
     unique: list[StageMessage] = []
@@ -361,12 +344,12 @@ def restriction_messages(*restrictions: "RestrictionStatus | None",
     generic: producing no message is what leaves a rejection indistinguishable from any other failure, and what
     the response then says instead is the caller's question to answer.
 
-    Both paths that describe a restriction come through here, so the error message cannot depend on which one
-    answered: the pre-check that refuses a request already restricted, and the evaluation that just restricted
-    it.
+    Called only by the pre-check that refuses a restricted request
+    (:func:`~privacyidea.api.lib.conditional_access._evaluate_rejection`): a restriction is described from the row
+    in force, on the requests it actually refuses, and never by the evaluation that wrote it.
     """
     # Deferred: policy imports the action/target enums from here, so importing it at module level
-    # would close a cycle. Same reason as run_post_eval's import of this module.
+    # would close a cycle.
     from privacyidea.lib.conditional_access.policy import default_error_message
 
     messages = []
@@ -385,33 +368,6 @@ def restriction_messages(*restrictions: "RestrictionStatus | None",
 
 
 @dataclass
-class ConditionalAccessEvaluation:
-    """
-    What one post-response evaluation produced: the user-facing messages to surface on the current response, and the
-    outcomes to record as the request's conditional-access history.
-
-    Each message is a :class:`StageMessage`, already rendered and ordered by :data:`ACTION_SEVERITY` so a caller
-    showing several leads with the one the user can do least about. Wording for a restriction is rendered from the
-    row now in force, not by the stage that wrote it: several policies can restrict the same subject in one request
-    and only one row survives them. Notification error message comes from the stage, the only place it exists.
-
-    The engine returns these instead of writing the history itself. It has no access to the id of the
-    authentication-log row (it runs before the row exists on the pre-auth path, and never sees it on the other), and
-    keeping the write out of here is what leaves the engine free of Flask and of the request lifecycle - see
-    :mod:`privacyidea.lib.conditional_access.outcome_log`.
-
-    Also used as the per-policy result inside :func:`_evaluate_policy`, since "what this produced" is the same shape
-    for one policy and for all of them.
-    """
-    messages: list[StageMessage] = field(default_factory=list)
-    outcomes: list[ConditionalAccessOutcome] = field(default_factory=list)
-    #: Which rows this evaluation left a restriction on, so the caller describes what ended up in force there -
-    #: see :func:`_restrictions_in_force`. A restricting action that never wrote anything is not in here: the
-    #: caller answers a request as a rejection on the strength of this set.
-    enforced_targets: set[ConditionalAccessTarget] = field(default_factory=set)
-
-
-@dataclass
 class AccessDecisionResult:
     """
     The verdict of the pre-auth decision step plus the outcomes it produced.
@@ -420,8 +376,7 @@ class AccessDecisionResult:
     nothing to record.
 
     One type for a single policy's contribution (:func:`_policy_access_decision`) and for the whole evaluation
-    (:func:`evaluate_access_decision`), the way :class:`ConditionalAccessEvaluation` serves one policy and all of
-    them. Hence the default: :attr:`AccessDecision.CONTINUE` reads "this policy has no opinion" for the one and
+    (:func:`evaluate_access_decision`). Hence the default: :attr:`AccessDecision.CONTINUE` reads "this policy has no opinion" for the one and
     "no policy decided" for the other - which is what ``CONTINUE`` already means, so nothing needs a separate
     ``None`` to say it.
     """
@@ -1305,33 +1260,8 @@ def _stage_denies(stage: ConditionalAccessPolicyStage, count: int) -> bool:
     return False
 
 
-def _restrictions_in_force(context: CAContext, targets: set[ConditionalAccessTarget]) -> list[StageMessage]:
-    """
-    The error message of the restrictions in force on the targets an evaluation restricted, one message per row.
-
-    Read back rather than rendered by the stage that aimed at it. Several policies can restrict the same subject
-    in one request and a stage can carry several restricting actions, but only one row survives them all - so the
-    stage that wrote the weaker restriction would otherwise describe a lock that is not in force, and two
-    policies locking the same user would tell the user twice. Reading the row also means ``{duration}`` counts
-    down the expiry that actually stands, whatever the upserts decided to keep, and that a write declined as
-    weakening still leaves the user told about the restriction that stands instead of about nothing.
-
-    Silent by default holds here as everywhere: a row carrying no error message produces none. A target whose
-    write failed outright is not passed here at all - it restricted nothing, so there is no row to describe and no
-    request to refuse (see :func:`_execute_stage_actions`).
-
-    :param targets: the targets this evaluation restricted, so an untouched row is never read
-    """
-    statuses = []
-    if ConditionalAccessTarget.USER in targets and context.user is not None:
-        statuses.append(get_user_lock(context.user))
-    if ConditionalAccessTarget.SOURCE_IP in targets and context.source_ip:
-        statuses.append(get_ip_block(context.source_ip))
-    return restriction_messages(*statuses, use_default_error_message=context.use_default_error_message)
-
-
 def evaluate_conditional_access_policies(context: CAContext, event_type: AuthEventType | None,
-                                         now: datetime | None = None) -> "ConditionalAccessEvaluation":
+                                         now: datetime | None = None) -> list[ConditionalAccessOutcome]:
     """
     Evaluate every enabled conditional-access policy that tracks *event_type* and execute
     the actions of the triggered stage, if any. This runs post-response, *after*
@@ -1350,14 +1280,13 @@ def evaluate_conditional_access_policies(context: CAContext, event_type: AuthEve
     successful login (see :func:`count_user_events`), so a fresh burst
     re-triggers the fire-once actions too.
 
-    The persistent side effects (lock state) are consulted by the *next* inbound
-    request via the pre-check, which reads the error message back off the row they wrote. A stage that only
-    notified leaves no such row, so its message is returned here instead, for the caller to surface on
-    the response this evaluation belongs to. Any error is the caller's to swallow; this
-    function itself only guards individual DB writes (see
+    Nothing is reported to the client from here. The persistent side effects (lock state) are consulted by the
+    *next* inbound request via the pre-check, which reads the error message back off the row they wrote, and that
+    is the only moment a conditional-access message is ever said. The request being evaluated has already been
+    answered. Any error is the caller's to swallow; this function itself only guards individual DB writes (see
     :func:`_upsert_user_lock_state`).
 
-    Alongside the messages, every action that actually ran (or, in dry run, would have run) is returned as a
+    Every action that actually ran (or, in dry run, would have run) is returned as a
     :class:`~privacyidea.models.conditional_access_outcome.ConditionalAccessOutcome` for the caller to record as this
     request's history.
     The engine deliberately does not write them: it never sees the id of the authentication-log row they belong to.
@@ -1370,11 +1299,10 @@ def evaluate_conditional_access_policies(context: CAContext, event_type: AuthEve
     :param event_type: the classified outcome of the request
         (:class:`AuthEventType`)
     :param now: the reference time; defaults to :func:`utc_now`
-    :return: a :class:`ConditionalAccessEvaluation` holding the de-duplicated, order-preserving user-facing
-        messages produced by executed actions, and the outcomes to record (both empty if nothing was triggered)
+    :return: the outcomes to record, one per action that ran (empty if nothing was triggered)
     """
     if not event_type:
-        return ConditionalAccessEvaluation()
+        return []
     now = naive_utc(now) if now is not None else utc_now()
     event_type = str(event_type)
     # Selects only enabled policies tracking the current event type via an indexed equality filter on the normalized
@@ -1388,33 +1316,19 @@ def evaluate_conditional_access_policies(context: CAContext, event_type: AuthEve
                ConditionalAccessPolicyCounterType.counter_type == event_type)
         .order_by(ConditionalAccessPolicy.priority.asc())
     ).all()
-    messages: list[StageMessage] = []
     outcomes: list[ConditionalAccessOutcome] = []
-    enforced: set[ConditionalAccessTarget] = set()
     for policy in policies:
         # Each policy is evaluated inside its own guard, so a broken policy cannot disable every policy ordered
         # behind it. The only unguarded step is the policy query above, which runs before any action, so a retry
         # always starts clean.
         try:
-            evaluation = _evaluate_policy(policy, context, event_type, now)
+            outcomes.extend(_evaluate_policy(policy, context, event_type, now))
         except Exception as ex:
             log.warning(f"Conditional-access policy {policy.name!r} failed to evaluate: {ex!r}; skipping it.")
             continue
-        messages.extend(evaluation.messages)
-        outcomes.extend(evaluation.outcomes)
-        enforced |= evaluation.enforced_targets
-    # Every restriction is described once, from the row left in force, ahead of the notifications the stages
-    # carry: two policies locking the same user leave one lock, and so must say so once.
-    messages = _restrictions_in_force(context, enforced) + messages
-    # Ranked and de-duplicated by rank_and_deduplicate, which is stable, so messages of equal severity stay in
-    # policy-priority order. The outcomes are *not* de-duplicated - each is a distinct thing that happened, and
-    # two policies locking the same user are two facts worth keeping apart.
-    #
-    # enforced_targets is carried out of here, not just used above: it is the only thing that says this request was
-    # restricted at all, and a *silent* restriction produces no message to infer it from. The caller needs it to
-    # answer such a request as the rejection it now is.
-    return ConditionalAccessEvaluation(messages=rank_and_deduplicate(messages), outcomes=outcomes,
-                                       enforced_targets=enforced)
+    # The outcomes are deliberately not de-duplicated - each is a distinct thing that happened, and two policies
+    # locking the same user are two facts worth keeping apart.
+    return outcomes
 
 
 def _stage_in_range(policy: ConditionalAccessPolicy, count: int) -> ConditionalAccessPolicyStage | None:
@@ -1457,7 +1371,7 @@ def _pending_actions(stage: ConditionalAccessPolicyStage, count: int) -> list[Co
 
 
 def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_type: str,
-                     now: datetime) -> "ConditionalAccessEvaluation":
+                     now: datetime) -> list[ConditionalAccessOutcome]:
     """
     Evaluate a single policy: count the user's events over the policy window,
     find the stage that owns the count (see :func:`_stage_in_range`), then execute
@@ -1471,14 +1385,13 @@ def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_
     So one stage can, for example, email once at threshold 8 while keeping the
     user locked for every further failure up to the threshold that supersedes it.
 
-    :return: a :class:`ConditionalAccessEvaluation` with the user-facing messages produced by the executed actions
-        and the outcomes describing what was done (both empty if no stage triggered; in dry run there are outcomes
-        but no messages, since nothing ran)
+    :return: the outcomes describing what was done, empty if no stage triggered. A dry run still produces them,
+        recording what enforcing the policy would have done.
     """
     # Applicability is checked first: a policy whose conditions exclude this request neither counts nor acts, and
     # costs no counting query.
     if not policy_matches_context(policy, context):
-        return ConditionalAccessEvaluation()
+        return []
     # A policy's conditions scope what is counted, not just whether it applies (see _count_scoping); matches_missing
     # and the SQL filter treat a missing value the same way, so the gate and the count never disagree.
     # This matters for a source-IP policy, whose rows span many identities and roles and would otherwise count the
@@ -1492,7 +1405,7 @@ def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_
         if not source_ip:
             # An IP-targeted policy cannot count or act without a source IP.
             log.debug(f"Skipping source-IP policy {policy.name!r}: the request carries no source IP.")
-            return ConditionalAccessEvaluation()
+            return []
         # Counts per the policy's mode: distinct targeted accounts (spraying) or plain per-IP volume; no mode resets
         # on success, since one account's login must not clear a signal aggregated across the whole IP (see
         # _policy_count_ip).
@@ -1503,7 +1416,7 @@ def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_
             # A user-target policy is keyed on the resolved (resolver, uid, realm)
             # user, so an unresolved user (unknown login, local admin) is never
             # locked. Source-IP policies above still run for such requests.
-            return ConditionalAccessEvaluation()
+            return []
         # With the policy's reset_on_success (the default) the lock counts consecutive
         # failures since the user's last completed login: a successful authentication
         # clears the slate, so a legitimate user is not re-locked by stale pre-login
@@ -1529,7 +1442,7 @@ def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_
     triggered_stage = _stage_in_range(policy, count)
     pending_actions = _pending_actions(triggered_stage, count) if triggered_stage else []
     if not pending_actions:
-        return ConditionalAccessEvaluation()
+        return []
 
     if policy.dry_run:
         log.info(f"[dry-run] policy {policy.name!r} would trigger stage {triggered_stage.id} "
@@ -1544,7 +1457,7 @@ def _evaluate_policy(policy: ConditionalAccessPolicy, context: CAContext, event_
                                       expires_at=_action_expiry(action, now))
                     for action in pending_actions
                     if action.action_type != ConditionalAccessAction.DENY]
-        return ConditionalAccessEvaluation(outcomes=outcomes)
+        return outcomes
 
     log.info(f"Policy {policy.name!r} triggered stage {triggered_stage.id} "
              f"(threshold {triggered_stage.failure_threshold}) for {subject_label}: "
@@ -1734,7 +1647,7 @@ def _send_action_email(action_type: "ConditionalAccessAction", stage_action: Con
 
 def _execute_stage_actions(policy: ConditionalAccessPolicy, stage: ConditionalAccessPolicyStage,
                            actions: Sequence[ConditionalAccessStageAction], context: CAContext,
-                           now: datetime, count: int, tags: dict) -> "ConditionalAccessEvaluation":
+                           now: datetime, count: int, tags: dict) -> list[ConditionalAccessOutcome]:
     """
     Execute the given *actions* of a triggered *stage* (the stage's pending
     actions, i.e. those whose per-action threshold condition is met). Each action
@@ -1754,39 +1667,16 @@ def _execute_stage_actions(policy: ConditionalAccessPolicy, stage: ConditionalAc
 
     :param policy: the triggering policy, for the outcomes
     :param count: the count that tripped the stage, for the outcomes
-    :return: a :class:`ConditionalAccessEvaluation` with this stage's message when it only notified, one outcome
-        per action that ran, and the targets those actions restricted (all empty if every action was skipped).
+    :return: one outcome per action that ran (empty if every action was skipped).
     """
     outcomes: list[ConditionalAccessOutcome] = []
-    # Which rows this stage left a restriction on - noted for an action that actually restricted one, not for one
-    # that was configured to. The caller answers a request as a rejection on the strength of this set, so an action
-    # whose write never happened - no valid duration, no source IP, a failed write - must not put a target here
-    # that no later request would be refused by.
-    #
-    # A write *declined as weakening* wrote nothing either, and the row it declined to weaken is still described:
-    # only a stronger restriction in force declines one, and that one was written either by an earlier action here
-    # or by another policy in this same evaluation - which recorded the target. (It cannot have been in force
-    # beforehand: the pre-check would have refused the request, and a rejection is never evaluated.) The union
-    # evaluate_conditional_access_policies collects therefore holds it, and the message comes from whatever stands
-    # on that row - never from the action that aimed at it.
-    enforced: set[ConditionalAccessTarget] = set()
-    # Whether the stage *aimed* at a restriction or a denial, which is a different question from what it achieved
-    # and is why these two are not read off `enforced`. The stage's one error message describes whatever the stage
-    # does; for those two the description belongs elsewhere - the row in force, or the pre-auth decision step - so
-    # the stage says nothing from here either way. A write that was declined or skipped leaves nothing to describe,
-    # not a lock-shaped sentence to append to the failure as though it were a notification.
-    restricts = False
-    decides = False
 
     user = context.user
     source_ip = context.source_ip
 
     def record(action_type: str, expires_at: datetime | None = None) -> None:
-        """Note that *action_type* ran, with the expiry it wrote (if any), and what it restricted."""
+        """Note that *action_type* ran, with the expiry it wrote (if any)."""
         outcomes.append(outcome_for_stage(policy, stage, action_type, count, expires_at=expires_at))
-        target = RESTRICTED_TARGET_BY_ACTION.get(action_type)
-        if target is not None:
-            enforced.add(target)
 
     for action in actions:
         try:
@@ -1794,8 +1684,6 @@ def _execute_stage_actions(policy: ConditionalAccessPolicy, stage: ConditionalAc
         except ValueError:
             log.warning(f"Unknown conditional-access action type {action.action_type!r} on stage {stage.id}; skipping.")
             continue
-        restricts = restricts or action_type in RESTRICTED_TARGET_BY_ACTION
-        decides = decides or action_type is ConditionalAccessAction.DENY
 
         try:
             if action_type == ConditionalAccessAction.LOCK_USER:
@@ -1846,29 +1734,7 @@ def _execute_stage_actions(policy: ConditionalAccessPolicy, stage: ConditionalAc
         except Exception as ex:
             log.warning(f"Conditional-access action {action_type} (id {action.id}) on stage {stage.id} "
                         f"failed: {ex!r}; skipping.")
-    if not outcomes:
-        # Nothing ran, so there is nothing to report - whatever the stage was configured to say.
-        rendered = None
-    elif stage.error_message:
-        # One free-text field for whatever the stage does, so it is rendered wherever that thing is described: a
-        # restriction from the row it left behind (_restrictions_in_force), a denial by the pre-auth decision step
-        # that makes it. Either way, repeating it here would tell the user twice - or tell them about a denial
-        # that did not turn this request away.
-        rendered = None if restricts or decides else render_error_message(stage.error_message)
-    elif context.use_default_error_message:
-        # The default error message is per action rather than per stage, so nothing is described twice and no
-        # such rule is needed: compose_default_error_message carries only what reports something, and leaves any
-        # restriction to its row. That is what lets a stage that locks *and* emails describe both.
-        # Deferred for the same reason as in restriction_messages: policy imports this module.
-        from privacyidea.lib.conditional_access.policy import compose_default_error_message
-        rendered = render_error_message(
-            compose_default_error_message([outcome.action_type for outcome in outcomes]))
-    else:
-        rendered = None
-    # Ranked by the most severe thing the stage actually did, so a caller showing several messages leads with that.
-    action = most_severe_action(outcome.action_type for outcome in outcomes)
-    messages = [StageMessage(rendered, action)] if rendered and action else []
-    return ConditionalAccessEvaluation(messages=messages, outcomes=outcomes, enforced_targets=enforced)
+    return outcomes
 
 
 def _delete_user_lock_state(state: UserLockState) -> None:

--- a/privacyidea/lib/conditional_access/engine.py
+++ b/privacyidea/lib/conditional_access/engine.py
@@ -282,9 +282,7 @@ class StageMessage:
     :ivar text: what to show; ``{duration}`` is substituted here, where the duration just written is known.
     :ivar action: the action this message is about, which ranks it (:data:`ACTION_SEVERITY`) so a caller showing
         several leads with the one the user can do least about. Read off the one thing that happened rather than
-        derived a second time. Whether the message *replaces* the failure's reason or is appended to it is a
-        separate question, answered by whether the request was restricted at all - see
-        :attr:`~privacyidea.lib.conditional_access.request_context.PostEvaluation.restricted`.
+        derived a second time.
     """
     text: str
     action: ConditionalAccessAction

--- a/privacyidea/lib/conditional_access/engine.py
+++ b/privacyidea/lib/conditional_access/engine.py
@@ -214,6 +214,15 @@ RESTRICTED_TARGET_BY_ACTION: dict[ConditionalAccessAction, ConditionalAccessTarg
     action: target for (target, _permanent), action in RESTRICTION_ACTIONS.items()
 }
 
+#: The actions whose effect a request can ever be told about: the ones that restrict a target, plus ``DENY``.
+#: A message is said by the pre-check refusing a restricted request - off the row in force - or by the pre-auth
+#: decision that denies one, so a stage carrying none of these turns no request away and its wording has nowhere
+#: to be shown. What an action *does* is the property here, which is why this is not read off the table of
+#: default wording (:data:`~privacyidea.lib.conditional_access.policy.DEFAULT_ERROR_MESSAGES`): that table
+#: happens to cover exactly these actions today, but it answers "which actions have a default sentence", and an
+#: editing convenience added to or taken from it must not silently change what the editor believes can report.
+REPORTING_ACTIONS: frozenset = frozenset(RESTRICTED_TARGET_BY_ACTION) | {ConditionalAccessAction.DENY}
+
 
 @dataclass(frozen=True)
 class RestrictionStatus:

--- a/privacyidea/lib/conditional_access/policy.py
+++ b/privacyidea/lib/conditional_access/policy.py
@@ -90,13 +90,15 @@ second set of recipients - and no stage may hold two actions of the same mutuall
 * ``PERMANENT_LOCK_USER`` / ``PERMANENT_BLOCK_IP`` / ``DENY`` - no value. These never expire and never read
   one, so a duration on them would only describe an expiry that does not happen.
 
-A stage's optional ``error_message`` is the text an end user sees when a request is turned away by that stage. It is
-opt-in: without one the rejection carries only the generic "Authentication failed.", so privacyIDEA never volunteers
-that an account is locked or an IP blocked unless an admin chose to say so - either by writing this field, or by
-setting the ``show_default_ca_error_message`` policy, which fills in the default wording for the stage's actions
-(:data:`DEFAULT_ERROR_MESSAGES`). ``{duration}`` is substituted with the remaining
-time at rejection, and only where there is one: on a permanent lock, a ``DENY`` or a notify-only stage it
-is left as written, like any other tag that is not substituted. Every other brace expression is left exactly
+A stage's optional ``error_message`` is the text an end user sees on a request that a lock, a block or a ``DENY``
+from that stage turns away - never on the request that trips the stage, which has already been answered on its own
+merits. A stage that only notifies turns no request away and can therefore never show one at all, whatever is
+written on it. It is opt-in: without one the rejection carries only the generic "Authentication failed.", so
+privacyIDEA never volunteers that an account is locked or an IP blocked unless an admin chose to say so - either by
+writing this field, or by setting the ``show_default_ca_error_message`` policy, which fills in the default wording
+for the stage's actions (:data:`DEFAULT_ERROR_MESSAGES`). ``{duration}`` is substituted with the remaining
+time at rejection, and only where there is one: on a permanent lock or a ``DENY`` it is left as written, like any
+other tag that is not substituted. Every other brace expression is left exactly
 as written - braces in prose need no escaping - so only the length is validated here.
 
 ``conditions`` is the *applicability* axis, orthogonal to the counting one: it restricts which requests the policy
@@ -119,7 +121,7 @@ from privacyidea.lib.conditional_access.authentication_event_types import (
     CountMode,
 )
 from privacyidea.lib.conditional_access.conditions import CONDITION_TYPES
-from privacyidea.lib.conditional_access.engine import (ACTION_SEVERITY, ADMIN_RECIPIENT_GROUPS,
+from privacyidea.lib.conditional_access.engine import (ACTION_SEVERITY, ADMIN_RECIPIENT_GROUPS, REPORTING_ACTIONS,
                                                        ConditionalAccessAction, ConditionalAccessTarget,
                                                        parse_lock_duration_seconds)
 from privacyidea.lib.error import ConflictError, ParameterError, ResourceNotFoundError
@@ -442,6 +444,11 @@ def get_default_error_messages() -> list[dict[str, str]]:
     request, off the row in force, and a row records what is in force rather than the notifications a stage also
     sent. So a notify-only stage gets no suggestion, its wording having nowhere to be shown.
 
+    That the two sets coincide today is not something to build on: this answers "which actions have a default
+    sentence", and :data:`~privacyidea.lib.conditional_access.engine.REPORTING_ACTIONS` - served per target by
+    :func:`get_target_constraints` - answers which actions can report at all. Adding or dropping a suggestion
+    here must not change what anything believes about the second.
+
     The same table backs the runtime fallback under ``show_default_ca_error_message``
     (:func:`default_error_message`), so an admin who edits a suggestion is editing the thing they would otherwise
     have got by default.
@@ -457,15 +464,21 @@ def get_default_error_messages() -> list[dict[str, str]]:
 def get_target_constraints() -> dict[str, dict[str, list]]:
     """
     The per-target policy constraints, as ``{target_value: {"actions": [...], "count_modes": [...],
-    "repeatable_actions": [...], "exclusive_action_groups": [[...], ...]}}``: for each target the stage actions it
-    allows (``_ACTIONS_BY_TARGET``), the count modes it supports (``_COUNT_MODES_BY_TARGET``), which of its
-    actions may appear more than once in one stage (:data:`REPEATABLE_ACTIONS`) and which of its actions contradict
-    each other within one stage (``_EXCLUSIVE_ACTION_GROUPS``), all sorted.
+    "repeatable_actions": [...], "exclusive_action_groups": [[...], ...], "reporting_actions": [...]}}``: for each
+    target the stage actions it allows (``_ACTIONS_BY_TARGET``), the count modes it supports
+    (``_COUNT_MODES_BY_TARGET``), which of its actions may appear more than once in one stage
+    (:data:`REPEATABLE_ACTIONS`), which of its actions contradict each other within one stage
+    (``_EXCLUSIVE_ACTION_GROUPS``) and which of them a request can ever be told about
+    (:data:`~privacyidea.lib.conditional_access.engine.REPORTING_ACTIONS`), all sorted.
 
-    The last two are served rather than left for the client to hard-code, for the same reason the condition-type
-    registry is: a rule the editor enforces should come from the one place that defines it. They are filtered to
-    the actions the target allows, so a group that cannot arise for this target (the lock pair under
-    ``source_ip``, the block pair under ``user``) is not offered as a rule the editor could never apply.
+    Everything but the first two is served rather than left for the client to hard-code, for the same reason the
+    condition-type registry is: a rule the editor enforces should come from the one place that defines it. In
+    particular the editor warns that a stage's wording can never be shown, which is a question about what its
+    actions *do* - not about which actions happen to have default wording to suggest, a table it would otherwise
+    have to infer this from (see :func:`get_default_error_messages`).
+
+    All three are filtered to the actions the target allows, so a rule that cannot arise for this target (the lock
+    pair under ``source_ip``, the block pair under ``user``) is not offered as one the editor could never apply.
     """
     constraints = {}
     for target in ConditionalAccessTarget:
@@ -476,6 +489,7 @@ def get_target_constraints() -> dict[str, dict[str, list]]:
             "repeatable_actions": sorted(action.value for action in REPEATABLE_ACTIONS & actions),
             "exclusive_action_groups": [sorted(action.value for action in group)
                                         for group in _EXCLUSIVE_ACTION_GROUPS if len(group & actions) > 1],
+            "reporting_actions": sorted(action.value for action in REPORTING_ACTIONS & actions),
         }
     return constraints
 

--- a/privacyidea/lib/conditional_access/policy.py
+++ b/privacyidea/lib/conditional_access/policy.py
@@ -107,7 +107,6 @@ unknown realm or a misspelled role would otherwise silently never match.
 """
 
 import logging
-from collections.abc import Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 
@@ -122,7 +121,7 @@ from privacyidea.lib.conditional_access.authentication_event_types import (
 from privacyidea.lib.conditional_access.conditions import CONDITION_TYPES
 from privacyidea.lib.conditional_access.engine import (ACTION_SEVERITY, ADMIN_RECIPIENT_GROUPS,
                                                        ConditionalAccessAction, ConditionalAccessTarget,
-                                                       NOTIFYING_ACTIONS, parse_lock_duration_seconds)
+                                                       parse_lock_duration_seconds)
 from privacyidea.lib.error import ConflictError, ParameterError, ResourceNotFoundError
 from privacyidea.lib.log import log_with
 from privacyidea.models import db
@@ -410,10 +409,6 @@ DEFAULT_ERROR_MESSAGES: dict[str, object] = {
         lazy_gettext("Access from your IP address is temporarily blocked. Please try again in about {duration}."),
     ConditionalAccessAction.DENY:
         lazy_gettext("Access has been denied."),
-    ConditionalAccessAction.EMAIL_USER:
-        lazy_gettext("A notification email has been sent to your email address."),
-    ConditionalAccessAction.EMAIL_ADMIN:
-        lazy_gettext("Your administrator has been notified by email."),
 }
 
 
@@ -428,22 +423,6 @@ def default_error_message(action: str) -> str | None:
     return str(message) if message else None
 
 
-def compose_default_error_message(action_types: Sequence[str]) -> str | None:
-    """
-    The default error message for a stage that only reported something, given the *action_types* that ran:
-    one sentence per action, most severe first.
-
-    Notifications only. A restriction is described from the row it left behind (see
-    :func:`~privacyidea.lib.conditional_access.engine._restrictions_in_force`), so composing one here would tell
-    the user twice - and with a ``{duration}`` this side cannot substitute. ``None`` when none of the actions has
-    an error message, which keeps such a stage silent.
-    """
-    carried = set(action_types)
-    sentences = [default_error_message(action) for action in ACTION_SEVERITY
-                 if action in NOTIFYING_ACTIONS and action in carried]
-    return " ".join(sentences) if sentences else None
-
-
 def get_default_error_messages() -> list[dict[str, str]]:
     """
     The suggested stage error messages, ordered by :data:`~privacyidea.lib.conditional_access.engine.
@@ -451,13 +430,16 @@ def get_default_error_messages() -> list[dict[str, str]]:
     request locale.
 
     An authoring aid for the policy editor, which composes one suggestion for a stage carrying several actions:
-    one sentence per action, kept in this order. That is the concatenation the runtime performs too - a request
-    reports one sentence per thing that happened to it, ranked the same way - so the wording the editor offers is
-    the wording a user would be shown, and the client needs no rule of its own beyond the order it is given.
+    one sentence per action, kept in this order.
 
-    The same table backs the runtime fallback under ``show_default_ca_error_message`` (:func:`default_error_message`,
-    :func:`compose_default_error_message`), so an admin who edits a suggestion is editing the thing they would
-    otherwise have got by default.
+    Only actions that *describe a standing state* are in here - a restriction in force, or a denial - because
+    those are the only ones anything can report: a message is said by the pre-check refusing a restricted
+    request, off the row in force, and a row records what is in force rather than the notifications a stage also
+    sent. So a notify-only stage gets no suggestion, its wording having nowhere to be shown.
+
+    The same table backs the runtime fallback under ``show_default_ca_error_message``
+    (:func:`default_error_message`), so an admin who edits a suggestion is editing the thing they would otherwise
+    have got by default.
 
     Deliberately not scoped by target: the binding is action to message, and a client picks the entry
     whose action the stage actually carries, so error message for an action a target cannot hold simply never

--- a/privacyidea/lib/conditional_access/request_context.py
+++ b/privacyidea/lib/conditional_access/request_context.py
@@ -403,14 +403,14 @@ class ConditionalAccessContext:
                             user_role=event.user_role, endpoint=event.endpoint,
                             use_default_error_message=self.use_default_error_message)
         try:
-            evaluation = evaluate_conditional_access_policies(context, event.event_type)
+            outcomes = evaluate_conditional_access_policies(context, event.event_type)
         except Exception as ex:
             log.warning(f"Conditional-access policy evaluation failed: {ex!r}")
             return
         # Marked evaluated only now: a failure above leaves the classification unevaluated, so the teardown call is
         # the retry rather than a skipped second attempt.
         self._evaluated_as = event.event_type
-        record_outcomes(evaluation.outcomes, event.row_id)
+        record_outcomes(outcomes, event.row_id)
 
     def finalize(self) -> None:
         """

--- a/privacyidea/lib/conditional_access/request_context.py
+++ b/privacyidea/lib/conditional_access/request_context.py
@@ -28,7 +28,7 @@ session it writes on.
 import logging
 import secrets
 from dataclasses import dataclass, field
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 from flask import has_request_context
 
@@ -42,11 +42,6 @@ from privacyidea.lib.conditional_access.outcome_log import record_outcomes
 from privacyidea.lib.framework import get_request_local_store
 from privacyidea.lib.user import User
 from privacyidea.models import ConditionalAccessOutcome
-
-if TYPE_CHECKING:
-    # Only for the annotation below: importing the engine at module level would risk an import-order cycle
-    # during app startup, which is why run_post_eval imports it inside the function instead.
-    from privacyidea.lib.conditional_access.engine import StageMessage
 
 log = logging.getLogger(__name__)
 
@@ -78,45 +73,6 @@ class AuthPrincipal:
     user: User = field(default_factory=User)
     username: str | None = None
     internal_admin: bool = False
-
-
-@dataclass(frozen=True)
-class PostEvaluation:
-    """
-    What the post-response evaluation left for the current response to say.
-
-    :ivar messages: the user-facing wording the triggered stages carry, most severe first. Empty when nothing was
-        triggered *and* when what was triggered carries no wording - silent by default holds here as everywhere.
-    :ivar restricted: whether this request left a restriction in force. Independent of :attr:`messages`, and that
-        is the whole reason it exists: a silent restriction produces no wording, yet the request still has to be
-        answered as the rejection it now is, exactly like every request the pre-check refuses after it.
-    """
-    messages: list["StageMessage"] = field(default_factory=list)
-    restricted: bool = False
-
-
-@dataclass(frozen=True)
-class RejectionShape:
-    """
-    How one endpoint answers a request conditional access refuses.
-
-    Passed by whichever gate guards the endpoint, because looking like an ordinary failed authentication is the
-    whole requirement and what one looks like differs per endpoint.
-
-    :ivar value: what ``result.value`` says. ``False`` everywhere except ``/validate/triggerchallenge``, where the
-        value is the number of challenges triggered and a boolean would change the type of a field its callers may
-        be reading as a number.
-    :ivar rid: the response id this endpoint renders with. ``prepare_result`` adds ``result.authentication`` only
-        for ``rid > 1``, so a rejection at ``/ttype/push`` - which renders with ``1`` - must not grow a field the
-        endpoint never carries.
-    :ivar carries_detail: whether an ordinary failed authentication here carries a ``detail`` at all. On
-        ``/validate/*`` every failure does, so a silent rejection carries the generic failure to have one too; at
-        ``/ttype/push`` none does, so a silent rejection carries none either - the generic message would be exactly
-        the tell that including it on ``/validate`` avoids.
-    """
-    value: Any = False
-    rid: int = 2
-    carries_detail: bool = True
 
 
 class ConditionalAccessContext:
@@ -152,8 +108,8 @@ class ConditionalAccessContext:
         Claim *message* as conditional access's own wording for this response, so ``hide_specific_error_message``
         and ``no_detail_on_fail`` show it instead of their own generic text (see :func:`claimed_ca_message`).
 
-        Only the gates claim: their responses are built inside the decorator stack, where those two actions can
-        still reach them. The ``after_request`` hook needs no claim, since it runs after both.
+        Only the gates claim, they being the only place a conditional-access message is ever said: their responses
+        are built inside the decorator stack, where those two actions can still reach them.
         """
         self.own_message = message
 
@@ -376,11 +332,14 @@ class ConditionalAccessContext:
         for name, value in fields.items():
             setattr(event, name, value)
 
-    def run_post_eval(self) -> PostEvaluation:
+    def run_post_eval(self) -> None:
         """
-        Let the conditional-access engine react to what this request logged, and report back what the current
-        response has to say about it: the wording the triggered stages carry, and whether this request left a
-        restriction in force (see :class:`PostEvaluation`).
+        Let the conditional-access engine react to what this request logged.
+
+        Nothing is reported back, because nothing is reported to the client: a restriction this request writes
+        applies from the *next* request, which the pre-check refuses (see
+        :func:`~privacyidea.api.lib.conditional_access.conditional_access_precheck`). The response in flight keeps
+        whatever it had coming.
 
         Nothing has to be scheduled: staging an authentication event *is* the signal, and everything the engine needs
         is already recorded - the classification comes from the latest staged event, the principal and source IP from
@@ -392,11 +351,11 @@ class ConditionalAccessContext:
         (``push_wait``: the challenge trigger, then the terminal outcome) the earlier ones are still counted - counts
         are taken over the stored rows - they just do not each provoke their own evaluation.
 
-        Runs **once per distinct classification**, not merely once: an endpoint that needs the messages in its own
-        response can run it early (``/auth`` does) and request teardown will not repeat the same evaluation. Should a
-        post-policy correct the outcome in between, however, teardown *does* evaluate again - otherwise the engine
-        would be left having judged a classification that no longer holds. A classification counts as evaluated only
-        once the engine returned, so an early call that failed is retried at teardown rather than swallowed.
+        Runs **once per distinct classification**, not merely once: a caller that has already evaluated will not
+        make request teardown repeat the same evaluation. Should a post-policy correct the outcome in between,
+        however, teardown *does* evaluate again - otherwise the engine would be left having judged a classification
+        that no longer holds. A classification counts as evaluated only once the engine returned, so a call that
+        failed is retried at teardown rather than swallowed.
 
         The evaluation counts events over the authentication log, so it must run **after** :meth:`flush` - otherwise
         the count would miss the very event that triggered it. That ordering also keeps the counts from reading a stale
@@ -429,11 +388,11 @@ class ConditionalAccessContext:
         """
         event = self.latest
         if event is None or event.event_type == self._evaluated_as:
-            return PostEvaluation()
+            return
         if event.event_type in CA_ENFORCEMENT_EVENT_TYPES:
             log.debug(f"Not evaluating conditional-access policies for {event.event_type}: this request was rejected "
                       f"by conditional access itself.")
-            return PostEvaluation()
+            return
         # Deferred import: the engine pulls in the ORM models, so importing it at module level would risk an
         # import-order cycle during app startup.
         from privacyidea.lib.conditional_access.engine import evaluate_conditional_access_policies
@@ -447,12 +406,11 @@ class ConditionalAccessContext:
             evaluation = evaluate_conditional_access_policies(context, event.event_type)
         except Exception as ex:
             log.warning(f"Conditional-access policy evaluation failed: {ex!r}")
-            return PostEvaluation()
+            return
         # Marked evaluated only now: a failure above leaves the classification unevaluated, so the teardown call is
         # the retry rather than a skipped second attempt.
         self._evaluated_as = event.event_type
         record_outcomes(evaluation.outcomes, event.row_id)
-        return PostEvaluation(messages=evaluation.messages, restricted=bool(evaluation.enforced_targets))
 
     def finalize(self) -> None:
         """

--- a/privacyidea/lib/conditional_access/request_context.py
+++ b/privacyidea/lib/conditional_access/request_context.py
@@ -351,11 +351,10 @@ class ConditionalAccessContext:
         (``push_wait``: the challenge trigger, then the terminal outcome) the earlier ones are still counted - counts
         are taken over the stored rows - they just do not each provoke their own evaluation.
 
-        Runs **once per distinct classification**, not merely once: a caller that has already evaluated will not
-        make request teardown repeat the same evaluation. Should a post-policy correct the outcome in between,
-        however, teardown *does* evaluate again - otherwise the engine would be left having judged a classification
-        that no longer holds. A classification counts as evaluated only once the engine returned, so a call that
-        failed is retried at teardown rather than swallowed.
+        Idempotent **per classification**, not merely once: once the engine has returned for one, a repeated call
+        is skipped, while a post-policy that corrects the outcome in between is evaluated again - the engine would
+        otherwise be left having judged a classification that no longer holds. Request teardown is the only caller,
+        so nothing reaches that guard today; it is what keeps the evaluation safe to drive from anywhere else.
 
         The evaluation counts events over the authentication log, so it must run **after** :meth:`flush` - otherwise
         the count would miss the very event that triggered it. That ordering also keeps the counts from reading a stale
@@ -406,8 +405,8 @@ class ConditionalAccessContext:
         except Exception as ex:
             log.warning(f"Conditional-access policy evaluation failed: {ex!r}")
             return
-        # Marked evaluated only now: a failure above leaves the classification unevaluated, so the teardown call is
-        # the retry rather than a skipped second attempt.
+        # Marked evaluated only now, so a failure above leaves the classification unevaluated: a later call for it
+        # evaluates rather than skipping a second attempt.
         self._evaluated_as = event.event_type
         record_outcomes(outcomes, event.row_id)
 

--- a/privacyidea/lib/conditional_access/request_context.py
+++ b/privacyidea/lib/conditional_access/request_context.py
@@ -99,8 +99,8 @@ class ConditionalAccessContext:
         # The wording conditional access claims for this response, so the masking actions show it (see claim_message).
         self.own_message: str | None = None
         # Whether a rejection with no error message of its own falls back to the default wording for what it did
-        # (see CAContext). Resolved once by the gate, where policies can be matched, and read again at
-        # post-response evaluation so both halves of one request answer the same way.
+        # (the show_default_ca_error_message policy). Resolved once by the gate, where policies can be matched, and
+        # read back there: a restriction is only ever described on the requests it refuses.
         self.use_default_error_message = False
 
     def claim_message(self, message: str) -> None:
@@ -400,8 +400,7 @@ class ConditionalAccessContext:
         # not "unknown" to a condition - it reads as *absent*, which an IN condition treats as no match and a NOT_IN
         # as a match. Omitting the endpoint silently inverted every ENDPOINT condition on this path.
         context = CAContext(user=self.principal.user or None, source_ip=self.source_ip,
-                            user_role=event.user_role, endpoint=event.endpoint,
-                            use_default_error_message=self.use_default_error_message)
+                            user_role=event.user_role, endpoint=event.endpoint)
         try:
             outcomes = evaluate_conditional_access_policies(context, event.event_type)
         except Exception as ex:

--- a/privacyidea/lib/conditional_access/request_context.py
+++ b/privacyidea/lib/conditional_access/request_context.py
@@ -100,10 +100,8 @@ class RejectionShape:
     """
     How one endpoint answers a request conditional access refuses.
 
-    Recorded by whichever gate guards the endpoint, so a request restricted by *itself* is answered exactly as the
-    gate answers every request after it - the whole response, not just the wording, and whatever the view was about
-    to return. Looking like an ordinary failed authentication is the whole requirement, and what one looks like
-    differs per endpoint.
+    Passed by whichever gate guards the endpoint, because looking like an ordinary failed authentication is the
+    whole requirement and what one looks like differs per endpoint.
 
     :ivar value: what ``result.value`` says. ``False`` everywhere except ``/validate/triggerchallenge``, where the
         value is the number of challenges triggered and a boolean would change the type of a field its callers may
@@ -115,18 +113,10 @@ class RejectionShape:
         ``/validate/*`` every failure does, so a silent rejection carries the generic failure to have one too; at
         ``/ttype/push`` none does, so a silent rejection carries none either - the generic message would be exactly
         the tell that including it on ``/validate`` avoids.
-    :ivar as_error: ``/auth``, the one entry point whose failed authentication is an error response rather than a
-        ``200`` carrying ``result.value`` false.
     """
     value: Any = False
     rid: int = 2
     carries_detail: bool = True
-    as_error: bool = False
-
-    @property
-    def reports_authentication(self) -> bool:
-        """Whether this endpoint's responses carry ``result.authentication`` at all (see :attr:`rid`)."""
-        return self.rid > 1
 
 
 class ConditionalAccessContext:
@@ -156,10 +146,6 @@ class ConditionalAccessContext:
         # (see CAContext). Resolved once by the gate, where policies can be matched, and read again at
         # post-response evaluation so both halves of one request answer the same way.
         self.use_default_error_message = False
-        # How this endpoint answers a refused request, recorded by whichever gate guards it so the response hook can
-        # answer a *restricted* request the same way - even when the view raised and the body to replace is an error.
-        # The default is the /validate shape, which is also the safest thing to assume for a request no gate ran on.
-        self.rejection_shape = RejectionShape()
 
     def claim_message(self, message: str) -> None:
         """

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -1022,7 +1022,8 @@ class PushTokenClass(TokenClass):
             # A silent rejection carries no detail, because an ordinary failed answer here carries none either -
             # the opposite of /validate/*, where every failure has one and a silent rejection needs the generic
             # message to have one too. Configured wording is surfaced on both. PUSH_ANSWER_REJECTION states that
-            # shape once, so the response hook answers a restriction *this* answer wrote in the same shape.
+            # shape once, for the pre-check below - the only thing that reports a restriction, and only on the
+            # answers it refuses. A restriction *this* answer trips speaks from the next one.
             from privacyidea.api.lib.conditional_access import (PUSH_ANSWER_REJECTION,
                                                                 conditional_access_rejection)
             rejection = conditional_access_rejection(cls._resolve_token_owner(serial), PUSH_ANSWER_REJECTION)

--- a/privacyidea/lib/tokens/pushtoken.py
+++ b/privacyidea/lib/tokens/pushtoken.py
@@ -1019,11 +1019,11 @@ class PushTokenClass(TokenClass):
             # answer) - never on enrollment or firebase token updates. The smartphone sends only the serial, so
             # the owner is resolved from it, and the answer is refused before the signature is verified.
             #
-            # A silent rejection carries no detail, because an ordinary failed answer here carries none either -
-            # the opposite of /validate/*, where every failure has one and a silent rejection needs the generic
-            # message to have one too. Configured wording is surfaced on both. PUSH_ANSWER_REJECTION states that
-            # shape once, for the pre-check below - the only thing that reports a restriction, and only on the
-            # answers it refuses. A restriction *this* answer trips speaks from the next one.
+            # PUSH_ANSWER_REJECTION describes how this endpoint answers a refusal - an ordinary failed answer here
+            # carries no detail at all, unlike /validate/* - and the pre-check resolves the wording against it, so
+            # rejection.message is already what to say and nothing here decides it again. The pre-check is the only
+            # thing that reports a restriction, and only on the answers it refuses: a restriction *this* answer
+            # trips speaks from the next one.
             from privacyidea.api.lib.conditional_access import (PUSH_ANSWER_REJECTION,
                                                                 conditional_access_rejection)
             rejection = conditional_access_rejection(cls._resolve_token_owner(serial), PUSH_ANSWER_REJECTION)

--- a/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.html
+++ b/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.html
@@ -136,6 +136,9 @@
             (input)="onErrorMessageInput($any($event.target).value)"></textarea>
           <mat-hint>
             <span i18n>{{ durationTag }} is replaced with the remaining time for temporary lock/block actions.</span>
+            @if (messageUnreachable()) {
+              <span class="ca-stage-message-warning">{{ messageUnreachableHint }}</span>
+            }
             @if (unknownTags().length) {
               <span
                 class="ca-stage-message-warning"

--- a/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.spec.ts
@@ -19,6 +19,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AuthService } from "@services/auth/auth.service";
 import {
+  ConditionalAccessActionType,
   ConditionalAccessPolicyService,
   ConditionalAccessPolicyStage,
   ConditionalAccessStageAction,
@@ -161,13 +162,15 @@ describe("ConditionalAccessStageItemComponent", () => {
 
   describe("error message", () => {
     // Served most severe first, the way /conditionalaccess/defaulterrormessages orders them: the composition
-    // is "join the ones this stage carries", so the order is the only rule under test here.
+    // is "join the ones this stage carries", so the order is the only rule under test here. The table holds only
+    // actions that describe a standing state - a restriction in force or a denial - because those are the only
+    // ones a request can be told about; EMAIL_* are deliberately absent.
     const SUGGESTIONS: DefaultErrorMessage[] = [
       { action_type: "PERMANENT_LOCK_USER", message: "Your account has been locked." },
+      { action_type: "PERMANENT_BLOCK_IP", message: "Your address has been blocked." },
       { action_type: "LOCK_USER", message: "Locked. Try again in about {duration}." },
-      { action_type: "DENY", message: "Access has been denied." },
-      { action_type: "EMAIL_USER", message: "An email has been sent to you." },
-      { action_type: "EMAIL_ADMIN", message: "Your administrator has been notified." }
+      { action_type: "BLOCK_IP", message: "Blocked. Try again in about {duration}." },
+      { action_type: "DENY", message: "Access has been denied." }
     ];
 
     let policyService: MockConditionalAccessPolicyService;
@@ -259,9 +262,9 @@ describe("ConditionalAccessStageItemComponent", () => {
       expect(component.suggestedErrorMessage()).toBe("Your account has been locked.");
     });
 
-    it("should join every other action the stage carries, in the order served", () => {
-      // No rule beyond the order: a stage that denies, locks and notifies is described by one sentence per
-      // action, which is what the engine reports for it too.
+    it("should join every reporting action the stage carries, in the order served", () => {
+      // No rule beyond the order: one sentence per action that describes a standing state. The notification is
+      // not one of them - no row records that an email went out, so nothing could ever report it.
       withStage({
         error_message: null,
         actions: [
@@ -270,27 +273,28 @@ describe("ConditionalAccessStageItemComponent", () => {
           { action_type: "PERMANENT_LOCK_USER", action_value: null }
         ]
       });
-      expect(component.suggestedErrorMessage()).toBe(
-        "Your account has been locked. Access has been denied. An email has been sent to you."
-      );
+      expect(component.suggestedErrorMessage()).toBe("Your account has been locked. Access has been denied.");
     });
 
-    it("should suggest nothing for an action that has no wording", () => {
+    it("should suggest nothing for a stage with no actions", () => {
       // A stage carries no actions until the admin picks one, so there is nothing to suggest and nothing to
-      // reset to. (Every action the server offers now has wording of its own.)
+      // reset to.
       withStage({ error_message: null, actions: [] });
       expect(component.suggestedErrorMessage()).toBeNull();
       expect(component.canResetErrorMessage()).toBe(false);
     });
 
-    it("should suggest the notification wording for a notify-only stage", () => {
+    it("should suggest nothing for a notify-only stage", () => {
+      // Such a stage refuses nothing, so no request is ever turned away while it applies and there is no
+      // moment at which wording for it could be shown.
       withStage({ error_message: null, actions: [{ action_type: "EMAIL_ADMIN", action_value: null }] });
-      expect(component.suggestedErrorMessage()).toBe("Your administrator has been notified.");
+      expect(component.suggestedErrorMessage()).toBeNull();
+      expect(component.canResetErrorMessage()).toBe(false);
     });
 
-    it("should lead with the restriction and append the notification when the stage does both", () => {
-      // Being emailed about is a separate fact from being locked out, so the user is told both - and in
-      // severity order rather than the order the actions were added, matching what the engine reports.
+    it("should describe only the restriction when the stage also notifies", () => {
+      // The lock is what later requests are refused by, and its row is what carries the wording; the email is
+      // a one-off event that no row remembers.
       withStage({
         error_message: null,
         actions: [
@@ -298,22 +302,7 @@ describe("ConditionalAccessStageItemComponent", () => {
           { action_type: "LOCK_USER", action_value: null }
         ]
       });
-      expect(component.suggestedErrorMessage()).toBe(
-        "Locked. Try again in about {duration}. Your administrator has been notified."
-      );
-    });
-
-    it("should append every notification the stage triggers", () => {
-      withStage({
-        error_message: null,
-        actions: [
-          { action_type: "EMAIL_USER", action_value: null },
-          { action_type: "EMAIL_ADMIN", action_value: null }
-        ]
-      });
-      expect(component.suggestedErrorMessage()).toBe(
-        "An email has been sent to you. Your administrator has been notified."
-      );
+      expect(component.suggestedErrorMessage()).toBe("Locked. Try again in about {duration}.");
     });
 
     it("should clear the message when switched off", () => {
@@ -449,6 +438,58 @@ describe("ConditionalAccessStageItemComponent", () => {
         actions: [{ action_type: "PERMANENT_LOCK_USER", action_value: null }]
       });
       expect(component.durationTagUnusable()).toBe(false);
+    });
+
+    it("should flag a message on a stage that reports nothing", () => {
+      // A notify-only stage refuses no request, so there is no moment at which this wording could be shown.
+      withStage({
+        error_message: "Your administrator has been notified.",
+        actions: [{ action_type: "EMAIL_ADMIN", action_value: null }]
+      });
+      expect(component.messageUnreachable()).toBe(true);
+    });
+
+    it("should flag a message on a stage with no actions at all", () => {
+      withStage({ error_message: "Locked.", actions: [] });
+      expect(component.messageUnreachable()).toBe(true);
+    });
+
+    it("should not flag a message on a stage that restricts or denies", () => {
+      // One reporting action is enough, whatever else the stage does alongside it.
+      const reporting: ConditionalAccessActionType[] = [
+        "LOCK_USER",
+        "PERMANENT_LOCK_USER",
+        "BLOCK_IP",
+        "PERMANENT_BLOCK_IP",
+        "DENY"
+      ];
+      for (const action_type of reporting) {
+        withStage({ error_message: "Locked.", actions: [{ action_type, action_value: null }] });
+        expect(component.messageUnreachable()).toBe(false);
+      }
+      withStage({
+        error_message: "Locked.",
+        actions: [
+          { action_type: "EMAIL_ADMIN", action_value: null },
+          { action_type: "LOCK_USER", action_value: null }
+        ]
+      });
+      expect(component.messageUnreachable()).toBe(false);
+    });
+
+    it("should not flag a stage that carries no message to show", () => {
+      // Nothing to warn about until there is wording: an empty or blank field is the silent default.
+      withStage({ error_message: null, actions: [{ action_type: "EMAIL_ADMIN", action_value: null }] });
+      expect(component.messageUnreachable()).toBe(false);
+      withStage({ error_message: "   ", actions: [{ action_type: "EMAIL_ADMIN", action_value: null }] });
+      expect(component.messageUnreachable()).toBe(false);
+    });
+
+    it("should stay silent until the suggestion table has loaded", () => {
+      // The reporting actions are read off that table, so an empty one must not flag every stage on the page.
+      policyService.defaultErrorMessages.set([]);
+      withStage({ error_message: "Locked.", actions: [{ action_type: "EMAIL_ADMIN", action_value: null }] });
+      expect(component.messageUnreachable()).toBe(false);
     });
 
     it("should report the message length for the counter", () => {

--- a/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.spec.ts
+++ b/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.spec.ts
@@ -23,6 +23,7 @@ import {
   ConditionalAccessPolicyService,
   ConditionalAccessPolicyStage,
   ConditionalAccessStageAction,
+  ConditionalAccessTarget,
   DefaultErrorMessage
 } from "@services/conditional-access/conditional-access-policy.service";
 import { SmtpService } from "@services/smtp/smtp.service";
@@ -173,14 +174,24 @@ describe("ConditionalAccessStageItemComponent", () => {
       { action_type: "DENY", message: "Access has been denied." }
     ];
 
+    // What /conditionalaccess/targets serves as each target's reporting actions: those that restrict it, plus
+    // DENY. Filtered per target there, so a user policy never offers the block pair and vice versa.
+    const REPORTING_BY_TARGET = {
+      user: ["DENY", "LOCK_USER", "PERMANENT_LOCK_USER"],
+      source_ip: ["BLOCK_IP", "DENY", "PERMANENT_BLOCK_IP"]
+    } as Record<ConditionalAccessTarget, ConditionalAccessActionType[]>;
+
     let policyService: MockConditionalAccessPolicyService;
 
     const withStage = (override: Partial<ConditionalAccessPolicyStage>) =>
       fixture.componentRef.setInput("stage", { ...stage, ...override });
 
+    const withTarget = (target: ConditionalAccessTarget) => fixture.componentRef.setInput("target", target);
+
     beforeEach(() => {
       policyService = TestBed.inject(ConditionalAccessPolicyService) as unknown as MockConditionalAccessPolicyService;
       policyService.defaultErrorMessages.set(SUGGESTIONS);
+      policyService.reportingActionsByTarget.set(REPORTING_BY_TARGET);
     });
 
     it("should emit the error_message exactly as typed", () => {
@@ -455,18 +466,22 @@ describe("ConditionalAccessStageItemComponent", () => {
     });
 
     it("should not flag a message on a stage that restricts or denies", () => {
-      // One reporting action is enough, whatever else the stage does alongside it.
-      const reporting: ConditionalAccessActionType[] = [
-        "LOCK_USER",
-        "PERMANENT_LOCK_USER",
-        "BLOCK_IP",
-        "PERMANENT_BLOCK_IP",
-        "DENY"
+      // One reporting action is enough, whatever else the stage does alongside it. Asked per target, since that
+      // is how the rule is served: the lock pair belongs to a user policy and the block pair to a source_ip one.
+      const reporting: [ConditionalAccessTarget, ConditionalAccessActionType][] = [
+        ["user", "LOCK_USER"],
+        ["user", "PERMANENT_LOCK_USER"],
+        ["user", "DENY"],
+        ["source_ip", "BLOCK_IP"],
+        ["source_ip", "PERMANENT_BLOCK_IP"],
+        ["source_ip", "DENY"]
       ];
-      for (const action_type of reporting) {
+      for (const [target, action_type] of reporting) {
+        withTarget(target);
         withStage({ error_message: "Locked.", actions: [{ action_type, action_value: null }] });
         expect(component.messageUnreachable()).toBe(false);
       }
+      withTarget("user");
       withStage({
         error_message: "Locked.",
         actions: [
@@ -485,10 +500,29 @@ describe("ConditionalAccessStageItemComponent", () => {
       expect(component.messageUnreachable()).toBe(false);
     });
 
-    it("should stay silent until the suggestion table has loaded", () => {
-      // The reporting actions are read off that table, so an empty one must not flag every stage on the page.
-      policyService.defaultErrorMessages.set([]);
+    it("should stay silent until the target's constraints have loaded", () => {
+      // An empty set is "not known yet", not "nothing can report", so it must not flag every stage on the page.
+      policyService.reportingActionsByTarget.set({} as Record<ConditionalAccessTarget, ConditionalAccessActionType[]>);
       withStage({ error_message: "Locked.", actions: [{ action_type: "EMAIL_ADMIN", action_value: null }] });
+      expect(component.messageUnreachable()).toBe(false);
+    });
+
+    it("should judge reachability by what the actions do, not by which have suggested wording", () => {
+      // The two are separate questions, and the suggestion table is only the answer to the second: wording for a
+      // notify action would be an authoring convenience, and must not make the editor believe it can be shown.
+      policyService.defaultErrorMessages.set([
+        ...SUGGESTIONS,
+        { action_type: "EMAIL_ADMIN", message: "Your administrator has been notified." }
+      ]);
+      withStage({
+        error_message: "Your administrator has been notified.",
+        actions: [{ action_type: "EMAIL_ADMIN", action_value: null }]
+      });
+      expect(component.messageUnreachable()).toBe(true);
+
+      // And the converse: an action that reports but carries no suggestion is still reachable.
+      policyService.defaultErrorMessages.set([]);
+      withStage({ error_message: "Locked.", actions: [{ action_type: "LOCK_USER", action_value: null }] });
       expect(component.messageUnreachable()).toBe(false);
     });
 

--- a/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.ts
+++ b/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.ts
@@ -118,12 +118,11 @@ leave the message empty.`;
 
   readonly errorMessageLength = computed(() => (this.stage().error_message ?? "").length);
 
-  // The actions whose wording a request could ever be shown: a restriction in force, or a denial. Read off the
-  // table the server serves rather than listed here, because that table holds exactly those actions - a message
-  // is said by the pre-check refusing a restricted request, off the row in force, and a row records what is in
-  // force rather than the notifications the stage also sent.
+  // The actions whose wording a request could ever be shown: a restriction in force, or a denial. Served for
+  // this target rather than listed here or inferred from the suggested wording - which answers "has a default
+  // sentence", not "can report at all" - so the rule comes from the place that defines it.
   private readonly reportingActions = computed(
-    () => new Set(this.policyService.defaultErrorMessages().map((entry) => entry.action_type))
+    () => new Set(this.policyService.reportingActionsByTarget()[this.target()] ?? [])
   );
 
   // The suggestion for this stage as it stands: one sentence per action it carries, in the order the server
@@ -164,8 +163,8 @@ leave the message empty.`;
 
   // Flagged because such a stage's wording has nowhere to be shown: it restricts nothing and denies nothing, so
   // no request is ever refused while it applies. Advisory like the tag warnings - the admin may be one action
-  // away from giving it a voice. Silent until the suggestion table has loaded, so an empty one does not flag
-  // every stage on the page.
+  // away from giving it a voice. Silent until the target's constraints have loaded, so an empty set does not
+  // flag every stage on the page.
   readonly messageUnreachable = computed(() => {
     const reporting = this.reportingActions();
     if (!reporting.size || !(this.stage().error_message ?? "").trim()) {

--- a/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.ts
+++ b/privacyidea/static_new/src/app/components/conditional-access/conditional-access-edit-page/stages-list/stage-item/conditional-access-stage-item.component.ts
@@ -95,11 +95,16 @@ export class ConditionalAccessStageItemComponent {
   readonly durationTagUnusableHint = $localize`{duration} needs a temporary lock or block to count down. This stage \
 has none, so it would be shown to the user as written - remove the tag, or add a temporary action.`;
 
-  readonly errorMessageHint = $localize`Shown to the user when authentication fails while this stage applies, \
-including on later attempts while a lock or block from it is still in force. It applies to this stage only. Left \
-empty, the user is told only "Authentication failed.", so a rejection cannot be told apart from any other failed \
-authentication - unless the "show_default_ca_error_message" policy is set, which fills in the default wording for this \
-stage's actions.`;
+  readonly errorMessageHint = $localize`Shown to the user on a request this stage turns away before the password \
+or OTP is checked: while a lock or block written by this stage is in force, or when this stage denies access. Not \
+on the request that trips the stage - that one gets the answer it had coming, and the restriction applies from the \
+next request. It applies to this stage only. Left empty, the user is told only "Authentication failed.", so a \
+rejection cannot be told apart from any other failed authentication - unless the \
+"show_default_ca_error_message" policy is set, which fills in the default wording for this stage's actions.`;
+
+  readonly messageUnreachableHint = $localize`This stage neither restricts access nor denies it, so no request is \
+ever turned away while it applies and this message would never be shown. Add a lock, block or deny action, or \
+leave the message empty.`;
 
   // Whether this stage carries wording of its own: absent or null means the admin has not turned it on, an
   // empty string means turned on but not written yet. The field itself is always rendered - disabled rather
@@ -113,12 +118,20 @@ stage's actions.`;
 
   readonly errorMessageLength = computed(() => (this.stage().error_message ?? "").length);
 
+  // The actions whose wording a request could ever be shown: a restriction in force, or a denial. Read off the
+  // table the server serves rather than listed here, because that table holds exactly those actions - a message
+  // is said by the pre-check refusing a restricted request, off the row in force, and a row records what is in
+  // force rather than the notifications the stage also sent.
+  private readonly reportingActions = computed(
+    () => new Set(this.policyService.defaultErrorMessages().map((entry) => entry.action_type))
+  );
+
   // The suggestion for this stage as it stands: one sentence per action it carries, in the order the server
-  // serves them (most severe first). That is the same concatenation the runtime performs, so the wording the
-  // editor offers is the wording a user would be shown - being emailed about is a separate fact from being
-  // locked out, and both are said. The only thing left out is the timed half of a redundant pair, which the
-  // runtime cannot show either: a restriction is never weakened, so the permanent action's row is the one in
-  // force. Null when the stage carries no action the server offers wording for.
+  // serves them (most severe first). That is the same wording the runtime shows, so the editor offers what a
+  // user would be told. The only thing left out is the timed half of a redundant pair, which the runtime cannot
+  // show either: a restriction is never weakened, so the permanent action's row is the one in force. Null when
+  // the stage carries no action the server offers wording for - a notify-only stage included, nothing being able
+  // to report what it did.
   readonly suggestedErrorMessage = computed(() => {
     const present = new Set(this.stage().actions.map((action) => action.action_type));
     const superseded = new Set(
@@ -148,6 +161,18 @@ stage's actions.`;
   readonly durationTagUnusable = computed(
     () => (this.stage().error_message ?? "").includes(DURATION_TAG) && !this.hasTimedAction()
   );
+
+  // Flagged because such a stage's wording has nowhere to be shown: it restricts nothing and denies nothing, so
+  // no request is ever refused while it applies. Advisory like the tag warnings - the admin may be one action
+  // away from giving it a voice. Silent until the suggestion table has loaded, so an empty one does not flag
+  // every stage on the page.
+  readonly messageUnreachable = computed(() => {
+    const reporting = this.reportingActions();
+    if (!reporting.size || !(this.stage().error_message ?? "").trim()) {
+      return false;
+    }
+    return !this.stage().actions.some((action) => reporting.has(action.action_type));
+  });
 
   // Tags in the message that the server will not substitute. Purely advisory: the admin can
   // save anyway, because an unsubstituted brace expression is shown as written, which is a

--- a/privacyidea/static_new/src/app/services/conditional-access/conditional-access-policy.service.spec.ts
+++ b/privacyidea/static_new/src/app/services/conditional-access/conditional-access-policy.service.spec.ts
@@ -217,7 +217,8 @@ describe("ConditionalAccessPolicyService", () => {
         actions: ["LOCK_USER", "PERMANENT_LOCK_USER", "EMAIL_ADMIN", "DENY"],
         count_modes: ["PER_ATTEMPT", "PER_REQUEST"],
         repeatable_actions: ["EMAIL_ADMIN"],
-        exclusive_action_groups: [["LOCK_USER", "PERMANENT_LOCK_USER"]]
+        exclusive_action_groups: [["LOCK_USER", "PERMANENT_LOCK_USER"]],
+        reporting_actions: ["DENY", "LOCK_USER", "PERMANENT_LOCK_USER"]
       },
       source_ip: {
         actions: ["BLOCK_IP", "DENY"],
@@ -311,6 +312,10 @@ describe("ConditionalAccessPolicyService", () => {
       expect(service.repeatableActionsByTarget()).toEqual({ user: ["EMAIL_ADMIN"], source_ip: [] });
       expect(service.exclusiveGroupsByTarget()).toEqual({
         user: [["LOCK_USER", "PERMANENT_LOCK_USER"]],
+        source_ip: []
+      });
+      expect(service.reportingActionsByTarget()).toEqual({
+        user: ["DENY", "LOCK_USER", "PERMANENT_LOCK_USER"],
         source_ip: []
       });
     });

--- a/privacyidea/static_new/src/app/services/conditional-access/conditional-access-policy.service.ts
+++ b/privacyidea/static_new/src/app/services/conditional-access/conditional-access-policy.service.ts
@@ -97,11 +97,13 @@ export const REDUNDANT_RESTRICTION_PAIRS: readonly (readonly [ConditionalAccessA
 export interface TargetConstraints {
   actions: ConditionalAccessActionType[];
   count_modes: CountMode[];
-  // Which of this target's actions may appear more than once within one stage, and which of them
-  // contradict each other there. Optional so a backend that does not serve them yet - and a spec fixture
-  // that omits them - simply yields no rules rather than a type error.
+  // Which of this target's actions may appear more than once within one stage, which of them
+  // contradict each other there, and which of them a request can ever be told about. Optional so a backend
+  // that does not serve them yet - and a spec fixture that omits them - simply yields no rules rather than a
+  // type error.
   repeatable_actions?: ConditionalAccessActionType[];
   exclusive_action_groups?: ConditionalAccessActionType[][];
+  reporting_actions?: ConditionalAccessActionType[];
 }
 
 export interface ConditionalAccessStageAction {
@@ -302,6 +304,7 @@ export interface ConditionalAccessPolicyServiceInterface {
   readonly actionsByTarget: Signal<Record<ConditionalAccessTarget, ConditionalAccessActionType[]>>;
   readonly repeatableActionsByTarget: Signal<Record<ConditionalAccessTarget, ConditionalAccessActionType[]>>;
   readonly exclusiveGroupsByTarget: Signal<Record<ConditionalAccessTarget, ConditionalAccessActionType[][]>>;
+  readonly reportingActionsByTarget: Signal<Record<ConditionalAccessTarget, ConditionalAccessActionType[]>>;
   readonly countModesByTarget: Signal<Record<ConditionalAccessTarget, CountMode[]>>;
   readonly defaultErrorMessagesResource: HttpResourceRef<PiResponse<DefaultErrorMessage[]> | undefined>;
   readonly defaultErrorMessages: Signal<DefaultErrorMessage[]>;
@@ -474,6 +477,17 @@ export class ConditionalAccessPolicyService implements ConditionalAccessPolicySe
             entry.exclusive_action_groups ?? []
           ])
         ) as Record<ConditionalAccessTarget, ConditionalAccessActionType[][]>
+    );
+
+  // Which of a target's actions a request can ever be told about: a restriction in force, or a denial. Served
+  // rather than derived from the suggested wording, because "has a default sentence" is a different question
+  // from "can report at all" - see get_target_constraints in lib/conditional_access/policy.py.
+  readonly reportingActionsByTarget: Signal<Record<ConditionalAccessTarget, ConditionalAccessActionType[]>> =
+    computed(
+      () =>
+        Object.fromEntries(
+          Object.entries(this.targetConstraints()).map(([target, entry]) => [target, entry.reporting_actions ?? []])
+        ) as Record<ConditionalAccessTarget, ConditionalAccessActionType[]>
     );
 
   readonly countModesByTarget: Signal<Record<ConditionalAccessTarget, CountMode[]>> = computed(

--- a/privacyidea/static_new/src/testing/mock-services/mock-conditional-access-policy-service.ts
+++ b/privacyidea/static_new/src/testing/mock-services/mock-conditional-access-policy-service.ts
@@ -67,6 +67,11 @@ export class MockConditionalAccessPolicyService implements ConditionalAccessPoli
   exclusiveGroupsByTarget = signal<Record<ConditionalAccessTarget, ConditionalAccessActionType[][]>>(
     {} as Record<ConditionalAccessTarget, ConditionalAccessActionType[][]>
   );
+  // Empty by default like the two above, so a spec that does not opt in sees no action as able to report and
+  // the unreachable-wording warning stays silent rather than firing on every stage.
+  reportingActionsByTarget = signal<Record<ConditionalAccessTarget, ConditionalAccessActionType[]>>(
+    {} as Record<ConditionalAccessTarget, ConditionalAccessActionType[]>
+  );
 
   targets = signal<ConditionalAccessTarget[]>([]);
 

--- a/tests/conditional_access_base.py
+++ b/tests/conditional_access_base.py
@@ -138,5 +138,5 @@ class ConditionalAccessTestCase(MyTestCase):
         The threshold is a stage's natural key within its policy, so this identifies which stage acted without
         depending on a surrogate id that a policy edit would replace. Empty when nothing fired.
         """
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user, source_ip), event_type)
-        return [outcome.threshold for outcome in evaluation.outcomes]
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user, source_ip), event_type)
+        return [outcome.threshold for outcome in outcomes]

--- a/tests/test_api_conditional_access.py
+++ b/tests/test_api_conditional_access.py
@@ -1714,15 +1714,6 @@ class ConditionalAccessAuthTestCase(MyApiTestCase):
                      "actions": [{"action_type": str(action), "action_value": None}]}],
             target=ConditionalAccessTarget.USER, priority=priority)
 
-    @staticmethod
-    def _make_block_ip_policy(*, threshold, duration=600, window=3600, priority=1, error_message=None):
-        create_conditional_access_policy(
-            name="ca_block_ip", time_window_seconds=window,
-            counter_types_to_track=_counter_types(AuthEventType.PASSWORD_FAIL),
-            stages=[{"failure_threshold": threshold, "error_message": error_message,
-                     "actions": [{"action_type": str(ConditionalAccessAction.BLOCK_IP), "action_value": duration}]}],
-            target=ConditionalAccessTarget.SOURCE_IP, priority=priority)
-
     def test_locked_user_rejected_silently_by_default(self):
         # Nothing is volunteered: with no message configured, a locked user is refused with the same generic
         # message as a wrong password, down to the absent severity hint - which would give the lock away on its own.
@@ -2019,7 +2010,8 @@ class ConditionalAccessAuthTestCase(MyApiTestCase):
         # After enough prior PASSWORD_FAILs the next login is denied pre-auth, even with
         # the correct password. The message states it was a conditional-access decision
         # (without naming the policy); no new log row and no persisted lock.
-        self._make_decision_policy(name="ca_deny", threshold=3, action=ConditionalAccessAction.DENY, error_message="MSG-DELTA")
+        self._make_decision_policy(name="ca_deny", threshold=3, action=ConditionalAccessAction.DENY,
+                                   error_message="MSG-DELTA")
         for _ in range(3):
             res = self._auth("cornelius", "wrongpass")
             self.assertEqual(401, res.status_code, res)

--- a/tests/test_api_conditional_access.py
+++ b/tests/test_api_conditional_access.py
@@ -333,9 +333,10 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         finally:
             delete_policy("ca_other_admin")
 
-    def test_the_request_that_trips_the_lock_reports_it(self):
-        # The lock is written during this very request - and any EMAIL_* action is sent now, not on the
-        # next login - so this is the response that reports it, not merely the ones after it.
+    def test_the_request_that_trips_the_lock_is_answered_as_if_it_had_not(self):
+        # The whole rule in one test: the request that writes the lock keeps the answer it had coming, and the
+        # lock speaks from the next request onwards. So the wording appears one request later than the write,
+        # and a silent lock is undetectable at the moment it trips.
         self._make_lock_policy(counter_type=AuthEventType.PIN_FAIL, threshold=2, duration=600,
                                error_message="Locked. Try again in about {duration}.")
         first = self._check({"user": "cornelius", "pass": "wrongpin123456"})
@@ -344,52 +345,55 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self.assertEqual("wrong otp pin", first["detail"]["message"], first)
 
         tripping = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-        self.assertFalse(tripping["result"]["value"], tripping)
-        self.assertEqual("Locked. Try again in about 10 minute(s).", tripping["detail"]["message"], tripping)
         self.assertTrue(is_user_locked(self.user))
+        # Indistinguishable from the request before it, though it just locked the account.
+        self.assertFalse(tripping["result"]["value"], tripping)
+        self.assertEqual("wrong otp pin", tripping["detail"]["message"], tripping)
+        self.assertEqual(AUTH_RESPONSE.REJECT, first["result"]["authentication"], first)
 
-    def test_the_request_that_trips_a_lock_on_triggerchallenge_reports_it(self):
-        # /validate/triggerchallenge has the gate, so it must also report a stage it trips - otherwise the
-        # admin driving it is answered with the plain result while the *next* request carries the message.
-        # A user with no challenge-capable token logs NO_TOKEN, which a policy may count like any failure.
+        # Only now is the lock in force for the pre-check, and only now is it reported.
+        refused = self._check({"user": "cornelius", "pass": "wrongpin123456"})
+        self.assertFalse(refused["result"]["value"], refused)
+        self.assertEqual("Locked. Try again in about 10 minute(s).", refused["detail"]["message"], refused)
+
+    def test_the_request_that_trips_a_lock_on_triggerchallenge_keeps_its_own_answer(self):
+        # /validate/triggerchallenge has the gate, so it is refused like any other endpoint - but only from the
+        # request after the one that wrote the lock. A user with no challenge-capable token logs NO_TOKEN, which
+        # a policy may count like any failure.
         self._make_lock_policy(counter_type=AuthEventType.NO_TOKEN, threshold=1, duration=600,
                                error_message="Locked. Try again in about {duration}.")
-        with self.app.test_request_context("/validate/triggerchallenge", method="POST",
-                                           data={"user": "selfservice", "realm": self.realm1},
-                                           headers={"PI-Authorization": self.at}):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(200, res.status_code, res.json)
-            body = res.json
-        # No token to challenge, so nothing was triggered - and the lock this very request wrote is what the
-        # response leads with rather than the bare count.
-        self.assertEqual(0, body["result"]["value"], body)
-        self.assertSetEqual({"message", "threadid"}, set(body["detail"]), body)
-        self.assertEqual("Locked. Try again in about 10 minute(s).", body["detail"]["message"], body)
-        self.assertTrue(is_user_locked(User("selfservice", self.realm1)))
+        locked_user = User("selfservice", self.realm1)
+        tripping = self._trigger_challenge(data={"user": "selfservice", "realm": self.realm1})
+        self.assertTrue(is_user_locked(locked_user))
+        # No token to challenge, so nothing was triggered - and that, not the lock, is what this request says.
+        self.assertEqual(0, tripping["result"]["value"], tripping)
+        self.assertNotIn("Locked", tripping.get("detail", {}).get("message", ""), tripping)
 
-    def test_a_challenge_that_succeeds_and_trips_a_lock_is_still_withdrawn(self):
-        # What decides is the restriction, not whether the response looked like a failure. That distinction matters
-        # here because result.value is the *number of challenges triggered*, so a request that both triggers one and
-        # trips a lock reads as a success - yet handing the client a transaction_id the pre-check would refuse on the
-        # very next request would answer differently from every request the lock then refuses.
+        refused = self._trigger_challenge(data={"user": "selfservice", "realm": self.realm1})
+        self.assertEqual(0, refused["result"]["value"], refused)
+        self.assertSetEqual({"message", "threadid"}, set(refused["detail"]), refused)
+        self.assertEqual("Locked. Try again in about 10 minute(s).", refused["detail"]["message"], refused)
+
+    def test_a_challenge_that_succeeds_and_trips_a_lock_is_handed_out_but_unanswerable(self):
+        # The sharpest case for the rule, because result.value here is the *number of challenges triggered*: a
+        # request that both triggers one and trips a lock reads as a success, and it is answered as one. The
+        # challenge is real and the client gets its transaction_id - it simply cannot be answered, because the
+        # lock refuses the request that would answer it.
         self._make_lock_policy(counter_type=AuthEventType.CHALLENGE_TRIGGERED, threshold=1, duration=600,
                                error_message="Locked. Try again in about {duration}.")
-        with self.app.test_request_context("/validate/triggerchallenge", method="POST",
-                                           data={"user": "cornelius", "realm": self.realm1},
-                                           headers={"PI-Authorization": self.at}):
-            res = self.app.full_dispatch_request()
-            self.assertEqual(200, res.status_code, res.json)
-            body = res.json
+        body = self._trigger_challenge(data={"user": "cornelius", "realm": self.realm1})
         self.assertTrue(is_user_locked(self.user))
-        # 0, not False: the value is a count on this endpoint, so a rejection answers with its kind of nothing.
-        self.assertEqual(0, body["result"]["value"], body)
+        # A count, and a truthy one: the challenge was triggered and is reported as such.
+        self.assertEqual(1, body["result"]["value"], body)
         self.assertNotIsInstance(body["result"]["value"], bool, body)
-        self.assertEqual(AUTH_RESPONSE.REJECT, body["result"]["authentication"], body)
-        # The reason and nothing that describes the challenge it overtook.
-        self.assertSetEqual({"message", "threadid"}, set(body["detail"]), body)
-        self.assertEqual("Locked. Try again in about 10 minute(s).", body["detail"]["message"], body)
-        # Withdrawn, not invalidated: the row is left to expire unanswered, exactly as on /validate/check.
+        transaction_id = body["detail"]["transaction_id"]
         self.assertTrue(get_challenges(serial=self.serial))
+
+        # Answering it meets the lock in the pre-check, before the challenge is ever looked up.
+        answered = self._check({"user": "cornelius", "pass": "287082",
+                                "transaction_id": transaction_id})
+        self.assertFalse(answered["result"]["value"], answered)
+        self.assertEqual("Locked. Try again in about 10 minute(s).", answered["detail"]["message"], answered)
 
     def test_triggering_a_challenge_without_a_restriction_is_untouched(self):
         # The other half of the count-as-value shape, and what the rewritten test above must not cost: with a
@@ -409,34 +413,6 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self.assertTrue(body["detail"]["transaction_ids"], body)
         self.assertEqual([self.serial], [entry["serial"] for entry in body["detail"]["multi_challenge"]], body)
 
-    def test_a_challenge_that_trips_a_lock_is_refused_like_any_other_request(self):
-        # A stage can be tripped by a challenge trigger like by any other tracked event. When it restricts, this
-        # request is refused - so the response carries the reason and nothing else, the challenge it was about to
-        # hand out included.
-        set_policy(name="ca_chalresp", scope=SCOPE.AUTH,
-                   action=f"{PolicyAction.CHALLENGERESPONSE}=hotp")
-        self._make_lock_policy(counter_type=AuthEventType.CHALLENGE_TRIGGERED, threshold=1, duration=600,
-                               error_message="Locked. Try again in about {duration}.")
-        try:
-            body = self._check({"user": "cornelius", "pass": "pin"})
-        finally:
-            delete_policy("ca_chalresp")
-        self.assertFalse(body["result"]["value"], body)
-        self.assertTrue(is_user_locked(self.user))
-        # One rule for what a conditional-access rejection says, whatever the request was doing when it was
-        # refused: the reason, and nothing that describes what it overtook.
-        # The whole detail, not just the absence of the keys this test thought to name: everything else in it
-        # described the challenge, and none of it may survive a rejection. threadid identifies the request
-        # rather than saying anything about it, so it stays.
-        self.assertSetEqual({"message", "threadid"}, set(body["detail"]), body)
-        self.assertEqual("Locked. Try again in about 10 minute(s).", body["detail"]["message"], body)
-        # REJECT rather than CHALLENGE: the challenge was withdrawn, so this response is a refusal like any other.
-        self.assertEqual(AUTH_RESPONSE.REJECT, body["result"]["authentication"], body)
-        # Writing the lock does not reclassify the request: USER_LOCKED is what the *pre-check* of a later
-        # request logs, so this one is still filed as the challenge trigger it was.
-        self.assertListEqual([AuthEventType.CHALLENGE_TRIGGERED],
-                             [entry.event_type for entry in get_authentication_logs()])
-
     def test_the_challenge_row_is_left_alone_by_the_rejection(self):
         # Withdrawing the challenge from the response is not invalidating it: conditional access does not reach
         # into the challenge itself, it simply never tells the client about it, and the row expires unanswered.
@@ -452,39 +428,6 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         # challenge lives in Redis and the table is empty, so a table count would "prove" the row was deleted on
         # every run. Keyed by serial because the cache cannot enumerate.
         self.assertEqual(1, len(get_challenges(serial=self.serial)))
-
-    def test_a_notification_is_appended_to_a_challenge_it_was_tripped_by(self):
-        # The other shape: a notify-only stage adds to what the response already said instead of replacing it,
-        # on a challenge exactly as on a failure. Threshold 2, so the first call is an untripped challenge to
-        # measure the second against - the detail must differ in nothing but the message.
-        set_policy(name="ca_chalresp", scope=SCOPE.AUTH,
-                   action=f"{PolicyAction.CHALLENGERESPONSE}=hotp")
-        add_smtpserver(identifier="ca_notify_mail", server="1.2.3.4", tls=False)
-        create_conditional_access_policy(
-            name="notify_on_challenge", time_window_seconds=3600,
-            counter_types_to_track=_counter_types(AuthEventType.CHALLENGE_TRIGGERED),
-            stages=[{"failure_threshold": 2, "error_message": "Your administrator was notified.",
-                     "actions": [{"action_type": str(ConditionalAccessAction.EMAIL_ADMIN),
-                                  "action_value": {"smtp_identifier": "ca_notify_mail",
-                                                   "recipient_group": "soc@example.com",
-                                                   "subject": "s", "body": "b"}}]}],
-            target=ConditionalAccessTarget.USER, priority=1)
-        try:
-            with mock.patch("privacyidea.lib.conditional_access.engine._send_action_email", return_value=True):
-                untripped = self._check({"user": "cornelius", "pass": "pin"})
-                body = self._check({"user": "cornelius", "pass": "pin"})
-        finally:
-            delete_policy("ca_chalresp")
-            delete_smtpserver("ca_notify_mail")
-        self.assertNotIn("Your administrator was notified.", untripped["detail"]["message"], untripped)
-        # Appended to the challenge's own prompt, not in place of it.
-        self.assertEqual(f"{untripped['detail']['message'].rstrip('.')}. Your administrator was notified.",
-                         body["detail"]["message"], body)
-        # And nothing else moved: the same keys an untripped challenge carries, and a usable challenge in them.
-        self.assertSetEqual(set(untripped["detail"]), set(body["detail"]), body)
-        self.assertTrue(body["detail"]["transaction_id"], body)
-        self.assertEqual(self.serial, body["detail"]["serial"], body)
-        self.assertFalse(is_user_locked(self.user))
 
     def test_a_challenge_from_before_the_lock_is_refused_when_it_is_answered(self):
         # A challenge handed out below the threshold stays answerable, and the answer is what meets the lock:
@@ -507,16 +450,6 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
             delete_policy("ca_chalresp")
         self.assertFalse(answered["result"]["value"], answered)
         self.assertEqual("Locked. Try again in about 10 minute(s).", answered["detail"]["message"], answered)
-
-    def test_the_tripping_request_says_only_what_a_rejection_says(self):
-        # With no wording configured the rejection says what every other failed authentication says - not what the
-        # token said about the credential it overtook. See
-        # test_a_silent_restriction_answers_like_the_rejections_after_it for the whole-response comparison.
-        self._make_lock_policy(counter_type=AuthEventType.PIN_FAIL, threshold=2, duration=600)
-        self._check({"user": "cornelius", "pass": "wrongpin123456"})
-        tripping = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-        self.assertEqual(str(GENERIC_AUTH_FAILURE), tripping["detail"]["message"], tripping)
-        self.assertTrue(is_user_locked(self.user))
 
     def test_both_restrictions_are_reported_on_validate_check(self):
         # Both restrictions are reported, most severe first: a user facing a permanent block behind a timed
@@ -552,33 +485,6 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self.assertEqual(str(AuthEventType.USER_LOCKED), entries[0].event_type, entries[0])
         self.assertNotIn("additional_event_types", entries[0].other_info or {}, entries[0])
 
-    def test_a_restriction_written_by_a_raising_request_is_still_answered_as_a_rejection(self):
-        # A view that raises skips every post-policy, so the response is built by an error handler. The engine
-        # still runs (at teardown), so the lock is written either way - and the response has to say so, as a
-        # rejection: the endpoint's own error must not survive, because "the token is locked" states the very
-        # reason a rejection withholds.
-        remove_token(self.serial)
-        init_token({"serial": self.serial, "type": "hotp", "otpkey": self.otpkey, "pin": "pin"}, user=self.user)
-        revoke_token(self.serial)
-        self._make_lock_policy(counter_type=AuthEventType.NO_USABLE_TOKEN, threshold=1, duration=600,
-                               error_message="Locked. Try again in about {duration}.")
-
-        tripping = self._check({"user": "cornelius", "pass": "pin755224"})
-        self.assertTrue(is_user_locked(self.user))
-        # The rejection shape, not the error shape: no result.error, and nothing of ERR1007 anywhere.
-        self.assertNotIn("error", tripping["result"], tripping)
-        self.assertTrue(tripping["result"]["status"], tripping)
-        self.assertFalse(tripping["result"]["value"], tripping)
-        self.assertEqual(AUTH_RESPONSE.REJECT, tripping["result"]["authentication"], tripping)
-        self.assertSetEqual({"message", "threadid"}, set(tripping["detail"]), tripping)
-        self.assertEqual("Locked. Try again in about 10 minute(s).", tripping["detail"]["message"], tripping)
-        self.assertNotIn("locked", str(tripping).replace("Locked.", ""), tripping)
-
-        # And it is the same answer the pre-check gives the requests after it.
-        after = self._check({"user": "cornelius", "pass": "pin755224"})
-        self.assertEqual(after["result"], tripping["result"], tripping)
-        self.assertEqual(after["detail"], tripping["detail"], tripping)
-
     def test_a_raising_request_without_a_restriction_keeps_its_own_error(self):
         # The counterpart: conditional access only overtakes a response it actually refused. With nothing
         # restricted the endpoint's error stands exactly as it did, code and all.
@@ -590,20 +496,6 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
             res = self.app.full_dispatch_request()
         self.assertEqual(400, res.status_code, res.json)
         self.assertEqual(Error.TOKEN_LOCKED, res.json["result"]["error"]["code"], res.json)
-
-    def test_a_silent_restriction_on_a_raising_request_answers_generically(self):
-        # Silent stays silent here too: the rejection says what every other failed authentication says, which is
-        # again exactly what the pre-check answers the following requests with.
-        remove_token(self.serial)
-        init_token({"serial": self.serial, "type": "hotp", "otpkey": self.otpkey, "pin": "pin"}, user=self.user)
-        revoke_token(self.serial)
-        self._make_lock_policy(counter_type=AuthEventType.NO_USABLE_TOKEN, threshold=1, duration=600)
-
-        tripping = self._check({"user": "cornelius", "pass": "pin755224"})
-        self.assertTrue(is_user_locked(self.user))
-        self.assertEqual(str(GENERIC_AUTH_FAILURE), tripping["detail"]["message"], tripping)
-        after = self._check({"user": "cornelius", "pass": "pin755224"})
-        self.assertEqual(after["detail"], tripping["detail"], tripping)
 
     def test_hide_specific_error_message_leaves_the_message_alone_on_validate_check(self):
         # The /validate mirror: the postpolicy replaces the whole detail, but not this error message.
@@ -618,31 +510,10 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         finally:
             delete_policy("ca_hide")
 
-    def test_a_silent_restriction_answers_like_the_rejections_after_it(self):
-        # The request that writes a lock is answered exactly as the requests the lock then refuses: the whole
-        # response, not merely the wording, and whether or not a stage carried any. So the token's own "wrong otp
-        # pin" and its details give way to the ordinary failure, because that is what the pre-check returns.
-        #
-        # The cost is accepted deliberately: a silent lock *is* detectable at the moment it trips, since the
-        # response changes shape. The alternative was worse - one lock answering two different ways depending on
-        # which request you happened to catch it on.
-        self._make_lock_policy(counter_type=AuthEventType.PIN_FAIL, threshold=2, duration=600)
-        below = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-        self.assertEqual("wrong otp pin", below["detail"]["message"], below)
-
-        tripping = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-        self.assertTrue(is_user_locked(self.user))
-        # The correct password, refused by the pre-check - so any difference here is the two paths disagreeing.
-        after = self._check({"user": "cornelius", "pass": "pin755224"})
-        self.assertEqual(after["result"], tripping["result"], tripping)
-        self.assertEqual(after["detail"], tripping["detail"], tripping)
-        self.assertEqual(str(GENERIC_AUTH_FAILURE), tripping["detail"]["message"], tripping)
-
-    def test_a_tripping_request_is_refused_at_radiuscheck_too(self):
-        # /validate/radiuscheck answers with a status code and an empty body, so construct_radius_response drops the
-        # JSON body - and with it the verdict. It therefore has to run *after* the conditional-access response hook,
-        # or the request that writes a restriction is answered 204 while /validate/check answers the very same
-        # request with a rejection: the RADIUS client would authenticate the user on the request that locks them.
+    def test_a_restriction_is_refused_at_radiuscheck_from_the_next_request(self):
+        # /validate/radiuscheck answers with a status code and an empty body, so a rejection there is the 400 every
+        # other failure gets. The request that writes the lock is still authenticated - it succeeded, and the
+        # evaluation does not revisit that - so the refusal begins with the request after it.
         #
         # A rate limit is the reachable shape of "authenticates and trips in one breath": LOGIN_SUCCESS is trackable
         # and reset_on_success=False keeps the success from clearing the counter it just fed.
@@ -652,10 +523,13 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self.assertEqual(204, self._radiuscheck({"user": "cornelius", "pass": "pin755224"}))
         self.assertFalse(is_user_locked(self.user))
 
-        # Second success reaches the threshold and locks. Same endpoint, same kind of request - the only difference
-        # is that this one tripped the restriction, and that has to reach the status code.
-        self.assertEqual(400, self._radiuscheck({"user": "cornelius", "pass": "pin287082"}))
+        # The second success reaches the threshold and locks - and is still answered as the success it was.
+        self.assertEqual(204, self._radiuscheck({"user": "cornelius", "pass": "pin287082"}))
         self.assertTrue(is_user_locked(self.user))
+
+        # From here the lock is in force, and the RADIUS client is told the same "not authenticated" it gets for
+        # any other failure.
+        self.assertEqual(400, self._radiuscheck({"user": "cornelius", "pass": "pin359152"}))
 
     def test_hide_specific_error_message_still_masks_an_ordinary_token_failure(self):
         # The policy keeps doing its job on everything that is not conditional access's: a wrong PIN is still
@@ -706,87 +580,10 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         finally:
             delete_policy("ca_nodetail")
 
-    def test_the_request_that_trips_the_lock_reports_it_under_no_detail_on_fail(self):
-        # The other half of the pair above: the pre-check and the request that writes the lock must answer with the
-        # same wording, whichever of them the policy stack happens to reach.
-        from privacyidea.lib.policy import set_policy, delete_policy, SCOPE
-        from privacyidea.lib.policies.actions import PolicyAction
-        self._make_lock_policy(counter_type=AuthEventType.PIN_FAIL, threshold=1, duration=600,
-                               error_message="Locked. Try again in about {duration}.")
-        set_policy(name="ca_nodetail", scope=SCOPE.AUTHZ, action=f"{PolicyAction.NODETAILFAIL}")
-        try:
-            tripping = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-            self.assertTrue(is_user_locked(self.user))
-            self.assertEqual("Locked. Try again in about 10 minute(s).", tripping["detail"]["message"], tripping)
-            # And the next request, refused by the pre-check, says exactly the same thing.
-            after = self._check({"user": "cornelius", "pass": "pin755224"})
-            self.assertEqual(tripping["detail"]["message"], after["detail"]["message"], after)
-        finally:
-            delete_policy("ca_nodetail")
-
     @smtpmock.activate
-    def test_no_detail_on_fail_masks_the_reason_a_notification_was_appended_to(self):
-        # A notification is appended to the failure's own reason, and that reason is exactly what this action
-        # strips. Only the stage's own sentence may come through.
-        from privacyidea.lib.policy import set_policy, delete_policy, SCOPE
-        from privacyidea.lib.policies.actions import PolicyAction
-        smtpmock.setdata(response={})
-        add_smtpserver(identifier="lockoutmail", server="1.2.3.4", tls=False)
-        set_policy(name="ca_nodetail", scope=SCOPE.AUTHZ, action=f"{PolicyAction.NODETAILFAIL}")
-        try:
-            create_conditional_access_policy(
-                name="ca_mail", time_window_seconds=3600,
-                counter_types_to_track=_counter_types(AuthEventType.PIN_FAIL),
-                stages=[{"failure_threshold": 1, "error_message": "Your administrator has been notified.",
-                         "actions": [{"action_type": str(ConditionalAccessAction.EMAIL_ADMIN),
-                                      "action_value": {"smtp_identifier": "lockoutmail",
-                                                       "recipient_group": "soc@example.com",
-                                                       "subject": "s", "body": "b"}}]}],
-                target=ConditionalAccessTarget.USER, priority=1)
-
-            body = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-            self.assertNotIn("wrong otp pin", body["detail"]["message"], body)
-            self.assertIn("Your administrator has been notified.", body["detail"]["message"], body)
-        finally:
-            delete_policy("ca_nodetail")
-            delete_smtpserver("lockoutmail")
-
-    @smtpmock.activate
-    def test_hide_specific_error_message_masks_the_reason_a_notification_was_appended_to(self):
-        # A notify-only stage is *appended* to the failure's own reason, so the response reads "wrong otp pin. Your
-        # administrator has been notified." Only the second half is conditional access's to keep: keeping the whole
-        # sentence would carry the token-layer reason straight past the policy that exists to suppress it.
-        from privacyidea.lib.policy import set_policy, delete_policy, SCOPE
-        from privacyidea.lib.policies.actions import PolicyAction
-        smtpmock.setdata(response={})
-        add_smtpserver(identifier="lockoutmail", server="1.2.3.4", tls=False)
-        set_policy(name="ca_hide", scope=SCOPE.AUTH, action=f"{PolicyAction.HIDE_SPECIFIC_ERROR_MESSAGE}")
-        try:
-            create_conditional_access_policy(
-                name="ca_mail", time_window_seconds=3600,
-                counter_types_to_track=_counter_types(AuthEventType.PIN_FAIL),
-                stages=[{"failure_threshold": 1, "error_message": "Your administrator has been notified.",
-                         "actions": [{"action_type": str(ConditionalAccessAction.EMAIL_ADMIN),
-                                      "action_value": {"smtp_identifier": "lockoutmail",
-                                                       "recipient_group": "soc@example.com",
-                                                       "subject": "s", "body": "b"}}]}],
-                target=ConditionalAccessTarget.USER, priority=1)
-
-            body = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-            self.assertFalse(body["result"]["value"], body)
-            # The stage's own sentence survives; the reason it was appended to does not.
-            self.assertEqual(f"{str(GENERIC_AUTH_FAILURE).rstrip('.')}. Your administrator has been notified.",
-                             body["detail"]["message"], body)
-            self.assertNotIn("wrong otp pin", body["detail"]["message"], body)
-            self.assertListEqual(["soc@example.com"], smtpmock.get_sent_recipient())
-        finally:
-            delete_policy("ca_hide")
-            delete_smtpserver("lockoutmail")
-
-    @smtpmock.activate
-    def test_a_notification_keeps_the_failure_reason_when_nothing_masks_it(self):
-        # The counterpart: with no masking policy the credential failure is still why the request was refused, so
-        # the notification is appended to it rather than replacing it.
+    def test_a_notification_leaves_the_response_untouched(self):
+        # A notify-only stage refuses nothing and leaves no row behind, so there is no request it could ever
+        # speak on - not even the one that triggered the mail. The failure keeps its own reason, unchanged.
         smtpmock.setdata(response={})
         add_smtpserver(identifier="lockoutmail", server="1.2.3.4", tls=False)
         try:
@@ -801,8 +598,9 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
                 target=ConditionalAccessTarget.USER, priority=1)
 
             body = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-            self.assertEqual("wrong otp pin. Your administrator has been notified.",
-                             body["detail"]["message"], body)
+            self.assertEqual("wrong otp pin", body["detail"]["message"], body)
+            # The mail did go out; it is simply not something the response mentions.
+            self.assertIn("soc@example.com", smtpmock.get_sent_recipient())
         finally:
             delete_smtpserver("lockoutmail")
 
@@ -834,23 +632,6 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         try:
             body = self._check({"user": "cornelius", "pass": "pin755224"})
             self.assertEqual("MSG-OWN", body["detail"]["message"], body)
-        finally:
-            delete_policy("ca_show")
-
-    def test_the_policy_describes_the_request_that_trips_the_lock(self):
-        # The post-response evaluation answers the same way the pre-check does - the gate resolves the policy
-        # once and the request context carries it, so one request cannot word a rejection two ways.
-        from privacyidea.lib.policy import set_policy, delete_policy, SCOPE
-        from privacyidea.lib.policies.actions import PolicyAction
-        self._make_lock_policy(counter_type=AuthEventType.PIN_FAIL, threshold=2, duration=600)
-        set_policy(name="ca_show", scope=SCOPE.CONDITIONAL_ACCESS,
-                   action=f"{PolicyAction.SHOW_DEFAULT_CA_ERROR_MESSAGE}")
-        try:
-            self._check({"user": "cornelius", "pass": "wrongpin123456"})
-            tripping = self._check({"user": "cornelius", "pass": "wrongpin123456"})
-            self.assertTrue(is_user_locked(self.user))
-            self.assertEqual(str(default_error_message(ConditionalAccessAction.LOCK_USER)).replace(
-                "{duration}", "10 minute(s)"), tripping["detail"]["message"], tripping)
         finally:
             delete_policy("ca_show")
 
@@ -1484,11 +1265,10 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
             self.assertEqual(200, response.status_code, response)
             return response.json
 
-    def test_initialize_that_trips_a_block_hands_out_no_challenge(self):
-        # /validate/initialize says result.value: false even on success, so it is the sharpest case for the rule
-        # that a rejection carries the reason and nothing else: a stage tripped by its own CHALLENGE_TRIGGERED
-        # event withdraws the passkey payload it was about to return. A source-IP policy, because the passkey
-        # flow resolves nobody - there is no user to lock.
+    def test_initialize_that_trips_a_block_still_hands_out_its_challenge(self):
+        # /validate/initialize says result.value: false even on success, so nothing about the verdict distinguishes
+        # the request that trips a stage here - what would have distinguished it is the payload, and that is handed
+        # over unchanged. A source-IP policy, because the passkey flow resolves nobody - there is no user to lock.
         self._set_relying_party_id()
         create_conditional_access_policy(
             name="ca_initialize_block", time_window_seconds=3600,
@@ -1498,12 +1278,15 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
             target=ConditionalAccessTarget.SOURCE_IP, count_mode=str(CountMode.PER_REQUEST), priority=1)
 
         body = self._initialize(remote_addr="203.0.113.7")
-        self.assertFalse(body["result"]["value"], body)
         self.assertTrue(is_ip_blocked("203.0.113.7"))
-        self.assertEqual("Blocked. Try again in about 10 minute(s).", body["detail"]["message"], body)
-        # Refused, so the passkey challenge is not handed over: a blocked client gets the reason and nothing
-        # else, exactly as it would from the pre-check on its next attempt.
-        self.assertSetEqual({"message", "threadid"}, set(body["detail"]), body)
+        # The challenge it was about to return is returned, and the block is not mentioned.
+        self.assertIn("passkey", body["detail"], body)
+        self.assertNotIn("Blocked", body["detail"].get("message", ""), body)
+
+        # The next attempt from that address meets the block in the pre-check and gets the reason, nothing else.
+        refused = self._initialize(remote_addr="203.0.113.7")
+        self.assertEqual("Blocked. Try again in about 10 minute(s).", refused["detail"]["message"], refused)
+        self.assertSetEqual({"message", "threadid"}, set(refused["detail"]), refused)
 
     def _set_relying_party_id(self) -> None:
         """The relying-party id the passkey challenge needs; without it the endpoint fails before creating one, which
@@ -1567,16 +1350,14 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         body = self._initialize(remote_addr="203.0.113.7")
         entries = assert_authentication_log([AuthEventType.CHALLENGE_TRIGGERED] * 2, same_attempt=False)
         self.assertTrue(is_ip_blocked("203.0.113.7"))
-        # This call both triggered a challenge and tripped the block, so it is answered as the rejection it became:
-        # the challenge is withdrawn from the response (left to expire unanswered, not invalidated).
-        self.assertNotIn("transaction_id", body["detail"], body)
-        self.assertNotIn("passkey", body["detail"], body)
-        # The transaction is taken from the row and then proved, rather than read out of the response: this call's
-        # challenge was withdrawn from the body, and it cannot be looked up in the challenge store either, since a
-        # passkey challenge carries no serial and an unfiltered get_challenges() returns nothing when the challenges
-        # live in Redis (the cache is keyed by serial/transaction and cannot enumerate). So assert what identifies
-        # it - a transaction of its own, not the first call's, naming a challenge that really was created.
+        # This call both triggered a challenge and tripped the block, and it is answered as the challenge request
+        # it was: the payload is handed over exactly as on the call before it.
+        self.assertIn("transaction_id", body["detail"], body)
+        self.assertIn("passkey", body["detail"], body)
+        # Taken from the row rather than the response only so the two are cross-checked: a transaction of its own,
+        # not the first call's, naming a challenge that really was created.
         tripping_transaction = entries.all[1].transaction_id
+        self.assertEqual(tripping_transaction, body["detail"]["transaction_id"], body)
         self.assertNotEqual(first_transaction, tripping_transaction, entries.all[1])
         self.assertTrue(get_challenges(transaction_id=tripping_transaction))
         assert_authentication_log_entry(entries.all[1], user=None, source_ip="203.0.113.7", peer_ip="203.0.113.7",
@@ -1627,12 +1408,15 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self._lock_policy_named("ca_worded", 1, "Locked. Try again in about {duration}.", 600)
         self._lock_policy_named("ca_silent", 2, None, 600)
 
-        body = self._check({"user": "cornelius", "pass": "wrongpin"})
-        self.assertEqual("Locked. Try again in about 10 minute(s).", body["detail"]["message"], body)
+        self._check({"user": "cornelius", "pass": "wrongpin"})
         self.assertEqual("Locked. Try again in about {duration}.", get_user_lock(self.user).error_message)
-        # Only the write that took effect is history; the one that changed nothing is not.
+        # Only the write that took effect is history; the one that changed nothing is not. Read before the next
+        # request, whose own row is the rejection and carries no outcome of its own.
         entries = get_authentication_logs()
         self.assertListEqual(["ca_worded"], [outcome.policy_name for outcome in get_outcomes(entries[-1].id)])
+        # The wording reaches the user on the request the lock refuses, not on the one that wrote it.
+        body = self._check({"user": "cornelius", "pass": "wrongpin"})
+        self.assertEqual("Locked. Try again in about 10 minute(s).", body["detail"]["message"], body)
 
     def test_a_permanent_lock_restated_keeps_the_first_wording(self):
         # The same for two permanent locks, where there is no expiry to compare at all.
@@ -1640,6 +1424,7 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
                                 action=ConditionalAccessAction.PERMANENT_LOCK_USER)
         self._lock_policy_named("ca_silent", 2, None, None, action=ConditionalAccessAction.PERMANENT_LOCK_USER)
 
+        self._check({"user": "cornelius", "pass": "wrongpin"})
         body = self._check({"user": "cornelius", "pass": "wrongpin"})
         self.assertEqual("Your account is locked.", body["detail"]["message"], body)
 
@@ -1649,18 +1434,20 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self._lock_policy_named("ca_short", 1, "Locked. Try again in about {duration}.", 600)
         self._lock_policy_named("ca_long", 2, "Locked for a while.", 3600)
 
+        self._check({"user": "cornelius", "pass": "wrongpin"})
+        self.assertAlmostEqual(3600, get_user_lock(self.user).seconds_remaining, delta=10)
         body = self._check({"user": "cornelius", "pass": "wrongpin"})
         self.assertEqual("Locked for a while.", body["detail"]["message"], body)
-        self.assertAlmostEqual(3600, get_user_lock(self.user).seconds_remaining, delta=10)
 
     def test_a_weaker_lock_is_still_declined_wording_and_all(self):
         # And so is declining: the shorter lock neither shortens the restriction nor gets to describe it.
         self._lock_policy_named("ca_long", 1, "Locked for a while.", 3600)
         self._lock_policy_named("ca_short", 2, "Locked. Try again in about {duration}.", 600)
 
+        self._check({"user": "cornelius", "pass": "wrongpin"})
+        self.assertAlmostEqual(3600, get_user_lock(self.user).seconds_remaining, delta=10)
         body = self._check({"user": "cornelius", "pass": "wrongpin"})
         self.assertEqual("Locked for a while.", body["detail"]["message"], body)
-        self.assertAlmostEqual(3600, get_user_lock(self.user).seconds_remaining, delta=10)
 
     def _block_policy_named(self, name, priority, message, duration,
                             action=ConditionalAccessAction.BLOCK_IP) -> None:
@@ -1677,18 +1464,20 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self._block_policy_named("ca_ip_worded", 1, "Blocked. Try again in about {duration}.", 600)
         self._block_policy_named("ca_ip_silent", 2, None, 600)
 
-        body = self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
-        self.assertEqual("Blocked. Try again in about 10 minute(s).", body["detail"]["message"], body)
+        self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
         self.assertEqual("Blocked. Try again in about {duration}.", get_ip_block(BLOCKED_IP).error_message)
-        # Only the write that took effect is history.
+        # Only the write that took effect is history. Read before the next request, whose own row is the rejection.
         entries = get_authentication_logs()
         self.assertListEqual(["ca_ip_worded"], [outcome.policy_name for outcome in get_outcomes(entries[-1].id)])
+        body = self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
+        self.assertEqual("Blocked. Try again in about 10 minute(s).", body["detail"]["message"], body)
 
     def test_a_permanent_block_restated_keeps_the_first_wording(self):
         self._block_policy_named("ca_ip_worded", 1, "Access from your address is blocked.", None,
                                  action=ConditionalAccessAction.PERMANENT_BLOCK_IP)
         self._block_policy_named("ca_ip_silent", 2, None, None, action=ConditionalAccessAction.PERMANENT_BLOCK_IP)
 
+        self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
         body = self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
         self.assertEqual("Access from your address is blocked.", body["detail"]["message"], body)
 
@@ -1696,17 +1485,19 @@ class ConditionalAccessValidateTestCase(MyApiTestCase):
         self._block_policy_named("ca_ip_short", 1, "Blocked. Try again in about {duration}.", 600)
         self._block_policy_named("ca_ip_long", 2, "Blocked for a while.", 3600)
 
+        self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
+        self.assertAlmostEqual(3600, get_ip_block(BLOCKED_IP).seconds_remaining, delta=10)
         body = self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
         self.assertEqual("Blocked for a while.", body["detail"]["message"], body)
-        self.assertAlmostEqual(3600, get_ip_block(BLOCKED_IP).seconds_remaining, delta=10)
 
     def test_a_weaker_block_is_still_declined_wording_and_all(self):
         self._block_policy_named("ca_ip_long", 1, "Blocked for a while.", 3600)
         self._block_policy_named("ca_ip_short", 2, "Blocked. Try again in about {duration}.", 600)
 
+        self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
+        self.assertAlmostEqual(3600, get_ip_block(BLOCKED_IP).seconds_remaining, delta=10)
         body = self._check({"user": "cornelius", "pass": "wrongpin"}, remote_addr=BLOCKED_IP)
         self.assertEqual("Blocked for a while.", body["detail"]["message"], body)
-        self.assertAlmostEqual(3600, get_ip_block(BLOCKED_IP).seconds_remaining, delta=10)
 
     # --- identity rewriting (legacy setrealm / mangle) --------------------------
 
@@ -2159,11 +1950,10 @@ class ConditionalAccessAuthTestCase(MyApiTestCase):
         finally:
             delete_policy("ca_hide")
 
-    def test_the_tripping_request_at_auth_carries_no_details(self):
-        # What the token made of the credential no longer decides anything once a restriction is written, so
-        # those details describe an overtaken attempt. The rejection carries the error message and nothing else.
-        # Logging in against privacyIDEA rather than the resolver, so the failure carries the token layer's
-        # own detail - the reason it refused, and what it refused with - for the restriction to overtake.
+    def test_the_tripping_request_at_auth_keeps_its_own_details(self):
+        # The login that writes the lock is still a login that failed on its credential, so it keeps the token
+        # layer's own detail and the wrong-credentials id; the lock speaks from the next login. Logging in against
+        # privacyIDEA rather than the resolver, so there is a token-layer detail to keep.
         from privacyidea.lib.policy import set_policy, delete_policy, SCOPE
         from privacyidea.lib.policies.actions import PolicyAction
         set_policy("ca_pi_login", scope=SCOPE.WEBUI, action=f"{PolicyAction.LOGINMODE}=privacyIDEA")
@@ -2180,18 +1970,25 @@ class ConditionalAccessAuthTestCase(MyApiTestCase):
             self.assertIn("message", first.json.get("detail") or {}, first.json)
 
             tripping = self._auth("cornelius", "wrongpin123456")
-            self.assertEqual(401, tripping.status_code, tripping)
-            self.assertEqual("MSG-ALPHA", tripping.json["result"]["error"]["message"], tripping.json)
-            self.assertFalse(tripping.json.get("detail"), tripping.json)
             self.assertTrue(is_user_locked(self.user))
+            self.assertEqual(401, tripping.status_code, tripping)
+            # Answered exactly as the login before it: its own reason, its own details, no mention of the lock.
+            self.assertEqual(first.json["result"]["error"]["code"], tripping.json["result"]["error"]["code"],
+                             tripping.json)
+            self.assertNotEqual("MSG-ALPHA", tripping.json["result"]["error"]["message"], tripping.json)
+            self.assertIn("message", tripping.json.get("detail") or {}, tripping.json)
+
+            # The next login meets the lock in the pre-check, and that one carries the stage's wording alone.
+            refused = self._auth("cornelius", "wrongpin123456")
+            self.assertEqual(401, refused.status_code, refused)
+            self.assertEqual("MSG-ALPHA", refused.json["result"]["error"]["message"], refused.json)
+            self.assertFalse(refused.json.get("detail"), refused.json)
         finally:
             delete_policy("ca_pi_login")
 
-    def test_a_challenge_at_auth_that_trips_a_lock_is_refused_as_a_login_failure_is(self):
-        # /auth hands back a challenge as a 200 and returns before it evaluates, so a restriction written on that
-        # request reaches the response hook with a success-shaped body in hand. Editing it in place would answer
-        # with value false and REJECT - a shape no failed login here ever has, and so the one field that would
-        # identify a rejection. It has to be rendered as the error response every failure here is.
+    def test_a_challenge_at_auth_that_trips_a_lock_is_still_handed_out(self):
+        # /auth hands back a challenge as a 200, and a lock written on that request does not take it away: the
+        # login is answered as the challenge request it was, and the lock refuses the answer instead.
         init_token({"serial": "CA_AUTH_HOTP", "type": "hotp", "otpkey": self.otpkey, "pin": "pin"}, user=self.user)
         set_policy("ca_webui_login", scope=SCOPE.WEBUI, action=f"{PolicyAction.LOGINMODE}=privacyIDEA")
         set_policy("ca_cr", scope=SCOPE.AUTH, action=f"{PolicyAction.CHALLENGERESPONSE}=hotp")
@@ -2203,43 +2000,20 @@ class ConditionalAccessAuthTestCase(MyApiTestCase):
             target=ConditionalAccessTarget.USER, priority=1)
         try:
             tripping = self._auth("cornelius", "pin")
-            self.assertEqual(401, tripping.status_code, tripping)
-            self.assertEqual(Error.AUTHENTICATE, tripping.json["result"]["error"]["code"], tripping.json)
             self.assertTrue(is_user_locked(self.user))
-            # The challenge goes with it: a transaction_id the next request would refuse is not handed out.
-            self.assertFalse(tripping.json.get("detail"), tripping.json)
+            # The challenge is handed over: a 200 carrying the transaction to answer, exactly as without a policy.
+            self.assertEqual(200, tripping.status_code, tripping.json)
+            self.assertIn("transaction_id", tripping.json.get("detail") or {}, tripping.json)
 
-            # And it reads exactly as the rejection the lock produces from now on, which is the whole promise.
+            # Answering it is what meets the lock, and that is the ordinary refused login: a 401 error response.
             refused = self._auth("cornelius", "pin")
-            self.assertEqual(tripping.status_code, refused.status_code, refused.json)
-            self.assertEqual(tripping.json["result"], refused.json["result"], refused.json)
-            self.assertEqual(tripping.json.get("detail"), refused.json.get("detail"), refused.json)
+            self.assertEqual(401, refused.status_code, refused.json)
+            self.assertEqual(Error.AUTHENTICATE, refused.json["result"]["error"]["code"], refused.json)
+            self.assertFalse(refused.json.get("detail"), refused.json)
         finally:
             remove_token("CA_AUTH_HOTP")
             delete_policy("ca_webui_login")
             delete_policy("ca_cr")
-
-    def test_ip_block_trip_message_at_auth(self):
-        # The failure that trips the BLOCK_IP stage (by crossing the distinct-user
-        # threshold) already tells the user about the block instead of "Wrong
-        # credentials".
-        self._make_block_ip_policy(threshold=3, error_message="Blocked. Try again in about {duration}.")
-        ip = "203.0.113.7"
-        # Below the threshold, a failure is just a plain wrong-credentials rejection.
-        res = self._auth("cornelius", "wrongpass", remote_addr=ip)
-        self.assertEqual(401, res.status_code, res)
-        self.assertEqual(str(GENERIC_AUTH_FAILURE), res.json["result"]["error"]["message"], res.json)
-        # Two other users spray the same IP: with cornelius that is 3 distinct users.
-        _seed_ip_spray(self.user, AuthEventType.PASSWORD_FAIL, ip, n_users=2)
-        # cornelius's next failure crosses the distinct-user threshold -> IP blocked.
-        res = self._auth("cornelius", "wrongpass", remote_addr=ip)
-        self.assertEqual(401, res.status_code, res)
-        message = res.json["result"]["error"]["message"]
-        self.assertIn("Blocked. Try again in about", message, message)
-        self.assertIn("minute", message.lower(), message)
-        self.assertNotIn(str(GENERIC_AUTH_FAILURE), message, message)
-        # The user themselves is not locked - only the IP was blocked.
-        self.assertFalse(is_user_locked(self.user))
 
     def test_deny_policy_rejects_at_auth(self):
         # After enough prior PASSWORD_FAILs the next login is denied pre-auth, even with
@@ -2362,85 +2136,32 @@ class ConditionalAccessAuthTestCase(MyApiTestCase):
 
     def test_the_error_id_follows_what_the_response_is_about(self):
         # AUTHENTICATE_WRONG_CREDENTIALS is a claim about the credential, so it is kept exactly where that claim
-        # holds and dropped where it does not. The line is the one compose_failure_message already draws for the
-        # message, so the id and the wording can never describe different things.
+        # holds and dropped where it does not. What decides is whether *this* request's credential was checked,
+        # which is also what moves the id: a login that writes a lock was checked, a login the lock refuses was not.
 
         # An ordinary failure: the credential was wrong and nothing else happened.
         ordinary = self._auth("cornelius", "wrongpass")
         self.assertEqual(4031, ordinary.json["result"]["error"]["code"], ordinary.json)
         self._clear()
 
-        # A stage that trips silently still *restricted* this login, so it is answered as the rejection it became -
-        # generic wording, no details, generic id - identically to the logins the lock then refuses. Whether an
-        # admin configured wording changes what is said, never whether this was a rejection.
+        # The login that trips the stage had its credential checked and was refused for it, so the claim still
+        # holds and the id is unchanged - writing a lock is not a statement about the password.
         self._make_password_policy(threshold=2)
         self._auth("cornelius", "wrongpass")
-        silent = self._auth("cornelius", "wrongpass")
+        tripping = self._auth("cornelius", "wrongpass")
         self.assertTrue(is_user_locked(self.user))
-        self.assertEqual(403, silent.json["result"]["error"]["code"], silent.json)
-        self.assertEqual(str(GENERIC_AUTH_FAILURE), silent.json["result"]["error"]["message"], silent.json)
-        self._clear()
+        self.assertEqual(4031, tripping.json["result"]["error"]["code"], tripping.json)
 
-        # With wording the response *is* about the restriction - it says so - so it takes the generic id.
-        create_conditional_access_policy(
-            name="ca_pw_worded", time_window_seconds=3600,
-            counter_types_to_track=_counter_types(AuthEventType.PASSWORD_FAIL),
-            stages=[{"failure_threshold": 2, "error_message": "Locked for {duration}.",
-                     "actions": [{"action_type": str(ConditionalAccessAction.LOCK_USER), "action_value": 600}]}],
-            target=ConditionalAccessTarget.USER, priority=1)
-        self._auth("cornelius", "wrongpass")
-        worded = self._auth("cornelius", "wrongpass")
-        self.assertTrue(is_user_locked(self.user))
-        self.assertEqual(403, worded.json["result"]["error"]["code"], worded.json)
-
-        # And every request after it is refused by the pre-check, which never looked at a credential at all - the
-        # case where AUTHENTICATE_WRONG_CREDENTIALS would be false outright. The correct password proves it.
+        # From here the pre-check refuses without looking at a credential at all - the case where
+        # AUTHENTICATE_WRONG_CREDENTIALS would be false outright. The correct password proves it.
         after = self._auth("cornelius", "test")
         self.assertEqual(403, after.json["result"]["error"]["code"], after.json)
+        self.assertEqual(str(GENERIC_AUTH_FAILURE), after.json["result"]["error"]["message"], after.json)
 
     @smtpmock.activate
-    def test_email_notice_surfaced_in_auth_rejection(self):
-        # When an EMAIL_* action fires on the failing request, its notice is appended to the
-        # rejection message so the login screen shows it, just like a lock message.
-        smtpmock.setdata(response={})
-        add_smtpserver(identifier="actionmail", server="1.2.3.4", tls=False)
-        try:
-            create_conditional_access_policy(
-                name="ca_mail", time_window_seconds=3600,
-                counter_types_to_track=_counter_types(AuthEventType.PASSWORD_FAIL),
-                stages=[{"failure_threshold": 2, "error_message": "MSG-DELTA",
-                         "actions": [{"action_type": str(ConditionalAccessAction.EMAIL_ADMIN),
-                                      "action_value": {"smtp_identifier": "actionmail",
-                                                       "recipient_group": "soc@example.com",
-                                                       "subject": "alert", "body": "alert"}}]}],
-                target=ConditionalAccessTarget.USER, priority=1)
-
-            # 1st failure is below the threshold: plain rejection, no email, nothing surfaced.
-            res = self._auth("cornelius", "wrongpass")
-            self.assertEqual(401, res.status_code, res)
-            self.assertEqual(str(GENERIC_AUTH_FAILURE), res.json["result"]["error"]["message"])
-
-            # 2nd failure trips the stage: the email goes out and the stage's own error message rides back on
-            # the 401. A notify-only stage leaves no lock row, so this is the one path where the message
-            # travels with the evaluation rather than being read off a restriction.
-            res = self._auth("cornelius", "wrongpass")
-            self.assertEqual(401, res.status_code, res)
-            # Appended to the ordinary failure, not replacing it: the credential failure is still the reason.
-            # compose_failure_message strips the reason's own full stop before joining, so the two sentences
-            # are separated by exactly one.
-            self.assertEqual(f"{str(GENERIC_AUTH_FAILURE).rstrip('.')}. MSG-DELTA",
-                             res.json["result"]["error"]["message"])
-            self.assertEqual(["soc@example.com"], smtpmock.get_sent_recipient())
-            # An EMAIL-only stage writes no lock state, so the pre-check still lets the user in.
-            self.assertFalse(is_user_locked(self.user))
-        finally:
-            delete_smtpserver("actionmail")
-
-    @smtpmock.activate
-    def test_the_policy_supplies_a_notify_only_stage_its_error_message(self):
-        # The fallback is not restrictions only: a stage that merely notified describes itself too, from the
-        # standard error message for the actions that actually ran. Appended to the failure, because a notification
-        # is not why the request was refused - the credential still is.
+    def test_the_policy_says_nothing_for_a_notify_only_stage(self):
+        # The fallback describes a restriction in force, and a notify-only stage leaves none - so there is no
+        # request for it to speak on and nothing for the policy to fill in. The mail still goes out.
         from privacyidea.lib.policy import set_policy, delete_policy, SCOPE
         from privacyidea.lib.policies.actions import PolicyAction
         smtpmock.setdata(response={})
@@ -2461,46 +2182,13 @@ class ConditionalAccessAuthTestCase(MyApiTestCase):
             self._auth("cornelius", "wrongpass")
             res = self._auth("cornelius", "wrongpass")
             self.assertEqual(401, res.status_code, res)
-            expected = f"{str(GENERIC_AUTH_FAILURE).rstrip('.')}. {default_error_message(ConditionalAccessAction.EMAIL_ADMIN)}"
-            self.assertEqual(expected, res.json["result"]["error"]["message"], res.json)
+            self.assertEqual(str(GENERIC_AUTH_FAILURE), res.json["result"]["error"]["message"], res.json)
             self.assertListEqual(["soc@example.com"], smtpmock.get_sent_recipient())
             # Still only a notification, so nothing was restricted and the details are the failure's own.
             self.assertFalse(is_user_locked(self.user))
         finally:
             delete_policy("ca_show")
             delete_smtpserver("lockoutmail")
-
-    @smtpmock.activate
-    def test_lock_message_and_email_notice_combined(self):
-        # A stage that both locks the user (timed) and emails the admin leads the locking request's rejection with the
-        # lock message and appends the email notice.
-        smtpmock.setdata(response={})
-        add_smtpserver(identifier="actionmail", server="1.2.3.4", tls=False)
-        try:
-            create_conditional_access_policy(
-                name="ca_lockmail", time_window_seconds=3600,
-                counter_types_to_track=_counter_types(AuthEventType.PASSWORD_FAIL),
-                stages=[{"failure_threshold": 2, "error_message": "Locked for {duration}. Your administrator has been notified.",
-                         "actions": [{"action_type": str(ConditionalAccessAction.LOCK_USER), "action_value": 600},
-                                     {"action_type": str(ConditionalAccessAction.EMAIL_ADMIN),
-                                      "action_value": {"smtp_identifier": "actionmail",
-                                                       "recipient_group": "soc@example.com",
-                                                       "subject": "s", "body": "b"}}]}],
-                target=ConditionalAccessTarget.USER, priority=1)
-
-            self._auth("cornelius", "wrongpass")  # 1st failure: below the threshold
-            res = self._auth("cornelius", "wrongpass")  # 2nd: trips the stage -> lock + email
-            self.assertEqual(401, res.status_code, res)
-            message = res.json["result"]["error"]["message"]
-            # One message, written by the admin to cover both facts, carried by the lock row. The stage
-            # does not also contribute it through the evaluation, or the user would be told twice.
-            self.assertIn("Locked for", message, message)
-            self.assertIn("minute", message.lower(), message)
-            self.assertEqual(1, message.count("administrator has been notified"), message)
-            self.assertNotIn(str(GENERIC_AUTH_FAILURE), message, message)
-            self.assertTrue(is_user_locked(self.user))
-        finally:
-            delete_smtpserver("actionmail")
 
     def test_endpoint_condition_reaches_the_post_response_lockout(self):
         # The pre-auth decision and the post-response lockout build their CAContext in two different places, so an
@@ -2551,42 +2239,6 @@ class ConditionalAccessAuthTestCase(MyApiTestCase):
         # a plain failure) rather than turned away by conditional access.
         self.assertEqual(200, response.status_code, response.json)
         self.assertFalse(response.json["result"]["value"], response.json)
-
-    @smtpmock.activate
-    def test_the_policy_describes_every_action_a_stage_ran(self):
-        # A stage that locks and notifies at once. With wording of its own an admin covers both facts in one
-        # sentence; falling back to the standard wording has to cover them too, or the user is told about the
-        # lock and left to discover the email.
-        from privacyidea.lib.policy import set_policy, delete_policy, SCOPE
-        from privacyidea.lib.policies.actions import PolicyAction
-        smtpmock.setdata(response={})
-        add_smtpserver(identifier="lockoutmail", server="1.2.3.4", tls=False)
-        set_policy(name="ca_show", scope=SCOPE.CONDITIONAL_ACCESS,
-                   action=f"{PolicyAction.SHOW_DEFAULT_CA_ERROR_MESSAGE}")
-        try:
-            create_conditional_access_policy(
-                name="ca_lockmail_generic", time_window_seconds=3600,
-                counter_types_to_track=_counter_types(AuthEventType.PASSWORD_FAIL),
-                # No error_message: the policy speaks for the stage, for every action it runs.
-                stages=[{"failure_threshold": 2, "actions": [{"action_type": str(ConditionalAccessAction.LOCK_USER), "action_value": 600},
-                                     {"action_type": str(ConditionalAccessAction.EMAIL_ADMIN),
-                                      "action_value": {"smtp_identifier": "lockoutmail",
-                                                       "recipient_group": "soc@example.com",
-                                                       "subject": "s", "body": "b"}}]}],
-                target=ConditionalAccessTarget.USER, priority=1)
-
-            self._auth("cornelius", "wrongpass")
-            res = self._auth("cornelius", "wrongpass")
-            self.assertEqual(401, res.status_code, res)
-            message = res.json["result"]["error"]["message"]
-            self.assertTrue(is_user_locked(self.user))
-            self.assertEqual(["soc@example.com"], smtpmock.get_sent_recipient())
-            lock = str(default_error_message(ConditionalAccessAction.LOCK_USER)).replace("{duration}", "10 minute(s)")
-            self.assertIn(lock, message, message)
-            self.assertIn(str(default_error_message(ConditionalAccessAction.EMAIL_ADMIN)), message, message)
-        finally:
-            delete_policy("ca_show")
-            delete_smtpserver("lockoutmail")
 
     def test_break_glass_local_admin_is_exempt_from_pre_auth_deny(self):
         # A blanket source-IP DENY exempts local admins; it must target source_ip, since a user-target policy already

--- a/tests/test_api_push_validate.py
+++ b/tests/test_api_push_validate.py
@@ -19,7 +19,8 @@ from privacyidea.lib.cache import ChallengeDTO
 from privacyidea.lib.challenge import get_challenges, delete_challenges
 from privacyidea.lib.conditional_access.authentication_event_types import AuthEventType, AuthEventReason
 from privacyidea.lib.conditional_access.engine import is_user_locked
-from privacyidea.models.conditional_access_policy import (ConditionalAccessPolicy, ConditionalAccessPolicyStage,
+from privacyidea.models.conditional_access_policy import (BlockList, ConditionalAccessPolicy,
+                                                          ConditionalAccessPolicyStage,
                                                           ConditionalAccessStageAction,
                                                           ConditionalAccessPolicyCounterType, UserLockState)
 from privacyidea.lib.config import set_privacyidea_config, delete_privacyidea_config
@@ -1829,7 +1830,7 @@ class PushAPITestCase(PushTokenTestMixin, MyApiTestCase):
             delete_policy("push_config")
 
     def _clear_ca(self):
-        for model in (UserLockState, ConditionalAccessStageAction, ConditionalAccessPolicyStage,
+        for model in (UserLockState, BlockList, ConditionalAccessStageAction, ConditionalAccessPolicyStage,
                       ConditionalAccessPolicyCounterType, ConditionalAccessPolicy, AuthenticationLog):
             db.session.query(model).delete()
         db.session.commit()
@@ -1988,10 +1989,10 @@ class PushAPITestCase(PushTokenTestMixin, MyApiTestCase):
             remove_token(self.serial_push)
             delete_policy("push_config")
 
-    def test_18h_push_answer_that_trips_a_lock_is_refused_in_this_endpoints_shape(self):
-        """An answer that locks its own owner is refused exactly as the answers after it are refused - the whole
-        response, not just the wording, and whether or not the stage carried any. Silent is the case that matters:
-        it produces no wording, so it can only be told apart from a refusal by the response still being one."""
+    def test_18h_push_answer_that_trips_a_lock_still_succeeds(self):
+        """An answer that locks its own owner is answered as the answer it was - it verified, so it succeeds - and
+        the lock refuses the answers after it. Nothing about this response mentions the lock, whether or not the
+        stage carried wording, so the moment a lock is written is not observable here at all."""
         from privacyidea.lib.conditional_access.engine import ConditionalAccessAction, ConditionalAccessTarget
         from privacyidea.lib.conditional_access.policy import create_conditional_access_policy
 
@@ -2024,22 +2025,124 @@ class PushAPITestCase(PushTokenTestMixin, MyApiTestCase):
                 return self.app.full_dispatch_request()
 
         try:
-            # Silent: the answer would have succeeded, and is refused with nothing to show for it - no detail,
-            # because an ordinary failed answer here has none, and no authentication verdict, because no response
-            # here has one.
+            # Silent: the answer verified, so it is accepted, and the lock it wrote is not mentioned.
             silent = answer_that_locks(None)
-            self.assertFalse(silent.json["result"]["value"], silent.json)
-            self.assertNotIn("detail", silent.json, silent.json)
-            self.assertNotIn("authentication", silent.json["result"], silent.json)
+            self.assertTrue(silent.json["result"]["value"], silent.json)
             self.assertTrue(is_user_locked(user))
 
-            # Worded: the same response, plus the sentence the stage carries.
+            # Worded changes nothing here: wording is said by the pre-check on the answers that follow, and this
+            # response is not a refusal to attach it to.
             worded = answer_that_locks("Locked. Try again in about {duration}.")
-            self.assertFalse(worded.json["result"]["value"], worded.json)
-            self.assertEqual("Locked. Try again in about 10 minute(s).",
-                             worded.json["detail"]["message"], worded.json)
-            self.assertNotIn("authentication", worded.json["result"], worded.json)
+            self.assertTrue(worded.json["result"]["value"], worded.json)
+            self.assertNotIn("Locked", (worded.json.get("detail") or {}).get("message", ""), worded.json)
             self.assertTrue(is_user_locked(user))
+        finally:
+            self._clear_ca()
+            delete_challenges(serial=self.serial_push)
+            remove_token(self.serial_push)
+            delete_policy("push_config")
+
+    def test_18i_push_auth_answer_gated_by_an_ip_block(self):
+        """The pre-check refuses a push answer for every reason it refuses anything, not only a locked owner: the
+        source IP is the other restriction it reads, and the smartphone answering from a blocked address is turned
+        away in this endpoint's shape, before the signature is verified."""
+        self.setUp_user_realms()
+        user = User("selfservice", self.realm1)
+        set_policy("push_config", scope=SCOPE.ENROLL,
+                   action=f"{PushAction.FIREBASE_CONFIG}={POLL_ONLY},"
+                          f"{PushAction.REGISTRATION_URL}={REGISTRATION_URL}")
+        self._clear_ca()
+        self._enroll_push_for(user)
+        blocked_ip = "203.0.113.9"
+        try:
+            # Trigger a real challenge from an address that is not blocked, then read its nonce.
+            with self.app.test_request_context('/validate/check', method='POST',
+                                               data={"user": "selfservice", "pass": "push_pin"}):
+                self.app.full_dispatch_request()
+            challenge = get_challenges(serial=self.serial_push)[0]
+            signature = self.smartphone_private_key.sign(
+                f"{challenge.challenge}|{self.serial_push}".encode("utf8"), padding.PKCS1v15(), hashes.SHA256())
+
+            # Block the address the smartphone will answer from, with wording so the refusal is identifiable.
+            db.session.add(BlockList(ip=blocked_ip, block_expires_at=utc_now() + datetime.timedelta(seconds=600),
+                                     error_message="Blocked. Try again in about {duration}."))
+            db.session.commit()
+            logs_before = db.session.query(AuthenticationLog).count()
+
+            with self.app.test_request_context('/ttype/push', method='POST',
+                                               data={"serial": self.serial_push,
+                                                     "signature": b32encode(signature)},
+                                               environ_base={"REMOTE_ADDR": blocked_ip}):
+                response = self.app.full_dispatch_request()
+            self.assertEqual(200, response.status_code, response)
+            # A valid signature that would have authenticated, refused before it was checked.
+            self.assertFalse(response.json["result"]["value"], response.json)
+            self.assertEqual("Blocked. Try again in about 10 minute(s).",
+                             response.json["detail"]["message"], response.json)
+            # Still this endpoint's shape: it renders with rid 1, so no rejection may grow an authentication verdict.
+            self.assertNotIn("authentication", response.json["result"], response.json)
+            # Classified as the block, replacing the approval row the answer would otherwise have written.
+            new_entries = db.session.query(AuthenticationLog).order_by(AuthenticationLog.id).all()[logs_before:]
+            self.assertListEqual([str(AuthEventType.IP_BLOCKED)], [entry.event_type for entry in new_entries])
+            # And the answer was never processed, so the challenge is still open.
+            self.assertTrue(get_challenges(transaction_id=challenge.transaction_id))
+        finally:
+            self._clear_ca()
+            delete_challenges(serial=self.serial_push)
+            remove_token(self.serial_push)
+            delete_policy("push_config")
+
+    def test_18j_push_auth_answer_refused_by_a_deny_policy(self):
+        """The pre-check's third reason at this endpoint: a conditional-access DENY. It stores no state and is
+        decided per request from the events already recorded, so the smartphone's answer is refused by policy
+        rather than by a row - and in the same shape a lock or a block is refused in."""
+        from privacyidea.lib.conditional_access.engine import ConditionalAccessAction, ConditionalAccessTarget
+        from privacyidea.lib.conditional_access.policy import create_conditional_access_policy
+
+        self.setUp_user_realms()
+        user = User("selfservice", self.realm1)
+        set_policy("push_config", scope=SCOPE.ENROLL,
+                   action=f"{PushAction.FIREBASE_CONFIG}={POLL_ONLY},"
+                          f"{PushAction.REGISTRATION_URL}={REGISTRATION_URL}")
+        self._clear_ca()
+        self._enroll_push_for(user)
+        try:
+            # Trigger a real challenge. This writes the one CHALLENGE_TRIGGERED row the policy below counts, so
+            # the threshold is reached by the time the answer arrives - but not yet while the trigger itself runs.
+            with self.app.test_request_context('/validate/check', method='POST',
+                                               data={"user": "selfservice", "pass": "push_pin"}):
+                self.app.full_dispatch_request()
+            challenge = get_challenges(serial=self.serial_push)[0]
+            signature = self.smartphone_private_key.sign(
+                f"{challenge.challenge}|{self.serial_push}".encode("utf8"), padding.PKCS1v15(), hashes.SHA256())
+            # No {duration} in the wording: a DENY leaves no restriction behind, so there is no remaining time to
+            # substitute and the tag would reach the smartphone as written.
+            create_conditional_access_policy(
+                name="ca_push_deny", time_window_seconds=3600,
+                counter_types_to_track=[str(AuthEventType.CHALLENGE_TRIGGERED)],
+                stages=[{"failure_threshold": 1, "error_message": "Access has been denied.",
+                         "actions": [{"action_type": str(ConditionalAccessAction.DENY)}]}],
+                target=ConditionalAccessTarget.USER, priority=1)
+            logs_before = db.session.query(AuthenticationLog).count()
+
+            with self.app.test_request_context('/ttype/push', method='POST',
+                                               data={"serial": self.serial_push,
+                                                     "signature": b32encode(signature)}):
+                response = self.app.full_dispatch_request()
+            self.assertEqual(200, response.status_code, response)
+            # The same valid signature that authenticates in test_18h, refused before it was checked.
+            self.assertFalse(response.json["result"]["value"], response.json)
+            self.assertEqual("Access has been denied.", response.json["detail"]["message"], response.json)
+            # Still this endpoint's shape: it renders with rid 1, so no rejection may grow an authentication verdict.
+            self.assertNotIn("authentication", response.json["result"], response.json)
+            # Classified as the denial, replacing the approval row the answer would otherwise have written.
+            new_entries = db.session.query(AuthenticationLog).order_by(AuthenticationLog.id).all()[logs_before:]
+            self.assertListEqual([str(AuthEventType.ACCESS_DENIED)], [entry.event_type for entry in new_entries])
+            # A DENY persists nothing, so nothing is left behind for an admin to lift.
+            self.assertFalse(is_user_locked(user))
+            self.assertEqual(0, db.session.query(UserLockState).count())
+            # And the answer was never processed, so the challenge is still open.
+            self.assertTrue(get_challenges(transaction_id=challenge.transaction_id))
         finally:
             self._clear_ca()
             delete_challenges(serial=self.serial_push)

--- a/tests/test_lib_conditional_access_engine.py
+++ b/tests/test_lib_conditional_access_engine.py
@@ -56,7 +56,6 @@ from privacyidea.lib.conditional_access.engine import (
     get_ip_block,
     parse_lock_duration_seconds,
     render_error_message,
-    most_severe_action,
     ACTION_SEVERITY,
     StageMessage,
     RestrictionStatus,
@@ -2776,17 +2775,13 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self.assertIsNone(undecided.error_message)
 
     def test_every_action_that_can_report_something_has_a_severity_rank(self):
-        # ACTION_SEVERITY has to cover the enum, not merely agree with the message table.
-        # A member added without a rank fails silently:
-        # most_severe_action answers None for it, and _execute_stage_actions drops the stage's error message
-        # rather than showing it out of order - so the admin's wording disappears with nothing to say why.
+        # ACTION_SEVERITY has to cover the enum, not merely agree with the message table: a member added without
+        # a rank sorts last among the messages of the restrictions in force (rank_and_deduplicate), so a wording
+        # would silently come out in the wrong order.
         #
         # The exemption is for an action that decides a request without turning anyone away, having nothing to
         # tell a user - and since ALLOW was removed there is no longer any such action.
         self.assertSetEqual(set(ConditionalAccessAction), set(ACTION_SEVERITY))
-        # And the rank is what a stage's message hangs on, so every covered action has to answer.
-        for action in ACTION_SEVERITY:
-            self.assertEqual(action, most_severe_action([action.value]), action)
 
     def test_a_stage_message_describes_its_longest_restriction(self):
         # One message covers however many actions a stage runs, and the row keeps the last expiry written, so

--- a/tests/test_lib_conditional_access_engine.py
+++ b/tests/test_lib_conditional_access_engine.py
@@ -291,8 +291,8 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                               ConditionalAccessAction.BLOCK_IP, {"duration_seconds": 3600})]),))
         self._seed_ip_events("203.0.113.9", AuthEventType.PASSWORD_FAIL, n_users=5)
         # No source IP on the current request -> the IP-targeted policy cannot act.
-        self.assertEqual([], evaluate_conditional_access_policies(CAContext(self.user, None),
-                                                      AuthEventType.PASSWORD_FAIL).messages)
+        self.assertListEqual([], evaluate_conditional_access_policies(CAContext(self.user, None),
+                                                                      AuthEventType.PASSWORD_FAIL))
 
     # --- count_user_events ----------------------------------------------------
 
@@ -928,10 +928,10 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         # as this request's history, since the engine itself never writes them.
         policy, _stages = self._make_policy(name="dry", counter_type=AuthEventType.MFA_FAIL, dry_run=True)
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
-        self.assertEqual(1, len(evaluation.outcomes))
-        outcome = evaluation.outcomes[0]
+        self.assertEqual(1, len(outcomes))
+        outcome = outcomes[0]
         self.assertTrue(outcome.dry_run)
         self.assertEqual(str(ConditionalAccessAction.LOCK_USER), outcome.action_type)
         self.assertEqual("dry", outcome.policy_name)
@@ -955,10 +955,10 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                           stages=(StageDefinition(
                               2, [StageActionDefinition(ConditionalAccessAction.PERMANENT_LOCK_USER)]),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         # dry_b's PERMANENT_LOCK_USER is fire-once at threshold 2 and the count is 3, so only dry_a matches.
-        self.assertEqual(["dry_a"], [outcome.policy_name for outcome in evaluation.outcomes])
+        self.assertEqual(["dry_a"], [outcome.policy_name for outcome in outcomes])
         self.assertIsNone(self._state())
 
     def test_dry_run_outcome_records_the_stage_name_when_the_stage_has_one(self):
@@ -969,14 +969,14 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
             stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 600)],
                                     name="Lock 10 min"),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        outcome = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes[0]
+        outcome = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)[0]
         self.assertEqual("Lock 10 min", outcome.stage_name)
 
     def test_dry_run_below_threshold_records_nothing(self):
         self._make_policy(name="dry", counter_type=AuthEventType.MFA_FAIL, dry_run=True)
         self._seed_events(AuthEventType.MFA_FAIL, 2)  # below the threshold of 3
         self.assertEqual([], evaluate_conditional_access_policies(CAContext(self.user),
-                AuthEventType.MFA_FAIL).outcomes)
+                AuthEventType.MFA_FAIL))
         self.assertIsNone(self._state())
 
     def test_dry_run_fire_once_records_nothing_above_threshold(self):
@@ -986,7 +986,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self._make_policy(name="dry", counter_type=AuthEventType.MFA_FAIL, dry_run=True)
         self._seed_events(AuthEventType.MFA_FAIL, 6)  # well past the threshold of 3
         self.assertEqual([], evaluate_conditional_access_policies(CAContext(self.user),
-                AuthEventType.MFA_FAIL).outcomes)
+                AuthEventType.MFA_FAIL))
 
     def test_dry_run_retrigger_records_a_outcome_above_threshold(self):
         # With a re-triggering action the dry run keeps reporting for as long as the count stays at or above the
@@ -995,7 +995,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         stages[0].actions[0].retrigger_above_threshold = True
         db.session.commit()
         self._seed_events(AuthEventType.MFA_FAIL, 6)  # count 6 >= threshold 3
-        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         self.assertEqual(1, len(outcomes))
         self.assertEqual(3, outcomes[0].threshold)
@@ -1011,10 +1011,10 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self._seed_events(AuthEventType.MFA_FAIL, 3)
 
         self.assertEqual(1, len(evaluate_conditional_access_policies(CAContext(self.user),
-                AuthEventType.MFA_FAIL).outcomes))
+                AuthEventType.MFA_FAIL)))
         self._seed_events(AuthEventType.MFA_FAIL, 1)
         self.assertEqual(1, len(evaluate_conditional_access_policies(CAContext(self.user),
-                AuthEventType.MFA_FAIL).outcomes))
+                AuthEventType.MFA_FAIL)))
         self.assertIsNone(self._state())
 
     def test_dry_run_records_one_outcome_per_pending_action_of_the_stage(self):
@@ -1025,7 +1025,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
             stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 600),
                                            StageActionDefinition(ConditionalAccessAction.PERMANENT_LOCK_USER)]),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         self.assertEqual([str(ConditionalAccessAction.LOCK_USER), str(ConditionalAccessAction.PERMANENT_LOCK_USER)],
                          [outcome.action_type for outcome in outcomes])
@@ -1040,7 +1040,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
             name="dry_broken", counter_type=AuthEventType.MFA_FAIL, dry_run=True,
             stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, "not-a-duration")]),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        outcome = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes[0]
+        outcome = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)[0]
         self.assertEqual(str(ConditionalAccessAction.LOCK_USER), outcome.action_type)
         self.assertIsNone(outcome.info)
 
@@ -1050,7 +1050,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                           target=ConditionalAccessTarget.SOURCE_IP,
                           stages=(StageDefinition(2, [StageActionDefinition(ConditionalAccessAction.BLOCK_IP, 600)]),))
         self._seed_ip_events(ip, AuthEventType.PASSWORD_FAIL, n_users=2, per_user=1)
-        outcomes = evaluate_conditional_access_policies(CAContext(self.user, ip), AuthEventType.PASSWORD_FAIL).outcomes
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user, ip), AuthEventType.PASSWORD_FAIL)
 
         self.assertEqual("dry_ip", outcomes[0].policy_name)
         self.assertEqual(str(ConditionalAccessAction.BLOCK_IP), outcomes[0].action_type)
@@ -1076,23 +1076,24 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
             return real(policy, *args, **kwargs)
 
         with mock.patch.object(engine, "_evaluate_policy", side_effect=fail_the_first):
-            evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+            outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         self.assertListEqual(["broken", "works"], calls)
         # The surviving policy still locked the user, and nothing propagated to the caller.
         self.assertListEqual([str(ConditionalAccessAction.LOCK_USER)],
-                [outcome.action_type for outcome in evaluation.outcomes])
+                [outcome.action_type for outcome in outcomes])
         self.assertTrue(is_user_locked(self.user))
 
-    def test_dry_run_returns_no_messages(self):
+    def test_dry_run_records_its_outcome_without_locking(self):
         self._make_policy(name="dry", counter_type=AuthEventType.MFA_FAIL, dry_run=True)
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        self.assertEqual([], evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).messages)
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+        self.assertListEqual([True], [outcome.dry_run for outcome in outcomes])
+        self.assertFalse(is_user_locked(self.user))
 
     @smtpmock.activate
     def test_dry_run_email_action_records_the_outcome_but_sends_nothing(self):
-        # Dry-run must not produce the side effect itself: the outcome names EMAIL_ADMIN, but no mail is sent and
-        # no user-facing notice is returned.
+        # Dry-run must not produce the side effect itself: the outcome names EMAIL_ADMIN, but no mail is sent.
         smtpmock.setdata(response={})
         add_smtpserver(identifier="actionmail", server="1.2.3.4", tls=False)
         db.session.add(Admin(username="ca_dry_adm", email="dryadm@example.com"))
@@ -1104,11 +1105,10 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                                                                      {"smtp_identifier": "actionmail",
                                                                       "subject": "s", "body": "b"})]),))
             self._seed_events(AuthEventType.MFA_FAIL, 3)
-            evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+            outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
             self.assertListEqual([str(ConditionalAccessAction.EMAIL_ADMIN)],
-                                 [outcome.action_type for outcome in evaluation.outcomes])
-            self.assertEqual([], evaluation.messages)
+                                 [outcome.action_type for outcome in outcomes])
             # Nothing was handed to the SMTP layer at all (the mock reports no recipient).
             self.assertIsNone(smtpmock.get_sent_recipient())
         finally:
@@ -1122,7 +1122,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self._make_policy(name="dry", counter_type=AuthEventType.MFA_FAIL, dry_run=True, priority=1)
         self._make_policy(name="live", counter_type=AuthEventType.MFA_FAIL, priority=2)
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         self.assertEqual([("dry", True), ("live", False)],
                          [(outcome.policy_name, outcome.dry_run) for outcome in outcomes])
@@ -1134,7 +1134,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self._make_policy(name="live", counter_type=AuthEventType.MFA_FAIL,
                           stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 600)]),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         self.assertEqual(1, len(outcomes))
         self.assertFalse(outcomes[0].dry_run)
@@ -1149,7 +1149,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                           stages=(StageDefinition(
                               3, [StageActionDefinition(ConditionalAccessAction.PERMANENT_LOCK_USER)]),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         self.assertEqual(str(ConditionalAccessAction.PERMANENT_LOCK_USER), outcomes[0].action_type)
         self.assertIsNone(outcomes[0].info)
@@ -1162,7 +1162,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
             stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, "not-a-duration")]),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
         self.assertListEqual([], evaluate_conditional_access_policies(CAContext(self.user),
-                AuthEventType.MFA_FAIL).outcomes)
+                AuthEventType.MFA_FAIL))
         self.assertFalse(is_user_locked(self.user))
 
     def test_never_block_ip_records_nothing(self):
@@ -1171,10 +1171,10 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                           target=ConditionalAccessTarget.SOURCE_IP,
                           stages=(StageDefinition(2, [StageActionDefinition(ConditionalAccessAction.BLOCK_IP, 600)]),))
         self._seed_ip_events("127.0.0.1", AuthEventType.PASSWORD_FAIL, n_users=2, per_user=1)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user, "127.0.0.1"),
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user, "127.0.0.1"),
                 AuthEventType.PASSWORD_FAIL)
 
-        self.assertListEqual([], evaluation.outcomes)
+        self.assertListEqual([], outcomes)
         self.assertIsNone(self._block("127.0.0.1"))
 
     def test_declined_downgrade_of_a_permanent_lock_records_nothing(self):
@@ -1189,7 +1189,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self._make_policy(name="timed", counter_type=AuthEventType.MFA_FAIL, priority=2,
                           stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 600)]),))
         self._seed_events(AuthEventType.MFA_FAIL, 1)
-        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         self.assertListEqual([], outcomes)
         # The permanent lock is untouched.
@@ -1238,7 +1238,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                                            StageActionDefinition(ConditionalAccessAction.PERMANENT_LOCK_USER, None,
                                                                  retrigger_above_threshold=False)]),))
         self._seed_events(AuthEventType.MFA_FAIL, 6)  # count 6 > threshold 3
-        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).outcomes
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
 
         self.assertListEqual([str(ConditionalAccessAction.LOCK_USER)], [outcome.action_type for outcome in outcomes])
 
@@ -1312,16 +1312,16 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
 
         # count 5 at 'now' -> the severe stage fires (fire-once, at its exact threshold).
         self._seed_events(AuthEventType.MFA_FAIL, 5, timestamp=now)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=now)
-        self.assertListEqual([severe_stage.failure_threshold], [o.threshold for o in evaluation.outcomes])
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=now)
+        self.assertListEqual([severe_stage.failure_threshold], [o.threshold for o in outcomes])
 
         # 250s later: the five events are now outside the 100s window (count decays to 0), and the severe stage's
         # 50s lock has long since expired. Three fresh failures bring the count back to 3 -> the mild stage's own
         # (re-triggering) threshold, and it fires again even though the severe stage already fired once.
         later = now + timedelta(seconds=250)
         self._seed_events(AuthEventType.MFA_FAIL, 3, timestamp=later)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=later)
-        self.assertListEqual([mild_stage.failure_threshold], [o.threshold for o in evaluation.outcomes])
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=later)
+        self.assertListEqual([mild_stage.failure_threshold], [o.threshold for o in outcomes])
 
     def test_permanent_lock_action(self):
         self._make_policy(name="perm", counter_type=AuthEventType.MFA_FAIL,
@@ -2094,9 +2094,9 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         self.assertIsNotNone(state)
 
     @smtpmock.activate
-    def test_notify_only_stage_returns_its_message(self):
-        # A stage that only notified leaves no lock or block to carry its error message, so the evaluation
-        # returns it for the caller to surface on this response.
+    def test_notify_only_stage_sends_its_mail_and_reports_nothing(self):
+        # A stage that only notified leaves no lock or block behind, so no request is ever refused while it
+        # applies and nothing it was configured to say can reach a user.
         smtpmock.setdata(response={})
         add_smtpserver(identifier="actionmail", server="1.2.3.4", tls=False)
         try:
@@ -2108,58 +2108,35 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                                                                       "subject": "s", "body": "b"})],
                                         error_message="Your administrator has been notified."),))
             self._seed_events(AuthEventType.MFA_FAIL, 3)
-            messages = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).messages
-            # Rank 2: it states an extra fact rather than the reason, so a caller appends it to the failure.
-            self.assertListEqual([StageMessage("Your administrator has been notified.", ConditionalAccessAction.EMAIL_ADMIN)],
-                                 messages)
+            outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+            # The mail went out and is recorded, but the stage restricted nothing, so it leaves no row behind for
+            # any request to be refused by - and its error message therefore never reaches anyone.
+            self.assertListEqual([str(ConditionalAccessAction.EMAIL_ADMIN)],
+                                 [outcome.action_type for outcome in outcomes])
+            self.assertIsNone(self._state())
+            self.assertFalse(is_user_locked(self.user))
         finally:
             delete_smtpserver("actionmail")
 
-    @smtpmock.activate
-    def test_notify_only_stage_without_a_message_returns_nothing(self):
-        # The default is silence here too: an email is sent, and the user is told nothing about it.
-        smtpmock.setdata(response={})
-        add_smtpserver(identifier="actionmail", server="1.2.3.4", tls=False)
-        try:
-            self._make_policy(
-                name="mailsilent", counter_type=AuthEventType.MFA_FAIL,
-                stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.EMAIL_ADMIN,
-                                                                     {"smtp_identifier": "lockoutmail",
-                                                                      "recipient_group": "soc@example.com",
-                                                                      "subject": "s", "body": "b"})]),))
-            self._seed_events(AuthEventType.MFA_FAIL, 3)
-            self.assertListEqual([], evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).messages)
-        finally:
-            delete_smtpserver("actionmail")
-
-    def test_a_locking_stage_returns_its_message_rendered(self):
-        # Rendered here, where the duration just written is known, so no caller has to read the row back.
-        # The template is still stored, for the requests that come after this one.
+    def test_a_locking_stage_stores_its_message_on_the_row(self):
+        # Stored as the template, not as finished text: the pre-check renders it for each request the lock
+        # refuses, so {duration} counts down the time left then rather than the duration written now. This
+        # request itself is told nothing.
         lock = [StageActionDefinition(ConditionalAccessAction.LOCK_USER, {"duration_seconds": 600})]
         self._make_policy(name="lockonly", counter_type=AuthEventType.MFA_FAIL,
                           stages=(StageDefinition(3, lock, error_message="Locked for {duration}."),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-        self.assertListEqual([StageMessage("Locked for 10 minute(s).", ConditionalAccessAction.LOCK_USER)],
-                             evaluation.messages)
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+        self.assertListEqual([str(ConditionalAccessAction.LOCK_USER)],
+                             [outcome.action_type for outcome in outcomes])
         self.assertTrue(is_user_locked(self.user))
         self.assertEqual("Locked for {duration}.", self._state().error_message)
 
-    def test_a_permanent_stage_outranks_a_timed_one(self):
-        # Rank 0 before rank 1, so a caller showing several leads with the one the user can do least about.
-        self._make_policy(name="perm", counter_type=AuthEventType.MFA_FAIL, priority=1,
-                          stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.PERMANENT_LOCK_USER)],
-                                                  error_message="Permanent."),))
-        self._seed_events(AuthEventType.MFA_FAIL, 3)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-        self.assertListEqual([StageMessage("Permanent.", ConditionalAccessAction.PERMANENT_LOCK_USER)], evaluation.messages)
-
     @smtpmock.activate
-    def test_a_declined_restriction_does_not_speak_as_a_notification(self):
+    def test_a_declined_restriction_records_nothing_and_leaves_the_wording_in_force(self):
         # The lower-priority stage restricts nothing - its timed lock would weaken the permanent one written just
-        # before it - but its mail goes out, so the stage did something. That must not turn its error message into a
-        # notification: it describes a lock, and rendering it here would append it to the failure with the
-        # {duration} it has no restriction to substitute against.
+        # before it - but its mail goes out, so the stage did something. The row keeps the wording of the policy
+        # that actually wrote it, which is what every request the lock refuses will be told.
         smtpmock.setdata(response={})
         add_smtpserver(identifier="lockoutmail", server="1.2.3.4", tls=False)
         try:
@@ -2175,21 +2152,20 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                                                                       "subject": "s", "body": "b"})],
                                         error_message="Locked for {duration}."),))
             self._seed_events(AuthEventType.MFA_FAIL, 3)
-            evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-            self.assertListEqual([StageMessage("Permanent.", ConditionalAccessAction.PERMANENT_LOCK_USER)],
-                                 evaluation.messages)
+            outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
             # The declined lock recorded nothing, the mail that did go out did.
-            self.assertEqual([str(ConditionalAccessAction.PERMANENT_LOCK_USER), str(ConditionalAccessAction.EMAIL_ADMIN)],
-                             [outcome.action_type for outcome in evaluation.outcomes])
+            self.assertListEqual([str(ConditionalAccessAction.PERMANENT_LOCK_USER), str(ConditionalAccessAction.EMAIL_ADMIN)],
+                                 [outcome.action_type for outcome in outcomes])
+            # And the surviving row still carries the higher-priority policy's wording, not the declined one's.
+            self.assertEqual("Permanent.", self._state().error_message)
         finally:
             delete_smtpserver("lockoutmail")
 
     @smtpmock.activate
-    def test_a_deny_stage_does_not_speak_from_the_post_response_engine(self):
-        # A DENY decides the request pre-auth, where its error message is rendered (_evaluate_rejection). Here it is a
-        # no-op - the count only reaches the threshold once this request's own event is written - so the mail is
-        # the whole of what this stage did, and the error message that describes the denial must not be appended to a
-        # request the denial did not turn away.
+    def test_a_deny_stage_records_nothing_from_the_post_response_engine(self):
+        # A DENY decides the request pre-auth, where its error message is read off the stage
+        # (_evaluate_rejection). Here it is a no-op - the count only reaches the threshold once this request's own
+        # event is written - so the mail is the whole of what this stage did here.
         smtpmock.setdata(response={})
         add_smtpserver(identifier="lockoutmail", server="1.2.3.4", tls=False)
         try:
@@ -2202,11 +2178,10 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                                                                       "subject": "s", "body": "b"})],
                                         error_message="Access denied."),))
             self._seed_events(AuthEventType.MFA_FAIL, 3)
-            evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-            self.assertListEqual([], evaluation.messages)
-            # The DENY records nothing here either - it is recorded by the decision step that makes it.
-            self.assertEqual([str(ConditionalAccessAction.EMAIL_ADMIN)],
-                             [outcome.action_type for outcome in evaluation.outcomes])
+            outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+            # The DENY records nothing here - it is recorded by the decision step that makes it.
+            self.assertListEqual([str(ConditionalAccessAction.EMAIL_ADMIN)],
+                                 [outcome.action_type for outcome in outcomes])
         finally:
             delete_smtpserver("lockoutmail")
 
@@ -2350,7 +2325,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
             conditions=[self._condition(ConditionType.USER_REALM, ConditionOperator.IN, [self.realm2])],
             stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 600)]),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        self.assertEqual([], evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).messages)
+        self.assertListEqual([], evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL))
         self.assertFalse(is_user_locked(self.user))
 
     def _spray_policy(self, *, threshold: int = 3,
@@ -2512,7 +2487,7 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
             conditions=[self._condition(ConditionType.USER_REALM, ConditionOperator.IN, [self.realm2])],
             stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER, 600)]),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        self.assertEqual([], evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL).messages)
+        self.assertListEqual([], evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL))
         self.assertFalse(is_user_locked(self.user))
 
     def test_a_condition_that_cannot_be_a_predicate_leaves_the_count_unscoped(self):
@@ -2783,21 +2758,9 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
         # tell a user - and since ALLOW was removed there is no longer any such action.
         self.assertSetEqual(set(ConditionalAccessAction), set(ACTION_SEVERITY))
 
-    def test_a_stage_message_describes_its_longest_restriction(self):
-        # One message covers however many actions a stage runs, and the row keeps the last expiry written, so
-        # the message describes the longest restriction the stage produced - the one in force.
-        actions = [StageActionDefinition(ConditionalAccessAction.LOCK_USER, {"duration_seconds": 3600}),
-                   StageActionDefinition(ConditionalAccessAction.LOCK_USER, {"duration_seconds": 600})]
-        self._make_policy(name="twolocks", counter_type=AuthEventType.MFA_FAIL,
-                          stages=(StageDefinition(3, actions, error_message="Locked for {duration}."),))
-        self._seed_events(AuthEventType.MFA_FAIL, 3)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-        self.assertListEqual([StageMessage("Locked for 1 hour(s).", ConditionalAccessAction.LOCK_USER)],
-                             evaluation.messages)
-
-    def test_two_policies_locking_the_same_user_produce_one_message(self):
+    def test_two_policies_locking_the_same_user_leave_one_row_and_one_wording(self):
         # Both policies trip on this request and both lock the same user, but there is only one lock row - so
-        # the user is told once, about the lock that survived, not once per policy.
+        # the requests it refuses read the wording of the lock that survived, not one sentence per policy.
         self._make_policy(name="hour", counter_type=AuthEventType.MFA_FAIL, priority=1,
                           stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER,
                                                                                {"duration_seconds": 3600})],
@@ -2807,14 +2770,16 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                                                                                {"duration_seconds": 600})],
                                                   error_message="Locked for a short while."),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-        # The hour-long lock is the one in force, so its error message - and its duration - is what the user reads.
-        self.assertListEqual([StageMessage("Locked for 1 hour(s).", ConditionalAccessAction.LOCK_USER)],
-                             evaluation.messages)
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+        # Only the hour-long lock is history: the ten-minute write would weaken it, so it is declined and
+        # records nothing. Its wording is declined with it - the row keeps what the surviving lock said.
+        self.assertListEqual([str(ConditionalAccessAction.LOCK_USER)],
+                             [outcome.action_type for outcome in outcomes])
+        self.assertEqual("Locked for {duration}.", self._state().error_message)
 
-    def test_a_notification_from_a_second_policy_survives_alongside_the_lock(self):
-        # Only restrictions collapse onto one row. A notify-only policy describes something else that happened,
-        # so its error message is still carried, after the restriction.
+    def test_a_notification_from_a_second_policy_leaves_the_lock_wording_alone(self):
+        # Only restrictions collapse onto one row. A notify-only policy writes no row at all, so it can neither
+        # replace the lock's wording nor add to it - it only contributes its own outcome.
         self._make_policy(name="lock", counter_type=AuthEventType.MFA_FAIL, priority=1,
                           stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER,
                                                                                {"duration_seconds": 600})],
@@ -2824,32 +2789,15 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                                                   error_message="We emailed you."),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
         with mock.patch("privacyidea.lib.conditional_access.engine._send_action_email", return_value=True):
-            evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-        self.assertListEqual([StageMessage("Locked for 10 minute(s).", ConditionalAccessAction.LOCK_USER),
-                              StageMessage("We emailed you.", ConditionalAccessAction.EMAIL_USER)],
-                             evaluation.messages)
+            outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+        self.assertListEqual([str(ConditionalAccessAction.LOCK_USER), str(ConditionalAccessAction.EMAIL_USER)],
+                             [outcome.action_type for outcome in outcomes])
+        self.assertEqual("Locked for {duration}.", self._state().error_message)
 
-    def test_shared_error_message_is_kept_as_the_restriction_it_also_describes(self):
-        # The same sentence configured on a notify-only stage and on a locking one. It is shown once, and as
-        # the restriction: kept as a notification, compose_failure_message would append it to the generic
-        # failure instead of replacing it, so the user would read "wrong credentials" for a locked account.
-        self._make_policy(name="notify", counter_type=AuthEventType.MFA_FAIL, priority=1,
-                          stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.EMAIL_USER)],
-                                                  error_message="Contact your administrator."),))
-        self._make_policy(name="lock", counter_type=AuthEventType.MFA_FAIL, priority=2,
-                          stages=(StageDefinition(3, [StageActionDefinition(ConditionalAccessAction.LOCK_USER,
-                                                                               {"duration_seconds": 600})],
-                                                  error_message="Contact your administrator."),))
-        self._seed_events(AuthEventType.MFA_FAIL, 3)
-        with mock.patch("privacyidea.lib.conditional_access.engine._send_action_email", return_value=True):
-            evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-        self.assertListEqual([StageMessage("Contact your administrator.", ConditionalAccessAction.LOCK_USER)],
-                             evaluation.messages)
-
-    def test_a_stage_whose_lock_was_declined_describes_the_lock_that_stands(self):
+    def test_a_stage_whose_lock_was_declined_leaves_the_lock_that_stands(self):
         # The permanent lock from the first policy wins, so the second policy's timed write is declined as
-        # weakening and records no outcome. The user is still told about the lock in force - the row is what
-        # describes a restriction, not the stage that aimed at it - rather than being told nothing at all.
+        # weakening and records no outcome. The row - and the wording the requests it refuses will read - is the
+        # one that actually stands, not the one the second stage aimed at.
         self._make_policy(name="permanent", counter_type=AuthEventType.MFA_FAIL, priority=1,
                           stages=(StageDefinition(3, [StageActionDefinition(
                               ConditionalAccessAction.PERMANENT_LOCK_USER)], error_message="Permanently locked."),))
@@ -2858,21 +2806,22 @@ class ConditionalAccessEngineTestCase(ConditionalAccessTestCase):
                                                                                {"duration_seconds": 600})],
                                                   error_message="Locked for a short while."),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-        self.assertListEqual([StageMessage("Permanently locked.", ConditionalAccessAction.PERMANENT_LOCK_USER)],
-                             evaluation.messages)
+        outcomes = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+        self.assertEqual("Permanently locked.", self._state().error_message)
         # And the declined write is left out of the history, since nothing happened.
         self.assertListEqual([str(ConditionalAccessAction.PERMANENT_LOCK_USER)],
-                             [outcome.action_type for outcome in evaluation.outcomes])
+                             [outcome.action_type for outcome in outcomes])
 
-    def test_a_permanent_action_sets_the_rank_whatever_the_order(self):
-        # The permanent lock is written second here, and still decides both the rank and the error message.
+    def test_a_permanent_action_wins_whatever_the_order(self):
+        # The permanent lock is written second here and still decides what stands: a restriction is never
+        # weakened, so the row is permanent and the stage's wording sits on it with no remaining time for
+        # {duration} to be substituted against.
         actions = [StageActionDefinition(ConditionalAccessAction.LOCK_USER, {"duration_seconds": 600}),
                    StageActionDefinition(ConditionalAccessAction.PERMANENT_LOCK_USER)]
         self._make_policy(name="mixed", counter_type=AuthEventType.MFA_FAIL,
                           stages=(StageDefinition(3, actions, error_message="Locked for {duration}."),))
         self._seed_events(AuthEventType.MFA_FAIL, 3)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
-        # No remaining time to substitute, so the tag is left as written - and the rank is the permanent one.
-        self.assertListEqual([StageMessage("Locked for {duration}.", ConditionalAccessAction.PERMANENT_LOCK_USER)],
-                             evaluation.messages)
+        evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL)
+        state = self._state()
+        self.assertIsNone(state.lock_expires_at)
+        self.assertEqual("Locked for {duration}.", state.error_message)

--- a/tests/test_lib_conditional_access_policy.py
+++ b/tests/test_lib_conditional_access_policy.py
@@ -39,7 +39,6 @@ from privacyidea.lib.conditional_access.policy import (
     MAX_COLUMN_INT,
     MAX_ERROR_MESSAGE_LENGTH,
     MAX_PRIORITY,
-    compose_default_error_message,
     create_conditional_access_policy,
     default_error_message,
     delete_conditional_access_policy,

--- a/tests/test_lib_conditional_access_policy.py
+++ b/tests/test_lib_conditional_access_policy.py
@@ -764,11 +764,13 @@ class ConditionalAccessPolicyCrudTestCase(MyTestCase):
         constraints = get_target_constraints()
         self.assertSetEqual({t.value for t in ConditionalAccessTarget}, set(constraints))
         for target, entry in constraints.items():
-            self.assertSetEqual({"actions", "count_modes", "repeatable_actions", "exclusive_action_groups"},
-                                set(entry))
+            self.assertSetEqual({"actions", "count_modes", "repeatable_actions", "exclusive_action_groups",
+                                 "reporting_actions"}, set(entry))
             self.assertListEqual(sorted(entry["actions"]), entry["actions"])
             self.assertListEqual(sorted(entry["count_modes"]), entry["count_modes"])
             self.assertListEqual(sorted(entry["repeatable_actions"]), entry["repeatable_actions"])
+            self.assertListEqual(sorted(entry["reporting_actions"]), entry["reporting_actions"])
+            self.assertTrue(set(entry["reporting_actions"]).issubset(entry["actions"]))
             # Every served rule is expressible for this target: a group only one of whose members the target
             # allows could never be violated, so offering it as a rule would be noise.
             for group in entry["exclusive_action_groups"]:

--- a/tests/test_lib_conditional_access_policy.py
+++ b/tests/test_lib_conditional_access_policy.py
@@ -762,32 +762,28 @@ class ConditionalAccessPolicyCrudTestCase(MyTestCase):
 
     def test_10a_default_error_messages_are_ordered_most_severe_first(self):
         # The exact list, because both membership and order are contracts: the order is ACTION_SEVERITY, the
-        # one ordering there is, an action that rejects nothing is absent for having nothing to say, and the
-        # EMAIL_* pair comes last. A new action added here has to be a deliberate decision, not a surprise.
+        # one ordering there is, and an action that turns nobody away is absent because nothing could ever show
+        # its wording - a message is said off the row a restriction leaves behind, and no row records that an
+        # email went out. A new action added here has to be a deliberate decision, not a surprise.
         suggestions = get_default_error_messages()
         self.assertListEqual([ConditionalAccessAction.PERMANENT_LOCK_USER.value, ConditionalAccessAction.PERMANENT_BLOCK_IP.value,
                               ConditionalAccessAction.LOCK_USER.value, ConditionalAccessAction.BLOCK_IP.value,
-                              ConditionalAccessAction.DENY.value, ConditionalAccessAction.EMAIL_USER.value,
-                              ConditionalAccessAction.EMAIL_ADMIN.value],
+                              ConditionalAccessAction.DENY.value],
                              [entry["action_type"] for entry in suggestions])
         # Resolved to plain strings, not lazy proxies the JSON encoder would choke on.
         for entry in suggestions:
             self.assertIsInstance(entry["message"], str)
             self.assertTrue(entry["message"])
 
-    def test_10a3_the_table_and_the_severity_ordering_cover_the_same_actions(self):
-        # One thing seen twice: every action that ranks has a message, and every message belongs to an action
-        # that ranks. Nothing may be reachable from only one of them.
-        self.assertSetEqual(set(ACTION_SEVERITY), set(DEFAULT_ERROR_MESSAGES))
-
-    def test_10a3b_a_suggestion_is_the_entries_joined_in_the_order_served(self):
-        # The order is the whole composition rule, so a client needs nothing but the list: joining the entries a
-        # stage carries is what the runtime reports for it. Asserted against the runtime's own composition, so
-        # the two cannot drift - here for a notify-only stage, which is all the runtime composes stage-side.
-        served = {entry["action_type"]: entry["message"] for entry in get_default_error_messages()}
-        actions = [ConditionalAccessAction.EMAIL_USER, ConditionalAccessAction.EMAIL_ADMIN]
-        self.assertEqual(" ".join(served[action.value] for action in actions),
-                         compose_default_error_message(actions))
+    def test_10a3_every_default_message_belongs_to_an_action_that_ranks(self):
+        # The table is a subset of the ordering, not its twin: an action only has wording if it turns a request
+        # away, while ACTION_SEVERITY ranks every action so that one added later is already ranked when it needs
+        # to be. What must never happen is a message whose action has no rank - it would sort last by accident.
+        self.assertTrue(set(DEFAULT_ERROR_MESSAGES) <= set(ACTION_SEVERITY),
+                        set(DEFAULT_ERROR_MESSAGES) - set(ACTION_SEVERITY))
+        # And the ones that are absent are absent for the one reason: they report rather than refuse.
+        self.assertSetEqual({ConditionalAccessAction.EMAIL_USER, ConditionalAccessAction.EMAIL_ADMIN},
+                            set(ACTION_SEVERITY) - set(DEFAULT_ERROR_MESSAGES))
 
     def test_10a4_a_restriction_row_finds_its_error_message_by_shape(self):
         # A stored restriction remembers its expiry and its subject, not which action wrote it. Those two
@@ -804,25 +800,9 @@ class ConditionalAccessPolicyCrudTestCase(MyTestCase):
         # An action the table does not cover has nothing to say, and a caller must not have to know which
         # those are - so the lookup answers for any action, not only the ones with error message.
         self.assertIsNone(default_error_message("SOME_FUTURE_ACTION"))
-        self.assertIsNone(compose_default_error_message(["SOME_FUTURE_ACTION"]))
-        self.assertIsNone(compose_default_error_message([]))
-
-    def test_10a6_a_stage_composes_its_notifications_most_severe_first(self):
-        # The order is ACTION_SEVERITY, not the order the actions were configured in, so a stage falling back
-        # to the default reads like the one next to it that had the suggestion written in.
-        composed = compose_default_error_message([ConditionalAccessAction.EMAIL_ADMIN, ConditionalAccessAction.EMAIL_USER])
-        self.assertEqual(" ".join([str(DEFAULT_ERROR_MESSAGES[ConditionalAccessAction.EMAIL_USER]),
-                                   str(DEFAULT_ERROR_MESSAGES[ConditionalAccessAction.EMAIL_ADMIN])]), composed)
-
-    def test_10a6b_the_restriction_is_left_to_the_row_that_holds_it(self):
-        # A restriction is described from the row it left behind, so composing a stage's fallback never
-        # includes one - otherwise the user reads it twice, once per source, and with a {duration} this side
-        # cannot substitute.
-        self.assertEqual(str(DEFAULT_ERROR_MESSAGES[ConditionalAccessAction.EMAIL_USER]),
-                         compose_default_error_message([ConditionalAccessAction.LOCK_USER, ConditionalAccessAction.EMAIL_USER]))
-        # A stage that only restricted has nothing left to say from here.
-        self.assertIsNone(compose_default_error_message([ConditionalAccessAction.LOCK_USER]))
-        self.assertIsNone(compose_default_error_message([ConditionalAccessAction.PERMANENT_BLOCK_IP, ConditionalAccessAction.DENY]))
+        # The notifying actions are exactly that case now: nothing can report them, so they carry no wording.
+        self.assertIsNone(default_error_message(ConditionalAccessAction.EMAIL_USER))
+        self.assertIsNone(default_error_message(ConditionalAccessAction.EMAIL_ADMIN))
 
     def test_10b_only_timed_restrictions_suggest_the_duration_tag(self):
         # A permanent lock has no remaining time, and DENY is not a restriction at all, so

--- a/tests/test_lib_conditional_access_policy_template.py
+++ b/tests/test_lib_conditional_access_policy_template.py
@@ -258,14 +258,14 @@ class ConditionalAccessTemplateBehaviourTestCase(ConditionalAccessTestCase):
             now = utc_now()
             self._create("mfa_bruteforce", configure_email=True)
             self._seed_events(AuthEventType.MFA_FAIL, 5, timestamp=now)
-            evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=now)
+            evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=now)
             status = get_user_lock(self.user, now=now)
             self.assertFalse(status.permanent, "lock is permanent, expected timed")
             self.assertEqual(1800, status.seconds_remaining, "wrong lock duration")
             self.assertIn("soc@example.com", smtpmock.get_sent_recipient(), "admin not emailed")
-            # The shipped templates carry no error_message, so nothing is surfaced: the email goes out
-            # and the user is told only that authentication failed.
-            self.assertListEqual([], evaluation.messages, "a shipped template should stay silent")
+            # The shipped templates carry no error_message, so the lock is silent: the requests it refuses are
+            # told only that authentication failed.
+            self.assertIsNone(status.error_message, "a shipped template should stay silent")
         finally:
             Admin.query.filter_by(username="ca_soc").delete()
             db.session.commit()
@@ -297,10 +297,10 @@ class ConditionalAccessTemplateBehaviourTestCase(ConditionalAccessTestCase):
         now = utc_now()
         self._create("mfa_bruteforce")  # email deliberately left unconfigured
         self._seed_events(AuthEventType.MFA_FAIL, 5, timestamp=now)
-        evaluation = evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=now)
-        self.assertEqual(1800, get_user_lock(self.user, now=now).seconds_remaining,
-                         "lock did not fire without SMTP configured")
-        self.assertListEqual([], evaluation.messages, "a shipped template should stay silent")
+        evaluate_conditional_access_policies(CAContext(self.user), AuthEventType.MFA_FAIL, now=now)
+        status = get_user_lock(self.user, now=now)
+        self.assertEqual(1800, status.seconds_remaining, "lock did not fire without SMTP configured")
+        self.assertIsNone(status.error_message, "a shipped template should stay silent")
 
     # --- per-user rate limit (all attempts, DENY) -----------------------------
 

--- a/tests/test_lib_conditional_access_request_context.py
+++ b/tests/test_lib_conditional_access_request_context.py
@@ -395,23 +395,24 @@ class ConditionalAccessContextTestCase(MyTestCase):
         # Staging an event is the signal to evaluate, so a request that logged nothing evaluates nothing.
         context = ConditionalAccessContext()
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            self.assertListEqual([], context.run_post_eval().messages)
+            context.run_post_eval()
         evaluate.assert_not_called()
 
     def test_24_post_eval_does_not_repeat_the_same_classification(self):
-        # /auth runs it in-view for the messages; request teardown must not repeat that same evaluation.
+        # A second call for an unchanged classification is a no-op, so request teardown cannot double-count a
+        # request an earlier caller already evaluated.
         context = ConditionalAccessContext()
         context.stage(self._event("alice"))
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
             evaluate.return_value = []
-            self.assertListEqual([StageMessage("a message", ConditionalAccessAction.EMAIL_ADMIN)], context.run_post_eval().messages)
-            self.assertListEqual([], context.run_post_eval().messages)
+            context.run_post_eval()
+            context.run_post_eval()
         self.assertEqual(1, evaluate.call_count)
 
     def test_24b_post_eval_runs_again_for_a_corrected_classification(self):
-        # The guard is "once per classification", not "once": if a post-policy corrects the outcome after an endpoint
-        # already evaluated in-view, teardown must evaluate the correction, or the engine is left having judged an
-        # outcome that no longer holds.
+        # The guard is "once per classification", not "once": if a post-policy corrects the outcome after an
+        # earlier call evaluated it, teardown must evaluate the correction, or the engine is left having judged
+        # an outcome that no longer holds.
         context = ConditionalAccessContext()
         context.stage(self._event("alice", AuthEventType.LOGIN_SUCCESS))
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
@@ -432,20 +433,20 @@ class ConditionalAccessContextTestCase(MyTestCase):
         context.stage(self._event("alice"))
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies",
                         side_effect=RuntimeError("engine boom")):
-            self.assertListEqual([], context.run_post_eval().messages)
+            context.run_post_eval()
 
     def test_25b_a_failed_evaluation_is_retried_at_teardown(self):
-        # /auth evaluates in-view and teardown evaluates again; a classification counts as evaluated only once the
-        # engine returns, so a transient failure in the early call does not cost the evaluation entirely.
+        # A classification counts as evaluated only once the engine returns, so a transient failure in an earlier
+        # call does not cost the evaluation entirely - teardown tries again.
         context = ConditionalAccessContext()
         context.stage(self._event("alice"))
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies",
                         side_effect=RuntimeError("engine boom")):
-            self.assertListEqual([], context.run_post_eval().messages)
+            context.run_post_eval()
 
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
             evaluate.return_value = []
-            self.assertListEqual([StageMessage("locked", ConditionalAccessAction.LOCK_USER)], context.run_post_eval().messages)
+            context.run_post_eval()
         evaluate.assert_called_once()
 
     def test_26_evaluation_counts_over_a_committed_read_view(self):
@@ -528,7 +529,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
         context.flush()
 
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            self.assertListEqual([], context.run_post_eval().messages)
+            context.run_post_eval()
         evaluate.assert_not_called()
 
     def test_34_post_eval_records_what_the_engine_returned(self):
@@ -537,7 +538,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
         context.flush()
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
             evaluate.return_value = [self._make_outcome(ConditionalAccessAction.PERMANENT_LOCK_USER)]
-            self.assertListEqual([StageMessage("a message", ConditionalAccessAction.EMAIL_ADMIN)], context.run_post_eval().messages)
+            context.run_post_eval()
 
         outcomes = get_outcomes(event.row_id)
         self.assertListEqual([str(ConditionalAccessAction.PERMANENT_LOCK_USER)],

--- a/tests/test_lib_conditional_access_request_context.py
+++ b/tests/test_lib_conditional_access_request_context.py
@@ -25,7 +25,7 @@ from sqlalchemy import select
 
 from privacyidea.lib.challenge import delete_challenges
 from privacyidea.lib.conditional_access.authentication_event_types import (CA_ENFORCEMENT_EVENT_TYPES, AuthEventType)
-from privacyidea.lib.conditional_access.engine import ConditionalAccessAction, ConditionalAccessEvaluation, StageMessage
+from privacyidea.lib.conditional_access.engine import ConditionalAccessAction
 from privacyidea.lib.conditional_access.outcome_log import get_outcomes
 from privacyidea.lib.conditional_access.authentication_log import (AuthLogUserRole, PendingAuthEvent,
                                                                   get_authentication_logs,
@@ -291,7 +291,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
 
         context.reclassify(AuthEventType.NOT_AUTHORIZED)
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            evaluate.return_value = ConditionalAccessEvaluation()
+            evaluate.return_value = []
             context.run_post_eval()
 
         # The engine is handed only the classification and the subject, as a CAContext describing the identity the row
@@ -310,7 +310,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
         context.principal = AuthPrincipal(username="admin", internal_admin=True)
 
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            evaluate.return_value = ConditionalAccessEvaluation()
+            evaluate.return_value = []
             context.run_post_eval()
 
         ca_context = evaluate.call_args.args[0]
@@ -328,7 +328,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
         context.principal = AuthPrincipal(user=User("cornelius", self.realm1))
 
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            evaluate.return_value = ConditionalAccessEvaluation()
+            evaluate.return_value = []
             context.run_post_eval()
 
         self.assertEqual("/validate/check", evaluate.call_args.args[0].endpoint)
@@ -403,7 +403,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
         context = ConditionalAccessContext()
         context.stage(self._event("alice"))
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            evaluate.return_value = ConditionalAccessEvaluation(messages=[StageMessage("a message", ConditionalAccessAction.EMAIL_ADMIN)])
+            evaluate.return_value = []
             self.assertListEqual([StageMessage("a message", ConditionalAccessAction.EMAIL_ADMIN)], context.run_post_eval().messages)
             self.assertListEqual([], context.run_post_eval().messages)
         self.assertEqual(1, evaluate.call_count)
@@ -415,7 +415,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
         context = ConditionalAccessContext()
         context.stage(self._event("alice", AuthEventType.LOGIN_SUCCESS))
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            evaluate.return_value = ConditionalAccessEvaluation()
+            evaluate.return_value = []
             context.run_post_eval()
             context.reclassify(AuthEventType.NOT_AUTHORIZED)
             context.run_post_eval()
@@ -444,8 +444,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
             self.assertListEqual([], context.run_post_eval().messages)
 
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            evaluate.return_value = ConditionalAccessEvaluation(
-                messages=[StageMessage("locked", ConditionalAccessAction.LOCK_USER)], outcomes=[])
+            evaluate.return_value = []
             self.assertListEqual([StageMessage("locked", ConditionalAccessAction.LOCK_USER)], context.run_post_eval().messages)
         evaluate.assert_called_once()
 
@@ -459,7 +458,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
         self.assertTrue(get_ca_session().in_transaction())
 
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            evaluate.return_value = ConditionalAccessEvaluation()
+            evaluate.return_value = []
             context.finalize()
 
         evaluate.assert_called_once()
@@ -537,8 +536,7 @@ class ConditionalAccessContextTestCase(MyTestCase):
         event = context.stage(self._event("alice"))
         context.flush()
         with mock.patch("privacyidea.lib.conditional_access.engine.evaluate_conditional_access_policies") as evaluate:
-            evaluate.return_value = ConditionalAccessEvaluation(messages=[StageMessage("a message", ConditionalAccessAction.EMAIL_ADMIN)],
-                                                      outcomes=[self._make_outcome(ConditionalAccessAction.PERMANENT_LOCK_USER)])
+            evaluate.return_value = [self._make_outcome(ConditionalAccessAction.PERMANENT_LOCK_USER)]
             self.assertListEqual([StageMessage("a message", ConditionalAccessAction.EMAIL_ADMIN)], context.run_post_eval().messages)
 
         outcomes = get_outcomes(event.row_id)


### PR DESCRIPTION
Takes one rule and applies it everywhere: conditional access reports on the requests it refuses, and says nothing on the request that trips it. The pre-auth check is unchanged. The post-response evaluation
  stops touching the response of the request it evaluates — no rewriting a body into a rejection, no appending a notification.                                                                                 
                                                                                                                                                                                                               
  This is what evaluation.rst already told administrators ("locks, blocks and notifications are created at this point, so they apply from the next request onwards"). The code contradicted its own documented 
  model, and the machinery that made it possible was the largest and least obvious part of the feature. Net −1359 / +742 across 21 files.                                                                                                                                                                                                                                                 
                                                                                                                                                                                                               