### PR TITLE
CA - Re-trigger last stage action in templates

### DIFF
--- a/doc/conditional_access/policies.rst
+++ b/doc/conditional_access/policies.rst
@@ -163,6 +163,15 @@ any credentials are checked and logged as ``ACCESS_DENIED``, a type no policy
 can count, so the very count that would carry it past the next threshold stops
 climbing while the refusal holds.
 
+It is worth giving the **highest** stage's restricting action - its lock, block
+or ``DENY`` - re-trigger above threshold. Because a fire-once action fires only
+on the request where the count *equals* the threshold, a subject that is already
+past it stays unrestricted: failures that predate the policy, or an
+administrator who lifted a lock while the failures behind it were still inside
+the window. The highest stage owns every count from its threshold upwards, so
+re-triggering there restricts on the next request whatever put the count up
+there. The shipped templates are written this way.
+
 Stages are evaluated from the highest threshold down, so the order follows the
 thresholds themselves and there is nothing else to configure.
 
@@ -289,7 +298,9 @@ The *New Conditional Access* page offers templates for the common cases - passwo
 brute force, MFA brute force, per-user and per-IP rate limits, password
 spraying and user enumeration. A template fills in tracked events, window,
 count mode, stages, actions and whether the count resets on a successful
-login; you pick the priority and review the thresholds. The two per-IP rate limit templates are pre-set to dry run, because
+login; you pick the priority and review the thresholds. The restricting action
+of each template's highest stage re-triggers above its threshold, as recommended
+above. The two per-IP rate limit templates are pre-set to dry run, because
 their threshold depends on how many users share an address, see
 :ref:`conditional_access_policies_dry_run`.
 

--- a/privacyidea/lib/conditional_access/policy_template.py
+++ b/privacyidea/lib/conditional_access/policy_template.py
@@ -57,6 +57,13 @@ class ConditionalAccessPolicyTemplate:
     policy: dict
 
 
+# The restricting action of every template's *highest* stage re-triggers. A fire-once action only fires on the request
+# where the count equals the threshold, so a subject already past it stays unrestricted - events that predate the
+# policy, or an administrator lifting a lock while the failures behind it are still inside the window. The highest
+# stage owns every count from its threshold upwards, so re-triggering there catches whatever put the count up there.
+# Notifications stay fire-once (one mail per request otherwise) and DENY already re-triggers by default
+# (DECISION_ACTIONS). Every timed restriction here lasts at least as long as its window, so nothing re-triggers while
+# the restriction stands.
 PASSWORD_BRUTEFORCE = ConditionalAccessPolicyTemplate(
     key="password_bruteforce",
     description=lazy_gettext("Lock a single user after repeated wrong passwords or PINs (password brute-force)."),
@@ -75,7 +82,8 @@ PASSWORD_BRUTEFORCE = ConditionalAccessPolicyTemplate(
         "stages": [
             {"failure_threshold": 10,
              "actions": [{"action_type": ConditionalAccessAction.LOCK_USER,
-                          "action_value": {"duration_seconds": 900}}]},
+                          "action_value": {"duration_seconds": 900},
+                          "retrigger_above_threshold": True}]},
         ],
     })
 
@@ -112,9 +120,13 @@ MFA_BRUTEFORCE = ConditionalAccessPolicyTemplate(
                                "{event_type} events. Time: {time}.")}},
              ]},
 
+            # A permanent lock expires only when an administrator lifts it, so re-triggering it means one thing:
+            # a failure after that unlock locks the user again while the count is still up. Reset on success is what
+            # makes the unlock stick - a completed login clears the count before the next failure can count.
             {"failure_threshold": 10,
              "actions": [
-                 {"action_type": ConditionalAccessAction.PERMANENT_LOCK_USER},
+                 {"action_type": ConditionalAccessAction.PERMANENT_LOCK_USER,
+                  "retrigger_above_threshold": True},
                  {"action_type": ConditionalAccessAction.EMAIL_ADMIN,
                   "action_value": {
                       "smtp_identifier": "",
@@ -210,7 +222,8 @@ PASSWORD_SPRAYING = ConditionalAccessPolicyTemplate(
         "stages": [
             {"failure_threshold": 20,
              "actions": [{"action_type": ConditionalAccessAction.BLOCK_IP,
-                          "action_value": {"duration_seconds": 3600}}]},
+                          "action_value": {"duration_seconds": 3600},
+                          "retrigger_above_threshold": True}]},
         ],
     })
 
@@ -232,7 +245,8 @@ USER_ENUMERATION = ConditionalAccessPolicyTemplate(
         "stages": [
             {"failure_threshold": 10,
              "actions": [{"action_type": ConditionalAccessAction.BLOCK_IP,
-                          "action_value": {"duration_seconds": 3600}}]},
+                          "action_value": {"duration_seconds": 3600},
+                          "retrigger_above_threshold": True}]},
         ],
     })
 


### PR DESCRIPTION
A fire-once stage action only fires on the request where the count *equals* its threshold                                                                                                                  
  (`_action_fires`: `retrigger_above_threshold or count == threshold`). A subject that is                                                                                                                    
  already past the threshold is therefore left unrestricted — failures that predate the policy,                                                                                                              
  or a lock an administrator lifted while the failures behind it were still inside the window.                                                                                                               
                                                                                                                                                                                                             
The highest stage owns every count from its threshold upwards, so re-triggering its                                                                                                                        
  restricting action turns it into a safety net: whatever put the count up there, the next                                                                                                                   
  request is restricted.